### PR TITLE
Add tooltip (?) to home cards explaining what each one is

### DIFF
--- a/home/home.go
+++ b/home/home.go
@@ -288,6 +288,15 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 	var leftHTML []string
 	var rightHTML []string
 
+	tooltips := map[string]string{
+		"blog":     "Microblog posts with daily AI-generated digests",
+		"news":     "Headlines from RSS feeds, sorted by time",
+		"markets":  "Live crypto, futures, and commodity prices",
+		"reminder": "Daily Islamic reminder with verse and hadith",
+		"social":   "Public discussion threads",
+		"video":    "Latest videos from curated channels",
+	}
+
 	for _, card := range Cards {
 		content := card.CachedHTML
 		if strings.TrimSpace(content) == "" {
@@ -296,7 +305,11 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 		if card.Link != "" {
 			content += app.Link("More", card.Link)
 		}
-		html := app.Card(card.ID, card.Title, content)
+		title := card.Title
+		if tip, ok := tooltips[card.ID]; ok {
+			title += fmt.Sprintf(` <span class="card-tooltip" title="%s">?</span>`, htmlEsc(tip))
+		}
+		html := fmt.Sprintf(app.CardTemplate, card.ID, card.ID, title, content)
 		if card.Column == "left" {
 			leftHTML = append(leftHTML, html)
 		} else {

--- a/internal/app/html/mu.css
+++ b/internal/app/html/mu.css
@@ -642,6 +642,28 @@ body.page-home #page-title ~ #customize-link {
   height: 100%;
 }
 
+.card-tooltip {
+  display: inline-block;
+  width: 16px;
+  height: 16px;
+  line-height: 16px;
+  text-align: center;
+  font-size: 11px;
+  font-weight: 600;
+  font-style: normal;
+  color: #bbb;
+  border: 1px solid #ddd;
+  border-radius: 50%;
+  cursor: help;
+  vertical-align: middle;
+  margin-left: 4px;
+  float: right;
+}
+.card-tooltip:hover {
+  color: #666;
+  border-color: #aaa;
+}
+
 #home-chat-form {
   display: flex;
   gap: 10px;


### PR DESCRIPTION
Each card title gets a small ? circle on the right that shows a description on hover/tap: "Live crypto, futures, and commodity prices" for Markets, "Headlines from RSS feeds" for News, etc.

Styled as a subtle circle that doesn't distract — light grey border, darkens on hover. Uses native title attribute for the tooltip so it works on both desktop (hover) and mobile (long press).

https://claude.ai/code/session_016UhaM3HefwZjArvB7hHbpE