### PR TITLE
Strip LaTeX at render time to fix stored content with dollar sign esc…

### DIFF
--- a/blog/blog.go
+++ b/blog/blog.go
@@ -1537,6 +1537,8 @@ func RenderMarkdown(text string) string {
 
 // Linkify converts markdown to HTML and embeds YouTube videos (for full post display)
 func Linkify(text string) string {
+	// Strip any LaTeX dollar signs before rendering
+	text = app.StripLatexDollars(text)
 	// Render markdown to HTML first
 	html := string(app.Render([]byte(text)))
 


### PR DESCRIPTION
…apes

Content already saved with \( and \) escapes wasn't being cleaned since StripLatexDollars only ran at generation time. Now Linkify strips LaTeX before markdown rendering, catching both old stored content and any edge cases from new generations.

https://claude.ai/code/session_01N1fSZGf1RugAs24vkR5TSb