### PR TITLE
Add box-sizing: border-box to .card so all cards render at consistent…

### DIFF
--- a/app/html/mu.css
+++ b/app/html/mu.css
@@ -743,6 +743,7 @@ body.page-home #content > div:has(> #page-title) {
    ======================================== */
 .card {
   max-width: 750px;
+  box-sizing: border-box;
   display: block;
   border: var(--border-width) solid var(--card-border);
   border-radius: var(--border-radius);


### PR DESCRIPTION
… 750px

Without border-box, padding and border shrink the content area below the 750px max-width, causing visual mismatch between cards.

