### PR TITLE
feat: add fact-check service as MCP tool and standalone endpoint

### DIFF
--- a/factcheck/factcheck.go
+++ b/factcheck/factcheck.go
@@ -1,0 +1,385 @@
+package factcheck
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"mu/internal/ai"
+	"mu/internal/app"
+	"mu/internal/auth"
+	"mu/search"
+	"mu/wallet"
+)
+
+// Result is the output of a fact-check operation
+type Result struct {
+	Content   string   `json:"content"`            // the fact-check text
+	Sources   []Source `json:"sources,omitempty"`   // reference links
+	Status    string   `json:"status"`             // "accurate", "misleading", "missing_context", "none"
+	CheckedAt time.Time `json:"checked_at"`
+}
+
+// Source is a reference link
+type Source struct {
+	Title string `json:"title"`
+	URL   string `json:"url"`
+}
+
+// Check performs a fact-check on the given claim text.
+// It searches the web for context and uses AI to assess accuracy.
+// Returns a Result with status "none" if no verifiable claims are found.
+func Check(claim string) *Result {
+	claim = strings.TrimSpace(claim)
+
+	// Skip very short claims
+	if len(claim) < 20 {
+		return &Result{
+			Status:    "none",
+			Content:   "Text too short to fact-check.",
+			CheckedAt: time.Now(),
+		}
+	}
+
+	// Step 1: Search the web for context
+	query := claim
+	if len(query) > 150 {
+		query = query[:150]
+	}
+
+	var webContext []string
+	var allResults []search.BraveResult
+
+	results, err := search.SearchBraveCached(query, 5)
+	if err == nil && len(results) > 0 {
+		allResults = append(allResults, results...)
+		for _, r := range results {
+			ctx := fmt.Sprintf("%s: %s (Source: %s)", r.Title, r.Description, r.URL)
+			if len(ctx) > 500 {
+				ctx = ctx[:500] + "..."
+			}
+			webContext = append(webContext, ctx)
+		}
+	}
+
+	// Step 2: Ask AI to assess the claims
+	var question strings.Builder
+	question.WriteString("## Claim to Fact-Check\n\n")
+	question.WriteString(claim)
+	question.WriteString("\n\n")
+
+	if len(webContext) > 0 {
+		question.WriteString("## Web Search Results\n\n")
+		for _, ctx := range webContext {
+			question.WriteString("- " + ctx + "\n")
+		}
+	}
+
+	prompt := &ai.Prompt{
+		System: `You are a fact-checker. You will receive a claim or statement and web search results.
+
+Your job:
+1. Determine if the text contains verifiable factual claims (names, dates, numbers, events, statistics, quotes)
+2. If it does, assess whether those claims are supported by the web search results and your knowledge
+
+IMPORTANT: Not every statement needs a note. Skip these:
+- Personal opinions, reflections, or questions
+- Religious/spiritual discussion without factual claims
+- General commentary without specific assertions
+- Statements that are clearly accurate based on widely known facts
+
+Respond in ONE of these formats:
+
+If no verifiable claims found:
+STATUS: none
+NOTE: No verifiable factual claims found.
+
+If claims are clearly accurate:
+STATUS: accurate
+NOTE: [1-2 sentences confirming the key facts with specifics]
+
+If claims need context or correction:
+STATUS: [misleading|missing_context]
+NOTE: [1-2 sentences providing factual context, corrections, or important missing information]
+
+Rules:
+- Be specific — cite facts, dates, and numbers
+- Be neutral — correct the record without taking sides
+- Do NOT lecture or moralise
+- Do NOT fact-check opinions or predictions
+- Write dollar amounts as plain numbers
+- CRITICAL: Keep the note under 300 characters`,
+		Question: question.String(),
+		Priority: ai.PriorityLow,
+	}
+
+	response, err := ai.Ask(prompt)
+	if err != nil {
+		app.Log("factcheck", "AI failed: %v", err)
+		return nil
+	}
+
+	response = strings.TrimSpace(app.StripLatexDollars(response))
+
+	if response == "" {
+		return nil
+	}
+
+	// Parse response
+	status := "none"
+	noteText := ""
+
+	if strings.HasPrefix(response, "STATUS:") {
+		lines := strings.SplitN(response, "\n", 3)
+		for _, line := range lines {
+			line = strings.TrimSpace(line)
+			if strings.HasPrefix(line, "STATUS:") {
+				s := strings.TrimSpace(strings.TrimPrefix(line, "STATUS:"))
+				s = strings.ToLower(s)
+				if s == "accurate" || s == "misleading" || s == "missing_context" || s == "none" {
+					status = s
+				}
+			}
+			if strings.HasPrefix(line, "NOTE:") {
+				noteText = strings.TrimSpace(strings.TrimPrefix(line, "NOTE:"))
+			}
+		}
+	} else if strings.HasPrefix(response, "NO_NOTE") {
+		return &Result{
+			Status:    "none",
+			Content:   "No verifiable factual claims found.",
+			CheckedAt: time.Now(),
+		}
+	}
+
+	if noteText == "" {
+		noteText = response
+		if idx := strings.Index(noteText, "NOTE:"); idx >= 0 {
+			noteText = strings.TrimSpace(noteText[idx+5:])
+		}
+	}
+
+	// Collect sources
+	var sources []Source
+	seen := map[string]bool{}
+	for _, r := range allResults {
+		if r.URL == "" || seen[r.URL] {
+			continue
+		}
+		seen[r.URL] = true
+		sources = append(sources, Source{Title: r.Title, URL: r.URL})
+		if len(sources) >= 3 {
+			break
+		}
+	}
+
+	return &Result{
+		Content:   noteText,
+		Sources:   sources,
+		Status:    status,
+		CheckedAt: time.Now(),
+	}
+}
+
+// Handler serves the /factcheck endpoint
+// GET: renders the fact-check page
+// POST: performs a fact-check and returns the result
+func Handler(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case "GET":
+		handlePage(w, r)
+	case "POST":
+		handleCheck(w, r)
+	default:
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+func handlePage(w http.ResponseWriter, r *http.Request) {
+	// JSON API — return usage info
+	if app.WantsJSON(r) {
+		app.RespondJSON(w, map[string]interface{}{
+			"service":     "fact_check",
+			"description": "Submit a claim or statement to fact-check against web sources",
+			"cost":        wallet.CostFactCheck,
+			"method":      "POST",
+			"params": map[string]string{
+				"claim": "The claim or statement to fact-check (required, min 20 chars)",
+			},
+		})
+		return
+	}
+
+	_, acc := auth.TrySession(r)
+
+	var sb strings.Builder
+	sb.WriteString(`<div class="card center-card-md">
+<h2 style="margin-top:0;">Fact Check</h2>
+<p class="text-muted">Submit any claim or statement to verify it against web sources.</p>`)
+
+	if acc != nil {
+		sb.WriteString(fmt.Sprintf(`<form method="POST" action="/factcheck" class="blog-form">
+<textarea name="claim" rows="4" placeholder="Enter a claim or statement to fact-check..." required minlength="20"></textarea>
+<button type="submit">Fact Check (%dp)</button>
+</form>`, wallet.CostFactCheck))
+	} else {
+		sb.WriteString(`<p class="text-muted"><a href="/login?redirect=/factcheck">Login</a> to use the fact-checker.</p>`)
+	}
+
+	sb.WriteString(`</div>`)
+
+	page := app.RenderHTMLForRequest("Fact Check", "Fact Check", sb.String(), r)
+	w.Write([]byte(page))
+}
+
+func handleCheck(w http.ResponseWriter, r *http.Request) {
+	_, acc, err := auth.RequireSession(r)
+	if err != nil {
+		app.Unauthorized(w, r)
+		return
+	}
+
+	var claim string
+
+	if app.SendsJSON(r) {
+		var req struct {
+			Claim string `json:"claim"`
+		}
+		if err := app.DecodeJSON(r, &req); err != nil {
+			app.BadRequest(w, r, "invalid json")
+			return
+		}
+		claim = strings.TrimSpace(req.Claim)
+	} else {
+		if err := r.ParseForm(); err != nil {
+			http.Error(w, "Failed to parse form", http.StatusBadRequest)
+			return
+		}
+		claim = strings.TrimSpace(r.FormValue("claim"))
+	}
+
+	if claim == "" {
+		app.BadRequest(w, r, "Claim is required")
+		return
+	}
+	if len(claim) < 20 {
+		app.BadRequest(w, r, "Claim must be at least 20 characters")
+		return
+	}
+
+	// Check quota
+	canProceed, _, cost, _ := wallet.CheckQuota(acc.ID, wallet.OpFactCheck)
+	if !canProceed {
+		if app.SendsJSON(r) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(402)
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"error":   "quota_exceeded",
+				"message": "Daily limit reached. Please top up credits at /wallet",
+				"cost":    cost,
+			})
+			return
+		}
+		c := wallet.QuotaExceededPage(wallet.OpFactCheck, cost)
+		page := app.RenderHTMLForRequest("Quota Exceeded", "Daily limit reached", c, r)
+		w.Write([]byte(page))
+		return
+	}
+
+	// Perform the fact-check
+	result := Check(claim)
+
+	// Consume quota
+	wallet.ConsumeQuota(acc.ID, wallet.OpFactCheck)
+
+	if result == nil {
+		if app.SendsJSON(r) || app.WantsJSON(r) {
+			app.RespondJSON(w, map[string]interface{}{
+				"status":  "error",
+				"message": "Fact-check failed. Please try again.",
+			})
+			return
+		}
+		page := app.RenderHTMLForRequest("Fact Check", "Fact Check", `<div class="card center-card-md"><p>Fact-check failed. Please try again.</p><p><a href="/factcheck">Try again</a></p></div>`, r)
+		w.Write([]byte(page))
+		return
+	}
+
+	// JSON response
+	if app.SendsJSON(r) || app.WantsJSON(r) {
+		app.RespondJSON(w, result)
+		return
+	}
+
+	// HTML response
+	var sb strings.Builder
+	sb.WriteString(`<div class="card center-card-md">`)
+	sb.WriteString(`<h2 style="margin-top:0;">Fact Check Result</h2>`)
+
+	// Show the original claim
+	sb.WriteString(fmt.Sprintf(`<div style="padding:10px 14px;background:#f8f8f8;border-radius:4px;margin-bottom:12px;font-size:13px;color:#555;">%s</div>`, app.RenderString(claim)))
+
+	// Show the result
+	sb.WriteString(RenderResult(result))
+
+	sb.WriteString(`<p style="margin-top:16px;"><a href="/factcheck">Check another claim</a></p>`)
+	sb.WriteString(`</div>`)
+
+	page := app.RenderHTMLForRequest("Fact Check", "Fact Check Result", sb.String(), r)
+	w.Write([]byte(page))
+}
+
+// RenderResult renders a fact-check result as HTML.
+// Exported so social and other packages can use it.
+func RenderResult(result *Result) string {
+	if result == nil {
+		return ""
+	}
+
+	icon := "&#9432;" // info
+	label := "Result"
+	borderColor := "#888"
+	bgColor := "#f8f8f8"
+
+	switch result.Status {
+	case "accurate":
+		icon = "&#10003;" // checkmark
+		label = "Accurate"
+		borderColor = "#2d8a4e"
+		bgColor = "#f0faf4"
+	case "misleading":
+		icon = "&#9888;" // warning
+		label = "Misleading"
+		borderColor = "#d94040"
+		bgColor = "#fff5f5"
+	case "missing_context":
+		icon = "&#9432;" // info
+		label = "Missing Context"
+		borderColor = "#e0a800"
+		bgColor = "#fffdf0"
+	case "none":
+		icon = "&#8212;" // em dash
+		label = "No Claims Found"
+	}
+
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf(`<div style="margin-top:8px;padding:10px 14px;border-left:3px solid %s;background:%s;border-radius:4px;font-size:13px;">`, borderColor, bgColor))
+	sb.WriteString(fmt.Sprintf(`<div style="font-weight:600;margin-bottom:4px;color:%s;">%s %s</div>`, borderColor, icon, label))
+	sb.WriteString(fmt.Sprintf(`<div style="color:#333;">%s</div>`, app.RenderString(result.Content)))
+
+	if len(result.Sources) > 0 {
+		sb.WriteString(`<div style="margin-top:6px;font-size:11px;color:#666;">`)
+		for i, src := range result.Sources {
+			if i > 0 {
+				sb.WriteString(" · ")
+			}
+			sb.WriteString(fmt.Sprintf(`<a href="%s" target="_blank" rel="noopener" style="color:#666;">%s</a>`, src.URL, src.Title))
+		}
+		sb.WriteString(`</div>`)
+	}
+
+	sb.WriteString(`</div>`)
+	return sb.String()
+}

