### PR TITLE
Fix nil pointer crash on /apps/{slug}/versions, harden against panics

### DIFF
--- a/agent/flows.go
+++ b/agent/flows.go
@@ -49,12 +49,46 @@ func init() {
 	}
 }
 
+// maxFlowsPerUser is the maximum number of flows kept per user.
+// When exceeded, the oldest completed flows are evicted.
+const maxFlowsPerUser = 200
+
 // saveFlow persists a new flow or updates an existing one.
 func saveFlow(f *Flow) error {
 	flowMu.Lock()
 	defer flowMu.Unlock()
 	flowStore[f.ID] = f
+	evictOldFlows(f.AccountID)
 	return persistFlows()
+}
+
+// evictOldFlows removes the oldest completed flows for an account when
+// the per-user limit is exceeded. Caller must hold flowMu.
+func evictOldFlows(accountID string) {
+	var userFlows []*Flow
+	for _, f := range flowStore {
+		if f.AccountID == accountID {
+			userFlows = append(userFlows, f)
+		}
+	}
+	if len(userFlows) <= maxFlowsPerUser {
+		return
+	}
+	// Sort oldest first
+	sort.Slice(userFlows, func(i, j int) bool {
+		return userFlows[i].CreatedAt.Before(userFlows[j].CreatedAt)
+	})
+	// Delete oldest completed flows until within limit
+	toRemove := len(userFlows) - maxFlowsPerUser
+	for _, f := range userFlows {
+		if toRemove <= 0 {
+			break
+		}
+		if f.Status == "done" || f.Status == "error" {
+			delete(flowStore, f.ID)
+			toRemove--
+		}
+	}
 }
 
 // getFlow returns the flow with the given ID, or nil if not found.

--- a/apps/apps.go
+++ b/apps/apps.go
@@ -661,7 +661,7 @@ func handleVersions(w http.ResponseWriter, r *http.Request, slug string) {
 	}
 
 	_, acc, _ := auth.RequireSession(r)
-	isAuthor := acc.ID == a.AuthorID
+	isAuthor := acc != nil && acc.ID == a.AuthorID
 
 	var sb strings.Builder
 	sb.WriteString(fmt.Sprintf(`<p><a href="/apps/%s">&larr; %s</a></p>`, htmlpkg.EscapeString(a.Slug), htmlpkg.EscapeString(a.Name)))

--- a/news/news.go
+++ b/news/news.go
@@ -597,6 +597,9 @@ func getMetadata(uri string, publishedAt time.Time) (*Metadata, bool, error) {
 	}
 
 	check := func(p []string) bool {
+		if len(p) < 2 {
+			return false
+		}
 		if p[0] == "twitter" {
 			return true
 		}


### PR DESCRIPTION
The crash was at apps.go:664 — accessing acc.ID when acc is nil (unauthenticated user viewing version history). Stack trace:
  panic: runtime error: invalid memory address or nil pointer dereference
  mu/apps.handleVersions apps/apps.go:664

Also fixes:
- news/news.go: check len(p) >= 2 before accessing p[1] in metadata parser — prevents index-out-of-bounds panic on meta tags without colon separators (e.g. property="description")
- agent/flows.go: cap flowStore at 200 flows per user, evict oldest completed flows to prevent unbounded memory growth

https://claude.ai/code/session_016UhaM3HefwZjArvB7hHbpE