### PR TITLE
Fix open redirect on login, remove unused GetMessage, harden redirects

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -512,7 +512,7 @@ func Login(w http.ResponseWriter, r *http.Request) {
 
 		// Check for redirect parameter, default to home
 		redirectTo := r.URL.Query().Get("redirect")
-		if redirectTo == "" {
+		if redirectTo == "" || redirectTo[0] != '/' || strings.HasPrefix(redirectTo, "//") {
 			redirectTo = "/home"
 		}
 		http.Redirect(w, r, redirectTo, 302)

--- a/mail/mail.go
+++ b/mail/mail.go
@@ -1624,18 +1624,6 @@ func FindMessageByMessageID(messageID string) *Message {
 }
 
 // GetMessage finds a message by its internal ID
-func GetMessage(msgID string) *Message {
-	mutex.RLock()
-	defer mutex.RUnlock()
-
-	for _, msg := range messages {
-		if msg.ID == msgID {
-			return msg
-		}
-	}
-	return nil
-}
-
 // DeleteMessage removes a message
 func DeleteMessage(msgID, userID string) error {
 	mutex.Lock()

--- a/user/user.go
+++ b/user/user.go
@@ -306,8 +306,17 @@ func StatusHandler(w http.ResponseWriter, r *http.Request) {
 
 	// Redirect back to referrer or home
 	ref := r.Header.Get("Referer")
-	if ref == "" {
-		ref = "/"
+	if ref == "" || !strings.HasPrefix(ref, "/") {
+		// Extract path from full URL referer
+		if i := strings.Index(ref, "://"); i >= 0 {
+			if j := strings.Index(ref[i+3:], "/"); j >= 0 {
+				ref = ref[i+3+j:]
+			} else {
+				ref = "/"
+			}
+		} else {
+			ref = "/"
+		}
 	}
 	http.Redirect(w, r, ref, http.StatusSeeOther)
 }


### PR DESCRIPTION
- Login redirect now rejects absolute URLs and protocol-relative URLs (//evil.com). Only relative paths starting with / are allowed.
- Remove unused mail.GetMessage() which had no access control
- Harden StatusHandler Referer redirect to extract path only

https://claude.ai/code/session_016UhaM3HefwZjArvB7hHbpE