### PR TITLE
Add X402 environment variables and payment status to server

### DIFF
--- a/admin/env.go
+++ b/admin/env.go
@@ -45,6 +45,11 @@ var knownEnvVars = []string{
 	"STRIPE_PUBLISHABLE_KEY",
 	"STRIPE_WEBHOOK_SECRET",
 	"GOCARDLESS_ACCESS_TOKEN",
+	// x402 crypto payments
+	"X402_PAY_TO",
+	"X402_FACILITATOR_URL",
+	"X402_NETWORK",
+	"X402_ASSET",
 	// Tor
 	"TOR_ONION",
 	// Misc

--- a/internal/app/status.go
+++ b/internal/app/status.go
@@ -274,15 +274,21 @@ func buildStatus() StatusResponse {
 		Status: googleConfigured,
 	})
 
-	// Check Payments (Stripe)
+	// Check Payments (Stripe + x402)
 	stripeConfigured := os.Getenv("STRIPE_SECRET_KEY") != "" && os.Getenv("STRIPE_PUBLISHABLE_KEY") != ""
+	x402Configured := os.Getenv("X402_PAY_TO") != ""
+	paymentsConfigured := stripeConfigured || x402Configured
 	quotaMode := "Unlimited (self-hosted)"
-	if stripeConfigured {
-		quotaMode = "Pay-as-you-go (card)"
+	if stripeConfigured && x402Configured {
+		quotaMode = "Card + crypto (x402)"
+	} else if stripeConfigured {
+		quotaMode = "Card (Stripe)"
+	} else if x402Configured {
+		quotaMode = "Crypto (x402)"
 	}
 	services = append(services, StatusCheck{
 		Name:    "Payments",
-		Status:  stripeConfigured,
+		Status:  paymentsConfigured,
 		Details: quotaMode,
 	})
 


### PR DESCRIPTION
- admin/env.go: track X402_PAY_TO, X402_FACILITATOR_URL, X402_NETWORK, X402_ASSET
- internal/app/status.go: show x402 payment status alongside Stripe

https://claude.ai/code/session_016UhaM3HefwZjArvB7hHbpE