### PR TITLE
Move Apps after Home in sidebar, alphabetize landing grid and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,16 +10,16 @@ Browsing is free. Searching, posting, and AI features use credits. You get 20 fr
 
 ### Services
 
-- **News** — Headlines and articles from RSS feeds, chronological, with AI summaries
-- **Markets** — Live crypto, futures, and commodity prices
-- **Video** — YouTube without ads, algorithms, or shorts
-- **Web** — Search the web without tracking
+- **Agent** — AI assistant that can search, answer, and build across every service
+- **Apps** — Build and use small, useful tools — or ask the agent to build one
 - **Blog** — Microblogging with daily AI-generated digests
 - **Chat** — AI-powered conversation on any topic
 - **Mail** — Private messaging and email
-- **Apps** — Build and use small, useful tools — or ask the agent to build one
-- **Agent** — AI assistant that can search, answer, and build across every service
+- **Markets** — Live crypto, futures, and commodity prices
+- **News** — Headlines and articles from RSS feeds, chronological, with AI summaries
+- **Video** — YouTube without ads, algorithms, or shorts
 - **Wallet** — Pay as you go — 1 credit = 1p
+- **Web** — Search the web without tracking
 
 Mu runs as a single Go binary on your own server or use the hosted version at [mu.xyz](https://mu.xyz).
 

--- a/home/home.go
+++ b/home/home.go
@@ -156,32 +156,18 @@ var landingTemplate = `<html lang="en">
       <h3>Services</h3>
       <p>The tools powering Mu</p>
       <div id="links">
-        <a href="/news" style="text-decoration: none; color: inherit;">
+        <a href="/agent" style="text-decoration: none; color: inherit;">
           <div class="block">
-            <img src="/news.png" alt="News" style="width: 32px; height: 32px; margin-bottom: 8px; filter: brightness(0);">
-            <b>News</b>
-            <div class="small">Headlines and articles with AI summaries</div>
+            <img src="/agent.svg" alt="Agent" style="width: 32px; height: 32px; margin-bottom: 8px; filter: brightness(0);">
+            <b>Agent</b>
+            <div class="small">AI that can search, answer, and build</div>
           </div>
         </a>
-        <a href="/markets" style="text-decoration: none; color: inherit;">
+        <a href="/apps" style="text-decoration: none; color: inherit;">
           <div class="block">
-            <img src="/markets.svg" alt="Markets" style="width: 32px; height: 32px; margin-bottom: 8px; filter: brightness(0);">
-            <b>Markets</b>
-            <div class="small">Live crypto, futures, and commodity prices</div>
-          </div>
-        </a>
-        <a href="/video" style="text-decoration: none; color: inherit;">
-          <div class="block">
-            <img src="/video.png" alt="Video" style="width: 32px; height: 32px; margin-bottom: 8px; filter: brightness(0);">
-            <b>Video</b>
-            <div class="small">YouTube without ads, algorithms, or shorts</div>
-          </div>
-        </a>
-        <a href="/web" style="text-decoration: none; color: inherit;">
-          <div class="block">
-            <img src="/search.svg" alt="Web" style="width: 32px; height: 32px; margin-bottom: 8px; filter: brightness(0);">
-            <b>Web</b>
-            <div class="small">Search the web without tracking</div>
+            <img src="/apps.svg" alt="Apps" style="width: 32px; height: 32px; margin-bottom: 8px; filter: brightness(0);">
+            <b>Apps</b>
+            <div class="small">Build small, useful tools — or ask the agent</div>
           </div>
         </a>
         <a href="/blog" style="text-decoration: none; color: inherit;">
@@ -205,18 +191,32 @@ var landingTemplate = `<html lang="en">
             <div class="small">Private messaging and email</div>
           </div>
         </a>
-        <a href="/apps" style="text-decoration: none; color: inherit;">
+        <a href="/markets" style="text-decoration: none; color: inherit;">
           <div class="block">
-            <img src="/apps.svg" alt="Apps" style="width: 32px; height: 32px; margin-bottom: 8px; filter: brightness(0);">
-            <b>Apps</b>
-            <div class="small">Build small, useful tools — or ask the agent</div>
+            <img src="/markets.svg" alt="Markets" style="width: 32px; height: 32px; margin-bottom: 8px; filter: brightness(0);">
+            <b>Markets</b>
+            <div class="small">Live crypto, futures, and commodity prices</div>
           </div>
         </a>
-        <a href="/agent" style="text-decoration: none; color: inherit;">
+        <a href="/news" style="text-decoration: none; color: inherit;">
           <div class="block">
-            <img src="/agent.svg" alt="Agent" style="width: 32px; height: 32px; margin-bottom: 8px; filter: brightness(0);">
-            <b>Agent</b>
-            <div class="small">AI that can search, answer, and build</div>
+            <img src="/news.png" alt="News" style="width: 32px; height: 32px; margin-bottom: 8px; filter: brightness(0);">
+            <b>News</b>
+            <div class="small">Headlines and articles with AI summaries</div>
+          </div>
+        </a>
+        <a href="/video" style="text-decoration: none; color: inherit;">
+          <div class="block">
+            <img src="/video.png" alt="Video" style="width: 32px; height: 32px; margin-bottom: 8px; filter: brightness(0);">
+            <b>Video</b>
+            <div class="small">YouTube without ads, algorithms, or shorts</div>
+          </div>
+        </a>
+        <a href="/web" style="text-decoration: none; color: inherit;">
+          <div class="block">
+            <img src="/search.svg" alt="Web" style="width: 32px; height: 32px; margin-bottom: 8px; filter: brightness(0);">
+            <b>Web</b>
+            <div class="small">Search the web without tracking</div>
           </div>
         </a>
       </div>

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -227,6 +227,7 @@ var Template = `
         </div>
         <div id="nav">
           <a href="/home"><img src="/home.png?` + Version + `"><span class="label">Home</span></a>
+          <a href="/apps"><img src="/apps.svg?` + Version + `"><span class="label">Apps</span></a>
           <a href="/agent"><img src="/agent.svg?` + Version + `"><span class="label">Agent</span></a>
           <a href="/blog"><img src="/post.png?` + Version + `"><span class="label">Blog</span></a>
           <a href="/chat"><img src="/chat.png?` + Version + `"><span class="label">Chat</span></a>
@@ -234,7 +235,6 @@ var Template = `
           <a href="/news"><img src="/news.png?` + Version + `"><span class="label">News</span></a>
           <a href="/video"><img src="/video.png?` + Version + `"><span class="label">Video</span></a>
           <a href="/web"><img src="/search.svg?` + Version + `"><span class="label">Web</span></a>
-          <a href="/apps"><img src="/apps.svg?` + Version + `"><span class="label">Apps</span></a>
           <a id="nav-wallet" href="/wallet"><img src="/wallet.png?` + Version + `"><span class="label">Wallet</span></a>
 
         </div>


### PR DESCRIPTION
- Sidebar: Apps now appears directly after Home
- Landing page services grid: alphabetical order (Agent → Web)
- README services list: alphabetical order

https://claude.ai/code/session_016UhaM3HefwZjArvB7hHbpE