### PR TITLE
Reminder page: h3 titles, muted subtitles, readable text color

### DIFF
--- a/internal/app/html/mu.css
+++ b/internal/app/html/mu.css
@@ -4326,17 +4326,23 @@ a.btn-secondary:hover, .btn-secondary:hover {
   padding-bottom: 0;
 }
 
-.reminder-section h5 {
+.reminder-section h3 {
   margin: 0 0 2px 0;
-  font-size: 0.95em;
+  font-size: 1.1em;
   font-weight: var(--font-weight-semibold);
   color: var(--text-primary);
+}
+
+.reminder-subtitle {
+  margin: 0 0 var(--spacing-sm) 0;
+  font-size: 0.85em;
+  color: var(--text-muted);
 }
 
 .reminder-text {
   font-size: 0.95em;
   line-height: 1.7;
-  color: var(--text-secondary);
+  color: var(--text-primary);
   white-space: pre-wrap;
   margin-bottom: var(--spacing-sm);
 }

--- a/reminder/reminder.go
+++ b/reminder/reminder.go
@@ -284,8 +284,8 @@ func generateReminderPage(rd *ReminderData) string {
 	// Verse section
 	if rd.Verse != "" {
 		content.WriteString(`<div class="reminder-section">`)
-		content.WriteString(`<h5>Verse</h5>`)
-		content.WriteString(`<p class="info">From the Quran</p>`)
+		content.WriteString(`<h3>Verse</h3>`)
+		content.WriteString(`<p class="reminder-subtitle">From the Quran</p>`)
 		content.WriteString(fmt.Sprintf(`<div class="reminder-text">%s</div>`, rd.Verse))
 		if rd.Links != nil {
 			if verseLink, ok := rd.Links["verse"].(string); ok && verseLink != "" {
@@ -298,8 +298,8 @@ func generateReminderPage(rd *ReminderData) string {
 	// Hadith section
 	if rd.Hadith != "" {
 		content.WriteString(`<div class="reminder-section">`)
-		content.WriteString(`<h5>Hadith</h5>`)
-		content.WriteString(`<p class="info">From Sahih Al Bukhari</p>`)
+		content.WriteString(`<h3>Hadith</h3>`)
+		content.WriteString(`<p class="reminder-subtitle">From Sahih Al Bukhari</p>`)
 		content.WriteString(fmt.Sprintf(`<div class="reminder-text">%s</div>`, rd.Hadith))
 		if rd.Links != nil {
 			if hadithLink, ok := rd.Links["hadith"].(string); ok && hadithLink != "" {
@@ -312,8 +312,8 @@ func generateReminderPage(rd *ReminderData) string {
 	// Name section
 	if rd.Name != "" {
 		content.WriteString(`<div class="reminder-section">`)
-		content.WriteString(`<h5>Name</h5>`)
-		content.WriteString(`<p class="info">From the names of Allah</p>`)
+		content.WriteString(`<h3>Name</h3>`)
+		content.WriteString(`<p class="reminder-subtitle">From the names of Allah</p>`)
 		content.WriteString(fmt.Sprintf(`<div class="reminder-text">%s</div>`, rd.Name))
 		if rd.Links != nil {
 			if nameLink, ok := rd.Links["name"].(string); ok && nameLink != "" {


### PR DESCRIPTION
- Section titles now h3 instead of h5
- Subtitles (From the Quran, etc.) styled as muted grey
- Content text uses text-primary instead of text-secondary so the actual verse/hadith/name text is easy to read

https://claude.ai/code/session_016UhaM3HefwZjArvB7hHbpE