### PR TITLE
Fix base input/textarea font to use Nunito Sans at 14px

### DIFF
--- a/internal/app/html/mu.css
+++ b/internal/app/html/mu.css
@@ -210,6 +210,13 @@ input {
   border-radius: 5px;
   border: 1px solid #e0e0e0;
   box-sizing: border-box;
+  font-family: "Nunito Sans", serif;
+  font-size: 14px;
+}
+
+textarea {
+  font-family: "Nunito Sans", serif;
+  font-size: 14px;
 }
 
 select {


### PR DESCRIPTION
The global input rule was missing font-family and font-size, causing inputs without specific overrides to use browser defaults.

https://claude.ai/code/session_01GRGLA9yj7BpqKiyi6xFwnm