### PR TITLE
Revert deploy to go install to avoid "Text file busy" error

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,7 +21,6 @@ jobs:
             cd ~/src/mu
             git pull origin main
             source ~/.env
-            go build -o mu
-            cp mu /home/mu/go/bin/mu
+            go install
             sudo -n systemctl restart mu
             echo "Deploy complete"


### PR DESCRIPTION
go install does an atomic rename, so it works even when the binary is running. The previous go build + cp approach failed because cp tries to write to the open file.

https://claude.ai/code/session_01QJaTh5F1pfgRaGzsQSZDcQ