### PR TITLE
Add 'Keep Reading' button to truncated blog posts on listing page

### DIFF
--- a/app/html/mu.css
+++ b/app/html/mu.css
@@ -1248,6 +1248,19 @@ body:has(#messages) #chat-back-link {
   text-decoration: underline;
 }
 
+.keep-reading {
+  display: inline-block;
+  font-size: 0.85em;
+  font-weight: 500;
+  color: var(--accent-color);
+  text-decoration: none;
+  margin-top: 4px;
+}
+
+.keep-reading:hover {
+  text-decoration: underline;
+}
+
 .post-tags {
   margin-top: 8px;
   font-size: small;

--- a/blog/blog.go
+++ b/blog/blog.go
@@ -476,6 +476,7 @@ func updateCacheUnlocked() {
 		content := post.Content
 
 		// Truncate plain text before rendering
+		truncated := false
 		if len(content) > 500 {
 			lastSpace := 500
 			for i := 499; i >= 0 && i < len(content); i-- {
@@ -485,6 +486,7 @@ func updateCacheUnlocked() {
 				}
 			}
 			content = content[:lastSpace] + "..."
+			truncated = true
 		}
 
 		// Add links and YouTube embeds
@@ -523,12 +525,18 @@ func updateCacheUnlocked() {
 			replyLink = fmt.Sprintf(` · <a href="/post?id=%s">Replies (%d)</a>`, post.ID, commentCount)
 		}
 
+		keepReading := ""
+		if truncated {
+			keepReading = fmt.Sprintf(`<a href="/post?id=%s" class="keep-reading">Keep Reading →</a>`, post.ID)
+		}
+
 		item := fmt.Sprintf(`<div class="post-item">
 			%s
 			<h3><a href="/post?id=%s">%s</a></h3>
 			<div class="info"><span data-timestamp="%d">%s</span> · Posted by %s%s</div>
 			<div>%s</div>
-		</div>`, tagsHtml, post.ID, title, post.CreatedAt.Unix(), app.TimeAgo(post.CreatedAt), authorLink, replyLink, content)
+			%s
+		</div>`, tagsHtml, post.ID, title, post.CreatedAt.Unix(), app.TimeAgo(post.CreatedAt), authorLink, replyLink, content, keepReading)
 		fullList = append(fullList, item)
 	}
 


### PR DESCRIPTION
Posts longer than 500 chars show a 'Keep Reading →' link below the truncated preview, linking to the full post page.

https://claude.ai/code/session_01QJaTh5F1pfgRaGzsQSZDcQ