### PR TITLE
Merge workspace into agent: exec, preview, save

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -171,7 +171,15 @@ func servePage(w http.ResponseWriter, r *http.Request) {
 </div>
 </div>
 
-<div id="agent-result"></div>`
+<div id="agent-result"></div>
+
+<div id="agent-preview-container" style="display:none;margin:12px 0">
+<iframe id="agent-preview" style="width:100%;min-height:50vh;border:1px solid #e0e0e0;border-radius:6px;background:#fff"></iframe>
+<div style="display:flex;gap:8px;padding:8px 0;align-items:center">
+<input type="text" id="agent-app-name" placeholder="App name" style="flex:1;padding:8px 12px;border:1px solid #e0e0e0;border-radius:6px;font-family:inherit;font-size:14px">
+<button onclick="saveApp()" style="padding:8px 16px;background:#000;color:#fff;border:none;border-radius:6px;cursor:pointer;font-family:inherit;font-size:13px">Save as App</button>
+</div>
+</div>`
 
 	// Layout: conversation mode puts the form at the bottom; landing puts it at the top.
 	isConversation := contextID != ""
@@ -201,6 +209,21 @@ if(!form)return;
 
 function esc(s){
   return String(s||'').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
+}
+
+function saveApp(){
+  if(!window._lastAppHTML){alert('Nothing to save');return}
+  var name=document.getElementById('agent-app-name').value.trim()||'Untitled App';
+  fetch('/apps',{method:'POST',headers:{'Content-Type':'application/json'},
+    body:JSON.stringify({name:name,html:window._lastAppHTML,public:true})
+  }).then(function(r){return r.json()}).then(function(j){
+    if(j.slug){
+      var result=document.getElementById('agent-result');
+      result.innerHTML='<div class="card"><p>Saved: <a href="/apps/'+j.slug+'/run">'+esc(j.name)+'</a></p></div>';
+    } else {
+      alert('Save failed: '+(j.error||'unknown'));
+    }
+  }).catch(function(e){alert('Save failed: '+e.message)});
 }
 
 // showResponse displays a completed response and enters conversation mode.
@@ -334,6 +357,42 @@ form.addEventListener('submit',function(e){
               if(d){
                 d.className='agent-step done';
                 d.innerHTML='<span class="step-icon" style="color:#1a1a1a">done</span><span>'+esc(ev.message)+'</span>';
+              }
+            } else if(ev.type==='exec'){
+              // Render HTML or execute code in preview
+              var pc=document.getElementById('agent-preview-container');
+              var pf=document.getElementById('agent-preview');
+              if(ev.html){
+                pc.style.display='block';
+                window._lastAppHTML=ev.html;
+                var pdoc=pf.contentDocument||pf.contentWindow.document;
+                pdoc.open();pdoc.write(ev.html);pdoc.close();
+                var sd=document.createElement('div');sd.className='agent-step';
+                sd.innerHTML='<span class="step-icon">done</span><span>App rendered</span>';
+                steps.appendChild(sd);
+                // Send feedback
+                setTimeout(function(){
+                  fetch('/agent/feedback',{method:'POST',headers:{'Content-Type':'application/json'},
+                    body:JSON.stringify({flow_id:currentFlowId,ok:true,result:'rendered',dom:pdoc.body?pdoc.body.textContent.slice(0,500):''})
+                  }).catch(function(){});
+                },1000);
+              }
+              if(ev.code){
+                (async function(){
+                  try{
+                    var r=await eval('(async function(){'+ev.code+'})()');
+                    fetch('/agent/feedback',{method:'POST',headers:{'Content-Type':'application/json'},
+                      body:JSON.stringify({flow_id:currentFlowId,ok:true,result:String(r||'ok')})
+                    }).catch(function(){});
+                  }catch(err){
+                    var sd=document.createElement('div');sd.className='agent-step';
+                    sd.innerHTML='<span class="step-icon" style="color:#c00">error</span><span>'+esc(err.message)+'</span>';
+                    steps.appendChild(sd);
+                    fetch('/agent/feedback',{method:'POST',headers:{'Content-Type':'application/json'},
+                      body:JSON.stringify({flow_id:currentFlowId,ok:false,error:err.message})
+                    }).catch(function(){});
+                  }
+                })();
               }
             } else if(ev.type==='response'){
               gotResponse=true;
@@ -660,6 +719,12 @@ func handleQuery(w http.ResponseWriter, r *http.Request) {
 
 	// Send flow_id immediately so the client can recover on disconnect.
 	sse(w, map[string]any{"type": "flow_id", "flow_id": flow.ID})
+
+	// If this is a build/create request, use the workspace exec flow
+	if looksLikeExecRequest(req.Prompt) {
+		runWorkspaceFlow(w, r, flow, req.Prompt, model)
+		return
+	}
 
 	// --- Step 1: plan tool calls ---
 	type toolCall struct {

--- a/agent/exec.go
+++ b/agent/exec.go
@@ -1,0 +1,166 @@
+package agent
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"mu/internal/ai"
+	"mu/internal/api"
+	"mu/internal/app"
+)
+
+// looksLikeExecRequest checks if the prompt is asking to build, create, or make something.
+func looksLikeExecRequest(prompt string) bool {
+	lower := strings.ToLower(prompt)
+	for _, keyword := range []string{
+		"build me", "build a", "build an", "create a", "create an",
+		"make me", "make a", "make an", "write a", "write an",
+		"build app", "create app", "make app",
+		"calculator", "timer", "converter", "generator", "tracker",
+		"editor", "viewer", "dashboard", "tool",
+	} {
+		if strings.Contains(lower, keyword) {
+			return true
+		}
+	}
+	return false
+}
+
+// runWorkspaceFlow handles build/exec requests within the agent SSE stream.
+func runWorkspaceFlow(w http.ResponseWriter, r *http.Request, flow *Flow, prompt string, model Model) {
+	sseSend := func(v any) {
+		b, _ := json.Marshal(v)
+		fmt.Fprintf(w, "data: %s\n\n", b)
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+	}
+
+	sseSend(map[string]any{"type": "thinking", "message": "Planning…"})
+
+	// Plan with exec capability
+	planSystem := `You are an AI agent on a browser-based app platform.
+
+STEP TYPES:
+1. {"type":"tool","name":"TOOL","args":{}} — fetch data server-side
+2. {"type":"exec","html":"..."} — render full HTML app in browser preview
+3. {"type":"exec","code":"..."} — run JS in browser
+4. {"type":"respond","message":"markdown text"} — text answer
+
+TOOLS (for fetching data):
+` + agentToolsDesc + `
+
+RULES:
+- Building apps → use EXEC with a complete HTML document
+- Data questions → use TOOLS then RESPOND
+- Simple questions → just RESPOND
+- NEVER use exec for fetching data
+
+Output ONLY a JSON array.`
+
+	planResult, err := ai.Ask(&ai.Prompt{
+		System:   planSystem,
+		Question: prompt,
+		Priority: ai.PriorityHigh,
+		Provider: model.Provider,
+		Model:    model.Model,
+		Caller:   "agent-exec-plan",
+	})
+	if err != nil {
+		sseSend(map[string]any{"type": "error", "message": err.Error()})
+		sseSend(map[string]any{"type": "done"})
+		return
+	}
+
+	type step struct {
+		Type    string         `json:"type"`
+		Code    string         `json:"code,omitempty"`
+		HTML    string         `json:"html,omitempty"`
+		Name    string         `json:"name,omitempty"`
+		Args    map[string]any `json:"args,omitempty"`
+		Message string         `json:"message,omitempty"`
+	}
+	var steps []step
+	stepsJSON := extractJSONArray(planResult)
+	if err := json.Unmarshal([]byte(stepsJSON), &steps); err != nil {
+		// Treat as text response
+		rendered := app.RenderString(planResult)
+		sseSend(map[string]any{"type": "response", "html": rendered, "flow_id": flow.ID})
+		updateFlow(flow.ID, func(f *Flow) { f.Status = "done"; f.Answer = planResult; f.HTML = rendered })
+		sseSend(map[string]any{"type": "done"})
+		return
+	}
+
+	// Execute steps
+	var toolResults []string
+	responded := false
+
+	for _, s := range steps {
+		switch s.Type {
+		case "exec":
+			code := stripCodeFences(s.Code)
+			sseSend(map[string]any{"type": "exec", "code": code, "html": s.HTML})
+			// Wait for browser feedback
+			fb := waitForFeedback(flow.ID, 15*time.Second)
+			if fb != nil && !fb.OK && fb.Error != "" {
+				sseSend(map[string]any{"type": "thinking", "message": "Fixing: " + fb.Error})
+				fixResult, fixErr := ai.Ask(&ai.Prompt{
+					System:   "Fix this error. Output ONLY the corrected code or HTML. No markdown fences.",
+					Question: fmt.Sprintf("Error: %s\nCode:\n%s", fb.Error, s.Code+s.HTML),
+					Priority: ai.PriorityHigh,
+					Caller:   "agent-exec-fix",
+				})
+				if fixErr == nil {
+					sseSend(map[string]any{"type": "exec", "code": stripCodeFences(fixResult), "html": ""})
+					waitForFeedback(flow.ID, 15*time.Second)
+				}
+			}
+
+		case "tool":
+			sseSend(map[string]any{"type": "tool_start", "name": s.Name, "message": toolLabel(s.Name)})
+			text, isErr, execErr := api.ExecuteTool(r, s.Name, s.Args)
+			if execErr != nil || isErr {
+				sseSend(map[string]any{"type": "tool_done", "name": s.Name, "message": s.Name + " — failed"})
+				continue
+			}
+			if len(text) > 8000 {
+				text = text[:8000]
+			}
+			toolResults = append(toolResults, fmt.Sprintf("### %s\n%s", s.Name, formatToolResult(s.Name, text, s.Args)))
+			sseSend(map[string]any{"type": "tool_done", "name": s.Name, "message": toolLabel(s.Name) + " — done"})
+
+		case "respond":
+			responded = true
+			rendered := app.RenderString(s.Message)
+			sseSend(map[string]any{"type": "response", "html": rendered, "flow_id": flow.ID})
+			updateFlow(flow.ID, func(f *Flow) { f.Status = "done"; f.Answer = s.Message; f.HTML = rendered })
+		}
+	}
+
+	// Synthesise if tools ran but no response
+	if len(toolResults) > 0 && !responded {
+		sseSend(map[string]any{"type": "thinking", "message": "Composing answer…"})
+		answer, err := ai.Ask(&ai.Prompt{
+			System:   "Summarise the results. Use markdown.",
+			Rag:      toolResults,
+			Question: prompt,
+			Priority: ai.PriorityHigh,
+			Caller:   "agent-exec-synth",
+		})
+		if err == nil {
+			answer = app.StripLatexDollars(answer)
+			rendered := app.RenderString(answer)
+			sseSend(map[string]any{"type": "response", "html": rendered, "flow_id": flow.ID})
+			updateFlow(flow.ID, func(f *Flow) { f.Status = "done"; f.Answer = answer; f.HTML = rendered })
+		}
+	}
+
+	if !responded && len(toolResults) == 0 {
+		updateFlow(flow.ID, func(f *Flow) { f.Status = "done"; f.Answer = "App built" })
+	}
+
+	sseSend(map[string]any{"type": "done"})
+}

--- a/main.go
+++ b/main.go
@@ -632,7 +632,6 @@ func main() {
 	http.HandleFunc("/agent", agent.Handler)
 	http.HandleFunc("/agent/", agent.Handler)
 	http.HandleFunc("/agent/run", agent.RunHandler)
-	http.HandleFunc("/agent/workspace", agent.WorkspaceHandler)
 	http.HandleFunc("/agent/feedback", agent.FeedbackHandler)
 
 	// serve mail inbox


### PR DESCRIPTION
## Summary

Merge workspace exec capability into the agent page. No separate workspace.

- Build requests ("build me a calculator") → exec flow with preview iframe
- Questions ("what's the weather") → existing tool flow
- Agent page gets preview iframe + Save as App button
- /agent/workspace removed

Three things: Agent (interface), Work (ledger), Apps (output).

https://claude.ai/code/session_01GRGLA9yj7BpqKiyi6xFwnm