--- a/main.go
+++ b/main.go
@@ -21,6 +21,7 @@ import (
 	"mu/chat"
 	"mu/internal/data"
 	"mu/docs"
+	"mu/factcheck"
 	"mu/home"
 	"mu/mail"
 	"mu/news"
@@ -277,6 +278,18 @@ func main() {
 		},
 	})
 
+	// fact_check tool — verify claims against web sources
+	api.RegisterTool(api.Tool{
+		Name:        "fact_check",
+		Description: "Fact-check a claim or statement by searching the web and assessing accuracy. Returns verdict (accurate, misleading, missing_context, none) with sources.",
+		Method:      "POST",
+		Path:        "/factcheck",
+		WalletOp:    "fact_check",
+		Params: []api.ToolParam{
+			{Name: "claim", Type: "string", Description: "The claim or statement to fact-check (minimum 20 characters)", Required: true},
+		},
+	})
+
 	authenticated := map[string]bool{
 		"/video":           false, // Public viewing, auth for interactive features
 		"/news":            false, // Public viewing, auth for search
@@ -311,9 +324,10 @@ func main() {
 		"/donate":          false,
 		"/wallet":          false, // Public - shows wallet info; auth checked in handler
 
-		"/search": false, // Public - local data index search
-		"/web":    false, // Public page, auth checked in handler (paid Brave web search)
-		"/fetch":  false, // Public page, auth checked in handler (paid web fetch)
+		"/search":    false, // Public - local data index search
+		"/web":       false, // Public page, auth checked in handler (paid Brave web search)
+		"/fetch":     false, // Public page, auth checked in handler (paid web fetch)
+		"/factcheck": false, // Public page, auth checked in handler (paid fact-check)
 
 		"/status": false, // Public - server health status
 		"/docs":   false, // Public - documentation
@@ -410,6 +424,9 @@ func main() {
 
 	// serve web fetch page (fetch and clean a URL)
 	http.HandleFunc("/fetch", search.FetchHandler)
+
+	// serve fact-check page and API
+	http.HandleFunc("/factcheck", factcheck.Handler)
 
 	// serve the home screen
 	http.HandleFunc("/home", home.Handler)

--- a/social/factcheck.go
+++ b/social/factcheck.go
@@ -1,13 +1,15 @@
 package social
 
 import (
+	"encoding/json"
 	"fmt"
-	"strings"
+	"net/http"
 	"time"
 
-	"mu/internal/ai"
+	"mu/factcheck"
 	"mu/internal/app"
-	"mu/search"
+	"mu/internal/auth"
+	"mu/wallet"
 )
 
 // factCheckThread runs a background fact-check on a user-posted thread.
@@ -96,160 +98,131 @@ func factCheckReply(threadID, replyID string) {
 	app.Log("social", "Fact-checked reply %s: %s", replyID, note.Status)
 }
 
-// checkClaims searches the web for claims in the content and uses AI
-// to assess accuracy. Returns nil if no verifiable claims are found
-// (opinions, questions, personal reflections don't need fact-checking).
+// checkClaims uses the factcheck package to verify claims and converts
+// the result to a CommunityNote. Returns nil if no actionable claims found.
 func checkClaims(title, content string) *CommunityNote {
 	fullText := content
 	if title != "" {
 		fullText = title + "\n\n" + content
 	}
 
-	// Skip very short posts — unlikely to contain verifiable claims
+	// Skip very short posts
 	if len(fullText) < 50 {
 		return nil
 	}
 
-	// Step 1: Search the web for context on the claims
-	query := fullText
-	if len(query) > 150 {
-		// Use the first substantive portion as search query
-		query = query[:150]
-	}
-
-	var webContext []string
-	var allResults []search.BraveResult
-
-	results, err := search.SearchBraveCached(query, 5)
-	if err == nil && len(results) > 0 {
-		allResults = append(allResults, results...)
-		for _, r := range results {
-			ctx := fmt.Sprintf("%s: %s (Source: %s)", r.Title, r.Description, r.URL)
-			if len(ctx) > 500 {
-				ctx = ctx[:500] + "..."
-			}
-			webContext = append(webContext, ctx)
-		}
-	}
-
-	// Step 2: Ask AI to assess the claims against the web context
-	var question strings.Builder
-	question.WriteString("## User Post\n\n")
-	if title != "" {
-		question.WriteString("**" + title + "**\n\n")
-	}
-	question.WriteString(content)
-	question.WriteString("\n\n")
-
-	if len(webContext) > 0 {
-		question.WriteString("## Web Search Results\n\n")
-		for _, ctx := range webContext {
-			question.WriteString("- " + ctx + "\n")
-		}
-	}
-
-	prompt := &ai.Prompt{
-		System: `You are a fact-checker for Mu, an independent truth-seeking platform. You will receive a user's social media post and web search results.
-
-Your job:
-1. Determine if the post contains verifiable factual claims (names, dates, numbers, events, statistics, quotes)
-2. If it does, assess whether those claims are supported by the web search results and your knowledge
-
-IMPORTANT: Not every post needs a note. Skip these:
-- Personal opinions, reflections, or questions
-- Religious/spiritual discussion without factual claims
-- General commentary without specific assertions
-- Posts that are clearly accurate based on widely known facts
-
-Respond in ONE of these formats:
-
-If no verifiable claims or claims are clearly accurate:
-NO_NOTE
-
-If claims need context or correction, write a concise community note:
-STATUS: [accurate|misleading|missing_context]
-NOTE: [1-2 sentences providing factual context, corrections, or important missing information]
-
-Rules:
-- Be specific — cite facts, dates, and numbers
-- Be neutral — correct the record without taking sides
-- Do NOT lecture or moralise
-- Do NOT fact-check opinions or predictions
-- Write dollar amounts as plain numbers
-- CRITICAL: Keep the note under 300 characters`,
-		Question: question.String(),
-		Priority: ai.PriorityLow,
-	}
-
-	response, err := ai.Ask(prompt)
-	if err != nil {
-		app.Log("social", "Fact-check AI failed: %v", err)
+	result := factcheck.Check(fullText)
+	if result == nil {
 		return nil
 	}
 
-	response = strings.TrimSpace(app.StripLatexDollars(response))
-
-	// Parse response — the AI should return "NO_NOTE" when no fact-check is needed,
-	// but may add extra text after it. Treat any response starting with NO_NOTE as no note.
-	if response == "" || strings.HasPrefix(response, "NO_NOTE") {
+	// Don't create notes for accurate or no-claims content
+	if result.Status == "accurate" || result.Status == "none" {
 		return nil
 	}
 
-	status := "missing_context"
-	noteText := response
-
-	if strings.HasPrefix(response, "STATUS:") {
-		lines := strings.SplitN(response, "\n", 3)
-		for _, line := range lines {
-			line = strings.TrimSpace(line)
-			if strings.HasPrefix(line, "STATUS:") {
-				s := strings.TrimSpace(strings.TrimPrefix(line, "STATUS:"))
-				s = strings.ToLower(s)
-				if s == "accurate" || s == "misleading" || s == "missing_context" {
-					status = s
-				}
-			}
-			if strings.HasPrefix(line, "NOTE:") {
-				noteText = strings.TrimSpace(strings.TrimPrefix(line, "NOTE:"))
-			}
-		}
-	}
-
-	// Don't create notes for accurate content — only add notes when
-	// something is misleading or missing context
-	if status == "accurate" {
-		return nil
-	}
-
-	if noteText == "" || noteText == response {
-		// Couldn't parse structured format, use full response as note
-		noteText = response
-		// Strip any STATUS: prefix from the note text
-		if idx := strings.Index(noteText, "NOTE:"); idx >= 0 {
-			noteText = strings.TrimSpace(noteText[idx+5:])
-		}
-	}
-
-	// Collect sources
+	// Convert factcheck.Result to CommunityNote
 	var sources []Source
-	seen := map[string]bool{}
-	for _, r := range allResults {
-		if r.URL == "" || seen[r.URL] {
-			continue
-		}
-		seen[r.URL] = true
-		sources = append(sources, Source{Title: r.Title, URL: r.URL})
-		if len(sources) >= 3 {
-			break
-		}
+	for _, s := range result.Sources {
+		sources = append(sources, Source{Title: s.Title, URL: s.URL})
 	}
 
 	return &CommunityNote{
-		Content:   noteText,
+		Content:   result.Content,
 		Sources:   sources,
-		Status:    status,
-		CheckedAt: time.Now(),
+		Status:    result.Status,
+		CheckedAt: result.CheckedAt,
 	}
+}
+
+// FactCheckHandler handles POST /social?id={id}&factcheck=true
+// Allows users to manually trigger a fact-check on a thread.
+func FactCheckHandler(w http.ResponseWriter, r *http.Request, threadID string) {
+	_, acc, err := auth.RequireSession(r)
+	if err != nil {
+		app.Unauthorized(w, r)
+		return
+	}
+
+	mutex.RLock()
+	t := getThread(threadID)
+	if t == nil {
+		mutex.RUnlock()
+		http.NotFound(w, r)
+		return
+	}
+	title := t.Title
+	content := t.Content
+	mutex.RUnlock()
+
+	// Check quota
+	canProceed, _, cost, _ := wallet.CheckQuota(acc.ID, wallet.OpFactCheck)
+	if !canProceed {
+		if app.SendsJSON(r) || app.WantsJSON(r) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(402)
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"error":   "quota_exceeded",
+				"message": "Daily limit reached. Please top up credits at /wallet",
+				"cost":    cost,
+			})
+			return
+		}
+		c := wallet.QuotaExceededPage(wallet.OpFactCheck, cost)
+		page := app.RenderHTMLForRequest("Quota Exceeded", "Daily limit reached", c, r)
+		w.Write([]byte(page))
+		return
+	}
+
+	// Perform fact-check using the factcheck package
+	fullText := title + "\n\n" + content
+	result := factcheck.Check(fullText)
+
+	// Consume quota
+	wallet.ConsumeQuota(acc.ID, wallet.OpFactCheck)
+
+	if result == nil {
+		if app.SendsJSON(r) || app.WantsJSON(r) {
+			app.RespondJSON(w, map[string]interface{}{
+				"status":  "error",
+				"message": "Fact-check failed. Please try again.",
+			})
+			return
+		}
+		http.Redirect(w, r, "/social?id="+threadID, http.StatusSeeOther)
+		return
+	}
+
+	// Store result as community note on the thread (if actionable)
+	if result.Status != "none" {
+		var sources []Source
+		for _, s := range result.Sources {
+			sources = append(sources, Source{Title: s.Title, URL: s.URL})
+		}
+		note := &CommunityNote{
+			Content:   result.Content,
+			Sources:   sources,
+			Status:    result.Status,
+			CheckedAt: result.CheckedAt,
+		}
+
+		mutex.Lock()
+		t = getThread(threadID)
+		if t != nil {
+			t.Note = note
+		}
+		mutex.Unlock()
+
+		save()
+		updateCache()
+		app.Log("social", "Manual fact-check on thread %s by %s: %s", threadID, acc.ID, note.Status)
+	}
+
+	if app.SendsJSON(r) || app.WantsJSON(r) {
+		app.RespondJSON(w, result)
+		return
+	}
+	http.Redirect(w, r, "/social?id="+threadID, http.StatusSeeOther)
 }
 
 // renderCommunityNote renders a community note as HTML.
@@ -259,38 +232,24 @@ func renderCommunityNote(note *CommunityNote) string {
 		return ""
 	}
 
-	icon := "&#9432;" // ℹ info circle
-	label := "Context"
-	borderColor := "#e0a800" // amber
-	bgColor := "#fffdf0"
-
-	switch note.Status {
-	case "misleading":
-		icon = "&#9888;" // ⚠ warning
-		label = "Fact Check"
-		borderColor = "#d94040"
-		bgColor = "#fff5f5"
-	case "missing_context":
-		icon = "&#9432;" // ℹ info
-		label = "Added Context"
+	// Convert to factcheck.Result for rendering
+	var sources []factcheck.Source
+	for _, s := range note.Sources {
+		sources = append(sources, factcheck.Source{Title: s.Title, URL: s.URL})
 	}
 
-	var sb strings.Builder
-	sb.WriteString(fmt.Sprintf(`<div style="margin-top:8px;padding:10px 14px;border-left:3px solid %s;background:%s;border-radius:4px;font-size:13px;">`, borderColor, bgColor))
-	sb.WriteString(fmt.Sprintf(`<div style="font-weight:600;margin-bottom:4px;color:%s;">%s %s</div>`, borderColor, icon, label))
-	sb.WriteString(fmt.Sprintf(`<div style="color:#333;">%s</div>`, app.RenderString(note.Content)))
-
-	if len(note.Sources) > 0 {
-		sb.WriteString(`<div style="margin-top:6px;font-size:11px;color:#666;">`)
-		for i, src := range note.Sources {
-			if i > 0 {
-				sb.WriteString(" · ")
-			}
-			sb.WriteString(fmt.Sprintf(`<a href="%s" target="_blank" rel="noopener" style="color:#666;">%s</a>`, src.URL, src.Title))
-		}
-		sb.WriteString(`</div>`)
-	}
-
-	sb.WriteString(`</div>`)
-	return sb.String()
+	return factcheck.RenderResult(&factcheck.Result{
+		Content:   note.Content,
+		Sources:   sources,
+		Status:    note.Status,
+		CheckedAt: note.CheckedAt,
+	})
 }
+
+// renderFactCheckButton renders a "Fact Check" button for a thread.
+func renderFactCheckButton(threadID string) string {
+	return fmt.Sprintf(`<form method="POST" action="/social?id=%s&factcheck=true" style="display:inline;margin-left:8px;">
+<button type="submit" style="background:none;border:1px solid #ccc;color:#666;font-size:11px;cursor:pointer;padding:2px 8px;border-radius:3px;" title="Fact-check this thread">Fact Check</button>
+</form>`, threadID)
+}
+

--- a/social/social.go
+++ b/social/social.go
@@ -219,6 +219,10 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 
 	switch r.Method {
 	case "POST":
+		if id != "" && r.URL.Query().Get("factcheck") == "true" {
+			FactCheckHandler(w, r, id)
+			return
+		}
 		if id != "" {
 			handleReply(w, r, id)
 		} else {
@@ -583,13 +587,19 @@ func handleThread(w http.ResponseWriter, r *http.Request, id string) {
 		deleteBtn = app.DeleteButton("/social?id="+t.ID, "Delete", "Delete this thread?")
 	}
 
+	// Fact-check button for logged-in users
+	var factCheckBtn string
+	if acc != nil {
+		factCheckBtn = renderFactCheckButton(t.ID)
+	}
+
 	sb.WriteString(fmt.Sprintf(`<div class="card">
 <h2 style="margin-top:0;">%s</h2>
 %s
 <div>%s</div>
 %s
 </div>`, titleHTML,
-		app.ItemMeta(app.Category(t.Topic, ""), app.AuthorLink(t.AuthorID, t.Author), app.Timestamp(t.CreatedAt), deleteBtn),
+		app.ItemMeta(app.Category(t.Topic, ""), app.AuthorLink(t.AuthorID, t.Author), app.Timestamp(t.CreatedAt), deleteBtn, factCheckBtn),
 		contentHTML,
 		renderCommunityNote(t.Note)))
 

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -31,6 +31,7 @@ var (
 	CostWeatherPollen     = getEnvInt("CREDIT_COST_WEATHER_POLLEN", 1)
 	CostWebSearch         = getEnvInt("CREDIT_COST_SEARCH", 5)
 	CostWebFetch          = getEnvInt("CREDIT_COST_FETCH", 3)
+	CostFactCheck         = getEnvInt("CREDIT_COST_FACTCHECK", 3)
 	CostAgentQuery        = getEnvInt("CREDIT_COST_AGENT", 3)
 	CostAgentQueryPremium = getEnvInt("CREDIT_COST_AGENT_PREMIUM", 9)
 	FreeDailyQuota        = getEnvInt("FREE_DAILY_QUOTA", 20)
@@ -57,6 +58,7 @@ const (
 	OpWeatherPollen     = "weather_pollen"
 	OpWebSearch         = "web_search"
 	OpWebFetch          = "web_fetch"
+	OpFactCheck         = "fact_check"
 	OpAgentQuery        = "agent_query"
 	OpAgentQueryPremium = "agent_query_premium"
 	OpTopup             = "topup"
@@ -363,6 +365,8 @@ func GetOperationCost(operation string) int {
 		return CostWebSearch
 	case OpWebFetch:
 		return CostWebFetch
+	case OpFactCheck:
+		return CostFactCheck
 	case OpAgentQuery:
 		return CostAgentQuery
 	case OpAgentQueryPremium:


### PR DESCRIPTION
Extract fact-checking logic from social into a reusable factcheck package. Expose as /factcheck endpoint (GET page, POST API) and register as fact_check MCP tool (3 credits). Add manual "Fact Check" button to social thread views so users can trigger on-demand verification against web sources.

https://claude.ai/code/session_011itVdcSDugddjFKJQimLDb