### PR TITLE
Add Agent and Markets to services lists across landing, about, and RE…

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,13 @@ Mu is a new social network. While other platforms monetize your attention with a
 ### Services
 
 - **Home** - At a glance dashboard
+- **Agent** - AI assistant across all services
 - **Blog** - Blogging with comments
 - **Chat** - Discuss topics with AI
 - **News** - RSS feeds with summaries
 - **Mail** - Private messaging & email
 - **Video** - Watch YouTube without ads
+- **Markets** - Live crypto, futures & commodities
 - **Web** - Search without tracking
 - **Wallet** - Pay as you go with credits
 
@@ -28,11 +30,13 @@ Mu runs as a single Go binary on your own server or use the hosted version at [m
 - [x] API - Basic API
 - [x] App - Basic PWA
 - [x] Home - Overview
+- [x] Agent - AI assistant
 - [x] Blog - Daily digests
 - [x] Chat - Discussion rooms
 - [x] News - RSS news feed
 - [x] Video - YouTube search
-- [x] Mail - Private messaging 
+- [x] Mail - Private messaging
+- [x] Markets - Live prices
 - [x] Web - Web search, no Ads
 - [x] Wallet - Card payments
 - [ ] Services - Marketplace, etc

--- a/docs/ABOUT.md
+++ b/docs/ABOUT.md
@@ -33,11 +33,13 @@ Mu was built to fix this problem.
 Each feature does one thing well:
 
 - **Home** — Your dashboard, everything in one place
+- **Agent** — AI assistant with access to every service
 - **Blog** — Microblogging with daily digests
 - **Chat** — Discuss topics with AI
 - **News** — RSS feeds, chronological
 - **Mail** — Private messaging & email
 - **Video** — YouTube without ads or shorts
+- **Markets** — Live crypto, futures, and commodities
 - **Web** — Web search without ads or tracking
 - **Wallet** — Credits and card payments
 

--- a/home/home.go
+++ b/home/home.go
@@ -156,6 +156,13 @@ var landingTemplate = `<html lang="en">
       <h3>Services</h3>
       <p>The tools powering Mu</p>
       <div id="links">
+        <a href="/agent" style="text-decoration: none; color: inherit;">
+          <div class="block">
+            <img src="/agent.svg" alt="Agent" style="width: 32px; height: 32px; margin-bottom: 8px; filter: brightness(0);">
+            <b>Agent</b>
+            <div class="small">AI assistant with access to every service</div>
+          </div>
+        </a>
         <a href="/blog" style="text-decoration: none; color: inherit;">
           <div class="block">
             <img src="/post.png" alt="Blog" style="width: 32px; height: 32px; margin-bottom: 8px; filter: brightness(0);">
@@ -189,6 +196,13 @@ var landingTemplate = `<html lang="en">
             <img src="/video.png" alt="Video" style="width: 32px; height: 32px; margin-bottom: 8px; filter: brightness(0);">
             <b>Video</b>
             <div class="small">Watch YouTube without ads, algorithms or shorts</div>
+          </div>
+        </a>
+        <a href="/markets" style="text-decoration: none; color: inherit;">
+          <div class="block">
+            <img src="/markets.svg" alt="Markets" style="width: 32px; height: 32px; margin-bottom: 8px; filter: brightness(0);">
+            <b>Markets</b>
+            <div class="small">Live crypto, futures and commodity prices</div>
           </div>
         </a>
         <a href="/web" style="text-decoration: none; color: inherit;">


### PR DESCRIPTION
…ADME

Agent is a first-class sidebar item and the first home card, but was missing from the landing page services grid, about page apps list, and README services list. Markets was similarly featured in live data tabs and home cards but absent from services lists. This aligns all surfaces to tell the same story about what Mu offers.

https://claude.ai/code/session_01N1fSZGf1RugAs24vkR5TSb