### PR TITLE
Use category labels for news posts, refresh social card, fix blog sor…

### DIFF
--- a/blog/blog.go
+++ b/blog/blog.go
@@ -207,9 +207,17 @@ func Load() {
 		return
 	}
 
-	// Sort posts by creation time (newest first)
+	// Sort posts by most recent activity (updated or created) newest first
 	sort.Slice(posts, func(i, j int) bool {
-		return posts[i].CreatedAt.After(posts[j].CreatedAt)
+		ti := posts[i].UpdatedAt
+		if ti.IsZero() {
+			ti = posts[i].CreatedAt
+		}
+		tj := posts[j].UpdatedAt
+		if tj.IsZero() {
+			tj = posts[j].CreatedAt
+		}
+		return ti.After(tj)
 	})
 
 	// Build postsMap for O(1) lookups
@@ -360,6 +368,19 @@ func updateCache() {
 
 // updateCacheUnlocked updates the cache without locking (caller must hold lock)
 func updateCacheUnlocked() {
+	// Re-sort posts by most recent activity (updated or created) newest first
+	sort.Slice(posts, func(i, j int) bool {
+		ti := posts[i].UpdatedAt
+		if ti.IsZero() {
+			ti = posts[i].CreatedAt
+		}
+		tj := posts[j].UpdatedAt
+		if tj.IsZero() {
+			tj = posts[j].CreatedAt
+		}
+		return ti.After(tj)
+	})
+
 	// Generate preview for home page (latest 1 post, exclude flagged and new accounts)
 	var preview []string
 	count := 0

--- a/home/home.go
+++ b/home/home.go
@@ -782,6 +782,12 @@ func Load() {
 			ForceRefresh()
 		}
 	}()
+	go func() {
+		sub := event.Subscribe("social_updated")
+		for range sub.Chan {
+			ForceRefresh()
+		}
+	}()
 }
 
 // RefreshCards updates card content and timestamps if content changed

--- a/social/social.go
+++ b/social/social.go
@@ -65,6 +65,8 @@ func addPost(p *Post) {
 
 	indexPosts([]*Post{p})
 	save()
+
+	event.Publish(event.Event{Type: "social_updated"})
 }
 
 func Load() {
@@ -120,17 +122,26 @@ func Load() {
 				content = content[:497] + "..."
 			}
 
+			// Look up the article's category from the index
+			itemID := fmt.Sprintf("%x", md5.Sum([]byte(uri)))[:16]
+			author := "News"
+			if entry := data.GetByID(itemID); entry != nil {
+				if cat, ok := entry.Metadata["category"].(string); ok && cat != "" {
+					author = cat
+				}
+			}
+
 			id := fmt.Sprintf("%x", md5.Sum([]byte("news:"+uri)))[:16]
 
 			addPost(&Post{
 				ID:       id,
-				Author:   "News",
+				Author:   author,
 				AuthorID: "_system",
 				Content:  content,
 				PostedAt: time.Now(),
 			})
 
-			app.Log("social", "Surfaced news: %s", content[:min(80, len(content))])
+			app.Log("social", "Surfaced %s: %s", author, content[:min(80, len(content))])
 		}
 	}()
 


### PR DESCRIPTION
…t order

- News posts now show their category (Politics, Finance, Tech, etc.) as the author instead of generic "News", looked up from the article's indexed metadata
- Publish "social_updated" event when posts are added so the home page forces a cache refresh immediately instead of waiting for 2min TTL
- Sort blog posts by UpdatedAt (falling back to CreatedAt) so edited posts rise to the top on both the blog page and the home card
- Re-sort on every cache rebuild, not just on initial load

https://claude.ai/code/session_016UhaM3HefwZjArvB7hHbpE