### PR TITLE
Reminder page: use message as card title, fix section spacing

### DIFF
--- a/internal/app/html/mu.css
+++ b/internal/app/html/mu.css
@@ -4312,14 +4312,8 @@ a.btn-secondary:hover, .btn-secondary:hover {
   max-width: 750px;
 }
 
-.reminder-intro {
-  color: var(--text-secondary);
-  line-height: 1.6;
-  margin-bottom: var(--spacing-md);
-}
-
 .reminder-section {
-  padding-top: var(--spacing-md);
+  padding: var(--spacing-lg) 0;
   border-top: 1px solid var(--border-color);
 }
 
@@ -4328,15 +4322,15 @@ a.btn-secondary:hover, .btn-secondary:hover {
   border-top: none;
 }
 
+.reminder-section:last-child {
+  padding-bottom: 0;
+}
+
 .reminder-section h5 {
   margin: 0 0 2px 0;
   font-size: 0.95em;
   font-weight: var(--font-weight-semibold);
   color: var(--text-primary);
-}
-
-.reminder-section-last {
-  padding-bottom: 0;
 }
 
 .reminder-text {

--- a/reminder/reminder.go
+++ b/reminder/reminder.go
@@ -272,12 +272,13 @@ func generateReminderPage(rd *ReminderData) string {
 
 	sb.WriteString(`<div class="reminder-page">`)
 
-	// Message as intro text above the card
+	// Message as the card title — avoids "Reminder" / "Reminder" duplication
+	cardTitle := "Today's Reminder"
 	if rd.Message != "" {
-		sb.WriteString(fmt.Sprintf(`<p class="reminder-intro">%s</p>`, rd.Message))
+		cardTitle = rd.Message
 	}
 
-	// Single card with all content
+	// Single card with all content as sections
 	var content strings.Builder
 
 	// Verse section
@@ -327,7 +328,7 @@ func generateReminderPage(rd *ReminderData) string {
 	content.WriteString(app.Link("Discuss this reminder", "/chat?id=reminder_daily"))
 	content.WriteString(`</div>`)
 
-	sb.WriteString(app.Card("reminder", "Reminder", content.String()))
+	sb.WriteString(app.Card("reminder", cardTitle, content.String()))
 
 	sb.WriteString(`</div>`)
 


### PR DESCRIPTION
- Card title is now the message text instead of "Reminder" (avoids duplicating the page title)
- Sections use generous top/bottom padding so the dividers and links have proper breathing room between them

https://claude.ai/code/session_016UhaM3HefwZjArvB7hHbpE