### PR TITLE
Remove agent and apps cards from dashboard

### DIFF
--- a/home/cards.json
+++ b/home/cards.json
@@ -1,18 +1,10 @@
 {
   "left": [
     {
-      "id": "apps",
-      "title": "Apps",
-      "type": "apps",
-      "position": 0,
-      "link": "/apps",
-      "icon": ""
-    },
-    {
       "id": "blog",
       "title": "Blog",
       "type": "blog",
-      "position": 1,
+      "position": 0,
       "link": "/blog",
       "icon": "/post.png"
     },
@@ -20,7 +12,7 @@
       "id": "news",
       "title": "News",
       "type": "news",
-      "position": 2,
+      "position": 1,
       "link": "/news",
       "icon": "/news.png"
     }
@@ -35,18 +27,10 @@
       "icon": "/reminder.svg"
     },
     {
-      "id": "agent",
-      "title": "Agent",
-      "type": "agent",
-      "position": 1,
-      "link": "",
-      "icon": "/agent.svg"
-    },
-    {
       "id": "markets",
       "title": "Markets",
       "type": "markets",
-      "position": 2,
+      "position": 1,
       "link": "/markets",
       "icon": "/markets.svg"
     },
@@ -54,7 +38,7 @@
       "id": "video",
       "title": "Video",
       "type": "video",
-      "position": 3,
+      "position": 2,
       "link": "/video",
       "icon": "/video.png"
     }

--- a/internal/app/html/mu.css
+++ b/internal/app/html/mu.css
@@ -2230,32 +2230,13 @@ a.highlight {
     font-size: 12px;
   }
 
-  /* Reorder cards on mobile: dynamic content first, utilities lower */
+  /* Reorder cards on mobile */
   #reminder { order: 1; }
   #news { order: 2; }
   #markets { order: 3; }
   #blog { order: 4; }
   #video { order: 5; }
-  #agent { order: 6; }
-  #apps { order: 7; }
-  #home-chat { order: 8; }
-
-  /* Compact agent card on mobile — single-line utility bar */
-  #agent #home-agent-form > div:last-child {
-    display: none;
-  }
-  #agent #home-agent-form > div:first-child input {
-    font-size: 13px;
-    padding: 6px;
-  }
-  #agent #home-agent-form > div:first-child button {
-    padding: 6px 12px;
-    font-size: 13px;
-  }
-
-  /* Compact apps card on mobile */
-  #apps p { font-size: 13px; margin: 4px 0; }
-  #apps p img { width: 16px; height: 16px; }
+  #home-chat { order: 6; }
 
   .cover {
     display: block;


### PR DESCRIPTION
Both are accessible from the sidebar. They were static cards taking up space without providing fresh content on each visit.

https://claude.ai/code/session_016UhaM3HefwZjArvB7hHbpE