### PR TITLE
Add apps_test: real API testing instead of AI guessing

### DIFF
--- a/agent/worker.go
+++ b/agent/worker.go
@@ -210,58 +210,19 @@ func editApp(post *work.Post, postID, feedback string) {
 	work.AddLog(postID, "build", "App updated", 0)
 }
 
-// verifyApp asks the AI to review the app against requirements.
+// verifyApp tests the app by checking structure and executing API calls.
 // Returns issues string (empty = passed).
 func verifyApp(post *work.Post, postID string) string {
-	html := readAppHTML(post.AuthorID, post.AppSlug)
-	if html == "" {
-		return "Could not read app HTML"
+	result := apps.TestApp(post.AppSlug, post.AuthorID)
+	if result == nil {
+		return "Could not test app"
 	}
 
-	// Basic structural checks
-	htmlLower := strings.ToLower(html)
-	if len(html) < 100 {
-		return "App HTML is too short — likely incomplete"
-	}
-	if !strings.Contains(htmlLower, "<body") {
-		return "Missing <body> tag"
-	}
-	if !strings.Contains(htmlLower, "<script") && strings.Contains(strings.ToLower(post.Description), "app") {
-		return "No JavaScript — app likely has no interactivity"
+	if len(result.Issues) > 0 {
+		return strings.Join(result.Issues, "; ")
 	}
 
-	// Check for common API usage mistakes
-	apiIssues := checkAPIUsage(html)
-	if apiIssues != "" {
-		return apiIssues
-	}
-
-	// AI review with API context
-	result, err := ai.Ask(&ai.Prompt{
-		System: `You are a code reviewer checking a web app. Given the requirements and HTML, check for functional issues.
-
-IMPORTANT API rules to verify:
-- /weather requires lat=NUMBER&lon=NUMBER (NOT a city name or ?q=)
-- mu.api.get/mu.api.post must be used (NOT fetch())
-- Apps cannot load external scripts (sandboxed iframe)
-
-Reply with ONLY one of:
-- "PASS" if the app should work correctly based on the code
-- "FAIL: <one-line description of the main issue>"
-Be strict. Check that the app actually implements the core functionality, not just the UI.`,
-		Question: fmt.Sprintf("Requirements:\n%s\n\nHTML:\n%s", post.Description, truncateStr(html, 4000)),
-		Priority: ai.PriorityHigh,
-		Caller:   "work-verify",
-	})
-	if err != nil {
-		return "" // AI failed, assume pass
-	}
-
-	result = strings.TrimSpace(result)
-	if strings.HasPrefix(strings.ToUpper(result), "PASS") {
-		return ""
-	}
-	return strings.TrimPrefix(strings.TrimPrefix(result, "FAIL:"), "FAIL: ")
+	return ""
 }
 
 // fixApp fixes issues in an existing app.
@@ -417,28 +378,6 @@ func getAppBySlug(authorID, slug string) *struct {
 		return nil
 	}
 	return &result
-}
-
-// checkAPIUsage looks for common API misuse patterns in app HTML.
-func checkAPIUsage(html string) string {
-	lower := strings.ToLower(html)
-
-	// Check for /weather?q= (wrong — needs lat/lon)
-	if strings.Contains(lower, "/weather?q=") || strings.Contains(lower, "/weather?city=") {
-		return "Weather API requires lat and lon parameters, not q or city. Use navigator.geolocation or geocode the city name first."
-	}
-
-	// Check for direct fetch() calls (blocked by CSP)
-	if strings.Contains(html, "fetch('http") || strings.Contains(html, `fetch("http`) || strings.Contains(html, "fetch(`http") {
-		return "App uses fetch() to call external URLs directly. This is blocked by the sandbox. Use mu.api.get() or mu.api.post() instead."
-	}
-
-	// Check for external script loads (blocked by CSP)
-	if strings.Contains(lower, `<script src="http`) || strings.Contains(lower, `<script src='http`) {
-		return "App loads external scripts which is blocked by the sandbox. All code must be inline."
-	}
-
-	return ""
 }
 
 // cleanHTML strips markdown fences and leading/trailing whitespace from AI HTML output.

--- a/apps/test.go
+++ b/apps/test.go
@@ -1,0 +1,154 @@
+package apps
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"strings"
+
+	"mu/internal/auth"
+)
+
+// TestResult contains the results of testing an app's API calls.
+type TestResult struct {
+	Total   int          `json:"total"`
+	Passed  int          `json:"passed"`
+	Failed  int          `json:"failed"`
+	Results []APICallResult `json:"results"`
+	Issues  []string     `json:"issues"`
+}
+
+// APICallResult records one API call test.
+type APICallResult struct {
+	Method string `json:"method"`
+	Path   string `json:"path"`
+	Status string `json:"status"` // "ok" or "error"
+	Error  string `json:"error,omitempty"`
+}
+
+// TestApp extracts mu.api calls from an app's HTML/JS code,
+// executes them server-side, and reports which ones work.
+func TestApp(slug, authorID string) *TestResult {
+	a := GetApp(slug)
+	if a == nil {
+		return &TestResult{Issues: []string{"App not found"}}
+	}
+
+	result := &TestResult{}
+	html := a.HTML
+
+	// Structural checks
+	lower := strings.ToLower(html)
+	if len(html) < 100 {
+		result.Issues = append(result.Issues, "HTML is too short — likely incomplete")
+	}
+	if !strings.Contains(lower, "<body") {
+		result.Issues = append(result.Issues, "Missing <body> tag")
+	}
+	if !strings.Contains(lower, "<script") {
+		result.Issues = append(result.Issues, "No JavaScript — app has no interactivity")
+	}
+
+	// Check for common mistakes
+	if strings.Contains(html, "fetch('http") || strings.Contains(html, `fetch("http`) {
+		result.Issues = append(result.Issues, "Uses fetch() to call external URLs — blocked by sandbox. Use mu.api instead.")
+	}
+	if strings.Contains(lower, `<script src="http`) || strings.Contains(lower, `<script src='http`) {
+		result.Issues = append(result.Issues, "Loads external scripts — blocked by sandbox CSP")
+	}
+	if strings.Contains(html, "/weather?q=") || strings.Contains(html, "/weather?city=") {
+		result.Issues = append(result.Issues, "Weather API needs lat/lon not city name. Use /weather?lat=NUMBER&lon=NUMBER")
+	}
+	if strings.Contains(html, `src="/apps/sdk.js"`) || strings.Contains(html, `src='/apps/sdk.js'`) {
+		result.Issues = append(result.Issues, "SDK script tag included — it's auto-injected, remove the <script src> tag")
+	}
+
+	// Extract mu.api.get() calls and test them
+	getPattern := regexp.MustCompile(`mu\.api\.get\(['"]([^'"]+)['"]\)`)
+	for _, match := range getPattern.FindAllStringSubmatch(html, -1) {
+		if len(match) < 2 {
+			continue
+		}
+		path := match[1]
+		result.Total++
+
+		// Skip dynamic paths
+		if strings.Contains(path, "${") || strings.Contains(path, "'+") || strings.Contains(path, `"+`) {
+			result.Results = append(result.Results, APICallResult{
+				Method: "GET", Path: path, Status: "skip",
+				Error: "Dynamic path — can't test statically",
+			})
+			continue
+		}
+
+		// Test by making an internal HTTP request
+		callResult := testAPICall(authorID, "GET", path)
+		result.Results = append(result.Results, callResult)
+		if callResult.Status == "ok" {
+			result.Passed++
+		} else {
+			result.Failed++
+			result.Issues = append(result.Issues, fmt.Sprintf("GET %s: %s", path, callResult.Error))
+		}
+	}
+
+	// Extract mu.api.post() calls
+	postPattern := regexp.MustCompile(`mu\.api\.post\(['"]([^'"]+)['"]`)
+	for _, match := range postPattern.FindAllStringSubmatch(html, -1) {
+		if len(match) < 2 {
+			continue
+		}
+		path := match[1]
+		result.Total++
+		// Just check the endpoint is valid — don't execute POST with unknown body
+		validPaths := map[string]bool{
+			"/places/search": true, "/places/nearby": true,
+			"/chat": true, "/news": true,
+		}
+		if validPaths[path] {
+			result.Passed++
+			result.Results = append(result.Results, APICallResult{
+				Method: "POST", Path: path, Status: "ok",
+			})
+		} else {
+			result.Results = append(result.Results, APICallResult{
+				Method: "POST", Path: path, Status: "skip",
+				Error: "Unknown POST endpoint",
+			})
+		}
+	}
+
+	return result
+}
+
+// testAPICall makes an internal HTTP request to a Mu API endpoint
+// and checks if it returns a successful response.
+func testAPICall(authorID, method, path string) APICallResult {
+	// Create authenticated request
+	sess, err := auth.CreateSession(authorID)
+	if err != nil {
+		return APICallResult{Method: method, Path: path, Status: "error", Error: "auth failed"}
+	}
+
+	req, _ := http.NewRequest(method, path, nil)
+	req.AddCookie(&http.Cookie{Name: "session", Value: sess.Token})
+	req.Header.Set("Accept", "application/json")
+
+	recorder := httptest.NewRecorder()
+	http.DefaultServeMux.ServeHTTP(recorder, req)
+
+	if recorder.Code >= 400 {
+		// Try to extract error message from JSON response
+		var errResp struct {
+			Error string `json:"error"`
+		}
+		if json.Unmarshal(recorder.Body.Bytes(), &errResp) == nil && errResp.Error != "" {
+			return APICallResult{Method: method, Path: path, Status: "error", Error: fmt.Sprintf("HTTP %d: %s", recorder.Code, errResp.Error)}
+		}
+		return APICallResult{Method: method, Path: path, Status: "error", Error: fmt.Sprintf("HTTP %d", recorder.Code)}
+	}
+
+	return APICallResult{Method: method, Path: path, Status: "ok"}
+}

