### PR TITLE
Fix reminder markdown in social threads and add proper reply threading

### DIFF
--- a/news/reminder/reminder.go
+++ b/news/reminder/reminder.go
@@ -70,16 +70,7 @@ func fetchReminder() {
 	data.SaveFile("reminder.html", html)
 	reminderMutex.Unlock()
 
-	// Index for search/RAG
-	verse := val["verse"].(string)
-	name := ""
-	if v, ok := val["name"]; ok {
-		name = v.(string)
-	}
-	hadith := ""
-	if h, ok := val["hadith"]; ok {
-		hadith = h.(string)
-	}
+	// Extract message and updated for indexing
 	message := ""
 	if m, ok := val["message"]; ok {
 		message = m.(string)
@@ -89,15 +80,21 @@ func fetchReminder() {
 		updated = u.(string)
 	}
 
-	content := fmt.Sprintf("Name of Allah: %s\n\nVerse: %s\n\nHadith: %s\n\n%s", name, verse, hadith, message)
+	// Index with just the message summary and a link to the full reminder page.
+	// The full content (verse, hadith, name) contains markdown that doesn't render
+	// well in chat threads, and it changes hourly so embedding it causes stale content.
+	summary := message
+	if summary == "" {
+		summary = "Today's Islamic reminder is ready."
+	}
 
 	// Index with ID "daily" (not "reminder_daily") because the chat room type extraction
 	// will split "reminder_daily" into type="reminder" and id="daily", then look up just "daily"
 	data.Index(
 		"daily",
 		"reminder",
-		"Daily Islamic Reminder",
-		content,
+		"Daily Reminder",
+		summary,
 		map[string]interface{}{
 			"url":     "/reminder",
 			"updated": updated,

--- a/social/seed.go
+++ b/social/seed.go
@@ -50,7 +50,9 @@ func seedReminder() {
 		return
 	}
 
-	// Build the thread content from reminder data
+	// Build the thread content with just the message summary and a link
+	// to the full reminder page. Embedding the full content (verse, hadith, name)
+	// causes markdown formatting issues (backticks become pre blocks, etc.)
 	var sb strings.Builder
 
 	if rd.Message != "" {
@@ -58,24 +60,8 @@ func seedReminder() {
 		sb.WriteString("\n\n")
 	}
 
-	if rd.Name != "" {
-		sb.WriteString("**Name of Allah:** ")
-		sb.WriteString(rd.Name)
-		sb.WriteString("\n\n")
-	}
-
-	if rd.Verse != "" {
-		sb.WriteString("**Quranic Verse:** ")
-		sb.WriteString(rd.Verse)
-		sb.WriteString("\n\n")
-	}
-
-	if rd.Hadith != "" {
-		sb.WriteString("**Hadith:** ")
-		sb.WriteString(rd.Hadith)
-		sb.WriteString("\n\n")
-	}
-
+	sb.WriteString("[Read the full reminder](/reminder)")
+	sb.WriteString("\n\n")
 	sb.WriteString("*Share your reflections and thoughts on today's reminder.*")
 
 	content := sb.String()

--- a/social/social.go
+++ b/social/social.go
@@ -364,25 +364,58 @@ func handleThread(w http.ResponseWriter, r *http.Request, id string) {
 <div>%s</div>
 </div>`, titleHTML, html.EscapeString(t.Topic), t.AuthorID, html.EscapeString(t.Author), app.TimeAgo(t.CreatedAt), deleteBtn, contentHTML))
 
-	// Replies
+	// Replies - render as a threaded tree
 	if len(t.Replies) > 0 {
 		sb.WriteString(`<h3 style="margin-top:20px;">Replies</h3>`)
+		// Build a map of parent -> children for threading
+		childMap := map[string][]*Reply{}
 		for _, reply := range t.Replies {
-			replyHTML := string(app.Render([]byte(reply.Content)))
-			var replyDelete string
-			if acc != nil && (acc.ID == reply.AuthorID || acc.Admin) {
-				replyDelete = fmt.Sprintf(` · <a href="#" onclick="if(confirm('Delete this reply?')){var f=document.createElement('form');f.method='POST';f.action='/social?id=%s&reply=%s';var i=document.createElement('input');i.type='hidden';i.name='_method';i.value='DELETE';f.appendChild(i);document.body.appendChild(f);f.submit();}return false;" class="text-error">Delete</a>`, t.ID, reply.ID)
-			}
-			sb.WriteString(fmt.Sprintf(`<div class="card" style="padding:10px 16px;margin-left:20px;">
-<div style="font-size:12px;color:#888;margin-bottom:6px;">
-<a href="/@%s" class="text-muted">%s</a> · %s%s
-</div>
-<div>%s</div>
-</div>`, reply.AuthorID, html.EscapeString(reply.Author), app.TimeAgo(reply.CreatedAt), replyDelete, replyHTML))
+			childMap[reply.ParentID] = append(childMap[reply.ParentID], reply)
 		}
+		// Render top-level replies (ParentID == "") and their children recursively
+		var renderReplies func(parentID string, depth int)
+		renderReplies = func(parentID string, depth int) {
+			children := childMap[parentID]
+			for _, reply := range children {
+				replyHTML := string(app.Render([]byte(reply.Content)))
+				var replyDelete string
+				if acc != nil && (acc.ID == reply.AuthorID || acc.Admin) {
+					replyDelete = fmt.Sprintf(` · <a href="#" onclick="if(confirm('Delete this reply?')){var f=document.createElement('form');f.method='POST';f.action='/social?id=%s&reply=%s';var i=document.createElement('input');i.type='hidden';i.name='_method';i.value='DELETE';f.appendChild(i);document.body.appendChild(f);f.submit();}return false;" class="text-error">Delete</a>`, t.ID, reply.ID)
+				}
+				var replyBtn string
+				if acc != nil {
+					replyBtn = fmt.Sprintf(` · <a href="#" class="text-muted" onclick="document.getElementById('rf-%s').style.display='block';this.style.display='none';return false;">Reply</a>`, reply.ID)
+				}
+				indent := ""
+				if depth > 0 {
+					px := depth * 16
+					if px > 64 {
+						px = 64 // cap nesting depth visually
+					}
+					indent = fmt.Sprintf("margin-left:%dpx;", px)
+				}
+				sb.WriteString(fmt.Sprintf(`<div id="r-%s" class="card" style="padding:10px 16px;%s">
+<div style="font-size:12px;color:#888;margin-bottom:6px;">
+<a href="/@%s" class="text-muted">%s</a> · %s%s%s
+</div>
+<div>%s</div>`, reply.ID, indent, reply.AuthorID, html.EscapeString(reply.Author), app.TimeAgo(reply.CreatedAt), replyBtn, replyDelete, replyHTML))
+				// Inline reply form (hidden by default)
+				if acc != nil {
+					sb.WriteString(fmt.Sprintf(`<form id="rf-%s" method="POST" action="/social?id=%s" style="display:none;margin-top:8px;">
+<input type="hidden" name="parent_id" value="%s">
+<textarea name="content" rows="2" placeholder="Reply..." required style="width:100%%;font-size:13px;"></textarea>
+<button type="submit" style="margin-top:4px;font-size:12px;">Reply</button>
+</form>`, reply.ID, t.ID, reply.ID))
+				}
+				sb.WriteString(`</div>`)
+				// Render children
+				renderReplies(reply.ID, depth+1)
+			}
+		}
+		renderReplies("", 0)
 	}
 
-	// Reply form
+	// Reply form for top-level replies
 	if acc != nil {
 		sb.WriteString(fmt.Sprintf(`<form method="POST" action="/social?id=%s" class="blog-form card mt-5">
 <textarea name="content" rows="3" placeholder="Be respectful and stay on topic..." required></textarea>
@@ -528,23 +561,26 @@ func handleReply(w http.ResponseWriter, r *http.Request, threadID string) {
 		return
 	}
 
-	var content string
+	var content, parentID string
 
 	if app.SendsJSON(r) {
 		var req struct {
-			Content string `json:"content"`
+			Content  string `json:"content"`
+			ParentID string `json:"parent_id"`
 		}
 		if err := app.DecodeJSON(r, &req); err != nil {
 			app.BadRequest(w, r, "invalid json")
 			return
 		}
 		content = strings.TrimSpace(req.Content)
+		parentID = strings.TrimSpace(req.ParentID)
 	} else {
 		if err := r.ParseForm(); err != nil {
 			http.Error(w, "Failed to parse form", http.StatusBadRequest)
 			return
 		}
 		content = strings.TrimSpace(r.FormValue("content"))
+		parentID = strings.TrimSpace(r.FormValue("parent_id"))
 	}
 
 	if content == "" {
@@ -592,6 +628,7 @@ func handleReply(w http.ResponseWriter, r *http.Request, threadID string) {
 	reply := &Reply{
 		ID:        fmt.Sprintf("%d", time.Now().UnixNano()),
 		ThreadID:  threadID,
+		ParentID:  parentID,
 		Content:   content,
 		Author:    acc.Name,
 		AuthorID:  acc.ID,


### PR DESCRIPTION
- seed.go: Only embed message summary + link to /reminder in daily reminder threads instead of full verse/hadith/name content that has markdown formatting issues (backticks becoming pre blocks)
- reminder.go: Index only the message summary for search/RAG, not the full markdown-heavy content
- social.go: Add proper threaded replies using ParentID field - replies render as a tree with indent, each reply has a Reply button that shows an inline form. Top-level replies have no indent, nested replies indent 16px per level (capped at 64px). handleReply now accepts parent_id from form/JSON.

https://claude.ai/code/session_011itVdcSDugddjFKJQimLDb