### PR TITLE
Fix NO_NOTE parsing in fact-checker to handle AI response variations

### DIFF
--- a/social/factcheck.go
+++ b/social/factcheck.go
@@ -189,8 +189,9 @@ Rules:
 
 	response = strings.TrimSpace(app.StripLatexDollars(response))
 
-	// Parse response
-	if response == "NO_NOTE" || response == "" {
+	// Parse response — the AI should return "NO_NOTE" when no fact-check is needed,
+	// but may add extra text after it. Treat any response starting with NO_NOTE as no note.
+	if response == "" || strings.HasPrefix(response, "NO_NOTE") {
 		return nil
 	}
 


### PR DESCRIPTION
The AI sometimes returns "NO_NOTE" with trailing text (e.g. "NO_NOTE - no verifiable claims found"). The exact equality check would miss these variations, causing the full response including "NO_NOTE" to be displayed as a community note with missing_context status. Use HasPrefix instead.

https://claude.ai/code/session_011itVdcSDugddjFKJQimLDb