### PR TITLE
Use LLM to generate web search topics from recent headlines

### DIFF
--- a/main.go
+++ b/main.go
@@ -100,6 +100,9 @@ func main() {
 	// This allows the priority queue to process new items first
 	data.StartIndexing()
 
+	// Start web search topics (loads cache from disk, generates in background)
+	search.StartTopics()
+
 	// Wire MCP quota checking using wallet credit system
 	api.QuotaCheck = func(r *http.Request, op string) (bool, int, error) {
 		sess, err := auth.GetSession(r)

--- a/search/topics.go
+++ b/search/topics.go
@@ -5,189 +5,136 @@ import (
 	"sync"
 	"time"
 
+	"mu/ai"
+	"mu/app"
 	"mu/data"
 )
 
-// topicCache holds extracted topics from recent content, refreshed periodically.
+// topicCache holds LLM-generated topics from recent content.
 var topicCache struct {
 	sync.RWMutex
 	topics  []string
 	updated time.Time
 }
 
-const topicCacheTTL = 30 * time.Minute
-const maxTopics = 12
+const topicCacheTTL = 1 * time.Hour
+const maxTopics = 10
 
-// GetTopics returns current topic suggestions extracted from recent indexed content.
+// GetTopics returns current topic suggestions. Returns cached results immediately;
+// regeneration happens in the background.
 func GetTopics() []string {
 	topicCache.RLock()
-	if time.Since(topicCache.updated) < topicCacheTTL && len(topicCache.topics) > 0 {
-		topics := topicCache.topics
-		topicCache.RUnlock()
-		return topics
-	}
+	topics := topicCache.topics
+	stale := time.Since(topicCache.updated) > topicCacheTTL
 	topicCache.RUnlock()
 
-	topics := extractTopics()
+	if stale {
+		go regenerateTopics()
+	}
+
+	return topics
+}
+
+// StartTopics loads cached topics from disk and kicks off background generation.
+func StartTopics() {
+	var cached []string
+	if err := data.LoadJSON("web_topics.json", &cached); err == nil && len(cached) > 0 {
+		topicCache.Lock()
+		topicCache.topics = cached
+		topicCache.updated = time.Now()
+		topicCache.Unlock()
+		app.Log("search", "Loaded %d cached topics from disk", len(cached))
+	}
+	go regenerateTopics()
+}
+
+var topicGenerating sync.Mutex
+
+func regenerateTopics() {
+	// Prevent concurrent generation
+	if !topicGenerating.TryLock() {
+		return
+	}
+	defer topicGenerating.Unlock()
+
+	// Gather recent content titles
+	var headlines []string
+
+	newsItems := data.GetByType("news", 30)
+	for _, item := range newsItems {
+		headlines = append(headlines, item.Title)
+	}
+
+	blogItems := data.GetByType("blog", 10)
+	for _, item := range blogItems {
+		headlines = append(headlines, item.Title)
+	}
+
+	videoItems := data.GetByType("video", 10)
+	for _, item := range videoItems {
+		headlines = append(headlines, item.Title)
+	}
+
+	if len(headlines) == 0 {
+		return
+	}
+
+	// Truncate to avoid sending too much context
+	if len(headlines) > 40 {
+		headlines = headlines[:40]
+	}
+
+	prompt := &ai.Prompt{
+		System: `You extract trending search topics from headlines. Return ONLY a newline-separated list of topics. Each topic should be:
+- A specific person, place, event, technology, or concept (e.g. "Iran nuclear talks", "Ramadan 2026", "Bitcoin ETF", "OpenAI Sora")
+- 1-4 words, suitable as a web search query
+- Something a reader would want to learn more about
+- No generic words, no duplicates, no numbering, no punctuation
+Return exactly 10 topics, one per line. Nothing else.`,
+		Question: "Extract 10 trending search topics from these recent headlines:\n\n" + strings.Join(headlines, "\n"),
+		Priority: ai.PriorityLow,
+	}
+
+	resp, err := ai.Ask(prompt)
+	if err != nil {
+		app.Log("search", "Failed to generate topics: %v", err)
+		return
+	}
+
+	// Parse response: one topic per line
+	var topics []string
+	for _, line := range strings.Split(resp, "\n") {
+		topic := strings.TrimSpace(line)
+		// Skip empty lines, numbered lines, or lines that are too long/short
+		if topic == "" || len(topic) < 3 || len(topic) > 60 {
+			continue
+		}
+		// Strip leading numbering like "1. " or "- "
+		if len(topic) > 2 && (topic[1] == '.' || topic[1] == ')') {
+			topic = strings.TrimSpace(topic[2:])
+		}
+		if len(topic) > 3 && (topic[2] == '.' || topic[2] == ')') {
+			topic = strings.TrimSpace(topic[3:])
+		}
+		topic = strings.TrimLeft(topic, "- ")
+		if topic != "" && len(topic) >= 3 {
+			topics = append(topics, topic)
+		}
+		if len(topics) >= maxTopics {
+			break
+		}
+	}
+
+	if len(topics) == 0 {
+		app.Log("search", "LLM returned no parseable topics")
+		return
+	}
 
 	topicCache.Lock()
 	topicCache.topics = topics
 	topicCache.updated = time.Now()
 	topicCache.Unlock()
 
-	return topics
-}
-
-// Common words to skip when extracting topics
-var stopWords = map[string]bool{
-	"a": true, "an": true, "the": true, "and": true, "or": true, "but": true,
-	"in": true, "on": true, "at": true, "to": true, "for": true, "of": true,
-	"with": true, "by": true, "from": true, "is": true, "are": true, "was": true,
-	"were": true, "be": true, "been": true, "being": true, "have": true, "has": true,
-	"had": true, "do": true, "does": true, "did": true, "will": true, "would": true,
-	"could": true, "should": true, "may": true, "might": true, "can": true,
-	"not": true, "no": true, "it": true, "its": true, "this": true, "that": true,
-	"than": true, "then": true, "so": true, "if": true, "as": true, "what": true,
-	"how": true, "why": true, "who": true, "which": true, "when": true, "where": true,
-	"up": true, "out": true, "about": true, "into": true, "over": true, "after": true,
-	"new": true, "says": true, "said": true, "just": true, "more": true, "most": true,
-	"also": true, "now": true, "get": true, "gets": true, "got": true, "go": true,
-	"here": true, "there": true, "all": true, "some": true, "any": true, "many": true,
-	"much": true, "very": true, "like": true, "us": true, "we": true, "our": true,
-	"they": true, "them": true, "their": true, "he": true, "she": true, "his": true,
-	"her": true, "you": true, "your": true, "my": true, "me": true, "i": true,
-	"am": true, "these": true, "those": true,
-	"each": true, "every": true, "both": true, "few": true, "other": true,
-	"such": true, "only": true, "own": true, "same": true, "too": true,
-	"first": true, "last": true, "while": true, "still": true, "back": true,
-	"make": true, "makes": true, "made": true, "take": true, "takes": true,
-	"set": true, "via": true, "per": true, "even": true, "well": true,
-	"top": true, "big": true, "best": true, "one": true, "two": true, "three": true,
-}
-
-// extractTopics pulls recent news and blog content and extracts distinctive topic phrases.
-func extractTopics() []string {
-	// Gather recent content titles
-	var titles []string
-
-	// News items (most current events)
-	newsItems := data.GetByType("news", 50)
-	for _, item := range newsItems {
-		titles = append(titles, item.Title)
-	}
-
-	// Blog posts
-	blogItems := data.GetByType("blog", 20)
-	for _, item := range blogItems {
-		titles = append(titles, item.Title)
-	}
-
-	// Video titles
-	videoItems := data.GetByType("video", 20)
-	for _, item := range videoItems {
-		titles = append(titles, item.Title)
-	}
-
-	// Extract meaningful phrases from titles
-	// Strategy: look for capitalized multi-word phrases (proper nouns / named entities)
-	// and high-frequency distinctive single words
-	phraseCount := make(map[string]int)
-	wordCount := make(map[string]int)
-
-	for _, title := range titles {
-		// Extract 2-3 word capitalized phrases (named entities like "Iran War", "Federal Reserve")
-		words := strings.Fields(title)
-		for i := 0; i < len(words); i++ {
-			w := cleanWord(words[i])
-			wLower := strings.ToLower(w)
-			if len(w) < 3 || stopWords[wLower] {
-				continue
-			}
-			// Count individual distinctive words
-			if isCapitalized(w) || len(w) > 5 {
-				wordCount[w]++
-			}
-
-			// Look for 2-word capitalized phrases
-			if i+1 < len(words) && isCapitalized(w) {
-				next := cleanWord(words[i+1])
-				if isCapitalized(next) && len(next) >= 2 && !stopWords[strings.ToLower(next)] {
-					phrase := w + " " + next
-					phraseCount[phrase]++
-				}
-			}
-		}
-	}
-
-	// Score and rank: phrases score higher than individual words
-	type scored struct {
-		term  string
-		score int
-	}
-	var candidates []scored
-
-	for phrase, count := range phraseCount {
-		if count >= 1 {
-			candidates = append(candidates, scored{phrase, count * 3})
-		}
-	}
-	for word, count := range wordCount {
-		if count >= 2 {
-			// Skip if already covered by a phrase
-			coveredByPhrase := false
-			for phrase := range phraseCount {
-				if strings.Contains(strings.ToLower(phrase), strings.ToLower(word)) {
-					coveredByPhrase = true
-					break
-				}
-			}
-			if !coveredByPhrase {
-				candidates = append(candidates, scored{word, count})
-			}
-		}
-	}
-
-	// Sort by score descending
-	for i := 0; i < len(candidates); i++ {
-		for j := i + 1; j < len(candidates); j++ {
-			if candidates[j].score > candidates[i].score {
-				candidates[i], candidates[j] = candidates[j], candidates[i]
-			}
-		}
-	}
-
-	// Deduplicate: skip terms that are substrings of already-selected terms
-	var topics []string
-	for _, c := range candidates {
-		if len(topics) >= maxTopics {
-			break
-		}
-		cLower := strings.ToLower(c.term)
-		duplicate := false
-		for _, existing := range topics {
-			eLower := strings.ToLower(existing)
-			if strings.Contains(eLower, cLower) || strings.Contains(cLower, eLower) {
-				duplicate = true
-				break
-			}
-		}
-		if !duplicate {
-			topics = append(topics, c.term)
-		}
-	}
-
-	return topics
-}
-
-// cleanWord strips leading/trailing punctuation from a word.
-func cleanWord(w string) string {
-	return strings.Trim(w, ".,;:!?\"'()[]{}—–-/\\|")
-}
-
-// isCapitalized returns true if the word starts with an uppercase letter.
-func isCapitalized(w string) bool {
-	if len(w) == 0 {
-		return false
-	}
-	return w[0] >= 'A' && w[0] <= 'Z'
+	data.SaveJSON("web_topics.json", topics)
+	app.Log("search", "Generated %d topics: %v", len(topics), topics)
 }


### PR DESCRIPTION
Replace naive keyword extraction with LLM-based topic generation. Sends recent news/blog/video headlines to the LLM with a focused prompt asking for 10 specific, search-worthy topics (people, events, technologies, concepts). Results are cached for 1 hour and persisted to disk. Generation runs in the background so it never blocks page load. Loads cached topics on startup via StartTopics().

https://claude.ai/code/session_01N1fSZGf1RugAs24vkR5TSb