### PR TITLE
Add app edit page and apps_edit MCP tool

### DIFF
--- a/apps/apps.go
+++ b/apps/apps.go
@@ -156,6 +156,9 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 		handleCodeRun(w, r)
 	case path == "/sdk.js":
 		handleSDK(w, r)
+	case strings.HasSuffix(path, "/edit"):
+		slug := strings.TrimSuffix(strings.TrimPrefix(path, "/"), "/edit")
+		handleEdit(w, r, slug)
 	case strings.HasSuffix(path, "/icon.svg"):
 		slug := strings.TrimSuffix(strings.TrimPrefix(path, "/"), "/icon.svg")
 		handleIcon(w, r, slug)
@@ -483,13 +486,43 @@ func handleView(w http.ResponseWriter, r *http.Request, slug string) {
 	// Edit/delete for author
 	_, acc, err := auth.RequireSession(r)
 	if err == nil && acc.ID == a.AuthorID {
-		sb.WriteString(fmt.Sprintf(`<p style="margin-top:16px;"><a href="/apps/%s/run">Preview</a> · <a href="#" onclick="if(confirm('Delete this app?')){fetch('/apps/%s',{method:'DELETE'}).then(()=>location='/apps')}">Delete</a></p>`,
-			htmlpkg.EscapeString(a.Slug), htmlpkg.EscapeString(a.Slug)))
+		sb.WriteString(fmt.Sprintf(`<p style="margin-top:16px;"><a href="/apps/%s/edit">Edit</a> · <a href="/apps/%s/run">Preview</a> · <a href="#" onclick="if(confirm('Delete this app?')){fetch('/apps/%s',{method:'DELETE'}).then(()=>location='/apps')}">Delete</a></p>`,
+			htmlpkg.EscapeString(a.Slug), htmlpkg.EscapeString(a.Slug), htmlpkg.EscapeString(a.Slug)))
 	}
 
 	app.Respond(w, r, app.Response{
 		Title:       a.Name,
 		Description: a.Description,
+		HTML:        sb.String(),
+	})
+}
+
+// handleEdit shows the builder pre-populated with the app's data for editing.
+func handleEdit(w http.ResponseWriter, r *http.Request, slug string) {
+	_, acc, err := auth.RequireSession(r)
+	if err != nil {
+		app.Unauthorized(w, r)
+		return
+	}
+
+	mutex.RLock()
+	a, ok := apps[slug]
+	mutex.RUnlock()
+	if !ok {
+		app.Error(w, r, http.StatusNotFound, "App not found")
+		return
+	}
+	if a.AuthorID != acc.ID {
+		app.Forbidden(w, r, "You can only edit your own apps")
+		return
+	}
+
+	var sb strings.Builder
+	sb.WriteString(editPageHTML(a))
+
+	app.Respond(w, r, app.Response{
+		Title:       "Edit " + a.Name,
+		Description: "Edit " + a.Name,
 		HTML:        sb.String(),
 	})
 }
@@ -822,6 +855,41 @@ func GetApp(slug string) *App {
 	mutex.RLock()
 	defer mutex.RUnlock()
 	return apps[slug]
+}
+
+// UpdateApp updates an existing app's fields. Only non-empty values are applied.
+// Returns the updated app or an error.
+func UpdateApp(slug, name, description, tags, html, icon string) (*App, error) {
+	mutex.Lock()
+	a, ok := apps[slug]
+	if !ok {
+		mutex.Unlock()
+		return nil, fmt.Errorf("app not found")
+	}
+	if name != "" {
+		a.Name = name
+	}
+	if description != "" {
+		a.Description = description
+	}
+	if tags != "" {
+		a.Tags = tags
+	}
+	if icon != "" {
+		a.Icon = icon
+	}
+	if html != "" {
+		if len(html) > MaxHTMLSize {
+			mutex.Unlock()
+			return nil, fmt.Errorf("HTML content exceeds 256KB limit")
+		}
+		a.HTML = html
+	}
+	a.UpdatedAt = time.Now()
+	mutex.Unlock()
+
+	save()
+	return a, nil
 }
 
 // GetPublicApps returns all public apps sorted by installs.

