### PR TITLE
Agent workspace: bidirectional browser agent with exec

### DIFF
--- a/agent/feedback.go
+++ b/agent/feedback.go
@@ -1,0 +1,76 @@
+package agent
+
+import (
+	"encoding/json"
+	"net/http"
+	"sync"
+	"time"
+
+	"mu/internal/app"
+)
+
+// ExecFeedback is the result of executing code in the browser.
+type ExecFeedback struct {
+	FlowID  string `json:"flow_id"`
+	OK      bool   `json:"ok"`
+	Result  string `json:"result,omitempty"`
+	Error   string `json:"error,omitempty"`
+	DOM     string `json:"dom,omitempty"` // text content of the preview
+	ReceivedAt time.Time
+}
+
+var (
+	feedbackMu    sync.Mutex
+	feedbackStore = map[string]chan *ExecFeedback{} // flowID → channel
+)
+
+// waitForFeedback creates a channel and waits for the browser to send back
+// the result of an exec. Returns nil on timeout.
+func waitForFeedback(flowID string, timeout time.Duration) *ExecFeedback {
+	ch := make(chan *ExecFeedback, 1)
+
+	feedbackMu.Lock()
+	feedbackStore[flowID] = ch
+	feedbackMu.Unlock()
+
+	defer func() {
+		feedbackMu.Lock()
+		delete(feedbackStore, flowID)
+		feedbackMu.Unlock()
+	}()
+
+	select {
+	case fb := <-ch:
+		return fb
+	case <-time.After(timeout):
+		return nil
+	}
+}
+
+// FeedbackHandler receives POST /agent/feedback from the browser after exec.
+func FeedbackHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != "POST" {
+		http.Error(w, "Method not allowed", 405)
+		return
+	}
+
+	var fb ExecFeedback
+	if err := json.NewDecoder(r.Body).Decode(&fb); err != nil {
+		app.RespondJSON(w, map[string]string{"error": "invalid request"})
+		return
+	}
+	fb.ReceivedAt = time.Now()
+
+	feedbackMu.Lock()
+	ch, ok := feedbackStore[fb.FlowID]
+	feedbackMu.Unlock()
+
+	if ok {
+		select {
+		case ch <- &fb:
+		default:
+		}
+	}
+
+	app.RespondJSON(w, map[string]string{"status": "ok"})
+}

