### PR TITLE
Fix apps: enable geolocation in iframes, add apps_edit to agent

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -519,6 +519,7 @@ const agentToolsDesc = `Available tools (use exact name):
 - apps_search: Search apps directory (args: {"q":"search term","tag":"productivity"})
 - apps_read: Read details of a specific app (args: {"slug":"app-slug"})
 - apps_build: AI-generate an app from a description (args: {"prompt":"a pomodoro timer with lap counter"})
+- apps_edit: Edit an existing app — update name, description, tags, icon, or HTML (args: {"slug":"app-slug","html":"<new html>","name":"New Name"})
 - apps_run: Run JavaScript code and return the result (args: {"code":"return 2+2"}). Use for calculations, data transforms, or any computation. Code runs as a function body — use 'return' to produce output.`
 
 // handleQuery processes an agent query request with SSE streaming.
@@ -845,6 +846,8 @@ func toolLabel(tool string) string {
 		return "📱 Reading app"
 	case "apps_build":
 		return "🔨 Building app"
+	case "apps_edit":
+		return "✏️ Editing app"
 	case "apps_run":
 		return "⚡ Running code"
 	default:
@@ -1182,6 +1185,8 @@ func formatToolResult(toolName, result string, args map[string]any) string {
 		return formatAppsReadResult(result)
 	case "apps_build":
 		return formatAppsBuildResult(result)
+	case "apps_edit":
+		return formatAppsBuildResult(result) // same format: returns app details
 	case "apps_run":
 		return formatAppsRunResult(result)
 	}
@@ -1829,7 +1834,7 @@ func renderRunCard(result string) string {
 		return ""
 	}
 	return `<div class="card"><h4>⚡ Result</h4>` +
-		`<iframe src="` + htmlEsc(data.Run) + `" sandbox="allow-scripts" ` +
+		`<iframe src="` + htmlEsc(data.Run) + `" sandbox="allow-scripts" allow="geolocation" ` +
 		`style="width:100%;min-height:120px;border:1px solid #eee;border-radius:6px;background:#fff;"></iframe>` +
 		`</div>`
 }

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -670,8 +670,8 @@ func TestRenderRunCard_ValidJSON(t *testing.T) {
 	if !strings.Contains(card, "<iframe") {
 		t.Errorf("expected iframe in card, got %q", card)
 	}
-	if !strings.Contains(card, "sandbox=\"allow-scripts\"") {
-		t.Errorf("expected sandboxed iframe, got %q", card)
+	if !strings.Contains(card, `sandbox="allow-scripts" allow="geolocation"`) {
+		t.Errorf("expected sandboxed iframe with geolocation, got %q", card)
 	}
 	if !strings.Contains(card, "Result") {
 		t.Errorf("expected Result heading, got %q", card)

--- a/apps/apps.go
+++ b/apps/apps.go
@@ -818,7 +818,7 @@ window.addEventListener('message',function(e){var d=e.data;if(d&&d.type&&d.type.
 	var sb strings.Builder
 	sb.WriteString(fmt.Sprintf(`<p><a href="/apps/%s">&larr; %s</a></p>`,
 		htmlpkg.EscapeString(a.Slug), htmlpkg.EscapeString(a.Name)))
-	sb.WriteString(fmt.Sprintf(`<iframe src="/apps/%s/run?raw=1" sandbox="allow-scripts" style="width:100%%;min-height:70vh;border:1px solid #eee;border-radius:8px;background:#fff;"></iframe>`,
+	sb.WriteString(fmt.Sprintf(`<iframe src="/apps/%s/run?raw=1" sandbox="allow-scripts" allow="geolocation" style="width:100%%;min-height:70vh;border:1px solid #eee;border-radius:8px;background:#fff;"></iframe>`,
 		htmlpkg.EscapeString(a.Slug)))
 
 	// SDK bridge in parent page: listens for postMessage from iframe and proxies to backend

--- a/apps/builder.go
+++ b/apps/builder.go
@@ -37,7 +37,8 @@ Rules:
 - Style guidelines: clean, minimal design. Use subtle borders (#e0e0e0), 6px border-radius, 16-24px padding, #333 text, #fff background
 - Button style: padding 8-10px 20-24px, border-radius 6px, primary buttons use background #000 color #fff
 - Keep it simple and functional — no external dependencies, no CDN links, no images
-- The app runs in a sandboxed iframe — no access to parent page
+- The app runs in a sandboxed iframe with geolocation enabled — no access to parent page
+- If the app uses geolocation (navigator.geolocation), ALWAYS provide a graceful fallback: show a manual location input or a sensible default when the user denies permission or the API fails. Never let the app be blank or broken if location is unavailable.
 - If the app needs AI features, include <script src="/apps/sdk.js"></script> and use mu.ai(prompt)
 - If the app needs persistent storage, use mu.store.set(key, value) and mu.store.get(key)
 - Maximum 256KB HTML
@@ -380,7 +381,7 @@ func builderPageHTML(initialCode string) string {
       <p>Your app preview will appear here.</p>
       <p>Type a prompt above or pick a template.</p>
     </div>
-    <iframe id="preview" class="preview-frame" sandbox="allow-scripts" style="display:none;"></iframe>
+    <iframe id="preview" class="preview-frame" sandbox="allow-scripts" allow="geolocation" style="display:none;"></iframe>
   </div>
 
   <div class="code-section" id="codeSection">
@@ -603,7 +604,7 @@ func editPageHTML(a *App) string {
         <h3>Preview</h3>
         <button class="code-toggle" onclick="updatePreview()">Refresh</button>
       </div>
-      <iframe id="preview" class="preview-frame" sandbox="allow-scripts" style="min-height:50vh;"></iframe>
+      <iframe id="preview" class="preview-frame" sandbox="allow-scripts" allow="geolocation" style="min-height:50vh;"></iframe>
     </div>
   </div>
 

--- a/apps/run.go
+++ b/apps/run.go
@@ -114,7 +114,7 @@ func handleCodeRun(w http.ResponseWriter, r *http.Request) {
 	var sb strings.Builder
 	sb.WriteString(`<div class="card">`)
 	sb.WriteString(`<h4>Code Run</h4>`)
-	sb.WriteString(fmt.Sprintf(`<iframe src="/apps/run?id=%s&raw=1" sandbox="allow-scripts" style="width:100%%;min-height:200px;border:1px solid #eee;border-radius:6px;background:#fff;"></iframe>`, id))
+	sb.WriteString(fmt.Sprintf(`<iframe src="/apps/run?id=%s&raw=1" sandbox="allow-scripts" allow="geolocation" style="width:100%%;min-height:200px;border:1px solid #eee;border-radius:6px;background:#fff;"></iframe>`, id))
 	sb.WriteString(`</div>`)
 
 	app.Respond(w, r, app.Response{


### PR DESCRIPTION
- Add allow="geolocation" to all 5 iframe locations (app run page, code run, builder preview, edit preview, agent result card)
- Add apps_edit tool to agent planner so it can update existing apps instead of always building new duplicates
- Update builder system prompt to require graceful geolocation fallbacks (manual input when permission denied or API fails)

Fixes: apps using navigator.geolocation were silently failing because the sandboxed iframe didn't have the geolocation permission. Agent had no way to edit apps, so re-asking always created duplicates.

https://claude.ai/code/session_016UhaM3HefwZjArvB7hHbpE