### PR TITLE
Work agent via events, app delete fix, builder prompt, readability

### DIFF
--- a/internal/app/content.go
+++ b/internal/app/content.go
@@ -142,6 +142,8 @@ func renderMenu(actions []Action) string {
 			sb.WriteString(fmt.Sprintf(`<a href="#" style="%s" onclick="var u=location.origin+'%s';if(navigator.share){navigator.share({url:u})}else if(navigator.clipboard){navigator.clipboard.writeText(u).then(function(){this.textContent='Copied!'}.bind(this))}else{prompt('Copy link:',u)};return false;">Share</a>`, style, a.URL))
 		case a.Label == "Edit":
 			sb.WriteString(fmt.Sprintf(`<a href="%s" style="%s">Edit</a>`, a.URL, style))
+		case a.Label == "Delete" && a.Confirm != "":
+			sb.WriteString(fmt.Sprintf(`<a href="#" style="%s" onclick="if(confirm('%s')){fetch('%s',{method:'POST',redirect:'follow'}).then(function(r){window.location=r.url})};return false;">%s</a>`, style, a.Confirm, a.URL, a.Label))
 		case a.Confirm != "":
 			sb.WriteString(fmt.Sprintf(`<a href="#" style="%s" onclick="if(confirm('%s')){fetch('%s',{method:'POST'}).then(function(){location.reload()})};return false;">%s</a>`, style, a.Confirm, a.URL, a.Label))
 		default:


### PR DESCRIPTION
## Summary

- **Event-driven agent**: Work tasks publish events (`task_created`, `task_retry`), agent subscribes and runs autonomously using all MCP tools — not limited to app building
- **`api.ExecuteToolAs`**: Execute any MCP tool on behalf of a user without an HTTP request
- **App delete route**: Added `POST /apps/slug/delete` for content controls dropdown
- **Builder prompt**: Explicit "no direct fetch, must use mu.api" for sandboxed iframe apps
- **Delete redirect**: ⋯ menu delete follows server redirect instead of reloading deleted page
- **Build fixes**: missing `strings` import, undefined `name` variable

https://claude.ai/code/session_01GRGLA9yj7BpqKiyi6xFwnm