### PR TITLE
Set session cookie after MCP login/signup for persistent auth

### DIFF
--- a/api/mcp.go
+++ b/api/mcp.go
@@ -435,6 +435,24 @@ func handleToolsCall(w http.ResponseWriter, originalReq *http.Request, req jsonr
 		if err != nil {
 			result.IsError = true
 		}
+
+		// If login/signup succeeded, set session cookie so subsequent
+		// MCP requests from the same client are authenticated.
+		if err == nil && (tool.Name == "login" || tool.Name == "signup") {
+			var resp struct {
+				Token string `json:"token"`
+			}
+			if json.Unmarshal([]byte(text), &resp) == nil && resp.Token != "" {
+				http.SetCookie(w, &http.Cookie{
+					Name:     "session",
+					Value:    resp.Token,
+					Path:     "/",
+					HttpOnly: true,
+					SameSite: http.SameSiteLaxMode,
+				})
+			}
+		}
+
 		writeResult(w, req.ID, result)
 		return
 	}


### PR DESCRIPTION
When login/signup succeeds via MCP, set the session token as an HTTP cookie on the response. This means subsequent MCP requests from the same client automatically carry the session, enabling authenticated actions like blog post creation without requiring PAT tokens.

https://claude.ai/code/session_01QJaTh5F1pfgRaGzsQSZDcQ