### PR TITLE
Full-page apps, Opus builder, correct SDK response shapes

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -624,6 +624,7 @@ const agentToolsDesc = `Available tools (use exact name):
 - wallet_topup: Get available topup options to add credits to your wallet (no args)
 - apps_search: Search apps directory (args: {"q":"search term","tag":"productivity"})
 - apps_read: Read details of a specific app (args: {"slug":"app-slug"})
+- mu_sdk: Get Mu platform SDK docs — call this before building/editing apps that need platform features like weather, news, markets, etc. (no args)
 - apps_build: AI-generate an app from a description (args: {"prompt":"a pomodoro timer with lap counter"})
 - apps_edit: Edit an existing app — update name, description, tags, icon, or HTML (args: {"slug":"app-slug","html":"<new html>","name":"New Name"})
 - apps_run: Run JavaScript code and return the result (args: {"code":"return 2+2"}). Use for calculations, data transforms, or any computation. Code runs as a function body — use 'return' to produce output.`
@@ -964,6 +965,8 @@ func toolLabel(tool string) string {
 		return "💳 Checking wallet balance"
 	case "wallet_topup":
 		return "💳 Getting topup options"
+	case "mu_sdk":
+		return "📖 Reading SDK docs"
 	case "apps_search":
 		return "📱 Searching apps"
 	case "apps_read":

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -64,6 +64,11 @@ func Load() {}
 // Handler dispatches GET (page) and POST (query) at /agent and /agent/*.
 func Handler(w http.ResponseWriter, r *http.Request) {
 	path := r.URL.Path
+	// /agent/exec — receive exec results from browser
+	if path == "/agent/exec" {
+		ExecResultHandler(w, r)
+		return
+	}
 	// /agent/flow/<id>  — view or delete a saved flow
 	if strings.HasPrefix(path, "/agent/flow/") {
 		id := strings.TrimPrefix(path, "/agent/flow/")
@@ -169,6 +174,10 @@ func servePage(w http.ResponseWriter, r *http.Request) {
 <h4 style="margin:0 0 12px;">Working…</h4>
 <div id="agent-steps"></div>
 </div>
+</div>
+
+<div id="agent-preview-container" style="display:none;margin:12px 0">
+<iframe id="agent-preview" style="width:100%;min-height:50vh;border:1px solid #e0e0e0;border-radius:6px;background:#fff"></iframe>
 </div>
 
 <div id="agent-result"></div>`
@@ -334,6 +343,33 @@ form.addEventListener('submit',function(e){
               if(d){
                 d.className='agent-step done';
                 d.innerHTML='<span class="step-icon">✓</span><span>'+esc(ev.message)+'</span>';
+              }
+            } else if(ev.type==='exec'){
+              var pc=document.getElementById('agent-preview-container');
+              var pf=document.getElementById('agent-preview');
+              if(ev.html){
+                pc.style.display='block';
+                window._lastAppHTML=ev.html;
+                var pdoc=pf.contentDocument||pf.contentWindow.document;
+                pdoc.open();pdoc.write(ev.html);pdoc.close();
+                var sd=document.createElement('div');sd.className='agent-step';
+                sd.innerHTML='<span class="step-icon">✓</span><span>App rendered</span>';
+                steps.appendChild(sd);
+                setTimeout(function(){
+                  var iwin=pf.contentWindow;
+                  var errors=[];
+                  try{if(iwin&&iwin.mu&&iwin.mu.errors)errors=iwin.mu.errors}catch(e){}
+                  var hasErr=errors.length>0;
+                  var errMsg=hasErr?errors.map(function(e){return e.message}).join('; '):'';
+                  if(hasErr){
+                    var ed=document.createElement('div');ed.className='agent-step';
+                    ed.innerHTML='<span class="step-icon" style="color:#c00">✗</span><span>'+esc(errMsg.slice(0,120))+'</span>';
+                    steps.appendChild(ed);
+                  }
+                  fetch('/agent/exec',{method:'POST',headers:{'Content-Type':'application/json'},
+                    body:JSON.stringify({session_id:currentFlowId,ok:!hasErr,result:hasErr?'':'rendered',error:errMsg,dom:pdoc.body?pdoc.body.textContent.slice(0,500):''})
+                  }).catch(function(){});
+                },2000);
               }
             } else if(ev.type==='response'){
               gotResponse=true;
@@ -660,6 +696,12 @@ func handleQuery(w http.ResponseWriter, r *http.Request) {
 
 	// Send flow_id immediately so the client can recover on disconnect.
 	sse(w, map[string]any{"type": "flow_id", "flow_id": flow.ID})
+
+	// Shortcut: if this looks like a build request, route to workspace flow
+	if looksLikeExecRequest(req.Prompt) {
+		runWorkspaceFlow(w, r, flow, req.Prompt, model)
+		return
+	}
 
 	// --- Step 1: plan tool calls ---
 	type toolCall struct {

--- a/agent/exec.go
+++ b/agent/exec.go
@@ -106,11 +106,8 @@ func runWorkspaceFlow(w http.ResponseWriter, r *http.Request, flow *Flow, prompt
 
 	sseSend(map[string]any{"type": "thinking", "message": "Building…"})
 
-	// Include SDK docs so the builder knows about platform APIs
-	buildPrompt := prompt + "\n\n" + apps.SDKDocs()
-
 	// Build the app
-	a, err := apps.BuildAndSave(buildPrompt, flow.AccountID, "Agent")
+	a, err := apps.BuildAndSave(prompt, flow.AccountID, "Agent")
 	if err != nil {
 		errMsg := err.Error()
 		if len(errMsg) > 200 {

--- a/agent/exec.go
+++ b/agent/exec.go
@@ -1,0 +1,215 @@
+package agent
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"mu/apps"
+	"mu/internal/app"
+)
+
+// looksLikeExecRequest checks if the prompt is asking to build, create, or make something.
+func looksLikeExecRequest(prompt string) bool {
+	lower := strings.ToLower(prompt)
+	for _, keyword := range []string{
+		"build me", "build a", "build an", "create a", "create an",
+		"make me", "make a", "make an", "write a", "write an",
+		"build app", "create app", "make app",
+		"calculator", "timer", "converter", "generator", "tracker",
+		"editor", "viewer", "dashboard", "tool",
+	} {
+		if strings.Contains(lower, keyword) {
+			return true
+		}
+	}
+	return false
+}
+
+// ExecResult is the result of executing code in the browser.
+type ExecResult struct {
+	SessionID string `json:"session_id"`
+	OK        bool   `json:"ok"`
+	Result    string `json:"result,omitempty"`
+	Error     string `json:"error,omitempty"`
+	DOM       string `json:"dom,omitempty"`
+}
+
+var (
+	execMu    sync.Mutex
+	execStore = map[string]chan *ExecResult{}
+)
+
+// waitForExecResult waits for the browser to send back the result of an exec.
+func waitForExecResult(sessionID string, timeout time.Duration) *ExecResult {
+	ch := make(chan *ExecResult, 1)
+
+	execMu.Lock()
+	execStore[sessionID] = ch
+	execMu.Unlock()
+
+	defer func() {
+		execMu.Lock()
+		delete(execStore, sessionID)
+		execMu.Unlock()
+	}()
+
+	select {
+	case r := <-ch:
+		return r
+	case <-time.After(timeout):
+		return nil
+	}
+}
+
+// ExecResultHandler receives POST /agent/exec from the browser.
+func ExecResultHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != "POST" {
+		http.Error(w, "Method not allowed", 405)
+		return
+	}
+
+	var result ExecResult
+	if err := json.NewDecoder(r.Body).Decode(&result); err != nil {
+		app.RespondJSON(w, map[string]string{"error": "invalid request"})
+		return
+	}
+
+	execMu.Lock()
+	ch, ok := execStore[result.SessionID]
+	execMu.Unlock()
+
+	if ok {
+		select {
+		case ch <- &result:
+		default:
+		}
+	}
+
+	app.RespondJSON(w, map[string]string{"status": "ok"})
+}
+
+const maxIterations = 3
+
+// runWorkspaceFlow handles build/exec requests within the agent SSE stream.
+func runWorkspaceFlow(w http.ResponseWriter, r *http.Request, flow *Flow, prompt string, model Model) {
+	sseSend := func(v any) {
+		b, _ := json.Marshal(v)
+		fmt.Fprintf(w, "data: %s\n\n", b)
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+	}
+
+	sseSend(map[string]any{"type": "thinking", "message": "Building…"})
+
+	// Build the app directly
+	a, err := apps.BuildAndSave(prompt, flow.AccountID, "Agent")
+	if err != nil {
+		errMsg := err.Error()
+		if len(errMsg) > 200 {
+			errMsg = errMsg[:200]
+		}
+		sseSend(map[string]any{"type": "error", "message": "Build failed: " + errMsg})
+		sseSend(map[string]any{"type": "done"})
+		return
+	}
+
+	slug := a.Slug
+	name := a.Name
+
+	// Iterate: render → check errors → fix → re-render
+	for attempt := 0; attempt <= maxIterations; attempt++ {
+		current := apps.GetApp(slug)
+		if current == nil || current.HTML == "" {
+			sseSend(map[string]any{"type": "error", "message": "App has no HTML"})
+			sseSend(map[string]any{"type": "done"})
+			return
+		}
+
+		// Inject the native SDK into the HTML before sending to preview
+		html := current.HTML
+		sdk := apps.NativeSDK(slug)
+		html = apps.InjectSDK(html, sdk)
+
+		sseSend(map[string]any{"type": "exec", "html": html})
+
+		// Wait for browser to render and report back
+		result := waitForExecResult(flow.ID, 8*time.Second)
+
+		if result == nil {
+			// No response from browser — can't iterate, just finish
+			break
+		}
+
+		if result.OK && result.Error == "" {
+			// Success — no errors
+			break
+		}
+
+		// There are errors — can we iterate?
+		if attempt >= maxIterations {
+			sseSend(map[string]any{"type": "thinking", "message": fmt.Sprintf("App has errors after %d attempts, saving as-is", maxIterations)})
+			break
+		}
+
+		// Tell the user we're fixing
+		errMsg := result.Error
+		if errMsg == "" {
+			errMsg = "unknown error"
+		}
+		sseSend(map[string]any{"type": "thinking", "message": fmt.Sprintf("Fixing: %s", truncateExec(errMsg, 100))})
+
+		// Edit the app to fix the error
+		fixPrompt := fmt.Sprintf("The app has a runtime error: %s\n\nFix this error. The app must work without errors.", errMsg)
+		if result.DOM != "" {
+			fixPrompt += fmt.Sprintf("\n\nCurrent DOM state: %s", truncateExec(result.DOM, 500))
+		}
+
+		_, editErr := apps.EditApp(slug, fixPrompt, flow.AccountID)
+		if editErr != nil {
+			sseSend(map[string]any{"type": "thinking", "message": "Could not auto-fix, saving as-is"})
+			break
+		}
+		// Loop back to re-render the fixed version
+	}
+
+	// Send response with link
+	rendered := app.RenderString(fmt.Sprintf("Built **%s** — [Open App](/apps/%s) · [Edit](/apps/%s/edit)", name, slug, slug))
+	sseSend(map[string]any{"type": "response", "html": rendered, "flow_id": flow.ID})
+	updateFlow(flow.ID, func(f *Flow) {
+		f.Status = "done"
+		f.Answer = fmt.Sprintf("Built %s — /apps/%s", name, slug)
+		f.HTML = rendered
+	})
+
+	sseSend(map[string]any{"type": "done"})
+}
+
+// truncateExec shortens a string to max length.
+func truncateExec(s string, max int) string {
+	if len(s) <= max {
+		return s
+	}
+	return s[:max] + "…"
+}
+
+// stripCodeFences removes markdown code fences from AI output.
+func stripCodeFences(s string) string {
+	s = strings.TrimSpace(s)
+	for _, prefix := range []string{"```javascript\n", "```js\n", "```html\n", "```\n"} {
+		if strings.HasPrefix(s, prefix) {
+			s = s[len(prefix):]
+			break
+		}
+	}
+	if strings.HasSuffix(s, "\n```") {
+		s = s[:len(s)-4]
+	} else if strings.HasSuffix(s, "```") {
+		s = s[:len(s)-3]
+	}
+	return strings.TrimSpace(s)
+}

--- a/agent/exec.go
+++ b/agent/exec.go
@@ -106,8 +106,11 @@ func runWorkspaceFlow(w http.ResponseWriter, r *http.Request, flow *Flow, prompt
 
 	sseSend(map[string]any{"type": "thinking", "message": "Building…"})
 
-	// Build the app directly
-	a, err := apps.BuildAndSave(prompt, flow.AccountID, "Agent")
+	// Include SDK docs so the builder knows about platform APIs
+	buildPrompt := prompt + "\n\n" + apps.SDKDocs()
+
+	// Build the app
+	a, err := apps.BuildAndSave(buildPrompt, flow.AccountID, "Agent")
 	if err != nil {
 		errMsg := err.Error()
 		if len(errMsg) > 200 {

--- a/apps/apps.go
+++ b/apps/apps.go
@@ -790,6 +790,76 @@ func handleFork(w http.ResponseWriter, r *http.Request, slug string) {
 }
 
 // handleRun renders the app in a sandboxed iframe.
+// NativeSDK returns the inline <script> that defines window.mu for a given app slug.
+// It runs synchronously so all platform APIs are available to subsequent scripts.
+func NativeSDK(slug string) string {
+	return fmt.Sprintf(`<script>
+(function(){
+  var slug=%q;
+  var j='application/json';
+  function get(p){return fetch(p,{headers:{Accept:j}}).then(function(r){return r.json()})}
+  function post(p,b){return fetch(p,{method:'POST',headers:{'Content-Type':j,Accept:j},body:JSON.stringify(b)}).then(function(r){return r.json()})}
+  function sdk(op,body){return post('/apps/'+slug+'/sdk/'+op,body)}
+
+  window.mu={
+    weather:function(o){return get('/weather?lat='+o.lat+'&lon='+o.lon+(o.pollen?'&pollen=1':''))},
+    news:function(){return get('/news')},
+    markets:function(o){return get('/markets'+(o&&o.category?'?category='+o.category:''))},
+    video:function(){return get('/video')},
+    blog:{
+      list:function(){return get('/blog')},
+      read:function(id){return get('/blog/post?id='+id)},
+      create:function(o){return post('/blog',o)},
+    },
+    social:function(){return get('/social')},
+    places:{
+      search:function(o){return post('/places/search',o)},
+      nearby:function(o){return post('/places/nearby',o)},
+    },
+    chat:function(prompt){return post('/chat',{prompt:prompt})},
+    search:function(q){return get('/search?q='+encodeURIComponent(q))},
+    apps:{
+      list:function(){return get('/apps')},
+      read:function(s){return get('/apps/'+s)},
+    },
+    ai:function(prompt,opts){return sdk('ai',{prompt:prompt,options:opts||{}}).then(function(j){return j.result||j})},
+    agent:function(prompt){return post('/agent/run',{prompt:prompt}).then(function(j){return j.answer||j})},
+    user:function(){return get('/session')},
+    store:{
+      set:function(k,v){return sdk('store',{op:'set',key:k,value:v})},
+      get:function(k){return sdk('store',{op:'get',key:k}).then(function(j){return j.result})},
+      del:function(k){return sdk('store',{op:'del',key:k})},
+      keys:function(){return sdk('store',{op:'keys'}).then(function(j){return j.result})},
+    },
+    get:function(p){return get(p)},
+    post:function(p,b){return post(p,b)},
+    errors:[],
+    eval:function(code){
+      try{var r=eval(code);return{ok:true,result:String(r)}}
+      catch(e){return{ok:false,error:e.message}}
+    },
+  };
+  window.onerror=function(msg,src,line){mu.errors.push({type:'error',message:msg,source:src,line:line});};
+  window.onunhandledrejection=function(e){mu.errors.push({type:'promise',message:String(e.reason)});};
+})();
+</script>`, slug)
+}
+
+// InjectSDK injects a script/HTML block after <head> or at the top of the document.
+func InjectSDK(html, sdk string) string {
+	if idx := strings.Index(strings.ToLower(html), "<head>"); idx >= 0 {
+		return html[:idx+6] + sdk + html[idx+6:]
+	}
+	if idx := strings.Index(strings.ToLower(html), "<body"); idx >= 0 {
+		end := strings.Index(html[idx:], ">")
+		if end >= 0 {
+			pos := idx + end + 1
+			return html[:pos] + sdk + html[pos:]
+		}
+	}
+	return sdk + html
+}
+
 func handleRun(w http.ResponseWriter, r *http.Request, slug string) {
 	mutex.RLock()
 	a, ok := apps[slug]
@@ -799,111 +869,34 @@ func handleRun(w http.ResponseWriter, r *http.Request, slug string) {
 		return
 	}
 
-	// Count launch (non-raw only, skip author's own launches)
-	if r.URL.Query().Get("raw") != "1" {
-		_, acc, _ := auth.RequireSession(r)
-		if acc == nil || acc.ID != a.AuthorID {
-			mutex.Lock()
-			a.Installs++
-			mutex.Unlock()
-			save()
-		}
+	// Count launches (skip author's own)
+	_, acc, _ := auth.RequireSession(r)
+	if acc == nil || acc.ID != a.AuthorID {
+		mutex.Lock()
+		a.Installs++
+		mutex.Unlock()
+		save()
 	}
 
-	// Serve raw HTML for iframe src (with sandbox origin isolation)
-	if r.URL.Query().Get("raw") == "1" {
-		w.Header().Set("Content-Type", "text/html; charset=utf-8")
-		w.Header().Set("Content-Security-Policy", "default-src 'unsafe-inline' 'self' data: blob:; script-src 'unsafe-inline'; style-src 'unsafe-inline';")
-		w.Header().Set("X-Frame-Options", "SAMEORIGIN")
+	// Full page app — no iframe, no sandbox
+	// The SDK is injected inline and uses direct fetch() (same origin, authenticated via session cookie)
+	sdk := NativeSDK(a.Slug)
+	html := a.HTML
+	// Strip any old SDK script tags the AI may have generated
+	html = strings.ReplaceAll(html, `<script src="/apps/sdk.js"></script>`, "")
+	html = strings.ReplaceAll(html, `<script src='/apps/sdk.js'></script>`, "")
+	html = InjectSDK(html, sdk)
 
-		// Inject SDK bridge script before closing </head> or at start
-		sdkBridge := `<script>
-window.mu={_id:0,_cb:{},
-_send:function(t,d){var id=++this._id;return new Promise(function(ok,fail){mu._cb[id]={ok:ok,fail:fail};window.parent.postMessage({type:'mu:'+t,id:id,data:d},'*');})},
-ai:function(p,o){return this._send('ai',{prompt:p,options:o||{}})},
-fetch:function(u){return this._send('fetch',{url:u})},
-user:function(){return this._send('user',{})},
-run:function(result){window.parent.postMessage({type:'mu:run',result:result},'*');},
-store:{
-set:function(k,v){return mu._send('store',{op:'set',key:k,value:v})},
-get:function(k){return mu._send('store',{op:'get',key:k})},
-del:function(k){return mu._send('store',{op:'del',key:k})},
-keys:function(){return mu._send('store',{op:'keys'})}
-}};
-window.addEventListener('message',function(e){var d=e.data;if(d&&d.type&&d.type.indexOf('mu:')===0&&d.id&&mu._cb[d.id]){if(d.error){mu._cb[d.id].fail(new Error(d.error))}else{mu._cb[d.id].ok(d.result)}delete mu._cb[d.id];}});
-</script>`
-		html := a.HTML
-		if idx := strings.Index(strings.ToLower(html), "<head>"); idx >= 0 {
-			html = html[:idx+6] + sdkBridge + html[idx+6:]
-		} else if idx := strings.Index(strings.ToLower(html), "<html"); idx >= 0 {
-			// Find the end of the <html> tag
-			end := strings.Index(html[idx:], ">")
-			if end >= 0 {
-				pos := idx + end + 1
-				html = html[:pos] + sdkBridge + html[pos:]
-			}
-		} else {
-			html = sdkBridge + html
-		}
-		w.Write([]byte(html))
-		return
-	}
+	// Add a minimal top bar
+	topBar := fmt.Sprintf(`<div style="position:fixed;top:0;left:0;right:0;background:#fff;border-bottom:1px solid #eee;padding:6px 16px;font-size:13px;font-family:'Nunito Sans',sans-serif;z-index:10000;display:flex;justify-content:space-between;align-items:center">
+<div><a href="/apps" style="color:#888;text-decoration:none">Apps</a> · <strong>%s</strong></div>
+<div><a href="/apps/%s/edit" style="color:#888;text-decoration:none">Edit</a></div>
+</div>
+<div style="height:36px"></div>`, htmlpkg.EscapeString(a.Name), htmlpkg.EscapeString(a.Slug))
+	html = InjectSDK(html, topBar)
 
-	// Render the run page with iframe
-	var sb strings.Builder
-	sb.WriteString(fmt.Sprintf(`<p><a href="/apps/%s">&larr; %s</a></p>`,
-		htmlpkg.EscapeString(a.Slug), htmlpkg.EscapeString(a.Name)))
-	sb.WriteString(fmt.Sprintf(`<iframe src="/apps/%s/run?raw=1" sandbox="allow-scripts" allow="geolocation" style="width:100%%;min-height:70vh;border:1px solid #eee;border-radius:8px;background:#fff;"></iframe>`,
-		htmlpkg.EscapeString(a.Slug)))
-
-	// SDK bridge in parent page: listens for postMessage from iframe and proxies to backend
-	sb.WriteString(fmt.Sprintf(`<script>
-window.addEventListener('message',function(e){
-var d=e.data;if(!d||!d.type||d.type.indexOf('mu:')!==0)return;
-var t=d.type.replace('mu:','');
-var slug=%q;
-var url='/apps/'+slug+'/sdk/';
-if(t==='ai'){url+='ai'}
-else if(t==='fetch'){url+='ai'}
-else if(t==='store'){url+='store'}
-else if(t==='api'){
-var method=d.data.method||'GET';
-var path=d.data.path||'/';
-var opts={method:method,headers:{'Content-Type':'application/json','Accept':'application/json'}};
-if(d.data.body)opts.body=JSON.stringify(d.data.body);
-fetch(path,opts).then(function(r){return r.json()}).then(function(j){
-var iframe=document.querySelector('iframe');
-iframe.contentWindow.postMessage({type:d.type+':res',id:d.id,result:j},'*');
-}).catch(function(err){
-var iframe=document.querySelector('iframe');
-iframe.contentWindow.postMessage({type:d.type+':res',id:d.id,error:err.message},'*');
-});return;
-}
-else if(t==='user'){
-fetch('/session').then(function(r){return r.json()}).then(function(j){
-var iframe=document.querySelector('iframe');
-iframe.contentWindow.postMessage({type:d.type+':res',id:d.id,result:j},'*');
-});return;
-}
-fetch(url,{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(d.data)})
-.then(function(r){return r.json()})
-.then(function(j){
-var iframe=document.querySelector('iframe');
-var res=(j&&j.result!==undefined)?j.result:j;
-iframe.contentWindow.postMessage({type:d.type+':res',id:d.id,result:res},'*');
-})
-.catch(function(err){
-var iframe=document.querySelector('iframe');
-iframe.contentWindow.postMessage({type:d.type+':res',id:d.id,error:err.message},'*');
-});
-});
-</script>`, a.Slug))
-
-	app.Respond(w, r, app.Response{
-		Title:       a.Name,
-		Description: a.Description,
-		HTML:        sb.String(),
-	})
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.Write([]byte(html))
 }
 
 // handleUpdate processes PATCH requests to update an app.

--- a/apps/apps.go
+++ b/apps/apps.go
@@ -797,8 +797,10 @@ func NativeSDK(slug string) string {
 (function(){
   var slug=%q;
   var j='application/json';
-  function get(p){return fetch(p,{headers:{Accept:j}}).then(function(r){return r.json()})}
-  function post(p,b){return fetch(p,{method:'POST',headers:{'Content-Type':j,Accept:j},body:JSON.stringify(b)}).then(function(r){return r.json()})}
+  var log=[];
+  function truncLog(v){var s=JSON.stringify(v);return s&&s.length>500?s.slice(0,500)+'…':s}
+  function get(p){return fetch(p,{headers:{Accept:j}}).then(function(r){return r.json()}).then(function(d){log.push({call:'GET '+p,response:truncLog(d)});return d})}
+  function post(p,b){return fetch(p,{method:'POST',headers:{'Content-Type':j,Accept:j},body:JSON.stringify(b)}).then(function(r){return r.json()}).then(function(d){log.push({call:'POST '+p,response:truncLog(d)});return d})}
   function sdk(op,body){return post('/apps/'+slug+'/sdk/'+op,body)}
 
   window.mu={
@@ -834,13 +836,23 @@ func NativeSDK(slug string) string {
     get:function(p){return get(p)},
     post:function(p,b){return post(p,b)},
     errors:[],
+    log:log,
     eval:function(code){
       try{var r=eval(code);return{ok:true,result:String(r)}}
       catch(e){return{ok:false,error:e.message}}
     },
   };
-  window.onerror=function(msg,src,line){mu.errors.push({type:'error',message:msg,source:src,line:line});};
-  window.onunhandledrejection=function(e){mu.errors.push({type:'promise',message:String(e.reason)});};
+  window.onerror=function(msg,src,line,col,err){
+    var entry={type:'error',message:msg,source:src,line:line};
+    if(err&&err.stack)entry.stack=err.stack.split('\n').slice(0,5).join('\n');
+    mu.errors.push(entry);
+  };
+  window.onunhandledrejection=function(e){
+    var msg=e.reason&&e.reason.message?e.reason.message:String(e.reason);
+    var entry={type:'promise',message:msg};
+    if(e.reason&&e.reason.stack)entry.stack=e.reason.stack.split('\n').slice(0,5).join('\n');
+    mu.errors.push(entry);
+  };
 })();
 </script>`, slug)
 }

--- a/apps/builder.go
+++ b/apps/builder.go
@@ -16,8 +16,9 @@ import (
 	"github.com/google/uuid"
 )
 
-// builderSystemPrompt instructs the AI to generate app HTML.
-const builderSystemPrompt = `You are an app builder for the Mu platform. You generate complete, self-contained HTML apps.
+// builderSystemPrompt is a generic HTML app builder — no platform-specific knowledge.
+// SDK docs are passed as context by the caller when needed.
+const builderSystemPrompt = `You are an app builder. You generate complete, self-contained HTML apps.
 
 Output format:
 - Output ONLY valid JSON: {"name":"Short Name","icon":"<svg>...</svg>","html":"<!DOCTYPE html>..."}
@@ -30,50 +31,65 @@ Style:
 - Clean minimal design: #fff background, #333 text, #e0e0e0 borders, 6px radius
 - Buttons: padding 8-10px 20-24px, radius 6px, primary: background #000 color #fff
 - No external dependencies, CDN links, or images
+- Responsive and mobile-friendly
 
-Mu SDK (auto-injected via window.mu — do NOT add script tags):
-Apps run as full pages on the same origin. The SDK provides typed access to every platform building block.
+Rules:
+- The app MUST have working JavaScript — not just a UI shell
+- Always check for errors and null-check nested properties
+- If using geolocation, provide a manual fallback input
+- When modifying an existing app, return the complete updated JSON (not a diff)`
 
-Platform APIs (all return Promises with JSON):
-- mu.weather({lat: NUMBER, lon: NUMBER}) — weather forecast
-- mu.news() — latest news feed
-- mu.markets({category: 'crypto'|'futures'|'commodities'}) — market prices
-- mu.video() — latest videos
-- mu.blog.list() — blog posts
-- mu.blog.read(id) — single post
-- mu.blog.create({title, content}) — create post
-- mu.social() — social threads
-- mu.places.search({q: 'cafe', near: 'London'}) — search places
-- mu.places.nearby({address: 'London', radius: 1000}) — nearby places
-- mu.chat(prompt) — AI chat
-- mu.search(query) — search all content
-- mu.apps.list() — list apps
-- mu.ai(prompt) — ask AI, returns response text
-- mu.user() — current user info
+// SDKDocs returns the Mu platform SDK reference documentation.
+// This is the single source of truth — used by the mu_sdk tool and
+// passed to the builder as context when the app needs platform APIs.
+func SDKDocs() string {
+	return `# Mu SDK Reference
 
-Agent (for complex queries that need multiple data sources):
-- mu.agent(prompt) — runs the full agent: plans tools, executes, returns synthesised answer
+Apps run as full pages on the same origin. The SDK is auto-injected as window.mu — do NOT add script tags for it.
 
-Storage (persistent, namespaced per app):
-- mu.store.set(key, value) / mu.store.get(key) / mu.store.del(key) / mu.store.keys()
+## Platform APIs (all return Promises with JSON)
 
-Raw fetch (for any endpoint):
-- mu.get(path) — GET, returns JSON
-- mu.post(path, body) — POST, returns JSON
+mu.weather({lat, lon})        — weather forecast (requires lat/lon numbers, not city name)
+mu.news()                     — latest news feed
+mu.markets({category})        — market prices (category: 'crypto'|'futures'|'commodities')
+mu.video()                    — latest videos
+mu.blog.list()                — blog posts
+mu.blog.read(id)              — single post
+mu.blog.create({title, content}) — create post
+mu.social()                   — social threads
+mu.places.search({q, near})   — search places (e.g. {q:'cafe', near:'London'})
+mu.places.nearby({address, radius}) — nearby places
+mu.chat(prompt)               — AI chat
+mu.search(query)              — search all content
+mu.apps.list()                — list apps
+mu.ai(prompt)                 — ask AI, returns response text
+mu.agent(prompt)              — full agent: plans tools, executes, returns answer
+mu.user()                     — current user info
 
-Geolocation:
-- navigator.geolocation works — ALWAYS provide a manual fallback input
+## Storage (persistent, namespaced per app)
 
-ABSOLUTE RULES:
-1. Do NOT add <script src="/apps/sdk.js"> — the SDK is auto-injected.
-2. Do NOT load external scripts or CDN links.
-3. mu.weather() requires lat/lon — NOT a city name. Use geolocation or mu.places.search() to geocode.
-4. Weather response shape: {Current:{TempC, FeelsLikeC, Description, Humidity, WindKph}, DailyItems:[{MaxTempC, MinTempC, Description}]}
-5. Always check for errors: if(data.error){showError(data.error);return}
-6. Always null-check nested properties before access.
-7. The app MUST have working JavaScript that implements full functionality, not just a UI shell.
+mu.store.set(key, value)
+mu.store.get(key)
+mu.store.del(key)
+mu.store.keys()
 
-When modifying an existing app, return the complete updated JSON (not a diff).`
+## Raw fetch (for any endpoint on the platform)
+
+mu.get(path)          — GET, returns JSON
+mu.post(path, body)   — POST, returns JSON
+
+## Response shapes
+
+Weather: {Current:{TempC, FeelsLikeC, Description, Humidity, WindKph}, DailyItems:[{MaxTempC, MinTempC, Description}]}
+Markets: array of {Symbol, Price, Change, ChangePercent}
+
+## Important notes
+
+- mu.weather() requires lat/lon — use geolocation or mu.places.search() to geocode city names
+- Do NOT add <script src="/apps/sdk.js"> — the SDK is already injected
+- Do NOT load external scripts or CDN links
+- Always handle errors: if(data.error){showError(data.error);return}`
+}
 
 // handleBuilder serves the app builder page.
 func handleBuilder(w http.ResponseWriter, r *http.Request) {
@@ -263,8 +279,8 @@ func EditApp(slug, prompt, accountID string) (*App, error) {
 		return nil, fmt.Errorf("app not found: %s", slug)
 	}
 
-	// Ask AI to fix the app with current HTML as context
-	question := fmt.Sprintf("Here is the current app HTML:\n\n%s\n\nModification requested: %s", a.HTML, prompt)
+	// Ask AI to fix the app — include SDK docs and current HTML as context
+	question := fmt.Sprintf("Here is the current app HTML:\n\n%s\n\nModification requested: %s\n\n%s", a.HTML, prompt, SDKDocs())
 	aiPrompt := &ai.Prompt{
 		System:   builderSystemPrompt,
 		Question: question,

--- a/apps/builder.go
+++ b/apps/builder.go
@@ -78,17 +78,44 @@ mu.store.keys()
 mu.get(path)          — GET, returns JSON
 mu.post(path, body)   — POST, returns JSON
 
-## Response shapes
+## Response shapes (EXACT — use these field names)
 
-Weather: {Current:{TempC, FeelsLikeC, Description, Humidity, WindKph}, DailyItems:[{MaxTempC, MinTempC, Description}]}
-Markets: array of {Symbol, Price, Change, ChangePercent}
+Weather:
+  var data = await mu.weather({lat: 51.5, lon: -0.12})
+  data.forecast.Current.TempC          // number, e.g. 15.0
+  data.forecast.Current.FeelsLikeC     // number
+  data.forecast.Current.Description    // string, e.g. "Partly cloudy"
+  data.forecast.Current.Humidity       // number, e.g. 65
+  data.forecast.Current.WindKph        // number
+  data.forecast.DailyItems             // array of {MaxTempC, MinTempC, Description, WillRain, RainMM}
+  data.forecast.HourlyItems            // array of {TempC, Description}
+
+Markets:
+  var data = await mu.markets({category: 'crypto'})
+  data.category                        // string, e.g. "crypto"
+  data.data                            // array of items:
+  data.data[0].symbol                  // string, e.g. "BTC"
+  data.data[0].price                   // number, e.g. 66556.03
+  data.data[0].change_24h              // number, e.g. -0.68 (percentage)
+  data.data[0].type                    // string, e.g. "crypto"
+
+News:
+  var data = await mu.news()
+  data.feed                            // array of items:
+  data.feed[0].title                   // string
+  data.feed[0].description             // string
+  data.feed[0].url                     // string
+  data.feed[0].category                // string
+  data.feed[0].published               // string (date)
+  data.feed[0].image                   // string (URL, may be empty)
 
 ## Important notes
 
 - mu.weather() requires lat/lon — use geolocation or mu.places.search() to geocode city names
 - Do NOT add <script src="/apps/sdk.js"> — the SDK is already injected
 - Do NOT load external scripts or CDN links
-- Always handle errors: if(data.error){showError(data.error);return}`
+- Always handle errors: if(!data || data.error){showError(data.error||'Failed to load');return}
+- Markets data is in data.data (array), news is in data.feed (array) — always check the wrapper`
 }
 
 // handleBuilder serves the app builder page.

--- a/apps/builder.go
+++ b/apps/builder.go
@@ -169,12 +169,12 @@ func handleGenerate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Build the AI prompt
-	question := req.Prompt
+	// Build the AI prompt — include SDK docs so the builder knows about platform APIs
+	question := req.Prompt + "\n\n" + SDKDocs()
 	var rag []string
 	if req.Code != "" {
 		rag = append(rag, "Current app HTML that the user wants to modify:\n```html\n"+req.Code+"\n```")
-		question = "Modify this existing app: " + req.Prompt
+		question = "Modify this existing app: " + req.Prompt + "\n\n" + SDKDocs()
 	}
 
 	prompt := &ai.Prompt{

--- a/apps/builder.go
+++ b/apps/builder.go
@@ -16,8 +16,7 @@ import (
 	"github.com/google/uuid"
 )
 
-// builderSystemPrompt is a generic HTML app builder — no platform-specific knowledge.
-// SDK docs are passed as context by the caller when needed.
+// builderSystemPrompt is a vanilla HTML app builder. No platform SDK, no external APIs.
 const builderSystemPrompt = `You are an app builder. You generate complete, self-contained HTML apps.
 
 Output format:
@@ -34,8 +33,10 @@ Style:
 - Responsive and mobile-friendly
 
 Rules:
+- The app MUST be completely self-contained — all data, logic, and UI in one HTML file
+- No external API calls, no fetch(), no XMLHttpRequest — everything runs locally
 - The app MUST have working JavaScript — not just a UI shell
-- Always check for errors and null-check nested properties
+- If the app needs sample data, hardcode realistic example data directly in the code
 - If using geolocation, provide a manual fallback input
 - When modifying an existing app, return the complete updated JSON (not a diff)`
 
@@ -178,7 +179,7 @@ func handleGenerate(w http.ResponseWriter, r *http.Request) {
 	}
 
 	prompt := &ai.Prompt{
-		System:   builderSystemPrompt + "\n\n" + SDKDocs(),
+		System:   builderSystemPrompt,
 		Rag:      rag,
 		Question: question,
 		Model:    "claude-opus-4-20250514",
@@ -223,7 +224,7 @@ func handleGenerate(w http.ResponseWriter, r *http.Request) {
 // Used by the MCP apps_build tool so the agent can create apps in one step.
 func BuildAndSave(prompt, authorID, authorName string) (*App, error) {
 	aiPrompt := &ai.Prompt{
-		System:   builderSystemPrompt + "\n\n" + SDKDocs(),
+		System:   builderSystemPrompt,
 		Question: prompt,
 		Model:    "claude-opus-4-20250514",
 		Priority: ai.PriorityHigh,
@@ -311,7 +312,7 @@ func EditApp(slug, prompt, accountID string) (*App, error) {
 	// Ask AI to fix the app with current HTML as context
 	question := fmt.Sprintf("Here is the current app HTML:\n\n%s\n\nModification requested: %s", a.HTML, prompt)
 	aiPrompt := &ai.Prompt{
-		System:   builderSystemPrompt + "\n\n" + SDKDocs(),
+		System:   builderSystemPrompt,
 		Question: question,
 		Model:    "claude-opus-4-20250514",
 		Priority: ai.PriorityHigh,
@@ -595,8 +596,20 @@ function updatePreview() { showPreview(); }
 
 function fixErrors() {
   if (lastErrors.length === 0) return;
-  var msgs = lastErrors.map(function(e){ return e.message; }).join('; ');
-  document.getElementById('prompt').value = 'Fix these errors: ' + msgs;
+  var parts = ['Fix these runtime errors:'];
+  lastErrors.forEach(function(e){
+    parts.push('- ' + e.message);
+    if (e.stack) parts.push('  Stack: ' + e.stack.split('\n').slice(0,3).join(' | '));
+  });
+  // Include actual API responses so the AI can see the real data shape
+  try {
+    var iwin = preview.contentWindow;
+    if (iwin && iwin.mu && iwin.mu.log && iwin.mu.log.length > 0) {
+      parts.push('\nAPI responses received:');
+      iwin.mu.log.forEach(function(l){ parts.push('- ' + l.call + ' returned: ' + l.response); });
+    }
+  } catch(e) {}
+  document.getElementById('prompt').value = parts.join('\n');
   generate();
 }
 
@@ -842,8 +855,20 @@ function updatePreview() { showPreview(); }
 
 function fixErrors() {
   if (lastErrors.length === 0) return;
-  var msgs = lastErrors.map(function(e){ return e.message; }).join('; ');
-  document.getElementById('prompt').value = 'Fix these errors: ' + msgs;
+  var parts = ['Fix these runtime errors:'];
+  lastErrors.forEach(function(e){
+    parts.push('- ' + e.message);
+    if (e.stack) parts.push('  Stack: ' + e.stack.split('\n').slice(0,3).join(' | '));
+  });
+  // Include actual API responses so the AI can see the real data shape
+  try {
+    var iwin = preview.contentWindow;
+    if (iwin && iwin.mu && iwin.mu.log && iwin.mu.log.length > 0) {
+      parts.push('\nAPI responses received:');
+      iwin.mu.log.forEach(function(l){ parts.push('- ' + l.call + ' returned: ' + l.response); });
+    }
+  } catch(e) {}
+  document.getElementById('prompt').value = parts.join('\n');
   generate();
 }
 

--- a/apps/builder.go
+++ b/apps/builder.go
@@ -761,18 +761,26 @@ func editPageHTML(a *App) string {
   .save-bar input { width: 100%%; }
   .prompt-bar { flex-direction: column; }
   .prompt-bar input, .prompt-bar button { width: 100%%; box-sizing: border-box; }
+  .edit-panels { flex-direction: column !important; }
+  .edit-panels > div { min-width: auto !important; }
 }
 </style>
 
 <div class="builder">
-  <p class="card-desc">Edit your app — modify with AI or update the code directly.</p>
+  <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:4px">
+    <p class="card-desc" style="margin:0">Edit your app</p>
+    <div style="display:flex;gap:8px;align-items:center;font-size:13px">
+      <a href="/apps/%s/run" style="color:#333;text-decoration:none;padding:4px 12px;border:1px solid #e0e0e0;border-radius:6px">Open App</a>
+      <button onclick="deleteApp()" style="padding:4px 12px;border:1px solid #e0e0e0;border-radius:6px;background:#fff;color:#c00;cursor:pointer;font-size:13px;font-family:inherit">Delete</button>
+    </div>
+  </div>
 
   <div class="prompt-bar">
     <input type="text" id="prompt" placeholder="Describe changes... e.g. add a dark mode toggle" onkeydown="if(event.key==='Enter')generate()">
     <button id="genBtn" onclick="generate()">Modify</button>
   </div>
 
-  <div style="display:flex;gap:12px;flex-wrap:wrap;">
+  <div class="edit-panels" style="display:flex;gap:12px;flex-wrap:wrap;">
     <div style="flex:1;min-width:300px;">
       <div class="code-header" style="margin-bottom:6px;">
         <h3>Code</h3>
@@ -951,5 +959,12 @@ function copyCode() {
     setTimeout(function() { document.getElementById('statusMsg').textContent = ''; }, 2000);
   });
 }
-</script>`, savedAt, versionLink, escapedIcon, escapedSlug, escapedSDK, escapedCode, escapedName, escapedDesc, escapedTags)
+
+function deleteApp() {
+  if (!confirm('Delete this app? This cannot be undone.')) return;
+  fetch('/apps/' + editSlug + '/delete', { method: 'POST' })
+  .then(function(r) { if (r.ok) window.location.href = '/apps'; else throw new Error('Delete failed'); })
+  .catch(function(e) { document.getElementById('statusMsg').textContent = e.message; });
+}
+</script>`, htmlpkg.EscapeString(a.Slug), savedAt, versionLink, escapedIcon, escapedSlug, escapedSDK, escapedCode, escapedName, escapedDesc, escapedTags)
 }

--- a/apps/builder.go
+++ b/apps/builder.go
@@ -448,6 +448,7 @@ func cleanGeneratedHTML(s string) string {
 // builderPageHTML returns the HTML for the app builder interface.
 func builderPageHTML(initialCode string) string {
 	escapedCode, _ := json.Marshal(initialCode)
+	escapedSDK, _ := json.Marshal(NativeSDK("_preview"))
 
 	// Build template buttons
 	var templateButtons strings.Builder
@@ -521,7 +522,8 @@ func builderPageHTML(initialCode string) string {
       <p>Your app preview will appear here.</p>
       <p>Type a prompt above or pick a template.</p>
     </div>
-    <iframe id="preview" class="preview-frame" sandbox="allow-scripts" allow="geolocation" style="display:none;"></iframe>
+    <iframe id="preview" class="preview-frame" allow="geolocation" style="display:none;"></iframe>
+    <div id="errorBar" style="display:none;padding:8px 12px;background:#fff0f0;border:1px solid #fcc;border-radius:6px;margin-top:6px;font-size:13px;color:#c00;cursor:pointer" onclick="fixErrors()" title="Click to auto-fix"></div>
   </div>
 
   <div class="code-section" id="codeSection">
@@ -548,6 +550,7 @@ var codeEl = document.getElementById('code');
 var preview = document.getElementById('preview');
 var emptyState = document.getElementById('emptyState');
 var appIcon = '';
+var previewSDK = %s;
 var initialCode = %s;
 if (initialCode) { codeEl.value = initialCode; showPreview(); }
 
@@ -561,15 +564,41 @@ codeEl.addEventListener('keydown', function(e) {
   }
 });
 
+var lastErrors = [];
+
 function showPreview() {
   var html = codeEl.value;
   if (!html.trim()) return;
   emptyState.style.display = 'none';
   preview.style.display = '';
-  preview.srcdoc = html;
+  document.getElementById('errorBar').style.display = 'none';
+  lastErrors = [];
+  // Inject SDK and write HTML directly (same origin, no sandbox)
+  var pdoc = preview.contentDocument || preview.contentWindow.document;
+  pdoc.open(); pdoc.write(previewSDK + html); pdoc.close();
+  // Check for errors after app loads
+  setTimeout(function() {
+    try {
+      var iwin = preview.contentWindow;
+      if (iwin && iwin.mu && iwin.mu.errors && iwin.mu.errors.length > 0) {
+        lastErrors = iwin.mu.errors;
+        var msgs = lastErrors.map(function(e){ return e.message; }).join('; ');
+        var bar = document.getElementById('errorBar');
+        bar.textContent = msgs.slice(0, 200) + ' — click to fix';
+        bar.style.display = 'block';
+      }
+    } catch(e) {}
+  }, 2500);
 }
 
 function updatePreview() { showPreview(); }
+
+function fixErrors() {
+  if (lastErrors.length === 0) return;
+  var msgs = lastErrors.map(function(e){ return e.message; }).join('; ');
+  document.getElementById('prompt').value = 'Fix these errors: ' + msgs;
+  generate();
+}
 
 function toggleCode() {
   var section = document.getElementById('codeSection');
@@ -666,7 +695,7 @@ function copyCode() {
 function slugify(s) {
   return s.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '').substring(0, 50);
 }
-</script>`, templateButtons.String(), string(escapedCode))
+</script>`, templateButtons.String(), string(escapedSDK), string(escapedCode))
 }
 
 // editPageHTML returns the HTML for editing an existing app (reuses builder UI).
@@ -677,6 +706,7 @@ func editPageHTML(a *App) string {
 	escapedTags, _ := json.Marshal(a.Tags)
 	escapedIcon, _ := json.Marshal(a.Icon)
 	escapedSlug, _ := json.Marshal(a.Slug)
+	escapedSDK, _ := json.Marshal(NativeSDK(a.Slug))
 
 	savedAt := "Last saved " + a.UpdatedAt.Format("2 Jan 2006 15:04")
 	versionLink := ""
@@ -744,7 +774,8 @@ func editPageHTML(a *App) string {
         <h3>Preview</h3>
         <button class="code-toggle" onclick="updatePreview()">Refresh</button>
       </div>
-      <iframe id="preview" class="preview-frame" sandbox="allow-scripts" allow="geolocation" style="min-height:50vh;"></iframe>
+      <iframe id="preview" class="preview-frame" allow="geolocation" style="min-height:50vh;"></iframe>
+      <div id="errorBar" style="display:none;padding:8px 12px;background:#fff0f0;border:1px solid #fcc;border-radius:6px;margin-top:6px;font-size:13px;color:#c00;cursor:pointer" onclick="fixErrors()" title="Click to auto-fix"></div>
     </div>
   </div>
 
@@ -766,6 +797,8 @@ var codeEl = document.getElementById('code');
 var preview = document.getElementById('preview');
 var appIcon = %s;
 var editSlug = %s;
+var previewSDK = %s;
+var lastErrors = [];
 
 // Pre-populate fields
 codeEl.value = %s;
@@ -787,10 +820,32 @@ function showPreview() {
   var html = codeEl.value;
   if (!html.trim()) return;
   preview.style.display = '';
-  preview.srcdoc = html;
+  document.getElementById('errorBar').style.display = 'none';
+  lastErrors = [];
+  var pdoc = preview.contentDocument || preview.contentWindow.document;
+  pdoc.open(); pdoc.write(previewSDK + html); pdoc.close();
+  setTimeout(function() {
+    try {
+      var iwin = preview.contentWindow;
+      if (iwin && iwin.mu && iwin.mu.errors && iwin.mu.errors.length > 0) {
+        lastErrors = iwin.mu.errors;
+        var msgs = lastErrors.map(function(e){ return e.message; }).join('; ');
+        var bar = document.getElementById('errorBar');
+        bar.textContent = msgs.slice(0, 200) + ' — click to fix';
+        bar.style.display = 'block';
+      }
+    } catch(e) {}
+  }, 2500);
 }
 
 function updatePreview() { showPreview(); }
+
+function fixErrors() {
+  if (lastErrors.length === 0) return;
+  var msgs = lastErrors.map(function(e){ return e.message; }).join('; ');
+  document.getElementById('prompt').value = 'Fix these errors: ' + msgs;
+  generate();
+}
 
 function toggleCode() {
   var section = document.getElementById('codeSection');
@@ -871,5 +926,5 @@ function copyCode() {
     setTimeout(function() { document.getElementById('statusMsg').textContent = ''; }, 2000);
   });
 }
-</script>`, savedAt, versionLink, escapedIcon, escapedSlug, escapedCode, escapedName, escapedDesc, escapedTags)
+</script>`, savedAt, versionLink, escapedIcon, escapedSlug, escapedSDK, escapedCode, escapedName, escapedDesc, escapedTags)
 }

--- a/apps/builder.go
+++ b/apps/builder.go
@@ -181,6 +181,7 @@ func handleGenerate(w http.ResponseWriter, r *http.Request) {
 		System:   builderSystemPrompt + "\n\n" + SDKDocs(),
 		Rag:      rag,
 		Question: question,
+		Model:    "claude-opus-4-20250514",
 		Priority: ai.PriorityHigh,
 		Caller:   "app-builder",
 	}
@@ -224,6 +225,7 @@ func BuildAndSave(prompt, authorID, authorName string) (*App, error) {
 	aiPrompt := &ai.Prompt{
 		System:   builderSystemPrompt + "\n\n" + SDKDocs(),
 		Question: prompt,
+		Model:    "claude-opus-4-20250514",
 		Priority: ai.PriorityHigh,
 		Caller:   "app-builder",
 	}
@@ -311,6 +313,7 @@ func EditApp(slug, prompt, accountID string) (*App, error) {
 	aiPrompt := &ai.Prompt{
 		System:   builderSystemPrompt + "\n\n" + SDKDocs(),
 		Question: question,
+		Model:    "claude-opus-4-20250514",
 		Priority: ai.PriorityHigh,
 		Caller:   "app-edit",
 	}

--- a/apps/builder.go
+++ b/apps/builder.go
@@ -169,16 +169,16 @@ func handleGenerate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Build the AI prompt — include SDK docs so the builder knows about platform APIs
-	question := req.Prompt + "\n\n" + SDKDocs()
+	// Build the AI prompt
+	question := req.Prompt
 	var rag []string
 	if req.Code != "" {
 		rag = append(rag, "Current app HTML that the user wants to modify:\n```html\n"+req.Code+"\n```")
-		question = "Modify this existing app: " + req.Prompt + "\n\n" + SDKDocs()
+		question = "Modify this existing app: " + req.Prompt
 	}
 
 	prompt := &ai.Prompt{
-		System:   builderSystemPrompt,
+		System:   builderSystemPrompt + "\n\n" + SDKDocs(),
 		Rag:      rag,
 		Question: question,
 		Priority: ai.PriorityHigh,
@@ -222,7 +222,7 @@ func handleGenerate(w http.ResponseWriter, r *http.Request) {
 // Used by the MCP apps_build tool so the agent can create apps in one step.
 func BuildAndSave(prompt, authorID, authorName string) (*App, error) {
 	aiPrompt := &ai.Prompt{
-		System:   builderSystemPrompt,
+		System:   builderSystemPrompt + "\n\n" + SDKDocs(),
 		Question: prompt,
 		Priority: ai.PriorityHigh,
 		Caller:   "app-builder",
@@ -306,10 +306,10 @@ func EditApp(slug, prompt, accountID string) (*App, error) {
 		return nil, fmt.Errorf("app not found: %s", slug)
 	}
 
-	// Ask AI to fix the app — include SDK docs and current HTML as context
-	question := fmt.Sprintf("Here is the current app HTML:\n\n%s\n\nModification requested: %s\n\n%s", a.HTML, prompt, SDKDocs())
+	// Ask AI to fix the app with current HTML as context
+	question := fmt.Sprintf("Here is the current app HTML:\n\n%s\n\nModification requested: %s", a.HTML, prompt)
 	aiPrompt := &ai.Prompt{
-		System:   builderSystemPrompt,
+		System:   builderSystemPrompt + "\n\n" + SDKDocs(),
 		Question: question,
 		Priority: ai.PriorityHigh,
 		Caller:   "app-edit",

--- a/apps/builder.go
+++ b/apps/builder.go
@@ -19,37 +19,61 @@ import (
 // builderSystemPrompt instructs the AI to generate app HTML.
 const builderSystemPrompt = `You are an app builder for the Mu platform. You generate complete, self-contained HTML apps.
 
-Rules:
-- Output ONLY valid JSON with this exact structure: {"name":"Short App Name","icon":"<svg>...</svg>","html":"<complete HTML document>"}
-- The name should be short and descriptive (2-4 words, max 50 chars). E.g. "Pomodoro Timer", "Unit Converter", "Habit Tracker"
-- The icon must be an SVG icon matching this exact style:
-  - viewBox="0 0 32 32" width="32" height="32"
-  - xmlns="http://www.w3.org/2000/svg"
-  - Stroke-based outlines only: stroke="#555", fill="none"
-  - stroke-width between 1.2 and 2.5, stroke-linecap="round" where appropriate
-  - Simple geometric shapes (circles, rects, lines, paths) — no text, no gradients, no filters
-  - Represent the app's purpose with a clear, minimal symbol
-  - Examples: a clock face for timer, grid of squares for calculator, checkmark for tracker
-- The html must be a complete HTML document: <!DOCTYPE html><html><head>...</head><body>...</body></html>
-- All CSS must be inline in a <style> tag in <head>
-- All JavaScript must be inline in a <script> tag before </body>
-- Use the font: font-family: 'Nunito Sans', -apple-system, BlinkMacSystemFont, sans-serif
-- Style guidelines: clean, minimal design. Use subtle borders (#e0e0e0), 6px border-radius, 16-24px padding, #333 text, #fff background
-- Button style: padding 8-10px 20-24px, border-radius 6px, primary buttons use background #000 color #fff
-- Keep it simple and functional — no external dependencies, no CDN links, no images
-- The app runs in a sandboxed iframe with geolocation enabled — no access to parent page
-- If the app uses geolocation (navigator.geolocation), ALWAYS provide a graceful fallback: show a manual location input or a sensible default when the user denies permission or the API fails. Never let the app be blank or broken if location is unavailable.
-- If the app needs AI features, include <script src="/apps/sdk.js"></script> and use mu.ai(prompt)
-- If the app needs persistent storage, use mu.store.set(key, value) and mu.store.get(key)
-- If the app needs platform data, include <script src="/apps/sdk.js"></script> and use:
-  - mu.api.get(path) — GET request to Mu API (e.g. mu.api.get('/weather?q=London'))
-  - mu.api.post(path, body) — POST request to Mu API (e.g. mu.api.post('/places/search', {q:'cafe',near:'London'}))
-  - Available APIs: /weather?q=, /places/search, /places/nearby, /news, /markets, /video, /chat
-- Maximum 256KB HTML
-- Make it responsive and mobile-friendly
-- Use semantic HTML and accessible patterns
+Output format:
+- Output ONLY valid JSON: {"name":"Short Name","icon":"<svg>...</svg>","html":"<!DOCTYPE html>..."}
+- The name should be 2-4 words (max 50 chars)
+- The icon: SVG, viewBox="0 0 32 32", stroke="#555", fill="none", stroke-width 1.2-2.5
+- The html: complete document with <!DOCTYPE html><html><head><style>...</style></head><body>...<script>...</script></body></html>
 
-When the user asks to modify an existing app, return the complete updated JSON (not a diff). Keep the same name and icon unless the user asks to change them.`
+Style:
+- Font: 'Nunito Sans', sans-serif
+- Clean minimal design: #fff background, #333 text, #e0e0e0 borders, 6px radius
+- Buttons: padding 8-10px 20-24px, radius 6px, primary: background #000 color #fff
+- No external dependencies, CDN links, or images
+
+Mu SDK (auto-injected via window.mu — do NOT add script tags):
+Apps run as full pages on the same origin. The SDK provides typed access to every platform building block.
+
+Platform APIs (all return Promises with JSON):
+- mu.weather({lat: NUMBER, lon: NUMBER}) — weather forecast
+- mu.news() — latest news feed
+- mu.markets({category: 'crypto'|'futures'|'commodities'}) — market prices
+- mu.video() — latest videos
+- mu.blog.list() — blog posts
+- mu.blog.read(id) — single post
+- mu.blog.create({title, content}) — create post
+- mu.social() — social threads
+- mu.places.search({q: 'cafe', near: 'London'}) — search places
+- mu.places.nearby({address: 'London', radius: 1000}) — nearby places
+- mu.chat(prompt) — AI chat
+- mu.search(query) — search all content
+- mu.apps.list() — list apps
+- mu.ai(prompt) — ask AI, returns response text
+- mu.user() — current user info
+
+Agent (for complex queries that need multiple data sources):
+- mu.agent(prompt) — runs the full agent: plans tools, executes, returns synthesised answer
+
+Storage (persistent, namespaced per app):
+- mu.store.set(key, value) / mu.store.get(key) / mu.store.del(key) / mu.store.keys()
+
+Raw fetch (for any endpoint):
+- mu.get(path) — GET, returns JSON
+- mu.post(path, body) — POST, returns JSON
+
+Geolocation:
+- navigator.geolocation works — ALWAYS provide a manual fallback input
+
+ABSOLUTE RULES:
+1. Do NOT add <script src="/apps/sdk.js"> — the SDK is auto-injected.
+2. Do NOT load external scripts or CDN links.
+3. mu.weather() requires lat/lon — NOT a city name. Use geolocation or mu.places.search() to geocode.
+4. Weather response shape: {Current:{TempC, FeelsLikeC, Description, Humidity, WindKph}, DailyItems:[{MaxTempC, MinTempC, Description}]}
+5. Always check for errors: if(data.error){showError(data.error);return}
+6. Always null-check nested properties before access.
+7. The app MUST have working JavaScript that implements full functionality, not just a UI shell.
+
+When modifying an existing app, return the complete updated JSON (not a diff).`
 
 // handleBuilder serves the app builder page.
 func handleBuilder(w http.ResponseWriter, r *http.Request) {
@@ -226,6 +250,62 @@ func BuildAndSave(prompt, authorID, authorName string) (*App, error) {
 
 	app.Log("apps", "Agent built app %q for %s", name, authorID)
 	event.Publish(event.Event{Type: "apps_updated"})
+	return a, nil
+}
+
+// EditApp uses AI to fix/modify an existing app based on a prompt.
+// Returns the updated app or an error.
+func EditApp(slug, prompt, accountID string) (*App, error) {
+	mutex.RLock()
+	a, ok := apps[slug]
+	mutex.RUnlock()
+	if !ok {
+		return nil, fmt.Errorf("app not found: %s", slug)
+	}
+
+	// Ask AI to fix the app with current HTML as context
+	question := fmt.Sprintf("Here is the current app HTML:\n\n%s\n\nModification requested: %s", a.HTML, prompt)
+	aiPrompt := &ai.Prompt{
+		System:   builderSystemPrompt,
+		Question: question,
+		Priority: ai.PriorityHigh,
+		Caller:   "app-edit",
+	}
+	result, err := ai.Ask(aiPrompt)
+	if err != nil {
+		return nil, fmt.Errorf("AI edit failed: %v", err)
+	}
+
+	result = cleanGeneratedJSON(result)
+	var generated struct {
+		Name string `json:"name"`
+		Icon string `json:"icon"`
+		HTML string `json:"html"`
+	}
+	if err := json.Unmarshal([]byte(result), &generated); err != nil {
+		generated.HTML = cleanGeneratedHTML(result)
+	}
+	if generated.HTML == "" {
+		generated.HTML = cleanGeneratedHTML(result)
+	}
+	if generated.HTML == "" {
+		return nil, fmt.Errorf("AI returned empty HTML")
+	}
+
+	mutex.Lock()
+	a.HTML = generated.HTML
+	if generated.Name != "" {
+		a.Name = generated.Name
+	}
+	if generated.Icon != "" {
+		a.Icon = generated.Icon
+	}
+	a.UpdatedAt = time.Now()
+	snapshotVersion(a, prompt)
+	mutex.Unlock()
+	save()
+
+	app.Log("apps", "Agent edited app %q for %s", a.Name, accountID)
 	return a, nil
 }
 

--- a/main.go
+++ b/main.go
@@ -465,6 +465,14 @@ Be concise. Focus on functional issues, not style.`,
 		},
 	})
 	api.RegisterTool(api.Tool{
+		Name:        "mu_sdk",
+		Description: "Get the Mu platform SDK documentation. Call this when building or editing apps that need platform features like weather, news, markets, places, storage, AI, etc.",
+		Params:      []api.ToolParam{},
+		Handle: func(args map[string]any) (string, error) {
+			return apps.SDKDocs(), nil
+		},
+	})
+	api.RegisterTool(api.Tool{
 		Name:        "apps_edit",
 		Description: "Edit an existing app — update its name, description, tags, icon, or HTML code",
 		Params: []api.ToolParam{

--- a/main.go
+++ b/main.go
@@ -97,33 +97,14 @@ func main() {
 
 	// Wire work → apps builder (avoids direct import between building blocks)
 	work.BuildApp = func(prompt, authorID, authorName string) (string, string, error) {
-		a, err := apps.BuildAndSave(prompt+"\n\n"+apps.SDKDocs(), authorID, authorName)
+		a, err := apps.BuildAndSave(prompt, authorID, authorName)
 		if err != nil {
 			return "", "", err
 		}
 		return a.Slug, a.Name, nil
 	}
 	work.RebuildApp = func(slug, feedback string) error {
-		a := apps.GetApp(slug)
-		if a == nil {
-			return fmt.Errorf("app not found: %s", slug)
-		}
-		// Ask AI to update the app based on feedback
-		result, err := ai.Ask(&ai.Prompt{
-			System:   apps.BuilderSystemPrompt(),
-			Question: fmt.Sprintf("Update this app based on the feedback below.\n\nOriginal requirements:\n%s\n\nFeedback:\n%s\n\nCurrent app HTML:\n%s\n\n%s", a.Description, feedback, a.HTML, apps.SDKDocs()),
-			Priority: ai.PriorityHigh,
-			Caller:   "work-rebuild",
-		})
-		if err != nil {
-			return fmt.Errorf("AI update failed: %v", err)
-		}
-		// Parse and update
-		html := apps.CleanGeneratedHTML(result)
-		if html == "" {
-			return fmt.Errorf("AI returned empty HTML")
-		}
-		_, err = apps.UpdateApp(slug, "", "", "", html, "")
+		_, err := apps.EditApp(slug, feedback, "work")
 		return err
 	}
 	work.VerifyApp = func(appSlug string) (string, bool) {

--- a/main.go
+++ b/main.go
@@ -170,7 +170,7 @@ Be concise. Focus on functional issues, not style.`,
 		if w.Balance < amount {
 			return fmt.Errorf("insufficient credits (%d available, %d needed)", w.Balance, amount)
 		}
-		wallet.ConsumeQuota(userID, wallet.OpChatQuery)
+		wallet.ConsumeQuota(userID, wallet.OpAppBuild)
 		return nil
 	}
 	work.Notify = func(toUserID, subject, body, threadID string) {
@@ -485,7 +485,7 @@ Be concise. Focus on functional issues, not style.`,
 	api.RegisterTool(api.Tool{
 		Name:        "apps_build",
 		Description: "AI-generate an app from a natural language description, save it, and return the app details with URL",
-		WalletOp:    "chat_query",
+		WalletOp:    "app_build",
 		Params: []api.ToolParam{
 			{Name: "prompt", Type: "string", Description: "Description of the app to build (e.g. 'a pomodoro timer with lap counter')", Required: true},
 		},

--- a/main.go
+++ b/main.go
@@ -97,7 +97,7 @@ func main() {
 
 	// Wire work → apps builder (avoids direct import between building blocks)
 	work.BuildApp = func(prompt, authorID, authorName string) (string, string, error) {
-		a, err := apps.BuildAndSave(prompt, authorID, authorName)
+		a, err := apps.BuildAndSave(prompt+"\n\n"+apps.SDKDocs(), authorID, authorName)
 		if err != nil {
 			return "", "", err
 		}
@@ -111,7 +111,7 @@ func main() {
 		// Ask AI to update the app based on feedback
 		result, err := ai.Ask(&ai.Prompt{
 			System:   apps.BuilderSystemPrompt(),
-			Question: fmt.Sprintf("Update this app based on the feedback below.\n\nOriginal requirements:\n%s\n\nFeedback:\n%s\n\nCurrent app HTML:\n%s", a.Description, feedback, a.HTML),
+			Question: fmt.Sprintf("Update this app based on the feedback below.\n\nOriginal requirements:\n%s\n\nFeedback:\n%s\n\nCurrent app HTML:\n%s\n\n%s", a.Description, feedback, a.HTML, apps.SDKDocs()),
 			Priority: ai.PriorityHigh,
 			Caller:   "work-rebuild",
 		})

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -33,6 +33,8 @@ var (
 	CostAgentQuery        = getEnvInt("CREDIT_COST_AGENT", 3)
 	CostAgentQueryPremium = getEnvInt("CREDIT_COST_AGENT_PREMIUM", 9)
 	CostSocialSearch      = getEnvInt("CREDIT_COST_SOCIAL", 1)
+	CostAppBuild          = getEnvInt("CREDIT_COST_APP_BUILD", 15) // Opus-powered app generation
+	CostAppEdit           = getEnvInt("CREDIT_COST_APP_EDIT", 10)  // Opus-powered app editing
 	FreeDailyQuota        = getEnvInt("FREE_DAILY_QUOTA", 20)
 )
 
@@ -59,6 +61,8 @@ const (
 	OpAgentQuery        = "agent_query"
 	OpAgentQueryPremium = "agent_query_premium"
 	OpSocialSearch      = "social_search"
+	OpAppBuild          = "app_build"
+	OpAppEdit           = "app_edit"
 	OpTopup             = "topup"
 	OpRefund            = "refund"
 	OpTransfer          = "transfer"
@@ -445,6 +449,10 @@ func GetOperationCost(operation string) int {
 		return CostAgentQueryPremium
 	case OpSocialSearch:
 		return CostSocialSearch
+	case OpAppBuild:
+		return CostAppBuild
+	case OpAppEdit:
+		return CostAppEdit
 	default:
 		return 1
 	}
@@ -456,7 +464,7 @@ func GetOperationCost(operation string) int {
 // the server as a proxy to fetch external URLs.
 func paidOnly(operation string) bool {
 	switch operation {
-	case OpMailSend, OpExternalEmail, OpBlogCreate, OpWebFetch:
+	case OpMailSend, OpExternalEmail, OpBlogCreate, OpWebFetch, OpAppBuild, OpAppEdit:
 		return true
 	}
 	return false

--- a/work/work.go
+++ b/work/work.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -567,7 +568,7 @@ func RetryWithFeedback(post *Post, feedback string) {
 
 		if Notify != nil {
 			Notify(authorID, "Agent updated: "+title,
-				fmt.Sprintf("The agent rebuilt %s with your feedback. Spent %d/%d credits.\n\n[Review delivery →](/work/%s)", name, post.Spent, post.Cost, postID), postID)
+				fmt.Sprintf("The agent rebuilt %s with your feedback. Spent %d/%d credits.\n\n[Review delivery →](/work/%s)", appName, post.Spent, post.Cost, postID), postID)
 		}
 	}()
 }

--- a/work/work.go
+++ b/work/work.go
@@ -361,7 +361,7 @@ func spendCredits(post *Post, authorID string, amount int) bool {
 
 const (
 	maxAgentIterations = 5
-	creditPerStep      = 3 // credits per AI call
+	creditPerStep      = 15 // credits per AI call (Opus)
 )
 
 // AssignToAgent assigns an open task to the AI agent.


### PR DESCRIPTION
## Summary

- Full-page apps: no iframe sandbox, apps run on same origin with native SDK injected
- App builder uses Opus for reliable code generation
- SDK response shapes fixed to match actual API responses (markets: `data.data[]`, news: `data.feed[]`, weather: `data.forecast.Current`)
- Builder prompt stripped to vanilla HTML/JS — SDK docs available via `mu_sdk` tool, not baked in
- Agent exec flow: build → render in preview → capture errors → auto-fix loop (up to 3 iterations)
- Edit page: Open App link + Delete button + mobile responsive
- Wallet: new `app_build` (15 credits) and `app_edit` (10 credits) operations for Opus pricing
- SDK logs API responses (`mu.log`) and captures stack traces in `mu.errors`
- Error bar in builder preview — click to auto-fix with error context

## Test plan

- [ ] Build a calculator app from the apps builder page — should work first try
- [ ] Build a crypto dashboard — should use `data.data[0].symbol` correctly
- [ ] Run an app at `/apps/slug/run` — full page with SDK available
- [ ] Edit page shows Open App and Delete buttons
- [ ] Mobile layout stacks code/preview vertically

https://claude.ai/code/session_01GRGLA9yj7BpqKiyi6xFwnm