### PR TITLE
Fix system posts being deleted on restart; left-align social feed

### DIFF
--- a/social/social.go
+++ b/social/social.go
@@ -87,27 +87,6 @@ func Load() {
 		}
 	}
 
-	// Remove system-generated news summary threads (not breaking news)
-	cleaned := false
-	mutex.Lock()
-	var kept []*Message
-	for _, m := range messages {
-		if m.AuthorID == "_system" && m.Author != "Breaking" {
-			cleaned = true
-			continue
-		}
-		kept = append(kept, m)
-	}
-	if cleaned {
-		messages = kept
-		updateCacheLocked()
-	}
-	mutex.Unlock()
-	if cleaned {
-		save()
-		app.Log("social", "Removed system-generated news summary threads")
-	}
-
 	loadedAt = time.Now()
 
 	// Detect breaking stories — headlines reported by multiple sources
@@ -641,7 +620,7 @@ func handleCreateReply(w http.ResponseWriter, r *http.Request) {
 
 func generateThreadHTML(p *Message, replies []*Message, r *http.Request) string {
 	var sb strings.Builder
-	sb.WriteString(`<div style="max-width:600px;margin:0 auto;">`)
+	sb.WriteString(`<div style="max-width:600px;">`)
 
 	// Back link
 	sb.WriteString(`<div style="margin-bottom:16px;"><a href="/social" style="color:#888;text-decoration:none;">&larr; Back to threads</a></div>`)
@@ -949,7 +928,7 @@ func generateCardHTML(allMessages []*Message) string {
 
 func generatePageHTML(visible []*Message, r *http.Request) string {
 	var sb strings.Builder
-	sb.WriteString(`<div style="max-width:600px;margin:0 auto;">`)
+	sb.WriteString(`<div style="max-width:600px;">`)
 
 	// Compose box (shown to logged-in users)
 	_, acc := auth.TrySession(r)


### PR DESCRIPTION
The cleanup filter was removing all _system posts whose Author != "Breaking", but we changed the author to category names (e.g. "Politics"). This caused all surfaced news posts to be wiped on every restart.

Also changed social feed from center-aligned to left-aligned to match the left-aligned page title on desktop.

https://claude.ai/code/session_016UhaM3HefwZjArvB7hHbpE