### PR TITLE
Decouple work agent via event system, use general-purpose tools

### DIFF
--- a/agent/worker.go
+++ b/agent/worker.go
@@ -1,0 +1,153 @@
+package agent
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"mu/internal/ai"
+	"mu/internal/api"
+	"mu/internal/event"
+	"mu/work"
+)
+
+// StartWorker subscribes to task events and runs them using the agent's tools.
+func StartWorker() {
+	taskSub := event.Subscribe(event.EventTaskCreated)
+	retrySub := event.Subscribe(event.EventTaskRetry)
+
+	go func() {
+		for evt := range taskSub.Chan {
+			postID, _ := evt.Data["post_id"].(string)
+			if postID == "" {
+				continue
+			}
+			go runTask(postID, "")
+		}
+	}()
+
+	go func() {
+		for evt := range retrySub.Chan {
+			postID, _ := evt.Data["post_id"].(string)
+			feedback, _ := evt.Data["feedback"].(string)
+			if postID == "" {
+				continue
+			}
+			go runTask(postID, feedback)
+		}
+	}()
+}
+
+// runTask executes a work task using the agent's tool-calling loop.
+func runTask(postID, feedback string) {
+	post := work.GetPost(postID)
+	if post == nil {
+		return
+	}
+
+	prompt := post.Description
+	if feedback != "" {
+		prompt += "\n\nFeedback from previous attempt:\n" + feedback
+	}
+
+	work.AddLog(postID, "plan", "Planning task...", 0)
+
+	// Step 1: Plan — ask AI what tools to use
+	planResult, err := ai.Ask(&ai.Prompt{
+		System: "You are an AI agent that completes tasks. Given a task description, output ONLY a JSON array of tool calls.\n\n" +
+			agentToolsDesc +
+			"\n\nOutput format: [{\"tool\":\"tool_name\",\"args\":{}}]\n" +
+			"If the task asks to build an app, use apps_build with the full description as the prompt.\n" +
+			"If the task asks to write a blog post, use blog_create.\n" +
+			"If the task asks for research, use web_search, news, or chat.\n" +
+			"Use at most 5 tool calls. Output [] if no tools needed.",
+		Question: prompt,
+		Priority: ai.PriorityHigh,
+		Caller:   "work-agent-plan",
+	})
+	if err != nil {
+		work.AddLog(postID, "error", "Planning failed: "+err.Error(), 0)
+		failTask(postID)
+		return
+	}
+
+	// Parse tool calls
+	type toolCall struct {
+		Tool string         `json:"tool"`
+		Args map[string]any `json:"args"`
+	}
+	var toolCalls []toolCall
+
+	planJSON := extractJSONArray(planResult)
+	if err := json.Unmarshal([]byte(planJSON), &toolCalls); err != nil || len(toolCalls) == 0 {
+		work.AddLog(postID, "error", "No tools planned", 0)
+		failTask(postID)
+		return
+	}
+
+	work.AddLog(postID, "plan", fmt.Sprintf("Planned %d tool calls", len(toolCalls)), 0)
+
+	// Step 2: Execute tools as the task author
+	var results []string
+	for _, tc := range toolCalls {
+		if tc.Tool == "" {
+			continue
+		}
+
+		// Check budget
+		remaining := work.BudgetRemaining(postID)
+		if remaining <= 0 && post.Cost > 0 {
+			work.AddLog(postID, "budget", "Budget exceeded", 0)
+			break
+		}
+
+		work.AddLog(postID, "tool", fmt.Sprintf("Running %s...", tc.Tool), 3)
+
+		text, isErr, execErr := api.ExecuteToolAs(post.AuthorID, tc.Tool, tc.Args)
+		if execErr != nil || isErr {
+			work.AddLog(postID, "error", fmt.Sprintf("%s failed: %v", tc.Tool, execErr), 0)
+			continue
+		}
+
+		if len(text) > 4000 {
+			text = text[:4000] + "..."
+		}
+		results = append(results, fmt.Sprintf("### %s\n%s", tc.Tool, text))
+		work.AddLog(postID, "tool", fmt.Sprintf("%s — done", tc.Tool), 0)
+	}
+
+	// Step 3: Synthesise result
+	work.AddLog(postID, "synth", "Composing result...", 0)
+
+	answer, err := ai.Ask(&ai.Prompt{
+		System:   "You are a helpful assistant completing a task. Summarise the results of your work. Use markdown.",
+		Rag:      results,
+		Question: "Task: " + prompt + "\n\nSummarise what was accomplished.",
+		Priority: ai.PriorityHigh,
+		Caller:   "work-agent-synth",
+	})
+	if err != nil {
+		work.AddLog(postID, "error", "Synthesis failed: "+err.Error(), 0)
+		failTask(postID)
+		return
+	}
+
+	// Deliver
+	work.SetDelivery(postID, answer)
+	work.SetStatus(postID, "delivered")
+	work.AddLog(postID, "complete", "Task delivered", 0)
+
+	// Notify
+	if work.Notify != nil {
+		work.Notify(post.AuthorID, "Task completed: "+post.Title,
+			fmt.Sprintf("Your task has been completed.\n\n[Review →](/work/%s)", postID), postID)
+	}
+}
+
+func failTask(postID string) {
+	work.SetStatus(postID, "open")
+	post := work.GetPost(postID)
+	if post != nil && work.Notify != nil {
+		work.Notify(post.AuthorID, "Task failed: "+post.Title,
+			"The agent could not complete this task.", postID)
+	}
+}

