### PR TITLE
Add spam detection system with heuristic scoring engine

### DIFF
--- a/admin/admin.go
+++ b/admin/admin.go
@@ -26,6 +26,7 @@ func AdminHandler(w http.ResponseWriter, r *http.Request) {
 		<a href="/admin/users">Users <span class="count">` + fmt.Sprintf("%d", len(users)) + `</span></a>
 		<a href="/admin/moderate">Moderation Queue</a>
 		<a href="/admin/blocklist">Mail Blocklist</a>
+		<a href="/admin/spam">Spam Filter</a>
 		<a href="/admin/email">Email Log</a>
 		<a href="/admin/api">API Log</a>
 		<a href="/admin/log">System Log</a>
@@ -303,6 +304,218 @@ func BlocklistHandler(w http.ResponseWriter, r *http.Request) {
 
 	html := app.RenderHTMLForRequest("Admin", "Mail Blocklist", content, r)
 	w.Write([]byte(html))
+}
+
+// SpamFilterHandler shows and manages the spam filter settings
+func SpamFilterHandler(w http.ResponseWriter, r *http.Request) {
+	_, _, err := auth.RequireAdmin(r)
+	if err != nil {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	if r.Method == "POST" {
+		if err := r.ParseForm(); err != nil {
+			app.BadRequest(w, r, "Failed to parse form")
+			return
+		}
+
+		action := r.FormValue("action")
+		value := r.FormValue("value")
+
+		switch action {
+		case "toggle":
+			sf := mail.GetSpamFilter()
+			mail.SetSpamFilterEnabled(!sf.Enabled) //nolint:errcheck
+		case "set_threshold":
+			t := 5
+			fmt.Sscanf(value, "%d", &t)
+			mail.SetSpamThreshold(t) //nolint:errcheck
+		case "toggle_reject":
+			sf := mail.GetSpamFilter()
+			mail.SetRejectSpam(!sf.RejectSpam) //nolint:errcheck
+		case "toggle_autoblock":
+			sf := mail.GetSpamFilter()
+			mail.SetAutoBlockDomains(!sf.AutoBlockDomains) //nolint:errcheck
+		case "add_tld":
+			if value != "" {
+				mail.AddBlockedTLD(value) //nolint:errcheck
+			}
+		case "remove_tld":
+			if value != "" {
+				mail.RemoveBlockedTLD(value) //nolint:errcheck
+			}
+		case "add_keyword":
+			if value != "" {
+				mail.AddBlockedKeyword(value) //nolint:errcheck
+			}
+		case "remove_keyword":
+			if value != "" {
+				mail.RemoveBlockedKeyword(value) //nolint:errcheck
+			}
+		case "add_allowed":
+			if value != "" {
+				mail.AddAllowedSender(value) //nolint:errcheck
+			}
+		case "remove_allowed":
+			if value != "" {
+				mail.RemoveAllowedSender(value) //nolint:errcheck
+			}
+		}
+
+		http.Redirect(w, r, "/admin/spam", http.StatusSeeOther)
+		return
+	}
+
+	sf := mail.GetSpamFilter()
+
+	enabledStatus := "Disabled"
+	enabledBtn := "Enable"
+	if sf.Enabled {
+		enabledStatus = "Enabled"
+		enabledBtn = "Disable"
+	}
+
+	rejectStatus := "Drop silently"
+	rejectBtn := "Switch to reject"
+	if sf.RejectSpam {
+		rejectStatus = "Save to filtered folder"
+		rejectBtn = "Switch to silent drop"
+	}
+
+	autoBlockStatus := "Off"
+	autoBlockBtn := "Enable"
+	if sf.AutoBlockDomains {
+		autoBlockStatus = "On"
+		autoBlockBtn = "Disable"
+	}
+
+	content := fmt.Sprintf(`<h2>Spam Filter</h2>
+
+	<div class="spam-settings">
+		<h3>Settings</h3>
+		<table class="blacklist-table">
+			<tr>
+				<td><strong>Filter Status</strong></td>
+				<td>%s</td>
+				<td>
+					<form method="POST" class="d-inline">
+						<input type="hidden" name="action" value="toggle">
+						<button type="submit">%s</button>
+					</form>
+				</td>
+			</tr>
+			<tr>
+				<td><strong>Spam Handling</strong></td>
+				<td>%s</td>
+				<td>
+					<form method="POST" class="d-inline">
+						<input type="hidden" name="action" value="toggle_reject">
+						<button type="submit">%s</button>
+					</form>
+				</td>
+			</tr>
+			<tr>
+				<td><strong>Auto-block spam domains</strong></td>
+				<td>%s</td>
+				<td>
+					<form method="POST" class="d-inline">
+						<input type="hidden" name="action" value="toggle_autoblock">
+						<button type="submit">%s</button>
+					</form>
+				</td>
+			</tr>
+			<tr>
+				<td><strong>Score Threshold</strong></td>
+				<td>%d</td>
+				<td>
+					<form method="POST" class="d-inline">
+						<input type="hidden" name="action" value="set_threshold">
+						<input type="number" name="value" value="%d" min="1" max="100" style="width:60px">
+						<button type="submit">Set</button>
+					</form>
+				</td>
+			</tr>
+		</table>
+	</div>`, enabledStatus, enabledBtn, rejectStatus, rejectBtn,
+		autoBlockStatus, autoBlockBtn, sf.Threshold, sf.Threshold)
+
+	// Blocked TLDs
+	content += `<div class="spam-section mt-4">
+		<h3>Blocked TLDs (` + fmt.Sprintf("%d", len(sf.BlockedTLDs)) + `)</h3>
+		<form method="POST" class="block-form">
+			<input type="hidden" name="action" value="add_tld">
+			<input type="text" name="value" placeholder=".vn, .xyz, .top" required>
+			<button type="submit">Block TLD</button>
+		</form>`
+
+	if len(sf.BlockedTLDs) > 0 {
+		content += `<table class="blacklist-table"><tbody>`
+		for _, tld := range sf.BlockedTLDs {
+			content += fmt.Sprintf(`<tr><td><code>%s</code></td><td class="text-center">
+				<form method="POST" class="d-inline">
+					<input type="hidden" name="action" value="remove_tld">
+					<input type="hidden" name="value" value="%s">
+					<button type="submit" class="btn-success">Remove</button>
+				</form></td></tr>`, tld, tld)
+		}
+		content += `</tbody></table>`
+	}
+	content += `</div>`
+
+	// Blocked keywords
+	content += `<div class="spam-section mt-4">
+		<h3>Blocked Keywords (` + fmt.Sprintf("%d", len(sf.BlockedKeywords)) + `)</h3>
+		<form method="POST" class="block-form">
+			<input type="hidden" name="action" value="add_keyword">
+			<input type="text" name="value" placeholder="keyword or phrase" required>
+			<button type="submit">Block Keyword</button>
+		</form>`
+
+	if len(sf.BlockedKeywords) > 0 {
+		content += `<table class="blacklist-table"><tbody>`
+		for _, kw := range sf.BlockedKeywords {
+			content += fmt.Sprintf(`<tr><td><code>%s</code></td><td class="text-center">
+				<form method="POST" class="d-inline">
+					<input type="hidden" name="action" value="remove_keyword">
+					<input type="hidden" name="value" value="%s">
+					<button type="submit" class="btn-success">Remove</button>
+				</form></td></tr>`, kw, kw)
+		}
+		content += `</tbody></table>`
+	}
+	content += `</div>`
+
+	// Allowed senders
+	content += `<div class="spam-section mt-4">
+		<h3>Allowed Senders (` + fmt.Sprintf("%d", len(sf.AllowedSenders)) + `)</h3>
+		<p class="text-sm text-muted">These senders bypass spam checks. Use @domain.com for entire domains.</p>
+		<form method="POST" class="block-form">
+			<input type="hidden" name="action" value="add_allowed">
+			<input type="text" name="value" placeholder="user@example.com or @domain.com" required>
+			<button type="submit">Allow Sender</button>
+		</form>`
+
+	if len(sf.AllowedSenders) > 0 {
+		content += `<table class="blacklist-table"><tbody>`
+		for _, s := range sf.AllowedSenders {
+			content += fmt.Sprintf(`<tr><td><code>%s</code></td><td class="text-center">
+				<form method="POST" class="d-inline">
+					<input type="hidden" name="action" value="remove_allowed">
+					<input type="hidden" name="value" value="%s">
+					<button type="submit" class="btn-success">Remove</button>
+				</form></td></tr>`, s, s)
+		}
+		content += `</tbody></table>`
+	}
+	content += `</div>`
+
+	content += `<div class="mt-6">
+		<p><a href="/admin">← Back to Admin</a></p>
+	</div>`
+
+	htmlPage := app.RenderHTMLForRequest("Admin", "Spam Filter", content, r)
+	w.Write([]byte(htmlPage))
 }
 
 // Helper functions to access mail package functions

--- a/mail/mail.go
+++ b/mail/mail.go
@@ -56,8 +56,11 @@ type Message struct {
 	Read      bool      `json:"read"`
 	ReplyTo   string    `json:"reply_to"`   // ID of message this is replying to
 	ThreadID  string    `json:"thread_id"`  // Root message ID for O(1) thread grouping
-	MessageID string    `json:"message_id"` // Email Message-ID header for threading
-	CreatedAt time.Time `json:"created_at"`
+	MessageID   string    `json:"message_id"`             // Email Message-ID header for threading
+	Spam        bool      `json:"spam,omitempty"`          // Whether this message was flagged as spam
+	SpamScore   int       `json:"spam_score,omitempty"`    // Spam detection score
+	SpamReasons []string  `json:"spam_reasons,omitempty"`  // Why it was flagged
+	CreatedAt   time.Time `json:"created_at"`
 }
 
 // Load messages from disk
@@ -87,6 +90,9 @@ func Load() {
 
 	// Load blocklist
 	loadBlocklist()
+
+	// Load spam filter
+	loadSpamFilter()
 
 	// Try to load DKIM config if keys exist (optional)
 	dkimDomain := os.Getenv("MAIL_DOMAIN")
@@ -172,6 +178,11 @@ func rebuildInboxes() {
 	inboxes = make(map[string]*Inbox)
 
 	for _, msg := range messages {
+		// Skip spam messages from normal inbox
+		if msg.Spam {
+			continue
+		}
+
 		// Add to sender's inbox (sent messages)
 		if msg.FromID != "" {
 			if inboxes[msg.FromID] == nil {
@@ -262,6 +273,26 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 
 	// Handle POST - send message or delete
 	if r.Method == "POST" {
+		// Handle spam filter actions
+		if r.URL.Query().Get("view") == "filtered" {
+			if err := r.ParseForm(); err == nil {
+				action := r.FormValue("action")
+				msgID := r.FormValue("msg_id")
+				switch action {
+				case "not_spam":
+					if err := NotSpamMessage(acc.ID, msgID); err != nil {
+						app.Log("mail", "Error marking not-spam: %v", err)
+					}
+				case "delete_spam":
+					if err := DeleteSpamMessage(acc.ID, msgID); err != nil {
+						app.Log("mail", "Error deleting spam: %v", err)
+					}
+				}
+			}
+			http.Redirect(w, r, "/mail?view=filtered", http.StatusSeeOther)
+			return
+		}
+
 		// JSON body for API/MCP callers (mail_send tool)
 		if app.SendsJSON(r) {
 			var req struct {
@@ -1030,7 +1061,7 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Check which view to show (inbox or sent)
+	// Check which view to show (inbox, sent, or filtered)
 	view := r.URL.Query().Get("view")
 	if view == "" {
 		view = "inbox"
@@ -1122,6 +1153,52 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 				items = append(items, renderThreadPreview(thread.Root.ID, thread.Latest, acc.ID, thread.HasUnread))
 			}
 		}
+	} else if view == "filtered" {
+		// Filtered view - show spam messages
+		spamMsgs := GetSpamMessages(acc.ID)
+		for _, msg := range spamMsgs {
+			reasons := ""
+			if len(msg.SpamReasons) > 0 {
+				reasons = strings.Join(msg.SpamReasons, ", ")
+			}
+			preview := html.EscapeString(msg.Subject)
+			if preview == "" {
+				preview = "(no subject)"
+			}
+			fromDisplay := html.EscapeString(msg.From)
+			if fromDisplay == "" {
+				fromDisplay = html.EscapeString(msg.FromID)
+			}
+			items = append(items, fmt.Sprintf(
+				`<div class="mail-item spam-item">
+					<div class="mail-item-header">
+						<span class="mail-from">%s</span>
+						<span class="mail-date">%s</span>
+					</div>
+					<div class="mail-subject">%s</div>
+					<div class="spam-info text-muted text-sm">Score: %d — %s</div>
+					<div class="spam-actions">
+						<form method="POST" action="/mail?view=filtered" class="d-inline">
+							<input type="hidden" name="action" value="not_spam">
+							<input type="hidden" name="msg_id" value="%s">
+							<button type="submit" class="btn-sm">Not Spam</button>
+						</form>
+						<form method="POST" action="/mail?view=filtered" class="d-inline">
+							<input type="hidden" name="action" value="delete_spam">
+							<input type="hidden" name="msg_id" value="%s">
+							<button type="submit" class="btn-sm btn-danger">Delete</button>
+						</form>
+					</div>
+				</div>`,
+				fromDisplay,
+				msg.CreatedAt.Format("Jan 2 15:04"),
+				preview,
+				msg.SpamScore,
+				html.EscapeString(reasons),
+				msg.ID,
+				msg.ID,
+			))
+		}
 	} else {
 		// Sent view - show threads where user has sent at least one message
 		threads := make([]*Thread, 0)
@@ -1153,6 +1230,8 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 	if len(items) == 0 {
 		if view == "sent" {
 			content = `<p class="text-muted p-5">No sent messages yet.</p>`
+		} else if view == "filtered" {
+			content = `<p class="text-muted p-5">No filtered messages.</p>`
 		} else {
 			content = `<p class="text-muted p-5">No messages yet.</p>`
 		}
@@ -1163,6 +1242,8 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 	title := "Mail"
 	if view == "sent" {
 		title = "Sent Mail"
+	} else if view == "filtered" {
+		title = "Filtered Mail"
 	} else if unreadCount > 0 {
 		title = fmt.Sprintf("Mail (%d new)", unreadCount)
 	}
@@ -1170,16 +1251,25 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 	// Build tab navigation
 	inboxClass := "mail-tab active"
 	sentClass := "mail-tab"
+	filteredClass := "mail-tab"
 	if view == "sent" {
 		inboxClass = "mail-tab"
 		sentClass = "mail-tab active"
+	} else if view == "filtered" {
+		inboxClass = "mail-tab"
+		filteredClass = "mail-tab active"
 	}
 	inboxLabel := "Inbox"
 	if unreadCount > 0 {
 		inboxLabel = fmt.Sprintf("Inbox (%d)", unreadCount)
 	}
-	tabs := fmt.Sprintf(`<div class="mail-tabs"><a href="/mail" class="%s">%s</a><a href="/mail?view=sent" class="%s">Sent</a></div>`,
-		inboxClass, inboxLabel, sentClass)
+	spamMsgs := GetSpamMessages(acc.ID)
+	filteredLabel := "Filtered"
+	if len(spamMsgs) > 0 {
+		filteredLabel = fmt.Sprintf("Filtered (%d)", len(spamMsgs))
+	}
+	tabs := fmt.Sprintf(`<div class="mail-tabs"><a href="/mail" class="%s">%s</a><a href="/mail?view=sent" class="%s">Sent</a><a href="/mail?view=filtered" class="%s">%s</a></div>`,
+		inboxClass, inboxLabel, sentClass, filteredClass, filteredLabel)
 
 	pageHTML := app.Page(app.PageOpts{
 		Action:  "/mail?compose=true",
@@ -1231,6 +1321,51 @@ func SendMessage(from, fromID, to, toID, subject, body, replyTo, messageID strin
 	return err
 }
 
+// SendMessageTagged creates a message with optional spam metadata
+func SendMessageTagged(from, fromID, to, toID, subject, body, replyTo, messageID string, spam bool, spamScore int, spamReasons []string) error {
+	msg := &Message{
+		ID:          fmt.Sprintf("%d", time.Now().UnixNano()),
+		From:        from,
+		FromID:      fromID,
+		To:          to,
+		ToID:        toID,
+		Subject:     subject,
+		Body:        body,
+		Read:        false,
+		ReplyTo:     replyTo,
+		MessageID:   messageID,
+		Spam:        spam,
+		SpamScore:   spamScore,
+		SpamReasons: spamReasons,
+		CreatedAt:   time.Now(),
+	}
+
+	// Compute ThreadID
+	mutex.Lock()
+	if replyTo != "" {
+		parent := GetMessageUnlocked(replyTo)
+		if parent != nil {
+			msg.ThreadID = computeThreadID(parent)
+		} else {
+			msg.ThreadID = msg.ID
+		}
+	} else {
+		msg.ThreadID = msg.ID
+	}
+
+	messages = append([]*Message{msg}, messages...)
+	rebuildInboxes()
+	err := save()
+	mutex.Unlock()
+
+	// Update stats (outside lock) — only for non-spam
+	if !spam {
+		updateStats(msg)
+	}
+
+	return err
+}
+
 // GetUnreadCount returns the number of unread messages for a user
 func GetUnreadCount(userID string) int {
 	mutex.RLock()
@@ -1240,6 +1375,51 @@ func GetUnreadCount(userID string) int {
 		return inbox.UnreadCount
 	}
 	return 0
+}
+
+// GetSpamMessages returns spam-flagged messages for a user
+func GetSpamMessages(userID string) []*Message {
+	mutex.RLock()
+	defer mutex.RUnlock()
+
+	var spam []*Message
+	for _, msg := range messages {
+		if msg.Spam && msg.ToID == userID {
+			spam = append(spam, msg)
+		}
+	}
+	return spam
+}
+
+// DeleteSpamMessage permanently removes a spam message
+func DeleteSpamMessage(userID, msgID string) error {
+	mutex.Lock()
+	defer mutex.Unlock()
+
+	for i, msg := range messages {
+		if msg.ID == msgID && msg.ToID == userID && msg.Spam {
+			messages = append(messages[:i], messages[i+1:]...)
+			return save()
+		}
+	}
+	return fmt.Errorf("spam message not found")
+}
+
+// NotSpamMessage marks a message as not-spam and moves it to the inbox
+func NotSpamMessage(userID, msgID string) error {
+	mutex.Lock()
+	defer mutex.Unlock()
+
+	for _, msg := range messages {
+		if msg.ID == msgID && msg.ToID == userID && msg.Spam {
+			msg.Spam = false
+			msg.SpamScore = 0
+			msg.SpamReasons = nil
+			rebuildInboxes()
+			return save()
+		}
+	}
+	return fmt.Errorf("spam message not found")
 }
 
 // GetRecentThreadsPreview returns HTML preview of recent threads for account page

--- a/mail/smtp.go
+++ b/mail/smtp.go
@@ -498,7 +498,25 @@ func (s *Session) Data(r io.Reader) error {
 			app.Log("mail", "⚠ Failed to thread message - will appear as new conversation")
 		}
 
-		if err := SendMessage(
+		// Run spam detection on inbound external mail
+		spamResult := CheckSpam(fromAddr.Address, subject, body, s.remoteIP)
+		if spamResult.IsSpam {
+			app.Log("mail", "Spam detected (score=%d) from %s: %v", spamResult.Score, fromAddr.Address, spamResult.Reasons)
+
+			// Auto-block the sender domain if enabled
+			sf := GetSpamFilter()
+			if sf.AutoBlockDomains {
+				if parts := strings.SplitN(fromAddr.Address, "@", 2); len(parts) == 2 {
+					_ = BlockEmail("*@" + parts[1])
+				}
+			}
+
+			if sf.RejectSpam {
+				// Still save with spam flag so user can review in filtered tab
+			}
+		}
+
+		if err := SendMessageTagged(
 			senderName,
 			fromAddr.Address, // Use email as sender ID
 			toAcc.Name,
@@ -507,6 +525,9 @@ func (s *Session) Data(r io.Reader) error {
 			body,
 			replyToID,
 			messageID,
+			spamResult.IsSpam,
+			spamResult.Score,
+			spamResult.Reasons,
 		); err != nil {
 			app.Log("mail", "Error saving message: %v", err)
 			continue

--- a/mail/spam.go
+++ b/mail/spam.go
@@ -1,0 +1,420 @@
+package mail
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"regexp"
+	"strings"
+	"sync"
+
+	"mu/app"
+	"mu/data"
+)
+
+// SpamResult holds the outcome of a spam check
+type SpamResult struct {
+	IsSpam  bool     // Whether the message is classified as spam
+	Score   int      // Total spam score (higher = more likely spam)
+	Reasons []string // Which rules triggered
+}
+
+// SpamFilter configuration
+type SpamFilter struct {
+	Enabled          bool     `json:"enabled"`            // Master switch
+	Threshold        int      `json:"threshold"`          // Score threshold for spam (default 5)
+	BlockedTLDs      []string `json:"blocked_tlds"`       // Blocked top-level domains (e.g., ".vn", ".xyz")
+	BlockedKeywords  []string `json:"blocked_keywords"`   // Blocked keywords in subject/body
+	AllowedSenders   []string `json:"allowed_senders"`    // Whitelisted email addresses or domains
+	RejectSpam       bool     `json:"reject_spam"`        // Reject at SMTP level (true) or silently drop (false)
+	AutoBlockDomains bool     `json:"auto_block_domains"` // Auto-add spam sender domains to blocklist
+}
+
+var (
+	spamMutex  sync.RWMutex
+	spamFilter = &SpamFilter{
+		Enabled:          true,
+		Threshold:        5,
+		BlockedTLDs:      []string{},
+		BlockedKeywords:  []string{},
+		AllowedSenders:   []string{},
+		RejectSpam:       true,
+		AutoBlockDomains: false,
+	}
+)
+
+// Common spam patterns compiled once
+var (
+	excessiveCapsRe  = regexp.MustCompile(`[A-Z]{10,}`)
+	urlPattern       = regexp.MustCompile(`https?://[^\s<>"]+`)
+	suspiciousURLRe  = regexp.MustCompile(`https?://\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}`)
+	homoglyphPattern = regexp.MustCompile(`[а-яА-Я]`) // Cyrillic characters mixed with Latin
+)
+
+// Spam keyword patterns (case-insensitive matching applied at check time)
+var spamPhrases = []string{
+	"act now", "click here", "click below",
+	"congratulations you", "dear winner", "you have been selected",
+	"claim your prize", "free gift", "winner notification",
+	"wire transfer", "bank transfer", "western union",
+	"nigerian prince", "inheritance fund",
+	"100% free", "no cost", "risk free",
+	"unsubscribe", "opt out", "opt-out",
+	"viagra", "cialis", "pharmacy",
+	"weight loss", "lose weight",
+	"casino", "lottery", "jackpot",
+	"make money fast", "earn extra cash", "work from home",
+	"invoice attached", "payment overdue", "account suspended",
+	"verify your account", "confirm your identity",
+	"limited time offer", "expires today", "urgent response",
+}
+
+// loadSpamFilter loads spam filter config from disk
+func loadSpamFilter() {
+	b, err := data.LoadFile("spamfilter.json")
+	if err != nil {
+		app.Log("mail", "No spam filter config found, using defaults")
+		return
+	}
+
+	spamMutex.Lock()
+	defer spamMutex.Unlock()
+
+	if err := json.Unmarshal(b, spamFilter); err != nil {
+		app.Log("mail", "Error loading spam filter config: %v", err)
+		return
+	}
+
+	app.Log("mail", "Loaded spam filter: enabled=%v threshold=%d blocked_tlds=%d keywords=%d allowed=%d",
+		spamFilter.Enabled, spamFilter.Threshold,
+		len(spamFilter.BlockedTLDs), len(spamFilter.BlockedKeywords), len(spamFilter.AllowedSenders))
+}
+
+// saveSpamFilter persists spam filter config (caller must hold spamMutex)
+func saveSpamFilter() error {
+	b, err := json.MarshalIndent(spamFilter, "", "  ")
+	if err != nil {
+		return err
+	}
+	return data.SaveFile("spamfilter.json", string(b))
+}
+
+// CheckSpam evaluates an inbound message for spam signals.
+// Returns a SpamResult with score and reasons.
+func CheckSpam(from, subject, body, ip string) SpamResult {
+	spamMutex.RLock()
+	defer spamMutex.RUnlock()
+
+	result := SpamResult{}
+
+	if !spamFilter.Enabled {
+		return result
+	}
+
+	fromLower := strings.ToLower(from)
+	subjectLower := strings.ToLower(subject)
+	bodyLower := strings.ToLower(body)
+	combined := subjectLower + " " + bodyLower
+
+	// Check allowlist first — skip scoring for trusted senders
+	for _, allowed := range spamFilter.AllowedSenders {
+		allowed = strings.ToLower(allowed)
+		if allowed == fromLower {
+			return result
+		}
+		if strings.HasPrefix(allowed, "@") && strings.HasSuffix(fromLower, allowed) {
+			return result
+		}
+	}
+
+	// --- Sender-based checks ---
+
+	// Extract sender domain
+	senderDomain := ""
+	if parts := strings.SplitN(fromLower, "@", 2); len(parts) == 2 {
+		senderDomain = parts[1]
+	}
+
+	// TLD check
+	if senderDomain != "" {
+		for _, tld := range spamFilter.BlockedTLDs {
+			tld = strings.ToLower(strings.TrimSpace(tld))
+			if !strings.HasPrefix(tld, ".") {
+				tld = "." + tld
+			}
+			if strings.HasSuffix(senderDomain, tld) {
+				result.Score += 4
+				result.Reasons = append(result.Reasons, fmt.Sprintf("blocked TLD: %s", tld))
+			}
+		}
+	}
+
+	// Reverse DNS mismatch — no PTR record for sending IP
+	if ip != "" {
+		names, err := net.LookupAddr(ip)
+		if err != nil || len(names) == 0 {
+			result.Score += 2
+			result.Reasons = append(result.Reasons, "no reverse DNS (PTR) for sender IP")
+		} else if senderDomain != "" {
+			// Check if any PTR record relates to the sender domain
+			matched := false
+			for _, name := range names {
+				if strings.Contains(strings.ToLower(name), senderDomain) {
+					matched = true
+					break
+				}
+			}
+			if !matched {
+				result.Score += 1
+				result.Reasons = append(result.Reasons, "reverse DNS does not match sender domain")
+			}
+		}
+	}
+
+	// --- Content-based checks ---
+
+	// Built-in spam phrases
+	for _, phrase := range spamPhrases {
+		if strings.Contains(combined, phrase) {
+			result.Score += 2
+			result.Reasons = append(result.Reasons, fmt.Sprintf("spam phrase: %q", phrase))
+		}
+	}
+
+	// Admin-configured keywords
+	for _, kw := range spamFilter.BlockedKeywords {
+		if strings.Contains(combined, strings.ToLower(kw)) {
+			result.Score += 3
+			result.Reasons = append(result.Reasons, fmt.Sprintf("blocked keyword: %q", kw))
+		}
+	}
+
+	// Excessive capitalisation in subject
+	if excessiveCapsRe.MatchString(subject) {
+		result.Score += 2
+		result.Reasons = append(result.Reasons, "excessive capitals in subject")
+	}
+
+	// Empty subject
+	if strings.TrimSpace(subject) == "" {
+		result.Score += 1
+		result.Reasons = append(result.Reasons, "empty subject")
+	}
+
+	// URL analysis
+	urls := urlPattern.FindAllString(body, -1)
+	if len(urls) > 5 {
+		result.Score += 2
+		result.Reasons = append(result.Reasons, fmt.Sprintf("excessive URLs (%d)", len(urls)))
+	}
+
+	// IP-based URLs (http://1.2.3.4/...)
+	if suspiciousURLRe.MatchString(body) {
+		result.Score += 3
+		result.Reasons = append(result.Reasons, "URL with raw IP address")
+	}
+
+	// Homoglyph / mixed-script detection (Cyrillic in Latin text)
+	if homoglyphPattern.MatchString(subject) || homoglyphPattern.MatchString(from) {
+		result.Score += 3
+		result.Reasons = append(result.Reasons, "mixed-script characters (possible homoglyph attack)")
+	}
+
+	// HTML-heavy body with little text (common in phishing)
+	if len(body) > 200 {
+		tagCount := strings.Count(bodyLower, "<")
+		textLen := len(strings.TrimSpace(stripHTMLTags(body)))
+		if tagCount > 10 && textLen < 100 {
+			result.Score += 2
+			result.Reasons = append(result.Reasons, "HTML-heavy body with little text content")
+		}
+	}
+
+	// Determine verdict
+	result.IsSpam = result.Score >= spamFilter.Threshold
+
+	return result
+}
+
+// stripHTMLTags removes HTML tags for text length estimation
+func stripHTMLTags(s string) string {
+	re := regexp.MustCompile(`<[^>]*>`)
+	return re.ReplaceAllString(s, "")
+}
+
+// --- Public API for admin management ---
+
+// GetSpamFilter returns a copy of the current spam filter config
+func GetSpamFilter() *SpamFilter {
+	spamMutex.RLock()
+	defer spamMutex.RUnlock()
+
+	return &SpamFilter{
+		Enabled:          spamFilter.Enabled,
+		Threshold:        spamFilter.Threshold,
+		BlockedTLDs:      append([]string{}, spamFilter.BlockedTLDs...),
+		BlockedKeywords:  append([]string{}, spamFilter.BlockedKeywords...),
+		AllowedSenders:   append([]string{}, spamFilter.AllowedSenders...),
+		RejectSpam:       spamFilter.RejectSpam,
+		AutoBlockDomains: spamFilter.AutoBlockDomains,
+	}
+}
+
+// SetSpamFilterEnabled toggles the spam filter on/off
+func SetSpamFilterEnabled(enabled bool) error {
+	spamMutex.Lock()
+	defer spamMutex.Unlock()
+	spamFilter.Enabled = enabled
+	app.Log("mail", "Spam filter enabled=%v", enabled)
+	return saveSpamFilter()
+}
+
+// SetSpamThreshold updates the spam score threshold
+func SetSpamThreshold(threshold int) error {
+	if threshold < 1 || threshold > 100 {
+		return fmt.Errorf("threshold must be between 1 and 100")
+	}
+	spamMutex.Lock()
+	defer spamMutex.Unlock()
+	spamFilter.Threshold = threshold
+	app.Log("mail", "Spam threshold set to %d", threshold)
+	return saveSpamFilter()
+}
+
+// SetRejectSpam sets whether to reject spam at SMTP level
+func SetRejectSpam(reject bool) error {
+	spamMutex.Lock()
+	defer spamMutex.Unlock()
+	spamFilter.RejectSpam = reject
+	app.Log("mail", "Spam reject mode=%v", reject)
+	return saveSpamFilter()
+}
+
+// SetAutoBlockDomains sets whether to auto-block spam sender domains
+func SetAutoBlockDomains(auto bool) error {
+	spamMutex.Lock()
+	defer spamMutex.Unlock()
+	spamFilter.AutoBlockDomains = auto
+	app.Log("mail", "Auto-block spam domains=%v", auto)
+	return saveSpamFilter()
+}
+
+// AddBlockedTLD adds a TLD to the blocked list
+func AddBlockedTLD(tld string) error {
+	tld = strings.ToLower(strings.TrimSpace(tld))
+	if tld == "" {
+		return fmt.Errorf("TLD cannot be empty")
+	}
+	if !strings.HasPrefix(tld, ".") {
+		tld = "." + tld
+	}
+
+	spamMutex.Lock()
+	defer spamMutex.Unlock()
+
+	for _, existing := range spamFilter.BlockedTLDs {
+		if existing == tld {
+			return fmt.Errorf("TLD already blocked")
+		}
+	}
+
+	spamFilter.BlockedTLDs = append(spamFilter.BlockedTLDs, tld)
+	app.Log("mail", "Blocked TLD: %s", tld)
+	return saveSpamFilter()
+}
+
+// RemoveBlockedTLD removes a TLD from the blocked list
+func RemoveBlockedTLD(tld string) error {
+	tld = strings.ToLower(strings.TrimSpace(tld))
+	if !strings.HasPrefix(tld, ".") {
+		tld = "." + tld
+	}
+
+	spamMutex.Lock()
+	defer spamMutex.Unlock()
+
+	for i, existing := range spamFilter.BlockedTLDs {
+		if existing == tld {
+			spamFilter.BlockedTLDs = append(spamFilter.BlockedTLDs[:i], spamFilter.BlockedTLDs[i+1:]...)
+			app.Log("mail", "Unblocked TLD: %s", tld)
+			return saveSpamFilter()
+		}
+	}
+	return fmt.Errorf("TLD not found in blocked list")
+}
+
+// AddBlockedKeyword adds a keyword to the blocked list
+func AddBlockedKeyword(keyword string) error {
+	keyword = strings.ToLower(strings.TrimSpace(keyword))
+	if keyword == "" {
+		return fmt.Errorf("keyword cannot be empty")
+	}
+
+	spamMutex.Lock()
+	defer spamMutex.Unlock()
+
+	for _, existing := range spamFilter.BlockedKeywords {
+		if existing == keyword {
+			return fmt.Errorf("keyword already blocked")
+		}
+	}
+
+	spamFilter.BlockedKeywords = append(spamFilter.BlockedKeywords, keyword)
+	app.Log("mail", "Blocked keyword: %s", keyword)
+	return saveSpamFilter()
+}
+
+// RemoveBlockedKeyword removes a keyword from the blocked list
+func RemoveBlockedKeyword(keyword string) error {
+	keyword = strings.ToLower(strings.TrimSpace(keyword))
+
+	spamMutex.Lock()
+	defer spamMutex.Unlock()
+
+	for i, existing := range spamFilter.BlockedKeywords {
+		if existing == keyword {
+			spamFilter.BlockedKeywords = append(spamFilter.BlockedKeywords[:i], spamFilter.BlockedKeywords[i+1:]...)
+			app.Log("mail", "Removed blocked keyword: %s", keyword)
+			return saveSpamFilter()
+		}
+	}
+	return fmt.Errorf("keyword not found in blocked list")
+}
+
+// AddAllowedSender adds an email or domain to the allow list
+func AddAllowedSender(sender string) error {
+	sender = strings.ToLower(strings.TrimSpace(sender))
+	if sender == "" {
+		return fmt.Errorf("sender cannot be empty")
+	}
+
+	spamMutex.Lock()
+	defer spamMutex.Unlock()
+
+	for _, existing := range spamFilter.AllowedSenders {
+		if existing == sender {
+			return fmt.Errorf("sender already allowed")
+		}
+	}
+
+	spamFilter.AllowedSenders = append(spamFilter.AllowedSenders, sender)
+	app.Log("mail", "Allowed sender: %s", sender)
+	return saveSpamFilter()
+}
+
+// RemoveAllowedSender removes an email or domain from the allow list
+func RemoveAllowedSender(sender string) error {
+	sender = strings.ToLower(strings.TrimSpace(sender))
+
+	spamMutex.Lock()
+	defer spamMutex.Unlock()
+
+	for i, existing := range spamFilter.AllowedSenders {
+		if existing == sender {
+			spamFilter.AllowedSenders = append(spamFilter.AllowedSenders[:i], spamFilter.AllowedSenders[i+1:]...)
+			app.Log("mail", "Removed allowed sender: %s", sender)
+			return saveSpamFilter()
+		}
+	}
+	return fmt.Errorf("sender not found in allow list")
+}

--- a/main.go
+++ b/main.go
@@ -209,6 +209,7 @@ func main() {
 		"/admin/users":     true,
 		"/admin/moderate":  true,
 		"/admin/blocklist": true,
+		"/admin/spam":      true,
 		"/admin/email":     true,
 		"/admin/api":       true,
 		"/admin/log":       true,
@@ -272,6 +273,9 @@ func main() {
 
 	// mail blocklist management
 	http.HandleFunc("/admin/blocklist", admin.BlocklistHandler)
+
+	// spam filter management
+	http.HandleFunc("/admin/spam", admin.SpamFilterHandler)
 
 	// email log
 	http.HandleFunc("/admin/email", admin.EmailLogHandler)


### PR DESCRIPTION
Introduces content-based spam filtering beyond simple blocklist/rate-limiting. The system uses a multi-signal scoring approach (TLD blocking, keyword matching, reverse DNS checks, URL analysis, homoglyph detection, HTML-to-text ratio) to classify inbound mail. Spam is saved to a user-visible "Filtered" tab where messages can be reviewed, rescued, or deleted. Admins can configure thresholds, blocked TLDs, keywords, and sender allowlists via /admin/spam.

https://claude.ai/code/session_01N1fSZGf1RugAs24vkR5TSb