### PR TITLE
Fix SDK CSP error: auto-inject inline, strip external script tag

### DIFF
--- a/apps/apps.go
+++ b/apps/apps.go
@@ -833,6 +833,10 @@ ai:function(p,o){return this._send('ai',{prompt:p,options:o||{}})},
 fetch:function(u){return this._send('fetch',{url:u})},
 user:function(){return this._send('user',{})},
 run:function(result){window.parent.postMessage({type:'mu:run',result:result},'*');},
+api:{
+get:function(p){return mu._send('api',{method:'GET',path:p})},
+post:function(p,b){return mu._send('api',{method:'POST',path:p,body:b})}
+},
 store:{
 set:function(k,v){return mu._send('store',{op:'set',key:k,value:v})},
 get:function(k){return mu._send('store',{op:'get',key:k})},
@@ -842,6 +846,9 @@ keys:function(){return mu._send('store',{op:'keys'})}
 window.addEventListener('message',function(e){var d=e.data;if(d&&d.type&&d.type.indexOf('mu:')===0&&d.id&&mu._cb[d.id]){if(d.error){mu._cb[d.id].fail(new Error(d.error))}else{mu._cb[d.id].ok(d.result)}delete mu._cb[d.id];}});
 </script>`
 		html := a.HTML
+		// Strip any <script src="/apps/sdk.js"> tags — the SDK is injected inline below
+		html = strings.ReplaceAll(html, `<script src="/apps/sdk.js"></script>`, "")
+		html = strings.ReplaceAll(html, `<script src='/apps/sdk.js'></script>`, "")
 		if idx := strings.Index(strings.ToLower(html), "<head>"); idx >= 0 {
 			html = html[:idx+6] + sdkBridge + html[idx+6:]
 		} else if idx := strings.Index(strings.ToLower(html), "<html"); idx >= 0 {

--- a/apps/builder.go
+++ b/apps/builder.go
@@ -38,7 +38,7 @@ Rules:
 - Button style: padding 8-10px 20-24px, border-radius 6px, primary buttons use background #000 color #fff
 - Keep it simple and functional — no external dependencies, no CDN links, no images
 - The app runs in a sandboxed iframe — it CANNOT use fetch() or XMLHttpRequest directly. All API calls MUST go through the Mu SDK.
-- IMPORTANT: Always include <script src="/apps/sdk.js"></script> at the top of your app if it needs any external data, AI, or storage.
+- IMPORTANT: Do NOT include <script src="/apps/sdk.js"></script> — the SDK is injected automatically. Just use mu.* functions directly.
 - If the app uses geolocation (navigator.geolocation), ALWAYS provide a graceful fallback: show a manual location input or a sensible default when the user denies permission or the API fails. Never let the app be blank or broken if location is unavailable.
 - For AI features: mu.ai(prompt) — returns a promise with the AI response
 - For persistent storage: mu.store.set(key, value), mu.store.get(key), mu.store.del(key)


### PR DESCRIPTION
Sandboxed iframe CSP blocks external script loads. SDK is already injected inline — strip the external tag, add mu.api to inline SDK.\n\nhttps://claude.ai/code/session_01GRGLA9yj7BpqKiyi6xFwnm