### PR TITLE
Add Blocked Users back to account settings

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -663,6 +663,7 @@ func Account(w http.ResponseWriter, r *http.Request) {
 
 <div class="card">
 <h4>Settings</h4>
+<p><a href="/app/blocked">Blocked Users →</a></p>
 <p><a href="/token">API Tokens →</a></p>
 %s
 <p style="margin-top:12px"><a href="/logout" class="text-error">Logout</a></p>


### PR DESCRIPTION
Blocking is a user feature — link should be in account settings for all users, not just admin dashboard.\n\nhttps://claude.ai/code/session_01GRGLA9yj7BpqKiyi6xFwnm