### PR TITLE
Design cleanup: consistent fonts, less clutter, cleaner pages

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -238,7 +238,6 @@ var Template = `
           <a href="/web"><img src="/search.svg?` + Version + `"><span class="label">Web</span></a>
           <a href="/work"><img src="/work.svg?` + Version + `"><span class="label">Work</span></a>
           <a id="nav-wallet" href="/wallet"><img src="/wallet.png?` + Version + `"><span class="label">Wallet</span></a>
-          <a href="/app/saved"><img src="/saved.svg?` + Version + `"><span class="label">Saved</span></a>
 
         </div>
         <div class="nav-bottom">
@@ -664,6 +663,7 @@ func Account(w http.ResponseWriter, r *http.Request) {
 <div class="card">
 <h4>Settings</h4>
 %s
+<p><a href="/app/saved">Saved →</a></p>
 <p><a href="/token">API Tokens →</a></p>
 <p><a href="/app/blocked">Blocked Users →</a></p>
 <p style="margin-top:12px"><a href="/logout" class="text-error">Logout</a></p>

--- a/internal/app/content.go
+++ b/internal/app/content.go
@@ -81,16 +81,10 @@ func ExternalControls(userID, contentType, contentID string) string {
 	return renderMenu(actions)
 }
 
-// StaticControls renders a ⋯ dropdown for cached content (no user context).
+// StaticControls is a no-op — cached content (news, video, blog listings)
+// shouldn't have per-item dropdown menus. They add noise.
 func StaticControls(contentType, contentID string) string {
-	u := contentURL(contentType, contentID)
-	actions := []Action{
-		{Label: "Save", URL: fmt.Sprintf("/app/save?type=%s&id=%s", contentType, contentID)},
-	}
-	if u != "" {
-		actions = append(actions, Action{Label: "Share", URL: u})
-	}
-	return renderMenu(actions)
+	return ""
 }
 
 // contentURL returns the permalink for a content item.

--- a/internal/app/controls.go
+++ b/internal/app/controls.go
@@ -201,24 +201,18 @@ func renderSavedPage(w http.ResponseWriter, r *http.Request, userID string) {
 			return items[i].time > items[j].time
 		})
 
+		sb.WriteString(`<div class="card">`)
 		for _, it := range items {
 			typeLabel := typeLabels[it.ct]
 			if typeLabel == "" {
 				typeLabel = it.ct
 			}
-
-			// Video thumbnail embed
-			extra := ""
-			if it.ct == "video" {
-				extra = fmt.Sprintf(`<div style="margin-top:8px"><iframe src="https://www.youtube.com/embed/%s" width="100%%" height="200" style="border:none;border-radius:6px" allowfullscreen></iframe></div>`, it.cid)
-			}
-
-			sb.WriteString(fmt.Sprintf(`<div class="card">
-				<p><a href="%s"><strong>%s</strong></a></p>
-				<p class="text-sm text-muted">%s · Saved %s</p>%s
-				<p style="margin-top:6px"><a href="#" class="text-sm text-muted" onclick="fetch('/app/unsave?type=%s&id=%s',{method:'POST'}).then(function(){location.reload()});return false;">Remove</a></p>
-			</div>`, it.url, it.label, typeLabel, it.time, extra, it.ct, it.cid))
+			sb.WriteString(fmt.Sprintf(`<div style="padding:8px 0;border-bottom:1px solid #f0f0f0">
+				<a href="%s">%s</a>
+				<span class="text-sm text-muted"> · %s · %s · <a href="#" onclick="fetch('/app/unsave?type=%s&id=%s',{method:'POST'}).then(function(){location.reload()});return false;">remove</a></span>
+			</div>`, it.url, it.label, typeLabel, it.time, it.ct, it.cid))
 		}
+		sb.WriteString(`</div>`)
 	}
 
 	html := RenderHTMLForRequest("Saved", "Your saved items", sb.String(), r)
@@ -233,12 +227,14 @@ func renderBlockedPage(w http.ResponseWriter, r *http.Request, userID string) {
 	if len(blocked) == 0 {
 		sb.WriteString(`<div class="card"><p class="text-muted">No blocked users.</p></div>`)
 	} else {
+		sb.WriteString(`<div class="card">`)
 		for uid, t := range blocked {
-			sb.WriteString(fmt.Sprintf(`<div class="card">
-				<p><a href="/@%s">%s</a></p>
-				<p class="text-sm text-muted">Blocked %s · <a href="#" onclick="fetch('/app/unblock?user=%s',{method:'POST'}).then(function(){location.reload()});return false;">Unblock</a></p>
+			sb.WriteString(fmt.Sprintf(`<div style="padding:8px 0;border-bottom:1px solid #f0f0f0">
+				<a href="/@%s">%s</a>
+				<span class="text-sm text-muted"> · %s · <a href="#" onclick="fetch('/app/unblock?user=%s',{method:'POST'}).then(function(){location.reload()});return false;">unblock</a></span>
 			</div>`, uid, uid, t.Format("2 Jan 2006"), uid))
 		}
