### PR TITLE
Fix apps_build: register tools before starting agent worker

### DIFF
--- a/agent/worker.go
+++ b/agent/worker.go
@@ -132,6 +132,13 @@ func runTask(postID, feedback string) {
 		}
 	}
 
+	// Check if any tools succeeded
+	if len(results) == 0 {
+		work.AddLog(postID, "error", "No tools succeeded", 0)
+		failTask(postID)
+		return
+	}
+
 	// Step 3: Synthesise result
 	work.AddLog(postID, "synth", "Composing result...", 0)
 

--- a/main.go
+++ b/main.go
@@ -103,8 +103,7 @@ func main() {
 		mail.SendMessage("Mu", "micro", acc.Name, toUserID, subject, body, threadID, "")
 	}
 
-	// Start the agent worker (subscribes to task events)
-	agent.StartWorker()
+
 
 	// load social
 	social.Load()
@@ -445,6 +444,9 @@ func main() {
 			return string(b), nil
 		},
 	})
+
+	// Start the agent worker after all tools are registered
+	agent.StartWorker()
 
 	authenticated := map[string]bool{
 		"/video":           false, // Public viewing, auth for interactive features


### PR DESCRIPTION
StartWorker was called before RegisterTool for apps_build, causing \"unknown tool\" errors. Also fails the task properly when no tools succeed.\n\nhttps://claude.ai/code/session_01GRGLA9yj7BpqKiyi6xFwnm