### PR TITLE
Fix weather API docs, API usage checks, remove email notifications

### DIFF
--- a/agent/worker.go
+++ b/agent/worker.go
@@ -217,7 +217,7 @@ func verifyApp(post *work.Post, postID string) string {
 		return "Could not read app HTML"
 	}
 
-	// Basic structural checks first
+	// Basic structural checks
 	htmlLower := strings.ToLower(html)
 	if len(html) < 100 {
 		return "App HTML is too short — likely incomplete"
@@ -229,9 +229,21 @@ func verifyApp(post *work.Post, postID string) string {
 		return "No JavaScript — app likely has no interactivity"
 	}
 
-	// AI review
+	// Check for common API usage mistakes
+	apiIssues := checkAPIUsage(html)
+	if apiIssues != "" {
+		return apiIssues
+	}
+
+	// AI review with API context
 	result, err := ai.Ask(&ai.Prompt{
 		System: `You are a code reviewer checking a web app. Given the requirements and HTML, check for functional issues.
+
+IMPORTANT API rules to verify:
+- /weather requires lat=NUMBER&lon=NUMBER (NOT a city name or ?q=)
+- mu.api.get/mu.api.post must be used (NOT fetch())
+- Apps cannot load external scripts (sandboxed iframe)
+
 Reply with ONLY one of:
 - "PASS" if the app should work correctly based on the code
 - "FAIL: <one-line description of the main issue>"
@@ -406,6 +418,28 @@ func getAppBySlug(slug string) *struct {
 	return &result
 }
 
+// checkAPIUsage looks for common API misuse patterns in app HTML.
+func checkAPIUsage(html string) string {
+	lower := strings.ToLower(html)
+
+	// Check for /weather?q= (wrong — needs lat/lon)
+	if strings.Contains(lower, "/weather?q=") || strings.Contains(lower, "/weather?city=") {
+		return "Weather API requires lat and lon parameters, not q or city. Use navigator.geolocation or geocode the city name first."
+	}
+
+	// Check for direct fetch() calls (blocked by CSP)
+	if strings.Contains(html, "fetch('http") || strings.Contains(html, `fetch("http`) || strings.Contains(html, "fetch(`http") {
+		return "App uses fetch() to call external URLs directly. This is blocked by the sandbox. Use mu.api.get() or mu.api.post() instead."
+	}
+
+	// Check for external script loads (blocked by CSP)
+	if strings.Contains(lower, `<script src="http`) || strings.Contains(lower, `<script src='http`) {
+		return "App loads external scripts which is blocked by the sandbox. All code must be inline."
+	}
+
+	return ""
+}
+
 // cleanHTML strips markdown fences and leading/trailing whitespace from AI HTML output.
 func cleanHTML(s string) string {
 	s = strings.TrimSpace(s)
@@ -458,17 +492,9 @@ func truncateStr(s string, n int) string {
 }
 
 func notifyComplete(post *work.Post, postID string) {
-	if work.Notify != nil {
-		work.Notify(post.AuthorID, "Task completed: "+post.Title,
-			fmt.Sprintf("Your task has been completed.\n\n[Review →](/work/%s)", postID), postID)
-	}
+	// No email — user sees live progress on the task page
 }
 
 func failTask(postID string) {
 	work.SetStatus(postID, "open")
-	post := work.GetPost(postID)
-	if post != nil && work.Notify != nil {
-		work.Notify(post.AuthorID, "Task failed: "+post.Title,
-			"The agent could not complete this task.", postID)
-	}
 }

--- a/apps/builder.go
+++ b/apps/builder.go
@@ -43,9 +43,17 @@ Rules:
 - For AI features: mu.ai(prompt) — returns a promise with the AI response
 - For persistent storage: mu.store.set(key, value), mu.store.get(key), mu.store.del(key)
 - For platform data — NEVER use fetch() directly, always use mu.api:
-  - mu.api.get(path) — GET request (e.g. mu.api.get('/weather?q=London'))
-  - mu.api.post(path, body) — POST request (e.g. mu.api.post('/places/search', {q:'cafe',near:'London'}))
-  - Available APIs: /weather?q=, /places/search, /places/nearby, /news, /markets, /video, /chat
+  - mu.api.get(path) — GET request, returns a promise with JSON response
+  - mu.api.post(path, body) — POST request, returns a promise with JSON response
+  - Available APIs and their EXACT parameters:
+    - /weather?lat=NUMBER&lon=NUMBER — weather forecast (REQUIRES lat/lon coordinates, NOT city name. Use geocoding first or navigator.geolocation)
+    - /places/search — POST with {q:"cafe", near:"London"} — search for places
+    - /places/nearby — POST with {address:"London", radius:1000} — find nearby places
+    - /news — GET, returns latest news feed
+    - /markets?category=crypto|futures|commodities — GET, returns market prices
+    - /video — GET, returns latest videos
+    - /chat — POST with {prompt:"question"} — ask the AI
+  - For weather apps: use navigator.geolocation to get lat/lon, OR use mu.api.post('/places/search', {q: cityName}) to geocode a city name, then pass the lat/lon to /weather
 - Maximum 256KB HTML
 - Make it responsive and mobile-friendly
 - Use semantic HTML and accessible patterns


### PR DESCRIPTION
- Fixed weather API docs (lat/lon not q=)\n- API usage checker catches /weather?q=, fetch(), external scripts\n- Removed task email notifications (live page is enough)\n\nhttps://claude.ai/code/session_01GRGLA9yj7BpqKiyi6xFwnm