--- a/agent/workspace.go
+++ b/agent/workspace.go
@@ -1,0 +1,351 @@
+package agent
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"mu/internal/ai"
+	"mu/internal/api"
+	"mu/internal/app"
+	"mu/internal/auth"
+)
+
+// WorkspaceHandler serves the agent workspace page.
+func WorkspaceHandler(w http.ResponseWriter, r *http.Request) {
+	// SSE stream when prompt is provided
+	if r.URL.Query().Get("prompt") != "" {
+		handleWorkspaceQuery(w, r)
+		return
+	}
+
+	_, _, err := auth.RequireSession(r)
+	if err != nil {
+		app.RedirectToLogin(w, r)
+		return
+	}
+
+	var sb strings.Builder
+	sb.WriteString(`<style>
+#ws{display:flex;flex-direction:column;height:calc(100vh - 60px);max-width:900px;margin:0 auto}
+#ws-log{flex:1;overflow-y:auto;padding:8px 0}
+#ws-preview{border:1px solid #e0e0e0;border-radius:6px;min-height:200px;display:none;margin-bottom:12px;padding:16px;background:#fff}
+#ws-input{display:flex;gap:8px;padding:8px 0}
+#ws-input input{flex:1;padding:10px 14px;border:1px solid #e0e0e0;border-radius:6px;font-size:15px;font-family:inherit}
+#ws-input button{padding:10px 24px;background:#000;color:#fff;border:none;border-radius:6px;cursor:pointer;font-family:inherit;font-size:15px}
+#ws-input button:disabled{background:#ccc;cursor:not-allowed}
+.ws-msg{margin:4px 0;font-size:14px}
+.ws-user{color:#1a1a1a;font-weight:600}
+.ws-agent{color:#555}
+.ws-status{color:#888;font-size:13px}
+.ws-error{color:#c00;font-size:13px}
+.ws-code{font-family:'SF Mono',monospace;font-size:12px;background:#f5f5f5;padding:8px;border-radius:4px;margin:4px 0;overflow-x:auto;white-space:pre-wrap}
+</style>
+<div id="ws">
+<div id="ws-log"></div>
+<div id="ws-preview"></div>
+<div id="ws-input">
+<input type="text" id="ws-prompt" placeholder="Tell the agent what to do..." autofocus>
+<button id="ws-btn" onclick="send()">Go</button>
+</div>
+</div>
+<script>
+var log=document.getElementById('ws-log');
+var preview=document.getElementById('ws-preview');
+var input=document.getElementById('ws-prompt');
+var btn=document.getElementById('ws-btn');
+var flowId='';
+
+function addMsg(cls,text){
+  var d=document.createElement('div');
+  d.className='ws-msg '+cls;
+  d.textContent=text;
+  log.appendChild(d);
+  log.scrollTop=log.scrollHeight;
+}
+
+function addHTML(cls,html){
+  var d=document.createElement('div');
+  d.className='ws-msg '+cls;
+  d.innerHTML=html;
+  log.appendChild(d);
+  log.scrollTop=log.scrollHeight;
+}
+
+function addCode(code){
+  var d=document.createElement('pre');
+  d.className='ws-code';
+  d.textContent=code.length>500?code.slice(0,500)+'...':code;
+  log.appendChild(d);
+  log.scrollTop=log.scrollHeight;
+}
+
+input.addEventListener('keydown',function(e){if(e.key==='Enter')send()});
+
+function send(){
+  var prompt=input.value.trim();
+  if(!prompt)return;
+  addMsg('ws-user',prompt);
+  input.value='';
+  btn.disabled=true;
+
+  var es=new EventSource('/agent/workspace?prompt='+encodeURIComponent(prompt)+'&flow_id='+flowId);
+
+  es.onmessage=function(e){
+    try{
+      var ev=JSON.parse(e.data);
+
+      if(ev.type==='flow_id'){
+        flowId=ev.flow_id;
+      }
+      else if(ev.type==='status'){
+        addMsg('ws-status',ev.message);
+      }
+      else if(ev.type==='exec'){
+        // Execute code in the preview context
+        addMsg('ws-status','Executing code...');
+        if(ev.html){
+          preview.style.display='block';
+          preview.innerHTML=ev.html;
+          // Execute any scripts in the injected HTML
+          var scripts=preview.querySelectorAll('script');
+          scripts.forEach(function(s){
+            var ns=document.createElement('script');
+            ns.textContent=s.textContent;
+            preview.appendChild(ns);
+            s.remove();
+          });
+        }
+        if(ev.code){
+          addCode(ev.code);
+          try{
+            var result=eval(ev.code);
+            feedback(flowId,true,String(result||'ok'),'',preview.textContent.slice(0,500));
+          }catch(err){
+            addMsg('ws-error','Error: '+err.message);
+            feedback(flowId,false,'',err.message,preview.textContent.slice(0,500));
+          }
+        } else {
+          // HTML only, no code to eval
+          feedback(flowId,true,'rendered','',preview.textContent.slice(0,500));
+        }
+      }
+      else if(ev.type==='response'){
+        addHTML('ws-agent',ev.html||ev.message||'');
+      }
+      else if(ev.type==='error'){
+        addMsg('ws-error',ev.message);
+      }
+      else if(ev.type==='done'){
+        btn.disabled=false;
+        es.close();
+      }
+      else if(ev.type==='save'){
+        addHTML('ws-agent','<a href="/apps/'+ev.slug+'/run" style="font-weight:600">Open App: '+ev.name+'</a>');
+      }
+    }catch(ex){console.error('parse error',ex)}
+  };
+
+  es.onerror=function(){
+    btn.disabled=false;
+    es.close();
+  };
+}
+
+function feedback(fid,ok,result,error,dom){
+  fetch('/agent/feedback',{
+    method:'POST',
+    headers:{'Content-Type':'application/json'},
+    body:JSON.stringify({flow_id:fid,ok:ok,result:result,error:error,dom:dom})
+  }).catch(function(){});
+}
+</script>`)
+
+	html := app.RenderHTMLForRequest("Agent", "Agent workspace", sb.String(), r)
+	w.Write([]byte(html))
+}
+
+// handleWorkspaceQuery handles the SSE stream for workspace queries.
+func handleWorkspaceQuery(w http.ResponseWriter, r *http.Request) {
+	prompt := r.URL.Query().Get("prompt")
+	if prompt == "" {
+		http.Error(w, "prompt required", 400)
+		return
+	}
+
+	_, acc, err := auth.RequireSession(r)
+	if err != nil {
+		http.Error(w, "auth required", 401)
+		return
+	}
+
+	model := Models[0]
+	if QuotaCheck != nil {
+		canProceed, _, err := QuotaCheck(r, model.WalletOp)
+		if !canProceed {
+			msg := "Insufficient credits"
+			if err != nil {
+				msg = err.Error()
+			}
+			http.Error(w, msg, 402)
+			return
+		}
+	}
+
+	_ = acc
+
+	// SSE setup
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("X-Accel-Buffering", "no")
+
+	flow := &Flow{
+		ID:        newFlowID(),
+		AccountID: acc.ID,
+		Prompt:    prompt,
+		Status:    "running",
+		CreatedAt: time.Now().UTC(),
+	}
+	saveFlow(flow)
+
+	sseSend := func(v any) {
+		b, _ := json.Marshal(v)
+		fmt.Fprintf(w, "data: %s\n\n", b)
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+	}
+
+	sseSend(map[string]any{"type": "flow_id", "flow_id": flow.ID})
+	sseSend(map[string]any{"type": "status", "message": "Processing..."})
+
+	// Step 1: Plan — ask AI what to do
+	planSystem := `You are an AI agent operating a browser-based platform. You can:
+1. Execute JavaScript code in the browser (use type:"exec" with code)
+2. Render HTML in the preview area (use type:"exec" with html)
+3. Call platform APIs via mu.* (mu.weather, mu.news, mu.search, mu.blog, mu.agent, etc.)
+4. Build and save apps
+
+Given the user's request, output a JSON array of steps:
+[{"type":"exec","code":"..."}, {"type":"exec","html":"<div>...</div>"}, {"type":"tool","name":"web_search","args":{"q":"..."}}, {"type":"respond","message":"..."}]
+
+For building apps: generate the full HTML and use {"type":"exec","html":"<!DOCTYPE html>..."} then iterate.
+For research: use tool calls then respond with a summary.
+For simple questions: just respond.
+
+Available mu.* functions: mu.weather({lat,lon}), mu.news(), mu.markets(), mu.blog.list(), mu.blog.create({title,content}), mu.places.search({q,near}), mu.chat(prompt), mu.search(query), mu.ai(prompt), mu.store.set/get/del
+
+Output ONLY the JSON array.`
+
+	planResult, err := ai.Ask(&ai.Prompt{
+		System:   planSystem,
+		Question: prompt,
+		Priority: ai.PriorityHigh,
+		Provider: model.Provider,
+		Model:    model.Model,
+		Caller:   "workspace-plan",
+	})
+	if err != nil {
+		sseSend(map[string]any{"type": "error", "message": err.Error()})
+		sseSend(map[string]any{"type": "done"})
+		return
+	}
+
+	// Parse steps
+	type step struct {
+		Type    string         `json:"type"`
+		Code    string         `json:"code,omitempty"`
+		HTML    string         `json:"html,omitempty"`
+		Name    string         `json:"name,omitempty"`
+		Args    map[string]any `json:"args,omitempty"`
+		Message string         `json:"message,omitempty"`
+	}
+	var steps []step
+	stepsJSON := extractJSONArray(planResult)
+	if err := json.Unmarshal([]byte(stepsJSON), &steps); err != nil {
+		// If parsing fails, treat the whole response as a text answer
+		sseSend(map[string]any{"type": "response", "message": planResult})
+		sseSend(map[string]any{"type": "done"})
+		return
+	}
+
+	// Step 2: Execute steps
+	var lastExecResult *ExecFeedback
+	var toolResults []string
+
+	for _, s := range steps {
+		switch s.Type {
+		case "exec":
+			sseSend(map[string]any{"type": "exec", "code": s.Code, "html": s.HTML})
+			// Wait for browser feedback
+			fb := waitForFeedback(flow.ID, 15*time.Second)
+			if fb != nil {
+				lastExecResult = fb
+				if !fb.OK {
+					sseSend(map[string]any{"type": "status", "message": "Error: " + fb.Error})
+					// Try to fix
+					fixResult, fixErr := ai.Ask(&ai.Prompt{
+						System:   "Fix this JavaScript error. Output ONLY the corrected code, no explanation.",
+						Question: fmt.Sprintf("Error: %s\n\nCode that failed:\n%s", fb.Error, s.Code),
+						Priority: ai.PriorityHigh,
+						Caller:   "workspace-fix",
+					})
+					if fixErr == nil {
+						sseSend(map[string]any{"type": "status", "message": "Fixing..."})
+						sseSend(map[string]any{"type": "exec", "code": fixResult})
+						fb2 := waitForFeedback(flow.ID, 15*time.Second)
+						if fb2 != nil {
+							lastExecResult = fb2
+						}
+					}
+				}
+			}
+
+		case "tool":
+			sseSend(map[string]any{"type": "status", "message": "Running " + s.Name + "..."})
+			text, isErr, execErr := api.ExecuteTool(r, s.Name, s.Args)
+			if execErr != nil || isErr {
+				sseSend(map[string]any{"type": "status", "message": s.Name + " failed"})
+				continue
+			}
+			if len(text) > 4000 {
+				text = text[:4000]
+			}
+			toolResults = append(toolResults, fmt.Sprintf("### %s\n%s", s.Name, text))
+			sseSend(map[string]any{"type": "status", "message": s.Name + " done"})
+
+		case "respond":
+			sseSend(map[string]any{"type": "response", "message": s.Message, "html": app.RenderString(s.Message)})
+		}
+	}
+
+	// Step 3: If we have tool results but no response yet, synthesise
+	if len(toolResults) > 0 {
+		sseSend(map[string]any{"type": "status", "message": "Composing answer..."})
+		answer, err := ai.Ask(&ai.Prompt{
+			System:   "Summarise the results. Use markdown.",
+			Rag:      toolResults,
+			Question: prompt,
+			Priority: ai.PriorityHigh,
+			Caller:   "workspace-synth",
+		})
+		if err == nil {
+			answer = app.StripLatexDollars(answer)
+			sseSend(map[string]any{"type": "response", "html": app.RenderString(answer)})
+		}
+	}
+
+	// If we rendered HTML, offer to save as app
+	if lastExecResult != nil && lastExecResult.OK && lastExecResult.DOM != "" {
+		sseSend(map[string]any{"type": "status", "message": "App rendered successfully"})
+	}
+
+	updateFlow(flow.ID, func(f *Flow) {
+		f.Status = "done"
+		f.Answer = prompt
+	})
+
+	sseSend(map[string]any{"type": "done"})
+}

--- a/main.go
+++ b/main.go
@@ -630,8 +630,10 @@ func main() {
 
 	// serve the agent
 	http.HandleFunc("/agent", agent.Handler)
-	http.HandleFunc("/agent/", agent.Handler) // Handle sub-routes like /agent/flow/...
+	http.HandleFunc("/agent/", agent.Handler)
 	http.HandleFunc("/agent/run", agent.RunHandler)
+	http.HandleFunc("/agent/workspace", agent.WorkspaceHandler)
+	http.HandleFunc("/agent/feedback", agent.FeedbackHandler)
 
 	// serve mail inbox
 	http.HandleFunc("/mail", mail.Handler)


### PR DESCRIPTION
## Summary

Agent workspace at /agent/workspace — bidirectional browser agent.

**Server → Browser (SSE):** exec events with JS code or HTML to render
**Browser → Server (POST):** eval results, errors, DOM state

The agent can:
- Execute JavaScript in the browser
- Render HTML live in a preview area
- Call any MCP tool (web_search, weather, news, etc.)
- See runtime errors and automatically fix them
- Compose any building block via mu.*

This is the browser as a VM, with the agent as the operator.

https://claude.ai/code/session_01GRGLA9yj7BpqKiyi6xFwnm