### PR TITLE
Fix premium model ID to use claude-opus-4-20250514

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -34,7 +34,7 @@ var defaultPremiumModel = func() string {
 	if v := os.Getenv("ANTHROPIC_PREMIUM_MODEL"); v != "" {
 		return v
 	}
-	return "claude-sonnet-4-5-20250514"
+	return "claude-opus-4-20250514"
 }()
 
 // Models lists the available model tiers.


### PR DESCRIPTION
The "Best" agent model was set to claude-sonnet-4-5-20250514 which doesn't exist in the Anthropic API. Changed to claude-opus-4-20250514 (Opus 4) which is the actual top-tier model.

https://claude.ai/code/session_016UhaM3HefwZjArvB7hHbpE