### PR TITLE
fix: remove duplicate h1 from digest page, add spacing to digest link

### DIFF
--- a/news/digest/digest.go
+++ b/news/digest/digest.go
@@ -143,7 +143,7 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	rendered := string(app.Render([]byte(d.Content)))
-	html := fmt.Sprintf(`<h1>Daily Digest — %s</h1><div class="digest">%s</div>`, d.CreatedAt.Format("2 Jan 2006"), rendered)
+	html := fmt.Sprintf(`<div class="digest">%s</div>`, rendered)
 
 	app.Respond(w, r, app.Response{
 		Title:       "Daily Digest — " + d.CreatedAt.Format("2 Jan 2006"),

--- a/news/news.go
+++ b/news/news.go
@@ -420,7 +420,7 @@ func generateNewsHtml() string {
 	// Link to daily digest if available
 	digestLink := ""
 	if HasDigest != nil && HasDigest() {
-		digestLink = `<a class="digest-link" href="/news/digest">Read today's digest</a>`
+		digestLink = `<a class="digest-link" href="/news/digest" style="display:block;margin:1rem 0">Read today's digest</a>`
 	}
 
 	// Get topics header


### PR DESCRIPTION
The page title is already rendered by app.Respond; the extra h1 was redundant. The digest link on /news now has margin so it doesn't touch the headlines.

https://claude.ai/code/session_011itVdcSDugddjFKJQimLDb