### PR TITLE
Add social media tracking and expand account coverage

### DIFF
--- a/social/social.go
+++ b/social/social.go
@@ -509,7 +509,7 @@ func handleGetFeed(w http.ResponseWriter, r *http.Request) {
 	body := pageBodyHTML
 	mutex.RUnlock()
 
-	if len(currentPosts) > 0 {
+	if body == "" {
 		body = generatePageHTML(currentPosts)
 	}
 


### PR DESCRIPTION
When pageBodyHTML is empty and no posts have been fetched, the page was blank. Now falls back to generatePageHTML which shows a "No posts yet" message.

https://claude.ai/code/session_016UhaM3HefwZjArvB7hHbpE