--- a/main.go
+++ b/main.go
@@ -453,6 +453,21 @@ func main() {
 			return string(b), nil
 		},
 	})
+	api.RegisterToolWithAuth(api.Tool{
+		Name:        "apps_test",
+		Description: "Test an app by checking its HTML structure and executing its mu.api calls server-side. Returns which API calls work and which fail.",
+		Params: []api.ToolParam{
+			{Name: "slug", Type: "string", Description: "The app's URL slug", Required: true},
+		},
+	}, func(args map[string]any, accountID string) (string, error) {
+		slug, _ := args["slug"].(string)
+		if slug == "" {
+			return `{"error":"slug required"}`, fmt.Errorf("missing slug")
+		}
+		result := apps.TestApp(slug, accountID)
+		b, _ := json.Marshal(result)
+		return string(b), nil
+	})
 
 	// Start the agent worker after all tools are registered
 	agent.StartWorker()


### PR DESCRIPTION
## Summary

New `apps_test` tool that actually tests app API calls server-side instead of asking AI to review code.

- Extracts `mu.api.get()` calls from app JS via regex
- Executes them against the real Mu API
- Reports real errors ("HTTP 400: lat and lon required")
- Agent worker uses this instead of AI code review

https://claude.ai/code/session_01GRGLA9yj7BpqKiyi6xFwnm