### PR TITLE
Interleave news across categories for diverse summaries

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1063,8 +1063,38 @@ func formatNewsResult(result string) string {
 	if len(items) == 0 {
 		return "No news available."
 	}
-	if len(items) > 15 {
-		items = items[:15]
+
+	// Interleave items across categories round-robin to ensure diversity.
+	// The raw feed groups items by category, so naively slicing gives only
+	// the first category. Instead, pick up to 2 items per category in
+	// round-robin order.
+	if data.Query == "" {
+		catOrder := []string{}
+		catItems := map[string][]item{}
+		for _, a := range items {
+			cat := a.Category
+			if cat == "" {
+				cat = "_"
+			}
+			if _, ok := catItems[cat]; !ok {
+				catOrder = append(catOrder, cat)
+			}
+			catItems[cat] = append(catItems[cat], a)
+		}
+		var mixed []item
+		maxPerCat := 3
+		for round := 0; round < maxPerCat; round++ {
+			for _, cat := range catOrder {
+				if round < len(catItems[cat]) {
+					mixed = append(mixed, catItems[cat][round])
+				}
+			}
+		}
+		items = mixed
+	}
+
+	if len(items) > 20 {
+		items = items[:20]
 	}
 	var sb strings.Builder
 	if data.Query != "" {


### PR DESCRIPTION
The news feed arrives grouped by category (alphabetically), so crypto items always came first. With the item cap, the AI only ever saw crypto news. Now formatNewsResult round-robins across categories (up to 3 per category, 20 total) before formatting, ensuring every category gets represented in the RAG context.

https://claude.ai/code/session_01QJaTh5F1pfgRaGzsQSZDcQ