### PR TITLE
Streamline nav: show primary links, collapse others under More

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -223,15 +223,18 @@ var Template = `
           <a href="/agent"><img src="/chat.png?` + Version + `"><span class="label">Agent</span></a>
           <a href="/blog"><img src="/post.png?` + Version + `"><span class="label">Blog</span></a>
           <a href="/chat"><img src="/chat.png?` + Version + `"><span class="label">Chat</span></a>
-          <a id="nav-mail" href="/mail" style="display: none;"><img src="/mail.png?` + Version + `"><span class="label">Mail</span><span id="nav-mail-badge"></span></a>
-          <a href="/markets"><img src="/markets.png?` + Version + `"><span class="label">Markets</span></a>
           <a href="/news"><img src="/news.png?` + Version + `"><span class="label">News</span></a>
-          <a href="/places"><img src="/places.png?` + Version + `"><span class="label">Places</span></a>
-          <a href="/reminder"><img src="/reminder.png?` + Version + `"><span class="label">Reminder</span></a>
-          <a href="/web"><img src="/search.svg?` + Version + `"><span class="label">Web</span></a>
           <a href="/video"><img src="/video.png?` + Version + `"><span class="label">Video</span></a>
+          <a href="/web"><img src="/search.svg?` + Version + `"><span class="label">Web</span></a>
+          <a id="nav-mail" href="/mail" style="display: none;"><img src="/mail.png?` + Version + `"><span class="label">Mail</span><span id="nav-mail-badge"></span></a>
           <a id="nav-wallet" href="/wallet" style="display: none;"><img src="/wallet.png?` + Version + `"><span class="label">Wallet</span></a>
-          <a href="/weather"><img src="/weather.png?` + Version + `"><span class="label">Weather</span></a>
+          <a id="nav-more-toggle" href="#" onclick="toggleNavMore(event)"><span class="label">More</span><span id="nav-more-arrow">&#9662;</span></a>
+          <div id="nav-more" style="display:none;">
+            <a href="/markets"><img src="/markets.png?` + Version + `"><span class="label">Markets</span></a>
+            <a href="/places"><img src="/places.png?` + Version + `"><span class="label">Places</span></a>
+            <a href="/reminder"><img src="/reminder.png?` + Version + `"><span class="label">Reminder</span></a>
+            <a href="/weather"><img src="/weather.png?` + Version + `"><span class="label">Weather</span></a>
+          </div>
         </div>
         <div class="nav-bottom">
           <div id="nav-username" style="display: none;"></div>
@@ -259,6 +262,29 @@ var Template = `
       function toggleMenu() {
         document.body.classList.toggle('menu-open');
       }
+      function toggleNavMore(e) {
+        e.preventDefault();
+        var m = document.getElementById('nav-more');
+        var a = document.getElementById('nav-more-arrow');
+        if (m.style.display === 'none') {
+          m.style.display = 'flex';
+          a.innerHTML = '&#9652;';
+        } else {
+          m.style.display = 'none';
+          a.innerHTML = '&#9662;';
+        }
+      }
+      // Auto-expand More if current page is in the More section
+      (function(){
+        var morePaths = ['/markets','/places','/reminder','/weather'];
+        var p = window.location.pathname;
+        if (morePaths.indexOf(p) !== -1) {
+          var m = document.getElementById('nav-more');
+          var a = document.getElementById('nav-more-arrow');
+          if (m) { m.style.display = 'flex'; }
+          if (a) { a.innerHTML = '&#9652;'; }
+        }
+      })();
   </script>
   </body>
 </html>

--- a/app/html/mu.css
+++ b/app/html/mu.css
@@ -368,26 +368,7 @@ td {
   position: relative;
 }
 
-/* Scroll indicator when nav has more items */
-#nav-container::after {
-  content: '⌄ more';
-  position: absolute;
-  bottom: 130px;
-  left: 25px;
-  right: 25px;
-  text-align: center;
-  font-size: 0.75em;
-  color: #999;
-  background: linear-gradient(transparent, white 50%);
-  padding: 15px 0 5px 0;
-  pointer-events: none;
-  opacity: 0;
-  transition: opacity 0.2s;
-}
-
-#nav-container.has-scroll::after {
-  opacity: 1;
-}
+/* Scroll indicator (unused — replaced by More toggle) */
 
 #nav a {
   color: var(--text-primary);
@@ -419,6 +400,27 @@ td {
 
 #nav .label {
   font-size: 1.1em;
+}
+
+#nav-more-toggle {
+  color: var(--text-secondary, #888);
+  cursor: pointer;
+  justify-content: space-between;
+}
+
+#nav-more-toggle:hover {
+  color: var(--text-primary);
+}
+
+#nav-more-arrow {
+  font-size: 0.8em;
+  margin-left: 6px;
+}
+
+#nav-more {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
 }
 
 .nav-divider {

--- a/app/html/mu.js
+++ b/app/html/mu.js
@@ -841,9 +841,10 @@ self.addEventListener('DOMContentLoaded', function() {
   // set nav active state
   var nav = document.getElementById("nav");
   var navContainer = document.getElementById("nav-container");
-  for (const el of nav.children) {
-    // Skip non-link elements (spacer, bottom container)
-    if (el.tagName !== 'A') continue;
+  var navLinks = nav.querySelectorAll("a[href]");
+  for (var i = 0; i < navLinks.length; i++) {
+    var el = navLinks[i];
+    if (el.id === 'nav-more-toggle') continue;
     if (el.getAttribute("href") == window.location.pathname) {
       el.classList.add("active");
     } else {
@@ -851,19 +852,6 @@ self.addEventListener('DOMContentLoaded', function() {
     }
   }
   
-  // Show scroll indicator if nav has overflow
-  function checkNavScroll() {
-    if (nav && navContainer && nav.scrollHeight > nav.clientHeight && nav.scrollTop < nav.scrollHeight - nav.clientHeight - 10) {
-      navContainer.classList.add('has-scroll');
-    } else if (navContainer) {
-      navContainer.classList.remove('has-scroll');
-    }
-  }
-  // Check after layout settles and on load
-  if (nav) nav.addEventListener('scroll', checkNavScroll);
-  window.addEventListener('resize', checkNavScroll);
-  window.addEventListener('load', checkNavScroll);
-  setTimeout(checkNavScroll, 100);
 
   // load chat
   if (window.location.pathname == CHAT_PATH) {


### PR DESCRIPTION
Primary nav: Home, Agent, Blog, Chat, News, Video, Web, Mail, Wallet
Secondary (under More toggle): Markets, Places, Reminder, Weather

Auto-expands More when visiting a secondary page. Removes old scroll-indicator in favour of the explicit More toggle.

https://claude.ai/code/session_01QJaTh5F1pfgRaGzsQSZDcQ