### PR TITLE
Revert deploy to use go install to fix 'Text file busy' error

### DIFF
--- a/admin/deploy.go
+++ b/admin/deploy.go
@@ -134,8 +134,7 @@ func handleDeploy(w http.ResponseWriter, r *http.Request) {
 		args []string
 	}{
 		{"git pull", "git", []string{"pull", "origin", "main"}},
-		{"go build", "go", []string{"build", "-o", "mu"}},
-		{"install binary", "cp", []string{"mu", "/home/mu/go/bin/mu"}},
+		{"go install", "go", []string{"install"}},
 		{"restart service", "sudo", []string{"-n", "systemctl", "restart", "mu"}},
 	}
 


### PR DESCRIPTION
Same fix as the GitHub Action: go install does an atomic rename so it works even when the binary is running.

https://claude.ai/code/session_01QJaTh5F1pfgRaGzsQSZDcQ