### PR TITLE
Always show Mail and Wallet in navbar, redirect to login if unauthent…

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -223,10 +223,10 @@ var Template = `
           <a href="/blog"><img src="/post.png?` + Version + `"><span class="label">Blog</span></a>
           <a href="/chat"><img src="/chat.png?` + Version + `"><span class="label">Chat</span></a>
           <a href="/news"><img src="/news.png?` + Version + `"><span class="label">News</span></a>
-          <a id="nav-mail" href="/mail" style="display: none;"><img src="/mail.png?` + Version + `"><span class="label">Mail</span><span id="nav-mail-badge"></span></a>
+          <a id="nav-mail" href="/mail"><img src="/mail.png?` + Version + `"><span class="label">Mail</span><span id="nav-mail-badge"></span></a>
           <a href="/video"><img src="/video.png?` + Version + `"><span class="label">Video</span></a>
           <a href="/web"><img src="/search.svg?` + Version + `"><span class="label">Web</span></a>
-          <a id="nav-wallet" href="/wallet" style="display: none;"><img src="/wallet.png?` + Version + `"><span class="label">Wallet</span></a>
+          <a id="nav-wallet" href="/wallet"><img src="/wallet.png?` + Version + `"><span class="label">Wallet</span></a>
         </div>
         <div class="nav-bottom">
           <div id="nav-username" style="display: none;"></div>

--- a/app/html/mu.js
+++ b/app/html/mu.js
@@ -595,8 +595,6 @@ function setSession() {
     if (sess.type == "account") {
       isAuthenticated = true;
       // Show authenticated nav items
-      if (navMail) navMail.style.display = 'flex';
-      if (navWallet) navWallet.style.display = 'flex';
       if (navAccount) navAccount.style.display = 'flex';
       if (navLogout) navLogout.style.display = 'flex';
       if (navLogin) navLogin.style.display = 'none';
@@ -619,9 +617,10 @@ function setSession() {
       }
     } else {
       isAuthenticated = false;
+      // Redirect mail/wallet to login when not authenticated
+      if (navMail) navMail.href = '/login?redirect=' + encodeURIComponent('/mail');
+      if (navWallet) navWallet.href = '/login?redirect=' + encodeURIComponent('/wallet');
       // Hide authenticated nav items, show login
-      if (navMail) navMail.style.display = 'none';
-      if (navWallet) navWallet.style.display = 'none';
       if (navAccount) navAccount.style.display = 'none';
       if (navLogout) navLogout.style.display = 'none';
       if (navLogin) {
@@ -644,8 +643,9 @@ function setSession() {
     var navAccount = document.getElementById("nav-account");
     var navLogout = document.getElementById("nav-logout");
     var navLogin = document.getElementById("nav-login");
-    if (navMail) navMail.style.display = 'none';
-    if (navWallet) navWallet.style.display = 'none';
+    // Redirect mail/wallet to login when not authenticated
+    if (navMail) navMail.href = '/login?redirect=' + encodeURIComponent('/mail');
+    if (navWallet) navWallet.href = '/login?redirect=' + encodeURIComponent('/wallet');
     if (navAccount) navAccount.style.display = 'none';
     if (navLogout) navLogout.style.display = 'none';
     if (navLogin) {


### PR DESCRIPTION
…icated

Instead of toggling Mail/Wallet visibility based on auth state, they are now always visible in the nav. When not logged in, clicking them redirects to the login page with the appropriate redirect parameter.

https://claude.ai/code/session_01QJaTh5F1pfgRaGzsQSZDcQ