### PR TITLE
fix: deadlock in social — getThread was acquiring nested RLock

### DIFF
--- a/social/social.go
+++ b/social/social.go
@@ -208,9 +208,9 @@ func getThreadLocked(id string) *Thread {
 	return nil
 }
 
-// getThread is deprecated - use GetThread instead
+// getThread returns a thread by ID. Caller must hold mutex (read or write).
 func getThread(id string) *Thread {
-	return GetThread(id)
+	return getThreadLocked(id)
 }
 
 // Handler serves the social page


### PR DESCRIPTION
getThread() called GetThread() which acquires mutex.RLock(), but callers already held the mutex (both RLock and Lock). When a writer was waiting between the two reads, Go's RWMutex blocked the nested RLock, deadlocking the entire social package.

Fix: make getThread() call getThreadLocked() directly (no lock acquisition), since all callers already hold the mutex.

https://claude.ai/code/session_011itVdcSDugddjFKJQimLDb