### PR TITLE
Fix breaking news detection: match on 2+ shared keywords instead of e…

### DIFF
--- a/social/social.go
+++ b/social/social.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 	"net/url"
 	"regexp"
-	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -139,83 +138,85 @@ func surfaceBreakingFromNews() {
 	// Only consider articles from the last 24 hours
 	cutoff := time.Now().Add(-24 * time.Hour)
 
-	// Group articles by normalised title keywords
-	type story struct {
-		title      string
-		url        string
-		categories map[string]bool
+	// Extract keywords from each recent article
+	type article struct {
+		title    string
+		url      string
+		category string
+		words    map[string]bool
 	}
-	stories := map[string]*story{}
+	var recent []article
 
 	for _, p := range feed {
 		if p.PostedAt.Before(cutoff) {
 			continue
 		}
-		key := normaliseTitle(p.Title)
-		if key == "" {
+		words := extractKeywords(p.Title)
+		if len(words) < 2 {
 			continue
 		}
-		if s, ok := stories[key]; ok {
-			s.categories[p.Category] = true
-		} else {
-			stories[key] = &story{
-				title:      p.Title,
-				url:        p.URL,
-				categories: map[string]bool{p.Category: true},
+		recent = append(recent, article{
+			title:    p.Title,
+			url:      p.URL,
+			category: p.Category,
+			words:    words,
+		})
+	}
+
+	// Find articles from different categories that share 2+ keywords
+	surfaced := map[string]bool{}
+	for i, a := range recent {
+		for j := i + 1; j < len(recent); j++ {
+			b := recent[j]
+			if a.category == b.category {
+				continue
+			}
+			// Count shared keywords
+			shared := 0
+			for w := range a.words {
+				if b.words[w] {
+					shared++
+				}
+			}
+			if shared >= 2 {
+				// Surface the first one (use URL as dedup key)
+				if !surfaced[a.url] {
+					surfaced[a.url] = true
+					SurfaceBreaking(a.title, a.url)
+					app.Log("social", "Breaking: %q matched across %s and %s", a.title, a.category, b.category)
+				}
 			}
 		}
 	}
-
-	// Surface stories covered by 2+ different categories
-	for _, s := range stories {
-		if len(s.categories) < 2 {
-			continue
-		}
-		SurfaceBreaking(s.title, s.url)
-	}
 }
 
-// normaliseTitle extracts key words from a title for fuzzy matching.
-// Strips common words and punctuation so "Trump signs new trade deal"
-// and "Trump Signs New Trade Deal With China" match on the same key.
-func normaliseTitle(title string) string {
+var stopWords = map[string]bool{
+	"a": true, "an": true, "the": true, "and": true, "or": true,
+	"but": true, "in": true, "on": true, "at": true, "to": true,
+	"for": true, "of": true, "with": true, "by": true, "from": true,
+	"is": true, "are": true, "was": true, "were": true, "be": true,
+	"has": true, "have": true, "had": true, "do": true, "does": true,
+	"did": true, "will": true, "would": true, "could": true, "should": true,
+	"may": true, "might": true, "can": true, "its": true, "it": true,
+	"that": true, "this": true, "as": true, "not": true, "no": true,
+	"new": true, "says": true, "said": true, "after": true, "over": true,
+	"into": true, "up": true, "out": true, "about": true, "than": true,
+	"how": true, "what": true, "when": true, "where": true, "who": true,
+	"why": true, "more": true, "been": true, "being": true, "just": true,
+}
+
+// extractKeywords pulls significant words from a headline
+func extractKeywords(title string) map[string]bool {
 	title = strings.ToLower(title)
-	// Remove punctuation
 	title = regexp.MustCompile(`[^a-z0-9\s]`).ReplaceAllString(title, "")
 
-	stop := map[string]bool{
-		"a": true, "an": true, "the": true, "and": true, "or": true,
-		"but": true, "in": true, "on": true, "at": true, "to": true,
-		"for": true, "of": true, "with": true, "by": true, "from": true,
-		"is": true, "are": true, "was": true, "were": true, "be": true,
-		"has": true, "have": true, "had": true, "do": true, "does": true,
-		"did": true, "will": true, "would": true, "could": true, "should": true,
-		"may": true, "might": true, "can": true, "its": true, "it": true,
-		"that": true, "this": true, "as": true, "not": true, "no": true,
-		"new": true, "says": true, "said": true, "after": true, "over": true,
-		"into": true, "up": true, "out": true, "about": true, "than": true,
-	}
-
-	var words []string
+	words := map[string]bool{}
 	for _, w := range strings.Fields(title) {
-		if !stop[w] && len(w) > 2 {
-			words = append(words, w)
+		if !stopWords[w] && len(w) > 2 {
+			words[w] = true
 		}
 	}
-
-	// Need at least 2 meaningful words to match
-	if len(words) < 2 {
-		return ""
-	}
-
-	// Use first 4 key words as the fingerprint
-	if len(words) > 4 {
-		words = words[:4]
-	}
-
-	// Sort so word order doesn't matter
-	sort.Strings(words)
-	return strings.Join(words, " ")
+	return words
 }
 
 // SurfaceBreaking creates a system thread from external sources (e.g., breaking news)


### PR DESCRIPTION
…xact key

Previous approach required exact match on first 4 sorted keywords, which almost never matched across sources. Now compares every pair of articles from different categories and surfaces when they share 2+ significant keywords. Logs which categories matched.

https://claude.ai/code/session_016UhaM3HefwZjArvB7hHbpE