### PR TITLE
Add synchronous agent endpoint, MCP tool, and SDK function

### DIFF
--- a/agent/run.go
+++ b/agent/run.go
@@ -1,0 +1,150 @@
+package agent
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"mu/internal/ai"
+	"mu/internal/api"
+	"mu/internal/app"
+	"mu/internal/auth"
+)
+
+// RunRequest is the input for the synchronous agent endpoint.
+type RunRequest struct {
+	Prompt string `json:"prompt"`
+	Model  string `json:"model"`
+}
+
+// RunResponse is the output of the synchronous agent endpoint.
+type RunResponse struct {
+	Answer string     `json:"answer"`
+	Tools  []ToolUsed `json:"tools,omitempty"`
+	Error  string     `json:"error,omitempty"`
+}
+
+// ToolUsed records a tool call and its result.
+type ToolUsed struct {
+	Name   string `json:"name"`
+	Status string `json:"status"` // "ok" or "error"
+}
+
+// RunHandler handles POST /agent/run — synchronous agent query.
+// Returns JSON with the answer instead of SSE streaming.
+func RunHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != "POST" {
+		http.Error(w, "Method not allowed", 405)
+		return
+	}
+
+	var req RunRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil || strings.TrimSpace(req.Prompt) == "" {
+		app.RespondJSON(w, RunResponse{Error: "prompt required"})
+		return
+	}
+
+	_, acc, err := auth.RequireSession(r)
+	if err != nil {
+		w.WriteHeader(401)
+		app.RespondJSON(w, RunResponse{Error: "authentication required"})
+		return
+	}
+
+	// Check quota
+	model := Models[0]
+	for _, m := range Models {
+		if m.ID == req.Model {
+			model = m
+			break
+		}
+	}
+	if QuotaCheck != nil {
+		canProceed, _, err := QuotaCheck(r, model.WalletOp)
+		if !canProceed {
+			w.WriteHeader(402)
+			msg := "Insufficient credits"
+			if err != nil {
+				msg = err.Error()
+			}
+			app.RespondJSON(w, RunResponse{Error: msg})
+			return
+		}
+	}
+
+	_ = acc // authenticated
+
+	// Step 1: Plan
+	planResult, err := ai.Ask(&ai.Prompt{
+		System: "You are an AI agent. Given a user question, output ONLY a JSON array of tool calls.\n\n" +
+			agentToolsDesc +
+			"\n\nOutput format: [{\"tool\":\"tool_name\",\"args\":{}}]\nUse at most 5 tool calls. Output [] if no tools needed.",
+		Question: req.Prompt,
+		Priority: ai.PriorityHigh,
+		Provider: model.Provider,
+		Model:    model.Model,
+		Caller:   "agent-run-plan",
+	})
+
+	type toolCall struct {
+		Tool string         `json:"tool"`
+		Args map[string]any `json:"args"`
+	}
+	var toolCalls []toolCall
+
+	if err == nil {
+		planJSON := extractJSONArray(planResult)
+		json.Unmarshal([]byte(planJSON), &toolCalls)
+	}
+
+	// Shortcut for common queries
+	if len(toolCalls) == 0 {
+		if tc := shortcutToolCalls(req.Prompt); len(tc) > 0 {
+			for _, s := range tc {
+				toolCalls = append(toolCalls, toolCall{Tool: s.Tool, Args: s.Args})
+			}
+		}
+	}
+
+	// Step 2: Execute tools
+	var ragParts []string
+	var toolsUsed []ToolUsed
+
+	for _, tc := range toolCalls {
+		if tc.Tool == "" {
+			continue
+		}
+		text, isErr, execErr := api.ExecuteTool(r, tc.Tool, tc.Args)
+		if execErr != nil || isErr {
+			toolsUsed = append(toolsUsed, ToolUsed{Name: tc.Tool, Status: "error"})
+			continue
+		}
+		if len(text) > 8000 {
+			text = text[:8000]
+		}
+		ragParts = append(ragParts, fmt.Sprintf("### %s\n%s", tc.Tool, formatToolResult(tc.Tool, text, tc.Args)))
+		toolsUsed = append(toolsUsed, ToolUsed{Name: tc.Tool, Status: "ok"})
+	}
+
+	// Step 3: Synthesise
+	today := time.Now().UTC().Format("Monday, 2 January 2006 (UTC)")
+	answer, err := ai.Ask(&ai.Prompt{
+		System: "You are a helpful assistant. Today's date is " + today + ". " +
+			"Answer using ONLY the tool results below. Use markdown.",
+		Rag:      ragParts,
+		Question: req.Prompt,
+		Priority: ai.PriorityHigh,
+		Provider: model.Provider,
+		Model:    model.Model,
+		Caller:   "agent-run-synth",
+	})
+	if err != nil {
+		app.RespondJSON(w, RunResponse{Error: err.Error(), Tools: toolsUsed})
+		return
+	}
+
+	answer = app.StripLatexDollars(answer)
+	app.RespondJSON(w, RunResponse{Answer: answer, Tools: toolsUsed})
+}

