### PR TITLE
Move blog card to left column above news, fix mobile ordering

### DIFF
--- a/app/html/mu.css
+++ b/app/html/mu.css
@@ -2103,45 +2103,42 @@ a.highlight {
     max-width: 100%;
   }
   
-  /* Home page layout */
+  /* Home page layout — flatten columns on mobile for unified card ordering */
   #home {
     display: flex;
     flex-direction: column;
     height: auto;
   }
-  .home-left {
-    margin-bottom: 10px;
-    width: 100%;
+  .home-left, .home-right {
+    display: contents;
   }
-  
-  /* Compact apps card on mobile */
-  .home-left .card {
+
+  /* Compact cards on mobile */
+  .home-left .card, .home-right .card {
     padding: 12px;
     margin-bottom: 10px;
+    width: 100%;
+    min-width: auto;
   }
-  
+
   .home-left .card h3 {
     font-size: 14px;
     margin-bottom: 8px;
   }
-  
+
   .home-left .card-link {
     font-size: 12px;
   }
-  
-  .home-right {
-    width: 100%;
-    display: flex;
-    flex-direction: column;
-  }
-  
-  /* Reorder cards: real-time info first */
-  #home-chat { order: 1; }
+
+  /* Reorder cards: agent first, then real-time info, then content */
+  #agent { order: 1; }
   #reminder { order: 2; }
-  #markets { order: 3; }
-  #news { order: 4; }
-  #blog { order: 5; }
-  #video { order: 6; }
+  #blog { order: 3; }
+  #markets { order: 4; }
+  #news { order: 5; }
+  #social { order: 6; }
+  #video { order: 7; }
+  #home-chat { order: 8; }
   
   .cover {
     display: block;

--- a/home/cards.json
+++ b/home/cards.json
@@ -9,10 +9,18 @@
       "icon": "/agent.svg"
     },
     {
+      "id": "blog",
+      "title": "Blog",
+      "type": "blog",
+      "position": 1,
+      "link": "/blog",
+      "icon": "/post.png"
+    },
+    {
       "id": "news",
       "title": "News",
       "type": "news",
-      "position": 1,
+      "position": 2,
       "link": "/news",
       "icon": "/news.png"
     }
@@ -43,18 +51,10 @@
       "icon": "/chat.png"
     },
     {
-      "id": "blog",
-      "title": "Blog",
-      "type": "blog",
-      "position": 3,
-      "link": "/blog",
-      "icon": "/post.png"
-    },
-    {
       "id": "video",
       "title": "Video",
       "type": "video",
-      "position": 4,
+      "position": 3,
       "link": "/video",
       "icon": "/video.png"
     }


### PR DESCRIPTION
Blog card moves from right column (position 3) to left column (position 1, between agent and news) in cards.json.

On mobile, use display:contents to flatten the left/right column containers so all cards participate in a single flex ordering: agent → reminder → blog → markets → news → social → video.

https://claude.ai/code/session_011itVdcSDugddjFKJQimLDb