### PR TITLE
Replace created timestamp with updated timestamp and simplify LaTeX s…

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -908,41 +908,14 @@ func Render(md []byte) []byte {
 	return markdown.Render(doc, renderer)
 }
 
-// StripLatexDollars removes LaTeX math delimiters that some LLMs use around
-// dollar amounts, e.g. \(69,811\) → $69,811, \$69,811 → $69,811,
-// and \[69,811\] → $69,811.
+// StripLatexDollars removes LaTeX math delimiters that LLMs insert around
+// dollar amounts. Handles \$, \(, \), \[, \] — all replaced with $.
 func StripLatexDollars(s string) string {
 	s = strings.ReplaceAll(s, `\$`, "$")
-	// Handle \(...\) inline math delimiters
-	for {
-		idx := strings.Index(s, `\(`)
-		if idx == -1 {
-			break
-		}
-		rest := s[idx+2:]
-		endIdx := strings.Index(rest, `\)`)
-		if endIdx == -1 {
-			s = s[:idx] + "$" + s[idx+2:]
-			continue
-		}
-		inner := rest[:endIdx]
-		s = s[:idx] + "$" + inner + s[idx+2+endIdx+2:]
-	}
-	// Handle \[...\] display math delimiters
-	for {
-		idx := strings.Index(s, `\[`)
-		if idx == -1 {
-			break
-		}
-		rest := s[idx+2:]
-		endIdx := strings.Index(rest, `\]`)
-		if endIdx == -1 {
-			s = s[:idx] + "$" + s[idx+2:]
-			continue
-		}
-		inner := rest[:endIdx]
-		s = s[:idx] + "$" + inner + s[idx+2+endIdx+2:]
-	}
+	s = strings.ReplaceAll(s, `\(`, "$")
+	s = strings.ReplaceAll(s, `\)`, "$")
+	s = strings.ReplaceAll(s, `\[`, "$")
+	s = strings.ReplaceAll(s, `\]`, "$")
 	return s
 }
 

--- a/blog/blog.go
+++ b/blog/blog.go
@@ -435,12 +435,19 @@ func updateCacheUnlocked() {
 			replyLink = fmt.Sprintf(` · <a href="/post?id=%s">Replies (%d)</a>`, post.ID, commentCount)
 		}
 
+		previewTime := post.CreatedAt
+		previewTimeLabel := app.TimeAgo(previewTime)
+		if !post.UpdatedAt.IsZero() {
+			previewTime = post.UpdatedAt
+			previewTimeLabel = "Updated " + app.TimeAgo(previewTime)
+		}
+
 		item := fmt.Sprintf(`<div class="post-item">
 		%s
 		<h3><a href="/post?id=%s">%s</a></h3>
 		<div class="info"><span data-timestamp="%d">%s</span> · Posted by %s%s</div>
 		<div>%s</div>
-	</div>`, tagsHtml, post.ID, title, post.CreatedAt.Unix(), app.TimeAgo(post.CreatedAt), authorLink, replyLink, content)
+	</div>`, tagsHtml, post.ID, title, previewTime.Unix(), previewTimeLabel, authorLink, replyLink, content)
 		preview = append(preview, item)
 	}
 
@@ -531,13 +538,20 @@ func updateCacheUnlocked() {
 			keepReading = fmt.Sprintf(`<a href="/post?id=%s" class="keep-reading">Keep Reading →</a>`, post.ID)
 		}
 
+		listTime := post.CreatedAt
+		listTimeLabel := app.TimeAgo(listTime)
+		if !post.UpdatedAt.IsZero() {
+			listTime = post.UpdatedAt
+			listTimeLabel = "Updated " + app.TimeAgo(listTime)
+		}
+
 		item := fmt.Sprintf(`<div class="post-item">
 			%s
 			<h3><a href="/post?id=%s">%s</a></h3>
 			<div class="info"><span data-timestamp="%d">%s</span> · Posted by %s%s</div>
 			<div>%s</div>
 			%s
-		</div>`, tagsHtml, post.ID, title, post.CreatedAt.Unix(), app.TimeAgo(post.CreatedAt), authorLink, replyLink, content, keepReading)
+		</div>`, tagsHtml, post.ID, title, listTime.Unix(), listTimeLabel, authorLink, replyLink, content, keepReading)
 		fullList = append(fullList, item)
 	}
 
@@ -621,7 +635,7 @@ func previewUncached() string {
 		// Generate fresh timestamp
 		listTimeInfo := app.TimeAgo(post.CreatedAt)
 		if !post.UpdatedAt.IsZero() {
-			listTimeInfo += " (updated " + app.TimeAgo(post.UpdatedAt) + ")"
+			listTimeInfo = "Updated " + app.TimeAgo(post.UpdatedAt)
 		}
 
 		item := fmt.Sprintf(`<div class="post-item">
@@ -1436,7 +1450,7 @@ func PostHandler(w http.ResponseWriter, r *http.Request) {
 
 	timeInfo := app.TimeAgo(post.CreatedAt)
 	if !post.UpdatedAt.IsZero() {
-		timeInfo += " (updated " + app.TimeAgo(post.UpdatedAt) + ")"
+		timeInfo = "Updated " + app.TimeAgo(post.UpdatedAt)
 	}
 
 	content := fmt.Sprintf(`<div id="blog">


### PR DESCRIPTION
…tripping

- When a post has UpdatedAt set, show "Updated X ago" instead of the created time (replaces it, no parenthetical clutter)
- Applied consistently across all four render paths: post detail, blog list, home preview, and full blog list
- Simplified StripLatexDollars to do plain string replacements for \(, \), \[, \], \$ — the paired-delimiter approach failed when LLMs used them as independent dollar sign escapes (e.g. \(300B)

https://claude.ai/code/session_01N1fSZGf1RugAs24vkR5TSb