### PR TITLE
Add work notifications, nav icons, fix social timestamp overlap

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -236,9 +236,9 @@ var Template = `
           <a href="/social"><img src="/social.svg?` + Version + `"><span class="label">Social</span></a>
           <a href="/video"><img src="/video.png?` + Version + `"><span class="label">Video</span></a>
           <a href="/web"><img src="/search.svg?` + Version + `"><span class="label">Web</span></a>
-          <a href="/work"><span class="label">Work</span></a>
+          <a href="/work"><img src="/work.svg?` + Version + `"><span class="label">Work</span></a>
           <a id="nav-wallet" href="/wallet"><img src="/wallet.png?` + Version + `"><span class="label">Wallet</span></a>
-          <a href="/app/saved"><span class="label">Saved</span></a>
+          <a href="/app/saved"><img src="/saved.svg?` + Version + `"><span class="label">Saved</span></a>
 
         </div>
         <div class="nav-bottom">

--- a/internal/app/html/saved.svg
+++ b/internal/app/html/saved.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z"/></svg>

--- a/internal/app/html/work.svg
+++ b/internal/app/html/work.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="7" width="20" height="14" rx="2" ry="2"/><path d="M16 7V5a2 2 0 0 0-2-2h-4a2 2 0 0 0-2 2v2"/></svg>

--- a/main.go
+++ b/main.go
@@ -102,6 +102,13 @@ func main() {
 		}
 		return a.Slug, a.Name, nil
 	}
+	work.Notify = func(toUserID, subject, body string) {
+		acc, err := auth.GetAccount(toUserID)
+		if err != nil {
+			return
+		}
+		mail.SendMessage("Mu", "micro", acc.Name, toUserID, subject, body, "", "")
+	}
 
 	// load social
 	social.Load()

--- a/social/social.go
+++ b/social/social.go
@@ -660,7 +660,7 @@ func generateThreadHTML(p *Message, replies []*Message, r *http.Request) string 
 	}
 	sb.WriteString(fmt.Sprintf(`<div class="headline" style="border-bottom:2px solid #eee;">
   %s
-  <div style="display:flex;justify-content:space-between;align-items:baseline;">
+  <div style="display:flex;justify-content:space-between;align-items:baseline;margin-right:24px">
     <div>%s</div>
     <div><span data-timestamp="%d" style="color:#888;font-size:12px;">%s</span></div>
   </div>
@@ -1027,7 +1027,7 @@ func generatePageHTML(visible []*Message, r *http.Request) string {
 		}
 		sb.WriteString(fmt.Sprintf(`<div class="headline">
   %s
-  <div style="display:flex;justify-content:space-between;align-items:baseline;">
+  <div style="display:flex;justify-content:space-between;align-items:baseline;margin-right:24px">
     <div>%s</div>
     <div><span data-timestamp="%d" style="color:#888;font-size:12px;">%s</span></div>
   </div>

--- a/work/handlers.go
+++ b/work/handlers.go
@@ -8,6 +8,7 @@ import (
 
 	"mu/internal/app"
 	"mu/internal/auth"
+	"mu/mail"
 	"mu/wallet"
 )
 
@@ -613,6 +614,12 @@ func handleClaim(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Notify the poster
+	if post := GetPost(id); post != nil {
+		notifyWork(post.AuthorID, "Task claimed: "+post.Title,
+			fmt.Sprintf("%s claimed your task. View it at /work/%s", acc.Name, id))
+	}
+
 	if app.SendsJSON(r) || app.WantsJSON(r) {
 		app.RespondJSON(w, map[string]string{"status": "claimed"})
 		return
@@ -646,6 +653,12 @@ func handleDeliver(w http.ResponseWriter, r *http.Request) {
 	if err := DeliverTask(id, sess.Account, delivery); err != nil {
 		respondPostError(w, r, id, err.Error())
 		return
+	}
+
+	// Notify the poster
+	if post := GetPost(id); post != nil {
+		notifyWork(post.AuthorID, "Delivery submitted: "+post.Title,
+			fmt.Sprintf("Work has been delivered for your task. Review it at /work/%s", id))
 	}
 
 	if app.SendsJSON(r) || app.WantsJSON(r) {
@@ -683,6 +696,12 @@ func handleAccept(w http.ResponseWriter, r *http.Request) {
 		} else {
 			wallet.ReleaseEscrow(post.WorkerID, post.Cost, post.ID)
 		}
+	}
+
+	// Notify the worker (if human)
+	if post.WorkerID != "agent" && post.WorkerID != "" {
+		notifyWork(post.WorkerID, "Task accepted: "+post.Title,
+			fmt.Sprintf("Your delivery was accepted and %d credits have been released. View it at /work/%s", post.Cost, id))
 	}
 
 	if app.SendsJSON(r) || app.WantsJSON(r) {
@@ -839,4 +858,13 @@ func respondError(w http.ResponseWriter, r *http.Request, redirect, msg string) 
 
 func respondPostError(w http.ResponseWriter, r *http.Request, id, msg string) {
 	respondError(w, r, "/work/"+id, msg)
+}
+
+// notifyWork sends an internal mail notification for work events.
+func notifyWork(toID, subject, body string) {
+	acc, err := auth.GetAccount(toID)
+	if err != nil {
+		return
+	}
+	mail.SendMessage("Mu", "micro", acc.Name, toID, subject, body, "", "")
 }

--- a/work/work.go
+++ b/work/work.go
@@ -63,6 +63,10 @@ type Comment struct {
 // Takes (prompt, authorID, authorName) and returns (appSlug, appName, error).
 var BuildApp func(prompt, authorID, authorName string) (string, string, error)
 
+// Notify is wired by main.go to send notifications (e.g. internal mail).
+// Takes (toUserID, subject, body).
+var Notify func(toUserID, subject, body string)
+
 var (
 	mutex sync.RWMutex
 	posts = map[string]*Post{}
@@ -361,7 +365,15 @@ func AssignToAgent(postID, authorID string) error {
 		post.Status = StatusDelivered
 		post.DeliveredAt = time.Now()
 		save()
+		authorID := post.AuthorID
+		title := post.Title
+		postID := post.ID
 		mutex.Unlock()
+
+		if Notify != nil {
+			Notify(authorID, "Agent completed: "+title,
+				fmt.Sprintf("The agent built %s for your task. Review it at /work/%s", name, postID))
+		}
 	}()
 
 	return nil


### PR DESCRIPTION
Work events now send internal mail notifications:
- Claim: notify poster
- Deliver: notify poster
- Accept: notify worker (with credits amount)
- Agent complete: notify poster (via Notify callback)

Added Work and Saved icons to left nav sidebar (briefcase and bookmark SVGs).

Fixed social timestamp overlapping ⋯ by adding margin-right:24px to the flex header row.

https://claude.ai/code/session_01GRGLA9yj7BpqKiyi6xFwnm