### PR TITLE
Rewrite docs to lead with MCP + x402 as the agent story

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,24 @@ Mu exposes a [Model Context Protocol](https://modelcontextprotocol.io) (MCP) ser
 
 See [MCP Server docs](docs/MCP.md) for available tools and usage.
 
+### For AI Agents
+
+Mu is an API for the real world that AI agents can pay for on the fly. 30+ tools — news, search, weather, places, video, email, markets — accessible via MCP with per-request crypto payments through the [x402 protocol](https://x402.org).
+
+**No API keys. No accounts. Just call and pay.**
+
+An autonomous agent can search the web ($0.05), check the weather ($0.01), look up nearby restaurants ($0.05), and send an email ($0.04) — paying for each request with USDC from its own wallet. Zero onboarding friction.
+
+```bash
+# Call any tool — if payment is required, the server returns 402 with pricing
+curl -X POST https://mu.xyz/mcp \
+  -H "Content-Type: application/json" \
+  -H "X-PAYMENT: <payment-payload>" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"web_search","arguments":{"query":"..."}}}'
+```
+
+See [MCP Server docs](docs/MCP.md) for the full x402 payment flow and tool list.
+
 ## Screenshots
 
 ### Home

--- a/docs/MARKETPLACE.md
+++ b/docs/MARKETPLACE.md
@@ -339,17 +339,52 @@ Help providers build and test services.
 - **Integration**: Services work seamlessly with the agent — no context switching
 - **No lock-in**: Services are standard MCP — you can call them directly if you prefer
 
+## x402 and the Marketplace
+
+The [x402 protocol](https://x402.org) changes the marketplace economics. Instead of all payments flowing through Mu's credit system, providers can receive payments directly on-chain.
+
+### Two Settlement Models
+
+**Proxied (default):** Mu handles billing. User pays credits, Mu takes a cut, provider gets credited.
+
+```
+Agent → Mu (proxy) → Provider
+         ↓
+    Credit deduction
+    Provider payout
+```
+
+**Direct (x402):** Provider runs their own x402-enabled MCP server. Agents pay them directly. Mu acts as a discovery layer, not a payment intermediary.
+
+```
+Agent → Mu (discovery) → finds provider endpoint
+Agent → Provider (direct) → pays via x402
+```
+
+### Why This Matters
+
+Direct settlement via x402 means:
+- **Providers keep 100%** of revenue (no platform cut on direct calls)
+- **Lower latency** — no proxy hop for the actual service call
+- **Permissionless** — anyone can run an x402 MCP server, no approval needed
+- **Composable** — agents can chain calls across multiple providers in a single workflow
+
+Mu's value shifts from payment intermediary to **discovery and trust**: which services are reliable, well-reviewed, and worth paying for. The marketplace becomes a directory with reputation signals, and the agent uses it to find the best tool for the job.
+
+### The Stack
+
+This is what a services marketplace looks like when you start from first principles:
+
+- **Protocol**: MCP (JSON-RPC 2.0) — simple, standardised, AI-native
+- **Payments**: x402 — HTTP-native, per-request, on-chain settlement
+- **Discovery**: Marketplace registry — browsable, searchable, agent-discoverable
+- **Trust**: Reviews + verification — community-driven quality signals
+
 ## Relation to Micro
 
 Mu's architecture draws from the microservices philosophy — small, focused services with clear interfaces. The Go Micro framework pioneered this pattern: services that are easy to build, deploy, and compose.
 
-The marketplace extends this to the platform level. Instead of services running inside one binary, they run anywhere and connect via MCP. The protocol is the contract. The marketplace is the directory. The wallet is the settlement layer.
-
-This is what a services marketplace looks like when you start from first principles:
-- **Protocol**: MCP (JSON-RPC 2.0) — simple, standardised, AI-native
-- **Discovery**: Marketplace registry — browsable, searchable, agent-discoverable
-- **Billing**: Credits — transparent, per-use, no subscriptions
-- **Trust**: Reviews + verification — community-driven quality signals
+The marketplace extends this to the platform level. Instead of services running inside one binary, they run anywhere and connect via MCP. The protocol is the contract. The marketplace is the directory. x402 is the settlement layer.
 
 ---
 

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -2,15 +2,83 @@
 
 Mu includes an [MCP](https://modelcontextprotocol.io) (Model Context Protocol) server that allows AI assistants and tools to interact with Mu services programmatically.
 
-## Overview
-
-The MCP server exposes Mu services (blog, chat, news, video, mail, search) as tools that any MCP-compatible client can use. It implements the [MCP specification](https://spec.modelcontextprotocol.io) using the Streamable HTTP transport at a single endpoint.
+The MCP server exposes 30+ tools — news, search, video, weather, places, mail, blog, apps, markets — that any MCP-compatible client can use. It implements the [MCP specification](https://spec.modelcontextprotocol.io) using the Streamable HTTP transport at a single endpoint.
 
 **Endpoint:** `POST /mcp`
 
-## Configuration
+## Pay with Crypto (x402)
 
-Add Mu as an MCP server in your client configuration:
+AI agents can pay per-request with USDC stablecoins via the [x402 protocol](https://x402.org). No account, no API key, no signup. Just call and pay.
+
+When x402 is enabled on the server (`X402_PAY_TO` is set), any metered tool call without sufficient credits returns `HTTP 402` with payment requirements. The agent pays on-chain, retries, and gets the response.
+
+### Example: x402 Payment Flow
+
+**1. Call a tool without payment:**
+
+```bash
+curl -X POST https://mu.xyz/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"web_search","arguments":{"query":"latest AI news"}}}'
+```
+
+**2. Server returns 402 with payment requirements:**
+
+```
+HTTP/1.1 402 Payment Required
+X-PAYMENT-REQUIRED: eyJzY2hlbWUiOiJleGFjdCIsIm5ldHdvcmsi...
+
+{
+  "error": "Payment required",
+  "x402": [{
+    "scheme": "exact",
+    "network": "eip155:8453",
+    "maxAmountRequired": "$0.05",
+    "resource": "/mcp",
+    "description": "Access to web_search",
+    "payTo": "0x...",
+    "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
+  }],
+  "accepts": ["x402"]
+}
+```
+
+**3. Agent pays on-chain and retries with payment proof:**
+
+```bash
+curl -X POST https://mu.xyz/mcp \
+  -H "Content-Type: application/json" \
+  -H "X-PAYMENT: <base64-encoded-payment-payload>" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"web_search","arguments":{"query":"latest AI news"}}}'
+```
+
+**4. Server verifies, settles, and returns the result.**
+
+The `X-PAYMENT-REQUIRED` header contains base64-encoded JSON with all the information a client needs to construct a payment: network, asset, amount, and destination address.
+
+### Pricing
+
+Metered tools are priced at **1 credit = $0.01 USD** via x402:
+
+| Tool | x402 Price |
+|------|-----------|
+| `news_search` | $0.01 |
+| `video_search` | $0.02 |
+| `chat` | $0.03 |
+| `web_search` | $0.05 |
+| `web_fetch` | $0.03 |
+| `weather` | $0.01 |
+| `places_search` | $0.05 |
+| `places_nearby` | $0.02 |
+| `mail_send` | $0.04 |
+| `apps_build` | $0.03 |
+| `apps_run` | $0.01 |
+
+Free tools (news, blog_list, blog_read, video, markets, search, etc.) don't require payment.
+
+## Account-Based Authentication
+
+For human users or agents that prefer account-based billing, authenticate with a session token or Personal Access Token:
 
 ```json
 {
@@ -27,7 +95,29 @@ Add Mu as an MCP server in your client configuration:
 
 Replace `YOUR_TOKEN` with a session token from the `login` tool or a Personal Access Token created at `/token`.
 
-For self-hosted instances, replace `mu.xyz` with your domain.
+### Sign Up
+
+```bash
+curl -X POST https://mu.xyz/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"signup","arguments":{"id":"myagent","secret":"password123","name":"My Agent"}}}'
+```
+
+### Log In
+
+```bash
+curl -X POST https://mu.xyz/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"login","arguments":{"id":"myagent","secret":"password123"}}}'
+```
+
+Both return a session token. Use it in subsequent requests:
+
+```
+Authorization: Bearer SESSION_TOKEN
+```
+
+Account-based users get **10 free queries per day** and can top up with a card via Stripe.
 
 ## Available Tools
 
@@ -63,42 +153,6 @@ For self-hosted instances, replace `mu.xyz` with your domain.
 | `apps_build` | AI-generate an app from a description | 3 credits |
 | `apps_run` | Run JavaScript code in a sandbox | 1 credit |
 
-### Credits
-
-MCP tools use the same wallet credit system as the REST API:
-- **1 credit = 1 penny (£0.01)**
-- **10 free queries per day** (covers chat, news search, video search)
-- Metered tools will return an error if you have insufficient credits
-- Admin accounts have unlimited access
-
-## Authentication
-
-AI agents can authenticate using the `login` or `signup` tools:
-
-### Sign Up
-
-```bash
-curl -X POST https://mu.xyz/mcp \
-  -H "Content-Type: application/json" \
-  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"signup","arguments":{"id":"myagent","secret":"password123","name":"My Agent"}}}'
-```
-
-### Log In
-
-```bash
-curl -X POST https://mu.xyz/mcp \
-  -H "Content-Type: application/json" \
-  -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"login","arguments":{"id":"myagent","secret":"password123"}}}'
-```
-
-Both return a session token. Use it in subsequent requests:
-
-```
-Authorization: Bearer SESSION_TOKEN
-```
-
-Tools that require authentication (like `mail_read`, `blog_create`) will return errors if no valid token is provided. Public tools (like `news`, `blog_list`) work without authentication.
-
 ## Protocol
 
 The MCP server uses the Streamable HTTP transport. Clients send JSON-RPC 2.0 requests via POST:
@@ -121,6 +175,17 @@ curl -X POST https://mu.xyz/mcp \
 
 ### Call a Tool
 
+With x402 payment:
+
+```bash
+curl -X POST https://mu.xyz/mcp \
+  -H "Content-Type: application/json" \
+  -H "X-PAYMENT: <payment-payload>" \
+  -d '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"web_search","arguments":{"query":"latest news"}}}'
+```
+
+With account token:
+
 ```bash
 curl -X POST https://mu.xyz/mcp \
   -H "Content-Type: application/json" \
@@ -128,6 +193,19 @@ curl -X POST https://mu.xyz/mcp \
   -d '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"news","arguments":{}}}'
 ```
 
+## Two Ways to Pay
+
+| | x402 (Crypto) | Account (Card) |
+|---|---|---|
+| Setup required | None | Sign up + top up |
+| Auth header | `X-PAYMENT` | `Authorization: Bearer` |
+| Payment model | Per request | Pre-paid credits |
+| Currency | USDC | GBP |
+| Free tier | No | 10 queries/day |
+| Best for | Autonomous agents | Human users, MCP clients |
+
 ## Self-Hosting
 
 When running your own Mu instance, the MCP server is available automatically at `/mcp` with no additional configuration required.
+
+To enable x402 payments, set `X402_PAY_TO` to your USDC wallet address. See [Configuration](ENVIRONMENT_VARIABLES.md) for details.

--- a/docs/VISION.md
+++ b/docs/VISION.md
@@ -83,6 +83,26 @@ Every feature is available via REST API and MCP. Connect Claude Desktop, Cursor,
 }
 ```
 
+## The Agent Economy
+
+AI agents need access to real-world services — search, weather, places, email, markets. Today, each service requires a separate API key, a separate account, a separate billing relationship. An agent that wants to search the web, check the weather, and send an email needs three different providers, three signups, three payment methods.
+
+Mu collapses this into one endpoint. Every service is available via MCP at `/mcp`. And with the [x402 protocol](https://x402.org), agents pay per-request with USDC stablecoins — no account, no API key, no signup. The agent's wallet is its identity.
+
+This is what API access looks like when you build for machines, not just humans:
+
+| Traditional APIs | Mu + x402 |
+|---|---|
+| Sign up for each service | No account needed |
+| Manage API keys | No API keys |
+| Pre-pay or subscribe | Pay per request |
+| Different billing per provider | One wallet, one protocol |
+| Rate limits tied to API tiers | Pay for what you use |
+
+An autonomous agent can search the web ($0.05), check the weather ($0.01), look up nearby restaurants ($0.05), and send an email ($0.04) — all from a single MCP endpoint, paying on-chain for each call. Zero onboarding. Zero friction.
+
+The [services marketplace](MARKETPLACE.md) extends this further. Third-party developers can register their own MCP services — recipe extraction, flight tracking, translation — and agents discover and pay for them through the same protocol. x402 means providers can also receive payments directly on-chain, no intermediary required.
+
 ## Technology
 
 - **Language:** Go — single binary, no dependencies
@@ -96,6 +116,7 @@ Every feature is available via REST API and MCP. Connect Claude Desktop, Cursor,
 - **Free to browse** — news, blogs, videos, markets, all of it
 - **20 free credits per day** — covers search, chat, and AI features
 - **Pay as you go** — 1 credit = 1p, top up via card
+- **Pay with crypto** — AI agents pay per-request with USDC via [x402](https://x402.org)
 - **Self-host for free** — run your own instance, unlimited
 
 ## Get Started


### PR DESCRIPTION
- docs/MCP.md: lead with x402 pay-per-request, full curl examples of 402 flow, pricing table, two-ways-to-pay comparison. Auth-based access moved to secondary section.
- README.md: new "For AI Agents" section pitching zero-friction per-request payments via MCP + x402
- docs/VISION.md: new "The Agent Economy" section — one endpoint, one wallet, one protocol vs traditional multi-provider API keys
- docs/MARKETPLACE.md: new "x402 and the Marketplace" section with two settlement models (proxied vs direct), explains how x402 shifts Mu from payment intermediary to discovery + trust layer

https://claude.ai/code/session_016UhaM3HefwZjArvB7hHbpE