--- a/apps/apps.go
+++ b/apps/apps.go
@@ -852,8 +852,10 @@ func handleRun(w http.ResponseWriter, r *http.Request, slug string) {
       read:function(s){return get('/apps/'+s)},
     },
 
-    // AI
+    // AI — simple one-shot question
     ai:function(prompt,opts){return sdk('ai',{prompt:prompt,options:opts||{}}).then(function(j){return j.result||j})},
+    // Agent — plans tools, executes, synthesises (for complex multi-source queries)
+    agent:function(prompt){return post('/agent/run',{prompt:prompt}).then(function(j){return j.answer||j})},
 
     // User
     user:function(){return get('/session')},

--- a/apps/builder.go
+++ b/apps/builder.go
@@ -52,6 +52,9 @@ Platform APIs (all return Promises with JSON):
 - mu.ai(prompt) — ask AI, returns response text
 - mu.user() — current user info
 
+Agent (for complex queries that need multiple data sources):
+- mu.agent(prompt) — runs the full agent: plans tools, executes, returns synthesised answer
+
 Storage (persistent, namespaced per app):
 - mu.store.set(key, value) / mu.store.get(key) / mu.store.del(key) / mu.store.keys()
 

--- a/internal/api/mcp.go
+++ b/internal/api/mcp.go
@@ -181,6 +181,16 @@ var tools = []Tool{
 		Path:        "/session",
 	},
 	{
+		Name:        "agent",
+		Description: "Run the AI agent — plans which tools to use, executes them, and synthesises an answer. Use for complex queries that need multiple data sources.",
+		Method:      "POST",
+		Path:        "/agent/run",
+		WalletOp:    "agent_query",
+		Params: []ToolParam{
+			{Name: "prompt", Type: "string", Description: "What you want the agent to do", Required: true},
+		},
+	},
+	{
 		Name:        "chat",
 		Description: "Chat with AI assistant",
 		Method:      "POST",

--- a/main.go
+++ b/main.go
@@ -631,6 +631,7 @@ func main() {
 	// serve the agent
 	http.HandleFunc("/agent", agent.Handler)
 	http.HandleFunc("/agent/", agent.Handler) // Handle sub-routes like /agent/flow/...
+	http.HandleFunc("/agent/run", agent.RunHandler)
 
 	// serve mail inbox
 	http.HandleFunc("/mail", mail.Handler)


### PR DESCRIPTION
## Summary

- `POST /agent/run` — synchronous agent endpoint (plan → tools → answer)
- MCP tool `agent` — any MCP client can run agent queries
- `mu.agent(prompt)` in the JS SDK — apps can call the agent

https://claude.ai/code/session_01GRGLA9yj7BpqKiyi6xFwnm