+		sb.WriteString(`</div>`)
 	}
 
 	html := RenderHTMLForRequest("Blocked Users", "Blocked users", sb.String(), r)

--- a/internal/app/html/mu.css
+++ b/internal/app/html/mu.css
@@ -2586,7 +2586,7 @@ a.highlight {
 
 /* Font size */
 .text-xs { font-size: 12px; }
-.text-sm { font-size: 14px; }
+.text-sm { font-size: 13px; }
 .text-base { font-size: 16px; }
 .text-lg { font-size: 18px; }
 .text-xl { font-size: 24px; }

--- a/search/search.go
+++ b/search/search.go
@@ -175,10 +175,10 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 			b.WriteString(`<div class="card" style="margin-bottom:12px;">`)
 			b.WriteString(`<div><a href="` + html.EscapeString(link) + `" class="card-title">` +
 				html.EscapeString(entry.Title) + `</a>`)
-			b.WriteString(` <span class="category" style="font-size:11px;">` +
+			b.WriteString(` <span class="category" style="font-size:13px;">` +
 				html.EscapeString(entry.Type) + `</span>`)
 			if !entry.IndexedAt.IsZero() {
-				b.WriteString(` <span style="font-size:11px;color:#888;margin-left:4px;">` +
+				b.WriteString(` <span style="font-size:13px;color:#888;margin-left:4px;">` +
 					html.EscapeString(app.TimeAgo(entry.IndexedAt)) + `</span>`)
 			}
 			b.WriteString(`</div>`)
@@ -298,8 +298,7 @@ func WebHandler(w http.ResponseWriter, r *http.Request) {
 			if result.Age != "" {
 				meta += ` · ` + html.EscapeString(result.Age)
 			}
-			meta += app.ExternalControls(sess.Account, "web", url.QueryEscape(result.URL))
-			b.WriteString(`<div style="font-size:11px;color:#888;margin-top:2px;">` + meta + `</div>`)
+			b.WriteString(`<div style="font-size:13px;color:#888;margin-top:2px;">` + meta + `</div>`)
 			b.WriteString(`</div>`)
 		}
 	}

--- a/social/social.go
+++ b/social/social.go
@@ -662,7 +662,7 @@ func generateThreadHTML(p *Message, replies []*Message, r *http.Request) string 
   %s
   <div style="display:flex;justify-content:space-between;align-items:baseline;padding-right:20px">
     <div>%s</div>
-    <div><span data-timestamp="%d" style="color:#888;font-size:12px;">%s</span></div>
+    <div><span data-timestamp="%d" style="color:#888;font-size:13px;">%s</span></div>
   </div>
   <div style="margin-top:8px;font-size:15px;line-height:1.5;overflow-wrap:break-word;word-break:break-word;">%s</div>%s
 </div>`,
@@ -691,7 +691,7 @@ func generateThreadHTML(p *Message, replies []*Message, r *http.Request) string 
     <textarea name="content" id="reply-content" rows="2" placeholder="Write a message..." required
       style="width:100%%;box-sizing:border-box;padding:10px;border:1px solid #ddd;border-radius:8px;font-family:inherit;font-size:14px;resize:vertical;"></textarea>
     <div style="display:flex;justify-content:space-between;align-items:center;margin-top:8px;">
-      <span id="reply-char-count" style="font-size:12px;color:#888;">0/500</span>
+      <span id="reply-char-count" style="font-size:13px;color:#888;">0/500</span>
       <button type="submit" style="padding:6px 16px;background:#000;color:#fff;border:none;border-radius:6px;cursor:pointer;font-family:inherit;">Send</button>
     </div>
   </form>
@@ -724,7 +724,7 @@ func generateThreadHTML(p *Message, replies []*Message, r *http.Request) string 
 		sb.WriteString(fmt.Sprintf(`<div style="padding:12px 0;border-bottom:1px solid #f5f5f5;">
   <div style="display:flex;justify-content:space-between;align-items:baseline;">
     <div style="font-size:13px;"><b>%s</b></div>
-    <div><span data-timestamp="%d" style="color:#888;font-size:12px;">%s</span>%s</div>
+    <div><span data-timestamp="%d" style="color:#888;font-size:13px;">%s</span>%s</div>
   </div>
   <div style="margin-top:4px;overflow-wrap:break-word;word-break:break-word;">%s</div>
 </div>`,
@@ -950,7 +950,7 @@ func generatePageHTML(visible []*Message, r *http.Request) string {
     <textarea name="content" id="social-content" rows="3" placeholder="Start a thread..." required
       style="width:100%;box-sizing:border-box;padding:10px;border:1px solid #ddd;border-radius:8px;font-family:inherit;font-size:14px;resize:vertical;"></textarea>
     <div style="display:flex;justify-content:space-between;align-items:center;margin-top:8px;">
-      <span id="social-char-count" style="font-size:12px;color:#888;">0/500</span>
+      <span id="social-char-count" style="font-size:13px;color:#888;">0/500</span>
       <button type="submit" style="padding:8px 20px;background:#000;color:#fff;border:none;border-radius:6px;cursor:pointer;font-family:inherit;">Start Thread</button>
     </div>
   </form>
@@ -1011,13 +1011,13 @@ func generatePageHTML(visible []*Message, r *http.Request) string {
 		mutex.RLock()
 		rc := replyCount(p.ID)
 		mutex.RUnlock()
-		replyLink := fmt.Sprintf(`<a href="/social/thread?id=%s" style="color:#888;text-decoration:none;font-size:12px;">open thread</a>`, p.ID)
+		replyLink := fmt.Sprintf(`<a href="/social/thread?id=%s" style="color:#888;text-decoration:none;font-size:13px;">open thread</a>`, p.ID)
 		if rc > 0 {
 			noun := "messages"
 			if rc == 1 {
 				noun = "message"
 			}
-			replyLink = fmt.Sprintf(`<a href="/social/thread?id=%s" style="color:#888;text-decoration:none;font-size:12px;">%d %s</a>`, p.ID, rc, noun)
+			replyLink = fmt.Sprintf(`<a href="/social/thread?id=%s" style="color:#888;text-decoration:none;font-size:13px;">%d %s</a>`, p.ID, rc, noun)
 		}
 
 		ts := p.PostedAt.Unix()
@@ -1029,7 +1029,7 @@ func generatePageHTML(visible []*Message, r *http.Request) string {
   %s
   <div style="display:flex;justify-content:space-between;align-items:baseline;padding-right:20px">
     <div>%s</div>
-    <div><span data-timestamp="%d" style="color:#888;font-size:12px;">%s</span></div>
+    <div><span data-timestamp="%d" style="color:#888;font-size:13px;">%s</span></div>
   </div>
   <div style="margin-top:4px;overflow-wrap:break-word;word-break:break-word;">%s</div>%s
   <div style="margin-top:6px;">%s</div>
@@ -1087,7 +1087,7 @@ func renderLinkCard(rawURL string) string {
 			return ""
 		}
 		return fmt.Sprintf(`<a href="%s" target="_blank" rel="noopener noreferrer" style="display:block;border:1px solid #e1e1e1;border-radius:12px;padding:12px;margin-top:8px;text-decoration:none;color:inherit;">
-  <div style="font-size:12px;color:#888;">%s</div>
+  <div style="font-size:13px;color:#888;">%s</div>
 </a>`, htmlpkg.EscapeString(rawURL), htmlpkg.EscapeString(parsed.Hostname()))
 	}
 
@@ -1107,7 +1107,7 @@ func renderLinkCard(rawURL string) string {
 		}
 	}
 	if site != "" {
-		sb.WriteString(fmt.Sprintf(`<div style="font-size:12px;color:#888;margin-bottom:2px;">%s</div>`, htmlpkg.EscapeString(site)))
+		sb.WriteString(fmt.Sprintf(`<div style="font-size:13px;color:#888;margin-bottom:2px;">%s</div>`, htmlpkg.EscapeString(site)))
 	}
 
 	if md.Title != "" {

--- a/work/handlers.go
+++ b/work/handlers.go
@@ -78,18 +78,9 @@ func handleList(w http.ResponseWriter, r *http.Request) {
 
 	var sb strings.Builder
 
-	// Inline post form for logged-in users
-	if sess != nil {
-		sb.WriteString(`<div class="card">`)
-		sb.WriteString(renderPostForm("show", ""))
-		sb.WriteString(`</div>`)
-	} else {
-		sb.WriteString(`<div class="card"><p><a href="/login">Login</a> to post or interact.</p></div>`)
-	}
-
-	// Filter tabs
+	// Filter tabs + new post link
 	sb.WriteString(`<div class="card">`)
-	sb.WriteString(`<div style="display:flex;gap:6px;flex-wrap:wrap">`)
+	sb.WriteString(`<div style="display:flex;gap:6px;flex-wrap:wrap;align-items:center">`)
 	for _, f := range []struct{ val, label string }{
 		{"", "All"},
 		{"show", "Show"},
@@ -106,11 +97,18 @@ func handleList(w http.ResponseWriter, r *http.Request) {
 		}
 		sb.WriteString(fmt.Sprintf(`<a href="%s" style="%s">%s</a>`, href, style, f.label))
 	}
+	if sess != nil {
+		sb.WriteString(`<a href="/work/post" class="btn" style="margin-left:auto">+ New</a>`)
+	}
 	sb.WriteString(`</div>`)
 	sb.WriteString(`</div>`)
 
 	if len(allPosts) == 0 {
-		sb.WriteString(`<div class="card"><p class="text-muted">No posts yet.</p></div>`)
+		if sess != nil {
+			sb.WriteString(`<div class="card"><p class="text-muted">No posts yet. <a href="/work/post">Create one →</a></p></div>`)
+		} else {
+			sb.WriteString(`<div class="card"><p class="text-muted">No posts yet. <a href="/login">Login</a> to create one.</p></div>`)
+		}
 	}
 
 	for _, post := range allPosts {
@@ -289,7 +287,7 @@ func handleDetail(w http.ResponseWriter, r *http.Request) {
 			if entry.Credits > 0 {
 				credits = fmt.Sprintf(` · %dc`, entry.Credits)
 			}
-			sb.WriteString(fmt.Sprintf(`<p style="font-size:12px;margin:2px 0;color:#666"><span style="color:%s;font-weight:600">%s</span> %s%s</p>`,
+			sb.WriteString(fmt.Sprintf(`<p style="font-size:13px;margin:2px 0;color:#666"><span style="color:%s;font-weight:600">%s</span> %s%s</p>`,
 				color, entry.Step, entry.Message, credits))
 		}
 		sb.WriteString(`</div>`)


### PR DESCRIPTION
## Summary

- Standardise all small text to 13px (was mixed 11/12/13/14px)
- Remove ⋯ menus from cached content (news, video, blog listings)
- Remove Saved from nav (secondary page, in account settings)
- Move work post form to /work/post, show "+ New" button in filter bar
- Saved/blocked pages: single card with list, not card-per-item
- .text-sm is now 13px not 14px

https://claude.ai/code/session_01GRGLA9yj7BpqKiyi6xFwnm