### PR TITLE
Move LaTeX stripping into Render and fix raw markdown in previews/com…

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -895,6 +895,9 @@ func Donate(w http.ResponseWriter, r *http.Request) {
 
 // Render a markdown document as html
 func Render(md []byte) []byte {
+	// Strip LaTeX dollar sign escapes before parsing markdown
+	md = []byte(StripLatexDollars(string(md)))
+
 	// create markdown parser with extensions
 	extensions := parser.CommonExtensions | parser.AutoHeadingIDs | parser.NoEmptyLineBeforeBlock
 	p := parser.NewWithExtensions(extensions)

--- a/blog/blog.go
+++ b/blog/blog.go
@@ -658,10 +658,8 @@ func renderPostPreview(post *Post) string {
 		title = "Untitled"
 	}
 
-	// Use pre-rendered HTML and truncate for preview
+	// Truncate plain text before rendering to HTML
 	content := post.Content
-
-	// Truncate plain text before rendering
 	if len(content) > 256 {
 		lastSpace := 256
 		for i := 255; i >= 0 && i < len(content); i-- {
@@ -672,6 +670,8 @@ func renderPostPreview(post *Post) string {
 		}
 		content = content[:lastSpace] + "..."
 	}
+
+	content = Linkify(content)
 
 	authorLink := post.Author
 	if post.AuthorID != "" {
@@ -1537,9 +1537,7 @@ func RenderMarkdown(text string) string {
 
 // Linkify converts markdown to HTML and embeds YouTube videos (for full post display)
 func Linkify(text string) string {
-	// Strip any LaTeX dollar signs before rendering
-	text = app.StripLatexDollars(text)
-	// Render markdown to HTML first
+	// Render markdown to HTML first (Render handles LaTeX stripping)
 	html := string(app.Render([]byte(text)))
 
 	// Find YouTube links in the rendered HTML and replace with embeds


### PR DESCRIPTION
…ments

- Strip LaTeX in app.Render() so every markdown-to-HTML path is covered, including comments (which use RenderString, not Linkify)
- Fix renderPostPreview to render markdown via Linkify instead of outputting raw markdown text — this fixes bullets not appearing on new lines since raw "- item" wasn't being converted to <ul><li>

https://claude.ai/code/session_01N1fSZGf1RugAs24vkR5TSb