### PR TITLE
Fix social timestamp overlap with padding-right instead of margin-right

### DIFF
--- a/social/social.go
+++ b/social/social.go
@@ -660,7 +660,7 @@ func generateThreadHTML(p *Message, replies []*Message, r *http.Request) string 
 	}
 	sb.WriteString(fmt.Sprintf(`<div class="headline" style="border-bottom:2px solid #eee;">
   %s
-  <div style="display:flex;justify-content:space-between;align-items:baseline;margin-right:24px">
+  <div style="display:flex;justify-content:space-between;align-items:baseline;padding-right:20px">
     <div>%s</div>
     <div><span data-timestamp="%d" style="color:#888;font-size:12px;">%s</span></div>
   </div>
@@ -1027,7 +1027,7 @@ func generatePageHTML(visible []*Message, r *http.Request) string {
 		}
 		sb.WriteString(fmt.Sprintf(`<div class="headline">
   %s
-  <div style="display:flex;justify-content:space-between;align-items:baseline;margin-right:24px">
+  <div style="display:flex;justify-content:space-between;align-items:baseline;padding-right:20px">
     <div>%s</div>
     <div><span data-timestamp="%d" style="color:#888;font-size:12px;">%s</span></div>
   </div>


### PR DESCRIPTION
margin-right wasn't preventing the flex content from reaching under the ⋯ button. Switched to padding-right:20px on the flex header row.

https://claude.ai/code/session_01GRGLA9yj7BpqKiyi6xFwnm