### PR TITLE
Remove reminder page, redirect /reminder to reminder.dev

### DIFF
--- a/chat/chat.go
+++ b/chat/chat.go
@@ -441,12 +441,12 @@ func getOrCreateRoom(id string) *Room {
 			if len(room.Summary) > 2000 {
 				room.Summary = room.Summary[:2000] + "..."
 			}
-			room.URL = "/reminder"
+			room.URL = "https://reminder.dev"
 			app.Log("chat", "Room context - Title: %s, Summary length: %d, URL: %s", room.Title, len(room.Summary), room.URL)
 		} else if room.Title == "" {
 			app.Log("chat", "Reminder item %s not found in index", itemID)
 			room.Title = "Daily Reminder Discussion"
-			room.URL = "/reminder"
+			room.URL = "https://reminder.dev"
 		}
 
 		// Load persisted messages

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -665,45 +665,6 @@ func init() {
 		},
 	})
 
-	Endpoints = append(Endpoints, &Endpoint{
-		Name:        "Reminder",
-		Path:        "/reminder",
-		Method:      "GET",
-		Description: "Get the daily Islamic reminder with Quranic verse, hadith, and name of Allah",
-		Response: []*Value{
-			{
-				Type: "JSON",
-				Params: []*Param{
-					{
-						Name:        "verse",
-						Value:       "string",
-						Description: "Quranic verse",
-					},
-					{
-						Name:        "name",
-						Value:       "string",
-						Description: "Name of Allah",
-					},
-					{
-						Name:        "hadith",
-						Value:       "string",
-						Description: "Hadith text",
-					},
-					{
-						Name:        "message",
-						Value:       "string",
-						Description: "Additional message",
-					},
-					{
-						Name:        "updated",
-						Value:       "string",
-						Description: "Last updated timestamp",
-					},
-				},
-			},
-		},
-	})
-
 	// Weather endpoints
 	Endpoints = append(Endpoints, &Endpoint{
 		Name:        "Weather Forecast",

--- a/internal/app/html/index.html
+++ b/internal/app/html/index.html
@@ -109,7 +109,7 @@
              <div class="small">Live crypto, futures and commodity prices</div>
            </div>
          </a>
-         <a href="/reminder" style="text-decoration: none; color: inherit;">
+         <a href="https://reminder.dev" style="text-decoration: none; color: inherit;">
            <div class="block">
              <img src="/reminder.svg" alt="Reminder" style="width: 32px; height: 32px; margin-bottom: 8px; filter: brightness(0);">
              <b>Reminder</b>

--- a/internal/app/html/mu.css
+++ b/internal/app/html/mu.css
@@ -1857,42 +1857,6 @@ a.highlight {
   overflow-y: scroll;
   max-height: 200px;
 }
-
-/* Reminder page */
-.reminder-message {
-  font-size: 1.1em;
-  line-height: 1.6;
-  margin-bottom: 1.5em;
-  color: #333;
-}
-
-.reminder-section {
-  margin-bottom: 1.5em;
-}
-
-.reminder-section h3 {
-  font-size: 0.85em;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  color: #888;
-  margin: 0 0 0.5em;
-}
-
-.reminder-section blockquote {
-  margin: 0;
-  padding: 0.75em 1em;
-  border-left: 3px solid #ddd;
-  color: #444;
-  line-height: 1.6;
-  white-space: pre-wrap;
-}
-
-.reminder-section p {
-  margin: 0;
-  line-height: 1.6;
-  color: #444;
-}
-
 .video {
   position: relative;
   padding-bottom: 56.25%;

--- a/main.go
+++ b/main.go
@@ -406,7 +406,6 @@ func main() {
 		"/home":            false, // Public viewing
 		"/blog":            false, // Public viewing, auth for posting
 		"/markets":         false, // Public viewing
-		"/reminder":        false, // Public viewing
 		"/places":          false, // Public map, auth for search
 		"/weather":         false, // Public page, auth for forecast lookup
 		"/mail":            true,  // Require auth for inbox
@@ -544,7 +543,7 @@ func main() {
 	// serve markets page
 	http.HandleFunc("/markets", markets.Handler)
 
-	// serve reminder page
+	// redirect /reminder to reminder.dev
 	http.HandleFunc("/reminder", reminder.Handler)
 
 	// serve places page

--- a/reminder/reminder.go
+++ b/reminder/reminder.go
@@ -60,7 +60,7 @@ func fetchReminder() {
 	data.SaveFile("reminder.json", string(b))
 
 	html := fmt.Sprintf(`<div class="item"><div class="verse">%s</div></div>`, val["verse"])
-	html += app.Link("More", "/reminder")
+	html += app.Link("Read on reminder.dev", "https://reminder.dev")
 
 	reminderMutex.Lock()
 	reminderHTML = html
@@ -93,7 +93,7 @@ func fetchReminder() {
 		"Daily Reminder",
 		summary,
 		map[string]interface{}{
-			"url":     "/reminder",
+			"url":     "https://reminder.dev",
 			"updated": updated,
 			"source":  "daily",
 		},
@@ -119,84 +119,9 @@ type ReminderData struct {
 	Links   map[string]interface{} `json:"links"`
 }
 
-// Handler handles /reminder requests
+// Handler redirects /reminder to reminder.dev
 func Handler(w http.ResponseWriter, r *http.Request) {
-	// JSON response for API
-	if app.WantsJSON(r) {
-		handleJSON(w, r)
-		return
-	}
-
-	rd, _ := getReminderForRequest(r)
-	if rd == nil {
-		http.Error(w, "Reminder not available", http.StatusServiceUnavailable)
-		return
-	}
-
-	var content string
-
-	// Message first — the daily reflection
-	if rd.Message != "" {
-		content += fmt.Sprintf(`<div class="reminder-message"><p>%s</p></div>`, rd.Message)
-	}
-
-	// Verse
-	if rd.Verse != "" {
-		content += `<div class="reminder-section">`
-		content += `<h3>Quran</h3>`
-		content += fmt.Sprintf(`<blockquote>%s</blockquote>`, rd.Verse)
-		content += `</div>`
-	}
-
-	// Hadith
-	if rd.Hadith != "" {
-		content += `<div class="reminder-section">`
-		content += `<h3>Hadith</h3>`
-		content += fmt.Sprintf(`<blockquote>%s</blockquote>`, rd.Hadith)
-		content += `</div>`
-	}
-
-	// Name of Allah
-	if rd.Name != "" {
-		content += `<div class="reminder-section">`
-		content += `<h3>Name of Allah</h3>`
-		content += fmt.Sprintf(`<p>%s</p>`, rd.Name)
-		content += `</div>`
-	}
-
-	html := app.RenderHTMLForRequest("Daily Reminder", "Today's Islamic reminder with verse, hadith, and name of Allah", content, r)
-	w.Write([]byte(html))
-}
-
-// getReminderForRequest returns the appropriate reminder data based on the
-// request's ?date= query parameter. If a date is provided, fetches the fixed
-// daily reminder for that date. Otherwise returns the latest (hourly) reminder.
-func getReminderForRequest(r *http.Request) (rd *ReminderData, date string) {
-	date = r.URL.Query().Get("date")
-	if date != "" {
-		// Validate date format
-		if _, err := time.Parse("2006-01-02", date); err != nil {
-			date = ""
-		}
-	}
-
-	if date != "" {
-		return GetDailyReminderForDate(date), date
-	}
-	return GetReminderData(), ""
-}
-
-// handleJSON returns reminder data as JSON
-func handleJSON(w http.ResponseWriter, r *http.Request) {
-	reminderData, _ := getReminderForRequest(r)
-	if reminderData == nil {
-		app.RespondJSON(w, map[string]interface{}{
-			"error": "Reminder data not available",
-		})
-		return
-	}
-
-	app.RespondJSON(w, reminderData)
+	http.Redirect(w, r, "https://reminder.dev", http.StatusFound)
 }
 
 // GetReminderData loads the cached reminder data (from api/latest, rotates hourly)

--- a/reminder/reminder.go
+++ b/reminder/reminder.go
@@ -60,7 +60,7 @@ func fetchReminder() {
 	data.SaveFile("reminder.json", string(b))
 
 	html := fmt.Sprintf(`<div class="item"><div class="verse">%s</div></div>`, val["verse"])
-	html += app.Link("Read on reminder.dev", "https://reminder.dev")
+	html += app.Link("More", "https://reminder.dev")
 
 	reminderMutex.Lock()
 	reminderHTML = html


### PR DESCRIPTION
- Remove the full reminder page (Handler now just redirects to reminder.dev)
- Home card links to reminder.dev
- Chat room URLs point to reminder.dev
- Card "More" link says "Read on reminder.dev"
- Indexed URL points to reminder.dev
- Remove /reminder API endpoint docs
- Remove reminder-section CSS
- Agent and MCP tools unchanged

https://claude.ai/code/session_016UhaM3HefwZjArvB7hHbpE