### PR TITLE
Reorder mobile home cards: move markets above social

### DIFF
--- a/internal/app/html/mu.css
+++ b/internal/app/html/mu.css
@@ -2232,9 +2232,9 @@ a.highlight {
 
   /* Reorder cards on mobile */
   #reminder { order: 1; }
-  #social { order: 2; }
-  #news { order: 3; }
-  #markets { order: 4; }
+  #markets { order: 2; }
+  #social { order: 3; }
+  #news { order: 4; }
   #blog { order: 5; }
   #video { order: 6; }
   #home-chat { order: 7; }


### PR DESCRIPTION
Mobile order is now: reminder, markets, social, news — matching the right column order on desktop.

https://claude.ai/code/session_016UhaM3HefwZjArvB7hHbpE