### PR TITLE
Fix digest URLs, social links, and tag separators

### DIFF
--- a/blog/blog.go
+++ b/blog/blog.go
@@ -89,7 +89,7 @@ func formatTags(tags string) string {
 	if len(badges) == 0 {
 		return ""
 	}
-	return strings.Join(badges, " ")
+	return strings.Join(badges, " · ")
 }
 
 // parseTags parses comma-separated tags, validates, and normalizes them
@@ -1453,9 +1453,14 @@ func PostHandler(w http.ResponseWriter, r *http.Request) {
 
 	tagsHtml := ""
 	if post.Tags != "" {
+		var tagSpans []string
 		for _, tag := range strings.Split(post.Tags, ",") {
-			tagsHtml += fmt.Sprintf(`<span class="category">%s</span> `, strings.TrimSpace(tag))
+			tag = strings.TrimSpace(tag)
+			if tag != "" {
+				tagSpans = append(tagSpans, fmt.Sprintf(`<span class="category">%s</span>`, tag))
+			}
 		}
+		tagsHtml = strings.Join(tagSpans, " · ")
 	}
 
 	// Add private badge if post is private

--- a/main.go
+++ b/main.go
@@ -167,7 +167,7 @@ func main() {
 		return &social.SeedData{
 			Title:   d.Title,
 			Summary: summary,
-			Link:    "/news",
+			Link:    "/news/digest?date=" + d.ID,
 		}
 	}
 

--- a/news/digest/digest.go
+++ b/news/digest/digest.go
@@ -120,10 +120,31 @@ func GetLatestDigest() *DigestEntry {
 	return digests[0]
 }
 
+// GetDigestByDate returns the digest for a specific date (YYYY-MM-DD), or nil.
+func GetDigestByDate(date string) *DigestEntry {
+	digestMu.RLock()
+	defer digestMu.RUnlock()
+	for _, entry := range digests {
+		if entry.ID == date {
+			return entry
+		}
+	}
+	return nil
+}
+
 // Handler serves the daily digest page at /news/digest.
+// Supports ?date=YYYY-MM-DD to fetch a specific day's digest.
 func Handler(w http.ResponseWriter, r *http.Request) {
+	date := r.URL.Query().Get("date")
+
+	var d *DigestEntry
+	if date != "" {
+		d = GetDigestByDate(date)
+	} else {
+		d = GetLatestDigest()
+	}
+
 	if app.WantsJSON(r) {
-		d := GetLatestDigest()
 		if d == nil {
 			app.RespondJSON(w, map[string]any{"digest": nil})
 			return
@@ -132,12 +153,15 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	d := GetLatestDigest()
 	if d == nil {
+		msg := "No digest available yet. Check back soon."
+		if date != "" {
+			msg = fmt.Sprintf("No digest found for %s.", date)
+		}
 		app.Respond(w, r, app.Response{
 			Title:       "Daily Digest",
-			Description: "No digest available yet",
-			HTML:        `<p>No digest available yet. Check back soon.</p>`,
+			Description: "No digest available",
+			HTML:        fmt.Sprintf(`<p>%s</p>`, msg),
 		})
 		return
 	}


### PR DESCRIPTION
- Add GetDigestByDate and support ?date=YYYY-MM-DD in digest handler
- Social digest thread now links to /news/digest?date=ID instead of /news
- Tags in blog listings and post pages separated by · instead of spaces

https://claude.ai/code/session_011itVdcSDugddjFKJQimLDb