--- a/internal/api/mcp.go
+++ b/internal/api/mcp.go
@@ -9,6 +9,8 @@ import (
 	"net/url"
 	"strings"
 	"time"
+
+	"mu/internal/auth"
 )
 
 // MCP protocol version
@@ -693,6 +695,19 @@ func handleToolsCall(w http.ResponseWriter, originalReq *http.Request, req jsonr
 		result.IsError = true
 	}
 	writeResult(w, req.ID, result)
+}
+
+// ExecuteToolAs calls a tool on behalf of a user account (no HTTP request needed).
+// Creates a temporary session for auth. Used by background agents.
+func ExecuteToolAs(accountID, name string, args map[string]any) (string, bool, error) {
+	sess, err := auth.CreateSession(accountID)
+	if err != nil {
+		return "", true, fmt.Errorf("failed to create session: %v", err)
+	}
+
+	req, _ := http.NewRequest("POST", "/", nil)
+	req.AddCookie(&http.Cookie{Name: "session", Value: sess.Token})
+	return ExecuteTool(req, name, args)
 }
 
 // ExecuteTool calls a registered MCP tool with the given name and arguments,

--- a/internal/event/event.go
+++ b/internal/event/event.go
@@ -16,6 +16,8 @@ const (
 	EventSummaryGenerated   = "summary_generated"
 	EventGenerateTag        = "generate_tag"
 	EventTagGenerated       = "tag_generated"
+	EventTaskCreated        = "task_created"
+	EventTaskRetry          = "task_retry"
 )
 
 // Event represents a data event

