### PR TITLE
Add mail send quota and fix web search API/MCP error responses

### DIFF
--- a/mail/mail.go
+++ b/mail/mail.go
@@ -335,6 +335,14 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 				}
 				SendMessage(acc.Name, acc.ID, to, to, subject, body, replyTo, messageID) //nolint:errcheck
 			} else {
+				// Internal mail costs credits
+				if !acc.Admin {
+					canProceed, _, cost, _ := wallet.CheckQuota(acc.ID, wallet.OpMailSend)
+					if !canProceed {
+						app.RespondError(w, http.StatusPaymentRequired, fmt.Sprintf("sending mail requires %d credits", cost))
+						return
+					}
+				}
 				toAcc, err := auth.GetAccount(to)
 				if err != nil {
 					app.RespondError(w, http.StatusNotFound, "recipient not found")
@@ -343,6 +351,9 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 				if err := SendMessage(acc.Name, acc.ID, toAcc.Name, toAcc.ID, subject, body, replyTo, ""); err != nil {
 					app.RespondError(w, http.StatusInternalServerError, "failed to send message")
 					return
+				}
+				if !acc.Admin {
+					wallet.ConsumeQuota(acc.ID, wallet.OpMailSend) //nolint:errcheck
 				}
 			}
 			app.RespondJSON(w, map[string]bool{"success": true})
@@ -465,6 +476,13 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 			}
 		} else {
 			// Internal message - store plain text, render at display time
+			if !acc.Admin {
+				canProceed, _, cost, _ := wallet.CheckQuota(acc.ID, wallet.OpMailSend)
+				if !canProceed {
+					http.Error(w, fmt.Sprintf("Sending mail requires %d credits. Top up at /wallet", cost), http.StatusPaymentRequired)
+					return
+				}
+			}
 			toAcc, err := auth.GetAccount(to)
 			if err != nil {
 				http.Error(w, "Recipient not found", http.StatusNotFound)
@@ -475,6 +493,9 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 			if err := SendMessage(acc.Name, acc.ID, toAcc.Name, toAcc.ID, subject, bodyPlain, replyTo, ""); err != nil {
 				http.Error(w, "Failed to send message", http.StatusInternalServerError)
 				return
+			}
+			if !acc.Admin {
+				wallet.ConsumeQuota(acc.ID, wallet.OpMailSend) //nolint:errcheck
 			}
 		}
 

--- a/search/search.go
+++ b/search/search.go
@@ -234,6 +234,10 @@ func WebHandler(w http.ResponseWriter, r *http.Request) {
 	// Require authentication to charge for the search
 	sess, _, err := auth.RequireSession(r)
 	if err != nil {
+		if app.WantsJSON(r) {
+			app.RespondError(w, http.StatusUnauthorized, "authentication required")
+			return
+		}
 		app.Unauthorized(w, r)
 		return
 	}
@@ -241,6 +245,10 @@ func WebHandler(w http.ResponseWriter, r *http.Request) {
 	// Check quota (5p per search)
 	canProceed, _, cost, _ := wallet.CheckQuota(sess.Account, wallet.OpWebSearch)
 	if !canProceed {
+		if app.WantsJSON(r) {
+			app.RespondError(w, http.StatusPaymentRequired, fmt.Sprintf("web search requires %d credits", cost))
+			return
+		}
 		content := searchBar + wallet.QuotaExceededPage(wallet.OpWebSearch, cost)
 		w.Write([]byte(app.RenderHTMLForRequest("Web Search", "Web Search", content, r)))
 		return

--- a/search/topics.go
+++ b/search/topics.go
@@ -56,7 +56,7 @@ var stopWords = map[string]bool{
 	"much": true, "very": true, "like": true, "us": true, "we": true, "our": true,
 	"they": true, "them": true, "their": true, "he": true, "she": true, "his": true,
 	"her": true, "you": true, "your": true, "my": true, "me": true, "i": true,
-	"am": true, "been": true, "being": true, "these": true, "those": true,
+	"am": true, "these": true, "those": true,
 	"each": true, "every": true, "both": true, "few": true, "other": true,
 	"such": true, "only": true, "own": true, "same": true, "too": true,
 	"first": true, "last": true, "while": true, "still": true, "back": true,

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -22,6 +22,7 @@ var (
 	CostVideoWatch        = getEnvInt("CREDIT_COST_VIDEO_WATCH", 0) // Free - no value added over YouTube
 	CostChatQuery         = getEnvInt("CREDIT_COST_CHAT", 3)
 	CostChatRoom          = getEnvInt("CREDIT_COST_CHAT_ROOM", 1)
+	CostMailSend          = getEnvInt("CREDIT_COST_MAIL", 1)  // Internal mail send
 	CostExternalEmail     = getEnvInt("CREDIT_COST_EMAIL", 4) // External email (SMTP delivery cost)
 	CostPlacesSearch      = getEnvInt("CREDIT_COST_PLACES_SEARCH", 5)
 	CostPlacesNearby      = getEnvInt("CREDIT_COST_PLACES_NEARBY", 2)
@@ -47,6 +48,7 @@ const (
 	OpVideoWatch        = "video_watch"
 	OpChatQuery         = "chat_query"
 	OpChatRoom          = "chat_room"
+	OpMailSend          = "mail_send"
 	OpExternalEmail     = "external_email"
 	OpPlacesSearch      = "places_search"
 	OpPlacesNearby      = "places_nearby"
@@ -345,6 +347,8 @@ func GetOperationCost(operation string) int {
 		return CostChatQuery
 	case OpChatRoom:
 		return CostChatRoom
+	case OpMailSend:
+		return CostMailSend
 	case OpExternalEmail:
 		return CostExternalEmail
 	case OpPlacesSearch:


### PR DESCRIPTION
Mail sending: Add OpMailSend (1 credit) for internal messages. Both the JSON/MCP path and form path now check and consume quota. External email already had OpExternalEmail (4 credits). Admins bypass both.

Web search API: Return proper JSON errors (401, 402) for API/MCP callers instead of HTML pages on auth failure or quota exceeded.

Also fix duplicate map keys in topics.go stop words.

https://claude.ai/code/session_01N1fSZGf1RugAs24vkR5TSb