### PR TITLE
Re-enable news summaries and improve reader page formatting

### DIFF
--- a/internal/app/html/mu.css
+++ b/internal/app/html/mu.css
@@ -1567,6 +1567,106 @@ body:has(#messages) #chat-back-link {
   text-decoration: none;
 }
 
+/* Reader content styling */
+.reader-content {
+  line-height: 1.7;
+  font-size: 15px;
+  color: var(--text-primary);
+}
+
+.reader-content p {
+  margin: 0 0 16px;
+}
+
+.reader-content h1, .reader-content h2, .reader-content h3,
+.reader-content h4, .reader-content h5, .reader-content h6 {
+  margin: 24px 0 12px;
+  line-height: 1.3;
+}
+
+.reader-content h1 { font-size: 1.6em; }
+.reader-content h2 { font-size: 1.35em; }
+.reader-content h3 { font-size: 1.15em; }
+
+.reader-content ul, .reader-content ol {
+  margin: 0 0 16px;
+  padding-left: 24px;
+}
+
+.reader-content li {
+  margin-bottom: 6px;
+}
+
+.reader-content blockquote {
+  margin: 16px 0;
+  padding: 12px 20px;
+  border-left: 3px solid var(--border-color, #ddd);
+  color: var(--text-secondary);
+  background: var(--bg-secondary, #f8f8f8);
+  border-radius: 4px;
+}
+
+.reader-content pre {
+  margin: 16px 0;
+  padding: 14px;
+  background: var(--bg-secondary, #f5f5f5);
+  border-radius: 6px;
+  overflow-x: auto;
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.reader-content code {
+  font-size: 0.9em;
+  padding: 2px 5px;
+  background: var(--bg-secondary, #f5f5f5);
+  border-radius: 3px;
+}
+
+.reader-content pre code {
+  padding: 0;
+  background: none;
+}
+
+.reader-content a {
+  color: var(--link-color, #1a73e8);
+  text-decoration: underline;
+}
+
+.reader-content table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 16px 0;
+  font-size: 14px;
+}
+
+.reader-content th, .reader-content td {
+  padding: 8px 12px;
+  border: 1px solid var(--border-color, #ddd);
+  text-align: left;
+}
+
+.reader-content th {
+  background: var(--bg-secondary, #f5f5f5);
+  font-weight: 600;
+}
+
+.reader-content hr {
+  border: none;
+  border-top: 1px solid var(--border-color, #ddd);
+  margin: 24px 0;
+}
+
+.reader-content figure {
+  margin: 16px 0;
+}
+
+.reader-content figcaption {
+  font-size: 13px;
+  color: var(--text-secondary);
+  margin-top: 6px;
+}
+
 /* Video info styling */
 .thumbnail .info {
   font-size: 0.8em;

--- a/news/news.go
+++ b/news/news.go
@@ -799,14 +799,7 @@ func shouldRequestSummary(md *Metadata) bool {
 }
 
 // requestArticleSummary publishes a request for LLM summary generation.
-// DISABLED: Article summaries were consuming ~50 AI calls/day with no active users.
-// The RSS feed description is used as the summary fallback instead.
-// To re-enable, remove the early return below.
 func requestArticleSummary(uri string, md *Metadata) {
-	// Cost reduction: skip AI-generated summaries entirely.
-	// Articles already have descriptions from RSS feeds which serve as adequate summaries.
-	return
-
 	// Skip if we already have a summary
 	if md.Summary != "" {
 		return

--- a/search/fetch.go
+++ b/search/fetch.go
@@ -187,6 +187,170 @@ func FetchAndExtract(rawURL string) (string, string, error) {
 	return title, readable, nil
 }
 
+// FetchAndExtractHTML fetches a URL and returns the page title and sanitized readable HTML.
+// Unlike FetchAndExtract which returns plain text, this preserves structural HTML
+// (headings, paragraphs, lists, emphasis, links) for a clean reading experience.
+func FetchAndExtractHTML(rawURL string) (string, string, error) {
+	req, err := http.NewRequest("GET", rawURL, nil)
+	if err != nil {
+		return "", "", err
+	}
+	req.Header.Set("User-Agent", "Mozilla/5.0 (compatible; Mu/1.0; +https://mu.al)")
+	req.Header.Set("Accept", "text/html,application/xhtml+xml,*/*;q=0.8")
+
+	start := time.Now()
+	resp, err := fetchClient.Do(req)
+	duration := time.Since(start)
+	if err != nil {
+		app.RecordAPICall("fetch", "GET", rawURL, 0, duration, err, "", "")
+		return "", "", fmt.Errorf("request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		app.RecordAPICall("fetch", "GET", rawURL, resp.StatusCode, duration, fmt.Errorf("HTTP %d", resp.StatusCode), "", "")
+		return "", "", fmt.Errorf("HTTP %d %s", resp.StatusCode, resp.Status)
+	}
+
+	limited := io.LimitReader(resp.Body, 2*1024*1024)
+	bodyBytes, err := io.ReadAll(limited)
+	if err != nil {
+		app.RecordAPICall("fetch", "GET", rawURL, resp.StatusCode, duration, err, "", "")
+		return "", "", fmt.Errorf("failed to read response: %v", err)
+	}
+
+	app.RecordAPICall("fetch", "GET", rawURL, resp.StatusCode, duration, nil, "", "")
+
+	content := string(bodyBytes)
+	if !utf8.ValidString(content) {
+		runes := make([]rune, len(bodyBytes))
+		for i, b := range bodyBytes {
+			runes[i] = rune(b)
+		}
+		content = string(runes)
+	}
+
+	title := extractTitle(content)
+	readable := sanitizeHTML(content)
+
+	return title, readable, nil
+}
+
+// sanitizeHTML extracts the main content and preserves safe structural HTML.
+// It keeps headings, paragraphs, lists, emphasis, links, and blockquotes
+// while removing scripts, ads, nav, and all other dangerous or noisy elements.
+func sanitizeHTML(htmlStr string) string {
+	content := extractMainContent(htmlStr)
+
+	// Remove dangerous/noisy blocks entirely
+	content = commentRe.ReplaceAllString(content, "")
+	for _, re := range []*regexp.Regexp{
+		removeScriptRe, removeStyleRe, removeNoscriptRe, removeIframeRe,
+		removeSvgRe, removeNavRe, removeHeaderRe, removeFooterRe,
+		removeAsideRe, removeFormRe,
+	} {
+		content = re.ReplaceAllString(content, "")
+	}
+
+	// Remove image tags (they usually break without their CSS context)
+	imgRe := regexp.MustCompile(`(?i)<img[^>]*>`)
+	content = imgRe.ReplaceAllString(content, "")
+
+	// Remove button elements
+	buttonRe := regexp.MustCompile(`(?is)<button[^>]*>.*?</button>`)
+	content = buttonRe.ReplaceAllString(content, "")
+
+	// Remove input elements
+	inputRe := regexp.MustCompile(`(?i)<input[^>]*>`)
+	content = inputRe.ReplaceAllString(content, "")
+
+	// Preserve <a> tags but sanitize attributes — keep only href
+	aTagRe := regexp.MustCompile(`(?i)<a\s[^>]*href=["']([^"']*)["'][^>]*>`)
+	content = aTagRe.ReplaceAllString(content, `<a href="$1" target="_blank" rel="noopener noreferrer">`)
+
+	// Strip all attributes from safe block/inline tags (keep the tags themselves)
+	safeBlockTags := regexp.MustCompile(`(?i)<(/?(?:p|h[1-6]|ul|ol|li|blockquote|pre|code|br|hr|strong|b|em|i|sub|sup|table|thead|tbody|tr|td|th|figcaption|figure|dl|dt|dd))\b[^>]*>`)
+	content = safeBlockTags.ReplaceAllString(content, `<$1>`)
+
+	// Remove <div> and <section> tags but keep content (replace with paragraph breaks)
+	divOpenRe := regexp.MustCompile(`(?i)<(?:div|section|article|main)[^>]*>`)
+	content = divOpenRe.ReplaceAllString(content, "\n")
+	divCloseRe := regexp.MustCompile(`(?i)</(?:div|section|article|main)>`)
+	content = divCloseRe.ReplaceAllString(content, "\n")
+
+	// Remove <span> tags but keep content (add space to prevent words merging)
+	spanOpenRe := regexp.MustCompile(`(?i)<span[^>]*>`)
+	content = spanOpenRe.ReplaceAllString(content, "")
+	spanCloseRe := regexp.MustCompile(`(?i)</span>`)
+	content = spanCloseRe.ReplaceAllString(content, " ")
+
+	// Remove any remaining unsafe tags (but keep their text content with spacing)
+	unsafeTagRe := regexp.MustCompile(`(?i)</?(?:label|abbr|time|mark|small|cite|dfn|var|samp|kbd|data|ruby|rt|rp|bdi|bdo|wbr|details|summary|dialog|slot|template|canvas|video|audio|source|track|map|area|object|embed|param|picture)\b[^>]*>`)
+	content = unsafeTagRe.ReplaceAllString(content, " ")
+
+	// Remove any remaining unknown/unsafe tags but preserve content
+	remainingTagRe := regexp.MustCompile(`</?[a-zA-Z][a-zA-Z0-9]*[^>]*>`)
+	// Check if it's a safe tag before removing
+	content = remainingTagRe.ReplaceAllStringFunc(content, func(tag string) string {
+		lower := strings.ToLower(tag)
+		// Keep safe tags
+		for _, safe := range []string{"<p", "</p", "<h1", "<h2", "<h3", "<h4", "<h5", "<h6",
+			"</h1", "</h2", "</h3", "</h4", "</h5", "</h6",
+			"<ul", "</ul", "<ol", "</ol", "<li", "</li",
+			"<blockquote", "</blockquote", "<pre", "</pre", "<code", "</code",
+			"<br", "<hr",
+			"<strong", "</strong", "<b>", "</b", "<em", "</em", "<i>", "</i",
+			"<a ", "</a", "<table", "</table", "<thead", "</thead", "<tbody", "</tbody",
+			"<tr", "</tr", "<td", "</td", "<th", "</th",
+			"<sub", "</sub", "<sup", "</sup",
+			"<figcaption", "</figcaption", "<figure", "</figure",
+			"<dl", "</dl", "<dt", "</dt", "<dd", "</dd"} {
+			if strings.HasPrefix(lower, safe) {
+				return tag
+			}
+		}
+		return " "
+	})
+
+	// Collapse excessive whitespace but preserve structure
+	content = multiSpaceRe.ReplaceAllString(content, " ")
+	// Clean up excessive newlines
+	excessiveNewlines := regexp.MustCompile(`(\s*\n\s*){3,}`)
+	content = excessiveNewlines.ReplaceAllString(content, "\n\n")
+
+	// Filter out junk lines (cookie banners etc)
+	lines := strings.Split(content, "\n")
+	var cleaned []string
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			cleaned = append(cleaned, "")
+			continue
+		}
+		textOnly := stripTags(trimmed)
+		lower := strings.ToLower(textOnly)
+		skip := false
+		for _, junk := range junkPatterns {
+			if strings.Contains(lower, junk) && len(textOnly) < 200 {
+				skip = true
+				break
+			}
+		}
+		if !skip {
+			cleaned = append(cleaned, line)
+		}
+	}
+
+	content = strings.Join(cleaned, "\n")
+	content = strings.TrimSpace(content)
+
+	if len(content) > 50000 {
+		content = content[:50000] + "\n\n<p><em>[Content truncated]</em></p>"
+	}
+
+	return content
+}
+
 // extractTitle pulls the <title> from HTML.
 var titleRe = regexp.MustCompile(`(?i)<title[^>]*>(.*?)</title>`)
 

--- a/search/read.go
+++ b/search/read.go
@@ -63,8 +63,8 @@ func ReadHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Fetch and extract
-	title, body, fetchErr := FetchAndExtract(rawURL)
+	// Fetch and extract — use HTML-preserving extraction for the reader
+	title, body, fetchErr := FetchAndExtractHTML(rawURL)
 
 	if fetchErr == nil {
 		wallet.ConsumeQuota(sess.Account, wallet.OpWebFetch)
@@ -112,16 +112,9 @@ func ReadHandler(w http.ResponseWriter, r *http.Request) {
 	// Meta: source domain
 	b.WriteString(fmt.Sprintf(`<div class="article-meta"><span>Source: <i>%s</i></span></div>`, html.EscapeString(domain)))
 
-	// Content as paragraphs
-	b.WriteString(`<div class="article-description">`)
-	paragraphs := strings.Split(body, "\n\n")
-	for _, p := range paragraphs {
-		p = strings.TrimSpace(p)
-		if p == "" {
-			continue
-		}
-		b.WriteString(`<p>` + html.EscapeString(p) + `</p>`)
-	}
+	// Render sanitized HTML content
+	b.WriteString(`<div class="reader-content">`)
+	b.WriteString(body)
 	b.WriteString(`</div>`)
 
 	// Actions


### PR DESCRIPTION
1. News summaries: Remove the early return that was disabling AI summary generation. Summaries were useful and worth the cost.

2. Reader formatting: Replace plain-text extraction with HTML sanitization. Instead of stripping all HTML tags (which caused words to merge and lost all structure), the reader now preserves safe structural HTML — headings, paragraphs, lists, blockquotes, emphasis, links, tables, and code blocks. Dangerous elements (scripts, styles, iframes, nav, ads) are still removed.

3. Reader CSS: Add dedicated .reader-content styles for clean typography — proper spacing for paragraphs, headings, lists, blockquotes, code blocks, and tables.

https://claude.ai/code/session_016UhaM3HefwZjArvB7hHbpE