--- a/main.go
+++ b/main.go
@@ -16,7 +16,6 @@ import (
 	"mu/admin"
 	"mu/agent"
 	"mu/apps"
-	"mu/internal/ai"
 	"mu/internal/api"
 	"mu/internal/app"
 	"mu/internal/auth"
@@ -95,103 +94,7 @@ func main() {
 	// load work (task bounties)
 	work.Load()
 
-	// Wire work → apps builder (avoids direct import between building blocks)
-	work.BuildApp = func(prompt, authorID, authorName string) (string, string, error) {
-		a, err := apps.BuildAndSave(prompt, authorID, authorName)
-		if err != nil {
-			return "", "", err
-		}
-		return a.Slug, a.Name, nil
-	}
-	work.RebuildApp = func(slug, feedback string) error {
-		a := apps.GetApp(slug)
-		if a == nil {
-			return fmt.Errorf("app not found: %s", slug)
-		}
-		// Ask AI to update the app based on feedback
-		result, err := ai.Ask(&ai.Prompt{
-			System:   apps.BuilderSystemPrompt(),
-			Question: fmt.Sprintf("Update this app based on the feedback below.\n\nOriginal requirements:\n%s\n\nFeedback:\n%s\n\nCurrent app HTML:\n%s", a.Description, feedback, a.HTML),
-			Priority: ai.PriorityHigh,
-			Caller:   "work-rebuild",
-		})
-		if err != nil {
-			return fmt.Errorf("AI update failed: %v", err)
-		}
-		// Parse and update
-		html := apps.CleanGeneratedHTML(result)
-		if html == "" {
-			return fmt.Errorf("AI returned empty HTML")
-		}
-		_, err = apps.UpdateApp(slug, "", "", "", html, "")
-		return err
-	}
-	work.VerifyApp = func(appSlug string) (string, bool) {
-		a := apps.GetApp(appSlug)
-		if a == nil {
-			return "App not found", false
-		}
-		// Basic structural checks
-		html := a.HTML
-		if len(html) < 100 {
-			return "App HTML is too short — likely incomplete", false
-		}
-		if !strings.Contains(strings.ToLower(html), "<html") {
-			return "Missing <html> tag", false
-		}
-		if !strings.Contains(strings.ToLower(html), "<body") {
-			return "Missing <body> tag", false
-		}
-		// Ask AI to review against requirements
-		result, err := ai.Ask(&ai.Prompt{
-			System: `You are a QA reviewer. Given an app's HTML and its requirements, check if the app works correctly.
-Reply with ONLY one of:
-- "PASS" if the app meets the requirements
-- "FAIL: <brief description of issues>" if there are problems
-Be concise. Focus on functional issues, not style.`,
-			Question: fmt.Sprintf("Requirements:\n%s\n\nApp HTML (first 2000 chars):\n%s", a.Description, html[:min(len(html), 2000)]),
-			Priority: ai.PriorityLow,
-			Caller:   "work-verify",
-		})
-		if err != nil {
-			// If AI fails, pass by default
-			return "", true
-		}
-		result = strings.TrimSpace(result)
-		if strings.HasPrefix(strings.ToUpper(result), "PASS") {
-			return "", true
-		}
-		return strings.TrimPrefix(result, "FAIL: "), false
-	}
-	work.FixApp = func(appSlug, issues string) error {
-		a := apps.GetApp(appSlug)
-		if a == nil {
-			return fmt.Errorf("app not found")
-		}
-		result, err := ai.Ask(&ai.Prompt{
-			System:   apps.BuilderSystemPrompt(),
-			Question: fmt.Sprintf("Fix this app. Issues found:\n%s\n\nOriginal requirements:\n%s\n\nCurrent HTML:\n%s", issues, a.Description, a.HTML),
-			Priority: ai.PriorityHigh,
-			Caller:   "work-fix",
-		})
-		if err != nil {
-			return err
-		}
-		html := apps.CleanGeneratedHTML(result)
-		if html == "" {
-			return fmt.Errorf("AI returned empty HTML")
-		}
-		_, err = apps.UpdateApp(appSlug, "", "", "", html, "")
-		return err
-	}
-	work.ConsumeCredits = func(userID string, amount int) error {
-		w := wallet.GetWallet(userID)
-		if w.Balance < amount {
-			return fmt.Errorf("insufficient credits (%d available, %d needed)", w.Balance, amount)
-		}
-		wallet.ConsumeQuota(userID, wallet.OpChatQuery)
-		return nil
-	}
+	// Wire work notifications
 	work.Notify = func(toUserID, subject, body, threadID string) {
 		acc, err := auth.GetAccount(toUserID)
 		if err != nil {
@@ -199,6 +102,9 @@ Be concise. Focus on functional issues, not style.`,
 		}
 		mail.SendMessage("Mu", "micro", acc.Name, toUserID, subject, body, threadID, "")
 	}
+
+	// Start the agent worker (subscribes to task events)
+	agent.StartWorker()
 
 	// load social
 	social.Load()

--- a/work/handlers.go
+++ b/work/handlers.go
@@ -715,7 +715,7 @@ func handleRetry(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Reset to claimed and re-run agent with the feedback
-	RetryWithFeedback(post, feedback)
+	RetryWithFeedback(id, feedback)
 
 	if app.SendsJSON(r) || app.WantsJSON(r) {
 		app.RespondJSON(w, map[string]string{"status": "retrying"})

--- a/work/work.go
+++ b/work/work.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"strings"
 	"sync"
 	"time"
 
@@ -70,24 +69,7 @@ type Comment struct {
 	CreatedAt time.Time `json:"created_at"`
 }
 
-// BuildApp is wired by main.go to call the apps builder.
-// Takes (prompt, authorID, authorName) and returns (appSlug, appName, error).
-var BuildApp func(prompt, authorID, authorName string) (string, string, error)
-
-// VerifyApp is wired by main.go to check if an app works.
-// Takes (appSlug) and returns (issues string, ok bool).
-var VerifyApp func(appSlug string) (string, bool)
-
-// FixApp is wired by main.go to fix issues with an app.
-// Takes (appSlug, issues) and returns (error).
-var FixApp func(appSlug, issues string) error
-
-// ConsumeCredits is wired by main.go to charge credits.
-// Takes (userID, amount) and returns (error).
-var ConsumeCredits func(userID string, amount int) error
-
-// Notify is wired by main.go to send notifications (e.g. internal mail).
-// Takes (toUserID, subject, body, threadID) where threadID groups messages.
+// Notify is wired by main.go to send notifications.
 var Notify func(toUserID, subject, body, threadID string)
 
 var (
@@ -331,9 +313,14 @@ func ReleaseTask(postID, authorID string) error {
 	return nil
 }
 
-// addLog appends a log entry to a post and persists it.
-func addLog(post *Post, step, message string, credits int) {
+// AddLog appends a log entry to a post and persists it.
+func AddLog(postID, step, message string, credits int) {
 	mutex.Lock()
+	defer mutex.Unlock()
+	post, ok := posts[postID]
+	if !ok {
+		return
+	}
 	post.Log = append(post.Log, LogEntry{
 		Step:      step,
 		Message:   message,
@@ -342,31 +329,45 @@ func addLog(post *Post, step, message string, credits int) {
 	})
 	post.Spent += credits
 	save()
-	mutex.Unlock()
 }
 
-// spendCredits charges credits against a task's budget.
-// Returns false if the budget would be exceeded.
-func spendCredits(post *Post, authorID string, amount int) bool {
-	if post.Cost > 0 && post.Spent+amount > post.Cost {
-		return false
-	}
-	if ConsumeCredits != nil {
-		if err := ConsumeCredits(authorID, amount); err != nil {
-			return false
+// SetStatus updates a task's status.
+func SetStatus(postID, status string) {
+	mutex.Lock()
+	defer mutex.Unlock()
+	if post, ok := posts[postID]; ok {
+		post.Status = status
+		if status == StatusDelivered {
+			post.DeliveredAt = time.Now()
+		} else if status == StatusCompleted {
+			post.CompletedAt = time.Now()
 		}
+		save()
 	}
-	return true
 }
 
-const (
-	maxAgentIterations = 5
-	creditPerStep      = 3 // credits per AI call
-)
+// SetDelivery sets the delivery text for a task.
+func SetDelivery(postID, delivery string) {
+	mutex.Lock()
+	defer mutex.Unlock()
+	if post, ok := posts[postID]; ok {
+		post.Delivery = delivery
+		save()
+	}
+}
+
+// BudgetRemaining returns how many credits are left in the budget.
+func BudgetRemaining(postID string) int {
+	mutex.RLock()
+	defer mutex.RUnlock()
+	if post, ok := posts[postID]; ok {
+		return post.Cost - post.Spent
+	}
+	return 0
+}
 
 // AssignToAgent assigns an open task to the AI agent.
-// It claims the task as "agent", runs the app builder in a goroutine,
-// and posts the delivery when complete. The poster reviews the result.
+// Sets status to building and publishes a task_created event.
 func AssignToAgent(postID, authorID string) error {
 	mutex.Lock()
 	post, exists := posts[postID]
@@ -394,199 +395,58 @@ func AssignToAgent(postID, authorID string) error {
 	save()
 	mutex.Unlock()
 
-	// Run the agent in background
-	go runAgent(post)
+	// Publish event — agent picks it up
+	event.Publish(event.Event{
+		Type: event.EventTaskCreated,
+		Data: map[string]interface{}{
+			"post_id":   postID,
+			"author_id": authorID,
+		},
+	})
 
 	return nil
 }
 
-// runAgent executes the iterative build loop for a task.
-// Build → verify → fix → verify → ... until done or budget exceeded.
-// All progress is logged and persisted so it survives restarts.
-func runAgent(post *Post) {
-	if BuildApp == nil {
-		failAgent(post, "No builder configured")
-		return
-	}
-
-	authorID := post.AuthorID
-	description := post.Description
-
-	// Step 1: Build
-	if !spendCredits(post, authorID, creditPerStep) {
-		addLog(post, "budget", "Budget exceeded before build", 0)
-		failAgent(post, "Budget exceeded")
-		return
-	}
-
-	addLog(post, "build", "Building app from description...", creditPerStep)
-
-	slug, name, err := BuildApp(description, post.AuthorID, post.Author)
-	if err != nil {
-		addLog(post, "error", fmt.Sprintf("Build failed: %v", err), 0)
-		failAgent(post, "Build failed: "+err.Error())
-		return
-	}
-
-	addLog(post, "build", fmt.Sprintf("Built %s (/apps/%s/run)", name, slug), 0)
-
-	// Steps 2-N: Verify and fix loop
-	for i := 0; i < maxAgentIterations; i++ {
-		// Verify
-		if VerifyApp == nil {
-			// No verifier — accept what we have
-			break
-		}
-
-		if !spendCredits(post, authorID, creditPerStep) {
-			addLog(post, "budget", "Budget exceeded during verification", 0)
-			break
-		}
-
-		issues, ok := VerifyApp(slug)
-		addLog(post, "verify", fmt.Sprintf("Verify attempt %d: %s", i+1, issues), creditPerStep)
-
-		if ok {
-			addLog(post, "verify", "App verified successfully", 0)
-			break
-		}
-
-		// Fix
-		if FixApp == nil {
-			break
-		}
-
-		if !spendCredits(post, authorID, creditPerStep) {
-			addLog(post, "budget", "Budget exceeded during fix", 0)
-			break
-		}
-
-		if err := FixApp(slug, issues); err != nil {
-			addLog(post, "error", fmt.Sprintf("Fix failed: %v", err), creditPerStep)
-			break
-		}
-
-		addLog(post, "fix", fmt.Sprintf("Applied fix for: %s", issues), creditPerStep)
-	}
-
-	// Deliver the result
-	delivery := fmt.Sprintf("%s — /apps/%s/run", name, slug)
+// RetryWithFeedback resets a delivered task and publishes a retry event.
+func RetryWithFeedback(postID, feedback string) {
 	mutex.Lock()
-	post.Delivery = delivery
-	post.Status = StatusDelivered
-	post.DeliveredAt = time.Now()
-	save()
-	title := post.Title
-	postID := post.ID
-	mutex.Unlock()
-
-	addLog(post, "complete", fmt.Sprintf("Delivered: %s (spent %d credits)", delivery, post.Spent), 0)
-
-	if Notify != nil {
-		Notify(authorID, "Agent completed: "+title,
-			fmt.Sprintf("The agent built %s for your task. Spent %d of %d credits.\n\n[Review delivery →](/work/%s)", name, post.Spent, post.Cost, postID), postID)
-	}
-}
-
-// failAgent marks a task as failed and releases it back to open.
-func failAgent(post *Post, reason string) {
-	mutex.Lock()
-	post.WorkerID = ""
-	post.Worker = ""
-	post.Status = StatusOpen
-	post.ClaimedAt = time.Time{}
-	save()
-	authorID := post.AuthorID
-	title := post.Title
-	postID := post.ID
-	mutex.Unlock()
-
-	if Notify != nil {
-		Notify(authorID, "Agent failed: "+title, reason, postID)
-	}
-}
-
-// RebuildApp is wired by main.go to update an existing app based on feedback.
-// Takes (slug, feedback) and returns error.
-var RebuildApp func(slug, feedback string) error
-
-// RetryWithFeedback updates the delivered app based on user feedback.
-func RetryWithFeedback(post *Post, feedback string) {
-	// Extract app slug from delivery
-	appSlug := ""
-	appName := ""
-	if parts := strings.SplitN(post.Delivery, " — /apps/", 2); len(parts) == 2 {
-		appSlug = strings.TrimSuffix(parts[1], "/run")
-		appName = parts[0]
-	}
-
-	if appSlug == "" {
-		addLog(post, "error", "No app to update", 0)
+	post, ok := posts[postID]
+	if !ok {
+		mutex.Unlock()
 		return
 	}
-
-	mutex.Lock()
 	post.Status = StatusClaimed
 	save()
 	mutex.Unlock()
 
-	addLog(post, "retry", "Updating with feedback: "+feedback, 0)
+	AddLog(postID, "retry", "Retrying with feedback: "+feedback, 0)
 
-	go func() {
-		if RebuildApp == nil {
-			failAgent(post, "No builder configured")
-			return
-		}
-
-		authorID := post.AuthorID
-
-		if !spendCredits(post, authorID, creditPerStep) {
-			addLog(post, "budget", "Budget exceeded", 0)
-			failAgent(post, "Budget exceeded")
-			return
-		}
-
-		addLog(post, "build", "Updating app with feedback...", creditPerStep)
-
-		if err := RebuildApp(appSlug, feedback); err != nil {
-			addLog(post, "error", fmt.Sprintf("Update failed: %v", err), 0)
-			failAgent(post, "Update failed: "+err.Error())
-			return
-		}
-
-		delivery := fmt.Sprintf("%s — /apps/%s/run", appName, appSlug)
-		mutex.Lock()
-		post.Delivery = delivery
-		post.Status = StatusDelivered
-		post.DeliveredAt = time.Now()
-		save()
-		title := post.Title
-		postID := post.ID
-		mutex.Unlock()
-
-		addLog(post, "complete", fmt.Sprintf("Delivered: %s (spent %d credits)", delivery, post.Spent), 0)
-
-		if Notify != nil {
-			Notify(authorID, "Agent updated: "+title,
-				fmt.Sprintf("The agent rebuilt %s with your feedback. Spent %d/%d credits.\n\n[Review delivery →](/work/%s)", appName, post.Spent, post.Cost, postID), postID)
-		}
-	}()
+	event.Publish(event.Event{
+		Type: event.EventTaskRetry,
+		Data: map[string]interface{}{
+			"post_id":  postID,
+			"feedback": feedback,
+		},
+	})
 }
 
-// ResumeAgentWork restarts any in-progress agent tasks (e.g. after server restart).
+// ResumeAgentWork re-publishes events for any in-progress agent tasks.
 func ResumeAgentWork() {
 	mutex.RLock()
-	var inProgress []*Post
+	var inProgress []string
 	for _, p := range posts {
 		if p.WorkerID == "agent" && p.Status == StatusClaimed {
-			inProgress = append(inProgress, p)
+			inProgress = append(inProgress, p.ID)
 		}
 	}
 	mutex.RUnlock()
 
-	for _, p := range inProgress {
-		fmt.Printf("[work] Resuming agent task: %s\n", p.Title)
-		go runAgent(p)
+	for _, id := range inProgress {
+		fmt.Printf("[work] Resuming agent task: %s\n", id)
+		event.Publish(event.Event{
+			Type: event.EventTaskCreated,
+			Data: map[string]interface{}{"post_id": id},
+		})
 	}
 }
 


### PR DESCRIPTION
Major refactor: work package no longer calls agent/apps directly.

Work package:
- Publishes task_created/task_retry events instead of running agent
- Exported AddLog, SetStatus, SetDelivery, BudgetRemaining helpers
- Removed all callback vars (BuildApp, VerifyApp, FixApp, etc.)
- RetryWithFeedback publishes event instead of calling RebuildApp

Agent package:
- New worker.go subscribes to task events
- Uses the same plan → execute tools → synthesise flow as interactive agent
- Calls api.ExecuteToolAs to run any MCP tool as the task author
- Can build apps, write blog posts, do research, fetch weather — anything

API package:
- New ExecuteToolAs(accountID, tool, args) creates a temporary session to execute tools on behalf of a user without an HTTP request

main.go:
- Removed ~100 lines of callback wiring
- Just calls agent.StartWorker()

The work system is now fully async and event-driven. Tasks are not limited to app building — the agent uses whatever tools fit the task.

https://claude.ai/code/session_01GRGLA9yj7BpqKiyi6xFwnm