--- a/apps/builder.go
+++ b/apps/builder.go
@@ -526,3 +526,191 @@ function slugify(s) {
 }
 </script>`, templateButtons.String(), string(escapedCode))
 }
+
+// editPageHTML returns the HTML for editing an existing app (reuses builder UI).
+func editPageHTML(a *App) string {
+	escapedCode, _ := json.Marshal(a.HTML)
+	escapedName, _ := json.Marshal(a.Name)
+	escapedDesc, _ := json.Marshal(a.Description)
+	escapedTags, _ := json.Marshal(a.Tags)
+	escapedIcon, _ := json.Marshal(a.Icon)
+	escapedSlug, _ := json.Marshal(a.Slug)
+
+	return fmt.Sprintf(`
+<style>
+.builder { display: flex; flex-direction: column; gap: 12px; }
+.prompt-bar { display: flex; gap: 8px; }
+.prompt-bar input { flex: 1; padding: 10px 14px; border: 1px solid #e0e0e0; border-radius: 6px; font-size: 15px; font-family: inherit; }
+.prompt-bar button { padding: 10px 24px; background: #000; color: #fff; border: none; border-radius: 6px; cursor: pointer; font-family: inherit; font-size: 15px; white-space: nowrap; }
+.prompt-bar button:disabled { background: #ccc; cursor: not-allowed; }
+.preview-area { display: flex; flex-direction: column; min-height: 60vh; }
+.preview-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 6px; }
+.preview-header h3 { font-size: 14px; font-weight: 600; margin: 0; }
+.preview-frame { flex: 1; border: 1px solid #e0e0e0; border-radius: 6px; background: #fff; min-height: 50vh; }
+.code-toggle { padding: 4px 12px; border: 1px solid #e0e0e0; border-radius: 6px; background: #fff; color: #333; cursor: pointer; font-size: 12px; font-family: inherit; }
+.code-toggle:hover { background: #f5f5f5; color: #111; }
+.code-section { display: none; margin-top: 12px; }
+.code-section.visible { display: block; }
+.code-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 6px; }
+.code-header h3 { font-size: 14px; font-weight: 600; margin: 0; }
+.code-header .actions { display: flex; gap: 6px; }
+.code-header .actions button { padding: 4px 12px; border: 1px solid #e0e0e0; border-radius: 6px; background: #fff; color: #333; cursor: pointer; font-size: 12px; font-family: inherit; }
+.code-header .actions button:hover { background: #f5f5f5; color: #111; }
+.code-editor { width: 100%%; min-height: 300px; padding: 12px; border: 1px solid #e0e0e0; border-radius: 6px; font-family: 'SF Mono', 'Fira Code', 'Cascadia Code', monospace; font-size: 13px; line-height: 1.5; resize: vertical; tab-size: 2; background: #fafafa; }
+.save-bar { display: flex; gap: 8px; align-items: center; flex-wrap: wrap; }
+.save-bar input { padding: 8px 12px; border: 1px solid #e0e0e0; border-radius: 6px; font-family: inherit; font-size: 14px; color: #333; box-sizing: border-box; }
+.save-bar input.name { flex: 1; min-width: 150px; }
+.save-bar button { padding: 8px 20px; background: #000; color: #fff; border: none; border-radius: 6px; cursor: pointer; font-family: inherit; white-space: nowrap; }
+.status-msg { font-size: 13px; color: #999; margin-left: 8px; }
+@media (max-width: 768px) {
+  .save-bar { flex-direction: column; align-items: stretch; }
+  .save-bar input.name { width: 100%%; min-width: auto; }
+  .save-bar input { width: 100%%; }
+  .prompt-bar { flex-direction: column; }
+  .prompt-bar input, .prompt-bar button { width: 100%%; box-sizing: border-box; }
+}
+</style>
+
+<div class="builder">
+  <p class="card-desc">Edit your app — modify with AI or update the code directly.</p>
+
+  <div class="prompt-bar">
+    <input type="text" id="prompt" placeholder="Describe changes... e.g. add a dark mode toggle" onkeydown="if(event.key==='Enter')generate()">
+    <button id="genBtn" onclick="generate()">Modify</button>
+  </div>
+
+  <div class="preview-area">
+    <div class="preview-header">
+      <h3>Preview</h3>
+      <button class="code-toggle" id="codeToggle" onclick="toggleCode()">Show Code</button>
+    </div>
+    <iframe id="preview" class="preview-frame" sandbox="allow-scripts"></iframe>
+  </div>
+
+  <div class="code-section" id="codeSection">
+    <div class="code-header">
+      <h3>Code</h3>
+      <div class="actions">
+        <button onclick="copyCode()">Copy</button>
+        <button onclick="updatePreview()">Refresh Preview</button>
+      </div>
+    </div>
+    <textarea class="code-editor" id="code" spellcheck="false"></textarea>
+  </div>
+
+  <div class="save-bar">
+    <input class="name" type="text" id="appName" placeholder="App name">
+    <input type="text" id="appDesc" placeholder="Description" style="flex:1;min-width:120px;">
+    <input type="text" id="appTags" placeholder="Tags (optional)" style="width:140px;">
+    <button onclick="saveApp()">Save</button>
+    <span class="status-msg" id="statusMsg"></span>
+  </div>
+</div>
+
+<script>
+var codeEl = document.getElementById('code');
+var preview = document.getElementById('preview');
+var appIcon = %s;
+var editSlug = %s;
+
+// Pre-populate fields
+codeEl.value = %s;
+document.getElementById('appName').value = %s;
+document.getElementById('appDesc').value = %s;
+document.getElementById('appTags').value = %s;
+showPreview();
+
+codeEl.addEventListener('keydown', function(e) {
+  if (e.key === 'Tab') {
+    e.preventDefault();
+    var start = this.selectionStart, end = this.selectionEnd;
+    this.value = this.value.substring(0, start) + '  ' + this.value.substring(end);
+    this.selectionStart = this.selectionEnd = start + 2;
+  }
+});
+
+function showPreview() {
+  var html = codeEl.value;
+  if (!html.trim()) return;
+  preview.style.display = '';
+  preview.srcdoc = html;
+}
+
+function updatePreview() { showPreview(); }
+
+function toggleCode() {
+  var section = document.getElementById('codeSection');
+  var btn = document.getElementById('codeToggle');
+  if (section.classList.contains('visible')) {
+    section.classList.remove('visible');
+    btn.textContent = 'Show Code';
+  } else {
+    section.classList.add('visible');
+    btn.textContent = 'Hide Code';
+  }
+}
+
+function generate() {
+  var promptEl = document.getElementById('prompt');
+  var p = promptEl.value.trim();
+  if (!p) return;
+  var btn = document.getElementById('genBtn');
+  btn.disabled = true;
+  btn.textContent = 'Generating...';
+  document.getElementById('statusMsg').textContent = '';
+
+  fetch('/apps/build/generate', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ prompt: p, code: codeEl.value })
+  })
+  .then(function(r) { return r.json(); })
+  .then(function(data) {
+    if (data.error) { document.getElementById('statusMsg').textContent = data.error; return; }
+    codeEl.value = data.html;
+    showPreview();
+    if (data.icon) { appIcon = data.icon; }
+  })
+  .catch(function(e) { document.getElementById('statusMsg').textContent = 'Error: ' + e.message; })
+  .finally(function() { btn.disabled = false; btn.textContent = 'Modify'; });
+}
+
+function saveApp() {
+  var name = document.getElementById('appName').value.trim();
+  var desc = document.getElementById('appDesc').value.trim();
+  var tags = (document.getElementById('appTags').value || '').trim();
+  var html = codeEl.value.trim();
+  if (!name) { document.getElementById('statusMsg').textContent = 'App name is required'; return; }
+  if (!html) { document.getElementById('statusMsg').textContent = 'No code to save'; return; }
+
+  document.getElementById('statusMsg').textContent = 'Saving...';
+  fetch('/apps/' + editSlug, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name: name, icon: appIcon, description: desc, tags: tags, html: html })
+  })
+  .then(function(r) {
+    if (!r.ok) {
+      return r.text().then(function(t) {
+        try { var j = JSON.parse(t); throw new Error(j.error || 'Save failed'); }
+        catch(e) { if (e.message) throw e; throw new Error('Save failed (status ' + r.status + ')'); }
+      });
+    }
+    return r.json();
+  })
+  .then(function(data) {
+    if (data.error) { document.getElementById('statusMsg').textContent = data.error; return; }
+    document.getElementById('statusMsg').textContent = 'Saved!';
+    window.location.href = '/apps/' + editSlug;
+  })
+  .catch(function(e) { document.getElementById('statusMsg').textContent = e.message || 'Save failed'; });
+}
+
+function copyCode() {
+  navigator.clipboard.writeText(codeEl.value).then(function() {
+    document.getElementById('statusMsg').textContent = 'Copied!';
+    setTimeout(function() { document.getElementById('statusMsg').textContent = ''; }, 2000);
+  });
+}
+</script>`, escapedIcon, escapedSlug, escapedCode, escapedName, escapedDesc, escapedTags)
+}

--- a/main.go
+++ b/main.go
@@ -311,6 +311,35 @@ func main() {
 		},
 	})
 	api.RegisterTool(api.Tool{
+		Name:        "apps_edit",
+		Description: "Edit an existing app — update its name, description, tags, icon, or HTML code",
+		Params: []api.ToolParam{
+			{Name: "slug", Type: "string", Description: "The app's URL slug (e.g. pomodoro-timer)", Required: true},
+			{Name: "name", Type: "string", Description: "New app name", Required: false},
+			{Name: "description", Type: "string", Description: "New description", Required: false},
+			{Name: "tags", Type: "string", Description: "New comma-separated tags", Required: false},
+			{Name: "html", Type: "string", Description: "New HTML content (max 256KB)", Required: false},
+			{Name: "icon", Type: "string", Description: "New SVG icon", Required: false},
+		},
+		Handle: func(args map[string]any) (string, error) {
+			slug, _ := args["slug"].(string)
+			if slug == "" {
+				return `{"error":"slug is required"}`, fmt.Errorf("missing slug")
+			}
+			name, _ := args["name"].(string)
+			description, _ := args["description"].(string)
+			tags, _ := args["tags"].(string)
+			html, _ := args["html"].(string)
+			icon, _ := args["icon"].(string)
+			a, err := apps.UpdateApp(slug, name, description, tags, html, icon)
+			if err != nil {
+				return fmt.Sprintf(`{"error":"%s"}`, err.Error()), err
+			}
+			b, _ := json.Marshal(a)
+			return string(b), nil
+		},
+	})
+	api.RegisterTool(api.Tool{
 		Name:        "apps_build",
 		Description: "AI-generate an app from a natural language description, save it, and return the app details with URL",
 		WalletOp:    "chat_query",


### PR DESCRIPTION
- Add /apps/{slug}/edit route with builder UI pre-populated with app data
- Add Edit link on app view page for authors (alongside Preview and Delete)
- Add exported UpdateApp function for programmatic updates
- Register apps_edit MCP tool for AI agents to edit apps
- Edit page supports AI-assisted modifications via the same generate endpoint

https://claude.ai/code/session_016UhaM3HefwZjArvB7hHbpE