### PR TITLE
Thread agent replies under the human reply they're responding to

### DIFF
--- a/social/opinion_memory.go
+++ b/social/opinion_memory.go
@@ -299,10 +299,17 @@ Rules:
 		return
 	}
 
-	// Add the reply to the thread
+	// Add the reply to the thread, threaded under the first unanswered
+	// human reply so it's visually connected to what it's responding to.
+	parentID := ""
+	if len(unansweredHuman) > 0 {
+		parentID = unansweredHuman[0].ID
+	}
+
 	reply := &Reply{
 		ID:        fmt.Sprintf("%d", time.Now().UnixNano()),
 		ThreadID:  seedID,
+		ParentID:  parentID,
 		Content:   response,
 		Author:    app.SystemUserName,
 		AuthorID:  app.SystemUserID,


### PR DESCRIPTION
The agent's reply was appearing as a top-level reply with no visual connection to the human comment it was addressing. Set ParentID to the first unanswered human reply so the rendering system indents it as a nested reply, making the conversation flow clear.

https://claude.ai/code/session_011itVdcSDugddjFKJQimLDb