### PR TITLE
Clean up nav: remove More toggle, keep streamlined sidebar

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -225,6 +225,7 @@ var Template = `
           <a href="/news"><img src="/news.png?` + Version + `"><span class="label">News</span></a>
           <a id="nav-mail" href="/mail" style="display: none;"><img src="/mail.png?` + Version + `"><span class="label">Mail</span><span id="nav-mail-badge"></span></a>
           <a href="/video"><img src="/video.png?` + Version + `"><span class="label">Video</span></a>
+          <a href="/web"><img src="/search.svg?` + Version + `"><span class="label">Web</span></a>
           <a id="nav-wallet" href="/wallet" style="display: none;"><img src="/wallet.png?` + Version + `"><span class="label">Wallet</span></a>
         </div>
         <div class="nav-bottom">
@@ -253,29 +254,6 @@ var Template = `
       function toggleMenu() {
         document.body.classList.toggle('menu-open');
       }
-      function toggleNavMore(e) {
-        e.preventDefault();
-        var m = document.getElementById('nav-more');
-        var a = document.getElementById('nav-more-arrow');
-        if (m.style.display === 'none') {
-          m.style.display = 'flex';
-          a.innerHTML = '&#9652;';
-        } else {
-          m.style.display = 'none';
-          a.innerHTML = '&#9662;';
-        }
-      }
-      // Auto-expand More if current page is in the More section
-      (function(){
-        var morePaths = ['/markets','/places','/reminder','/weather'];
-        var p = window.location.pathname;
-        if (morePaths.indexOf(p) !== -1) {
-          var m = document.getElementById('nav-more');
-          var a = document.getElementById('nav-more-arrow');
-          if (m) { m.style.display = 'flex'; }
-          if (a) { a.innerHTML = '&#9652;'; }
-        }
-      })();
   </script>
   </body>
 </html>

--- a/app/html/mu.css
+++ b/app/html/mu.css
@@ -368,8 +368,6 @@ td {
   position: relative;
 }
 
-/* Scroll indicator (unused — replaced by More toggle) */
-
 #nav a {
   color: var(--text-primary);
   font-weight: var(--font-weight-medium);
@@ -400,27 +398,6 @@ td {
 
 #nav .label {
   font-size: 1.1em;
-}
-
-#nav-more-toggle {
-  color: var(--text-secondary, #888);
-  cursor: pointer;
-  justify-content: space-between;
-}
-
-#nav-more-toggle:hover {
-  color: var(--text-primary);
-}
-
-#nav-more-arrow {
-  font-size: 0.8em;
-  margin-left: 6px;
-}
-
-#nav-more {
-  display: flex;
-  flex-direction: column;
-  gap: 5px;
 }
 
 .nav-divider {


### PR DESCRIPTION
Remove leftover More toggle JS, CSS, and scroll indicator from previous iteration. Nav now shows core services only: Home, Blog, Chat, News, Mail, Video, Web, Wallet.

https://claude.ai/code/session_01QJaTh5F1pfgRaGzsQSZDcQ