### PR TITLE
Server-side app verification with auto-fix

### DIFF
--- a/apps/builder.go
+++ b/apps/builder.go
@@ -99,6 +99,52 @@ func matchTemplate(prompt string) *Template {
 	return nil
 }
 
+// findAppReference checks if the prompt mentions an existing app by slug or name.
+// Looks for patterns like "like bitcoin-tracker", "based on my-app", "fork weather".
+func findAppReference(prompt string) string {
+	lower := strings.ToLower(prompt)
+
+	// Check for explicit references: "like X", "based on X", "fork X", "from X"
+	for _, prefix := range []string{"like ", "based on ", "fork ", "from ", "use ", "start from "} {
+		idx := strings.Index(lower, prefix)
+		if idx < 0 {
+			continue
+		}
+		// Extract the word(s) after the prefix
+		rest := strings.TrimSpace(lower[idx+len(prefix):])
+		// Try the first 1-3 words as a potential slug
+		words := strings.Fields(rest)
+		for n := min(3, len(words)); n >= 1; n-- {
+			candidate := strings.Join(words[:n], "-")
+			candidate = strings.Trim(candidate, ".,!?\"'")
+			if a := GetApp(candidate); a != nil {
+				return a.HTML
+			}
+		}
+	}
+
+	// Also try matching any app name mentioned in the prompt
+	mutex.RLock()
+	defer mutex.RUnlock()
+	for _, a := range apps {
+		if a.HTML == "" {
+			continue
+		}
+		name := strings.ToLower(a.Name)
+		if len(name) >= 4 && strings.Contains(lower, name) {
+			return a.HTML
+		}
+	}
+	return ""
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
 // builderSystemPromptWithDocs returns the builder prompt with auto-generated API docs appended.
 func builderSystemPromptWithDocs() string {
 	// The typed SDK docs are already in the prompt (mu.weather, mu.news, etc.)
@@ -145,8 +191,9 @@ func handleGenerate(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var req struct {
-		Prompt string `json:"prompt"`
-		Code   string `json:"code"` // Existing code for follow-on prompts
+		Prompt   string `json:"prompt"`
+		Code     string `json:"code"`     // Existing code for follow-on prompts
+		Template string `json:"template"` // Slug of an existing app to use as base
 	}
 	if err := app.DecodeJSON(r, &req); err != nil {
 		app.RespondError(w, http.StatusBadRequest, "Invalid JSON")
@@ -164,9 +211,32 @@ func handleGenerate(w http.ResponseWriter, r *http.Request) {
 		rag = append(rag, "Current app HTML that the user wants to modify:\n```html\n"+req.Code+"\n```")
 		question = "Modify this existing app: " + req.Prompt
 	} else {
-		// For new builds, include a matching template as a starting reference
-		if t := matchTemplate(req.Prompt); t != nil {
-			rag = append(rag, "Here is a working reference template you can use as a base. Adapt it to match the user's request:\n```html\n"+t.HTML+"\n```")
+		// For new builds, find a starting reference
+		var baseHTML string
+
+		// 1. Explicit template slug (existing app or built-in template)
+		if req.Template != "" {
+			if a := GetApp(req.Template); a != nil {
+				baseHTML = a.HTML
+			} else if t := GetTemplate(req.Template); t != nil {
+				baseHTML = t.HTML
+			}
+		}
+
+		// 2. Check if prompt mentions an existing app slug (e.g. "like bitcoin-tracker")
+		if baseHTML == "" {
+			baseHTML = findAppReference(req.Prompt)
+		}
+
+		// 3. Fall back to keyword-matched built-in template
+		if baseHTML == "" {
+			if t := matchTemplate(req.Prompt); t != nil {
+				baseHTML = t.HTML
+			}
+		}
+
+		if baseHTML != "" {
+			rag = append(rag, "Here is a working reference app you can use as a base. Adapt it to match the user's request:\n```html\n"+baseHTML+"\n```")
 		}
 	}
 

--- a/apps/builder.go
+++ b/apps/builder.go
@@ -184,7 +184,7 @@ func handleGenerate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	_, _, err := auth.RequireSession(r)
+	_, acc, err := auth.RequireSession(r)
 	if err != nil {
 		app.Unauthorized(w, r)
 		return
@@ -270,6 +270,52 @@ func handleGenerate(w http.ResponseWriter, r *http.Request) {
 	}
 	if generated.HTML == "" {
 		generated.HTML = cleanGeneratedHTML(result)
+	}
+
+	// Test the generated HTML — check SDK calls work and field access is correct
+	testResult := TestHTML(generated.HTML, acc.ID)
+	if !testResult.OK && len(testResult.Issues) > 0 {
+		// Build a fix prompt with the real issues and actual API responses
+		var fixContext strings.Builder
+		fixContext.WriteString("The generated app has issues that need fixing:\n\n")
+		for _, issue := range testResult.Issues {
+			fixContext.WriteString("- " + issue + "\n")
+		}
+		for _, t := range testResult.APITests {
+			if t.Response != "" {
+				fixContext.WriteString(fmt.Sprintf("\nActual response from %s:\n%s\n", t.Call, t.Response))
+			}
+		}
+		fixContext.WriteString("\nFix the code to work with the actual response shapes shown above.")
+
+		fixPrompt := &ai.Prompt{
+			System:   builderSystemPromptWithDocs(),
+			Rag:      []string{"Original app HTML that needs fixing:\n```html\n" + generated.HTML + "\n```"},
+			Question: fixContext.String(),
+			Model:    "claude-opus-4-20250514",
+			Priority: ai.PriorityHigh,
+			Caller:   "app-builder-fix",
+		}
+		fixResult, fixErr := ai.Ask(fixPrompt)
+		if fixErr == nil {
+			fixResult = cleanGeneratedJSON(fixResult)
+			var fixed struct {
+				HTML string `json:"html"`
+				Name string `json:"name"`
+				Icon string `json:"icon"`
+			}
+			if json.Unmarshal([]byte(fixResult), &fixed) == nil && fixed.HTML != "" {
+				generated.HTML = fixed.HTML
+				if fixed.Name != "" {
+					generated.Name = fixed.Name
+				}
+				if fixed.Icon != "" {
+					generated.Icon = fixed.Icon
+				}
+			} else if h := cleanGeneratedHTML(fixResult); h != "" {
+				generated.HTML = h
+			}
+		}
 	}
 
 	resp := map[string]string{"html": generated.HTML}

--- a/apps/test.go
+++ b/apps/test.go
@@ -13,142 +13,215 @@ import (
 
 // TestResult contains the results of testing an app's API calls.
 type TestResult struct {
-	Total   int          `json:"total"`
-	Passed  int          `json:"passed"`
-	Failed  int          `json:"failed"`
-	Results []APICallResult `json:"results"`
-	Issues  []string     `json:"issues"`
+	OK       bool            `json:"ok"`
+	Issues   []string        `json:"issues"`
+	APITests []APITestResult `json:"api_tests,omitempty"`
 }
 
-// APICallResult records one API call test.
-type APICallResult struct {
-	Method string `json:"method"`
-	Path   string `json:"path"`
-	Status string `json:"status"` // "ok" or "error"
-	Error  string `json:"error,omitempty"`
+// APITestResult records one SDK call test with the actual response.
+type APITestResult struct {
+	Call     string `json:"call"`              // e.g. "mu.markets({category:'crypto'})"
+	Path     string `json:"path"`              // e.g. "/markets?category=crypto"
+	Status   int    `json:"status"`            // HTTP status code
+	Response string `json:"response,omitempty"` // truncated JSON response
+	Error    string `json:"error,omitempty"`
 }
 
-// TestApp extracts mu.api calls from an app's HTML/JS code,
-// executes them server-side, and reports which ones work.
+// TestApp tests an app by checking structure, extracting SDK calls,
+// executing them server-side, and verifying field access patterns.
 func TestApp(slug, authorID string) *TestResult {
 	a := GetApp(slug)
 	if a == nil {
 		return &TestResult{Issues: []string{"App not found"}}
 	}
+	return TestHTML(a.HTML, authorID)
+}
 
-	result := &TestResult{}
-	html := a.HTML
+// TestHTML tests raw HTML without requiring a saved app.
+func TestHTML(html, authorID string) *TestResult {
+	result := &TestResult{OK: true}
+	lower := strings.ToLower(html)
 
 	// Structural checks
-	lower := strings.ToLower(html)
 	if len(html) < 100 {
-		result.Issues = append(result.Issues, "HTML is too short — likely incomplete")
-	}
-	if !strings.Contains(lower, "<body") {
-		result.Issues = append(result.Issues, "Missing <body> tag")
+		result.Issues = append(result.Issues, "HTML too short — likely incomplete")
+		result.OK = false
 	}
 	if !strings.Contains(lower, "<script") {
-		result.Issues = append(result.Issues, "No JavaScript — app has no interactivity")
-	}
-
-	// Check for common mistakes
-	if strings.Contains(html, "fetch('http") || strings.Contains(html, `fetch("http`) {
-		result.Issues = append(result.Issues, "Uses fetch() to call external URLs — blocked by sandbox. Use mu.api instead.")
-	}
-	if strings.Contains(lower, `<script src="http`) || strings.Contains(lower, `<script src='http`) {
-		result.Issues = append(result.Issues, "Loads external scripts — blocked by sandbox CSP")
-	}
-	if strings.Contains(html, "/weather?q=") || strings.Contains(html, "/weather?city=") {
-		result.Issues = append(result.Issues, "Weather API needs lat/lon not city name. Use /weather?lat=NUMBER&lon=NUMBER")
+		result.Issues = append(result.Issues, "No <script> tag — app has no interactivity")
 	}
 	if strings.Contains(html, `src="/apps/sdk.js"`) || strings.Contains(html, `src='/apps/sdk.js'`) {
-		result.Issues = append(result.Issues, "SDK script tag included — it's auto-injected, remove the <script src> tag")
+		result.Issues = append(result.Issues, "Remove <script src=\"/apps/sdk.js\"> — SDK is auto-injected")
 	}
 
-	// Extract mu.api.get() calls and test them
-	getPattern := regexp.MustCompile(`mu\.api\.get\(['"]([^'"]+)['"]\)`)
-	for _, match := range getPattern.FindAllStringSubmatch(html, -1) {
-		if len(match) < 2 {
-			continue
-		}
-		path := match[1]
-		result.Total++
-
-		// Skip dynamic paths
-		if strings.Contains(path, "${") || strings.Contains(path, "'+") || strings.Contains(path, `"+`) {
-			result.Results = append(result.Results, APICallResult{
-				Method: "GET", Path: path, Status: "skip",
-				Error: "Dynamic path — can't test statically",
-			})
-			continue
-		}
-
-		// Test by making an internal HTTP request
-		callResult := testAPICall(authorID, "GET", path)
-		result.Results = append(result.Results, callResult)
-		if callResult.Status == "ok" {
-			result.Passed++
-		} else {
-			result.Failed++
-			result.Issues = append(result.Issues, fmt.Sprintf("GET %s: %s", path, callResult.Error))
+	// Extract and test SDK calls
+	sdkCalls := extractSDKCalls(html)
+	for _, sc := range sdkCalls {
+		tr := executeSDKCall(sc, authorID)
+		result.APITests = append(result.APITests, tr)
+		if tr.Error != "" {
+			result.OK = false
 		}
 	}
 
-	// Extract mu.api.post() calls
-	postPattern := regexp.MustCompile(`mu\.api\.post\(['"]([^'"]+)['"]`)
-	for _, match := range postPattern.FindAllStringSubmatch(html, -1) {
-		if len(match) < 2 {
+	// Check field access patterns against real responses
+	for _, tr := range result.APITests {
+		if tr.Response == "" || tr.Error != "" {
 			continue
 		}
-		path := match[1]
-		result.Total++
-		// Just check the endpoint is valid — don't execute POST with unknown body
-		validPaths := map[string]bool{
-			"/places/search": true, "/places/nearby": true,
-			"/chat": true, "/news": true,
-		}
-		if validPaths[path] {
-			result.Passed++
-			result.Results = append(result.Results, APICallResult{
-				Method: "POST", Path: path, Status: "ok",
-			})
-		} else {
-			result.Results = append(result.Results, APICallResult{
-				Method: "POST", Path: path, Status: "skip",
-				Error: "Unknown POST endpoint",
-			})
+		issues := checkFieldAccess(html, tr)
+		result.Issues = append(result.Issues, issues...)
+		if len(issues) > 0 {
+			result.OK = false
 		}
 	}
 
 	return result
 }
 
-// testAPICall makes an internal HTTP request to a Mu API endpoint
-// and checks if it returns a successful response.
-func testAPICall(authorID, method, path string) APICallResult {
-	// Create authenticated request
+type sdkCall struct {
+	call string // full match, e.g. "mu.markets({category:'crypto'})"
+	api  string // "markets", "news", "weather"
+	path string // HTTP path to call
+}
+
+var sdkPatterns = []struct {
+	re   *regexp.Regexp
+	api  string
+	path func([]string) string
+}{
+	{
+		re:  regexp.MustCompile(`mu\.markets\s*\(\s*\{[^}]*category\s*:\s*['"](\w+)['"][^}]*\}\s*\)`),
+		api: "markets",
+		path: func(m []string) string {
+			return "/markets?category=" + m[1]
+		},
+	},
+	{
+		re:   regexp.MustCompile(`mu\.markets\s*\(\s*\)`),
+		api:  "markets",
+		path: func(m []string) string { return "/markets" },
+	},
+	{
+		re:   regexp.MustCompile(`mu\.news\s*\(\s*\)`),
+		api:  "news",
+		path: func(m []string) string { return "/news" },
+	},
+	{
+		re:  regexp.MustCompile(`mu\.weather\s*\(\s*\{[^}]*\}\s*\)`),
+		api: "weather",
+		// Use London as test coords
+		path: func(m []string) string { return "/weather?lat=51.5&lon=-0.12" },
+	},
+	{
+		re:   regexp.MustCompile(`mu\.video\s*\(\s*\)`),
+		api:  "video",
+		path: func(m []string) string { return "/video" },
+	},
+	{
+		re:   regexp.MustCompile(`mu\.social\s*\(\s*\)`),
+		api:  "social",
+		path: func(m []string) string { return "/social" },
+	},
+}
+
+func extractSDKCalls(html string) []sdkCall {
+	var calls []sdkCall
+	seen := map[string]bool{}
+	for _, p := range sdkPatterns {
+		for _, match := range p.re.FindAllStringSubmatch(html, -1) {
+			path := p.path(match)
+			if seen[path] {
+				continue
+			}
+			seen[path] = true
+			calls = append(calls, sdkCall{
+				call: match[0],
+				api:  p.api,
+				path: path,
+			})
+		}
+	}
+	return calls
+}
+
+func executeSDKCall(sc sdkCall, authorID string) APITestResult {
+	tr := APITestResult{Call: sc.call, Path: sc.path}
+
 	sess, err := auth.CreateSession(authorID)
 	if err != nil {
-		return APICallResult{Method: method, Path: path, Status: "error", Error: "auth failed"}
+		tr.Error = "auth failed"
+		return tr
 	}
 
-	req, _ := http.NewRequest(method, path, nil)
+	req, _ := http.NewRequest("GET", sc.path, nil)
 	req.AddCookie(&http.Cookie{Name: "session", Value: sess.Token})
 	req.Header.Set("Accept", "application/json")
 
 	recorder := httptest.NewRecorder()
 	http.DefaultServeMux.ServeHTTP(recorder, req)
 
+	tr.Status = recorder.Code
 	if recorder.Code >= 400 {
-		// Try to extract error message from JSON response
-		var errResp struct {
-			Error string `json:"error"`
-		}
-		if json.Unmarshal(recorder.Body.Bytes(), &errResp) == nil && errResp.Error != "" {
-			return APICallResult{Method: method, Path: path, Status: "error", Error: fmt.Sprintf("HTTP %d: %s", recorder.Code, errResp.Error)}
-		}
-		return APICallResult{Method: method, Path: path, Status: "error", Error: fmt.Sprintf("HTTP %d", recorder.Code)}
+		tr.Error = fmt.Sprintf("HTTP %d", recorder.Code)
+		return tr
 	}
 
-	return APICallResult{Method: method, Path: path, Status: "ok"}
+	// Truncate response for inclusion in error context
+	body := recorder.Body.String()
+	if len(body) > 800 {
+		body = body[:800] + "…"
+	}
+	tr.Response = body
+	return tr
+}
+
+// checkFieldAccess verifies the JS code accesses response fields correctly.
+func checkFieldAccess(html string, tr APITestResult) []string {
+	var issues []string
+	var response map[string]any
+	if err := json.Unmarshal([]byte(tr.Response), &response); err != nil {
+		return nil // can't parse, skip
+	}
+
+	switch {
+	case strings.Contains(tr.Path, "/markets"):
+		// Response is {category, data: [...]}
+		// Common mistake: data.forEach() instead of data.data.forEach()
+		if strings.Contains(html, "data.forEach") && !strings.Contains(html, "data.data.forEach") && !strings.Contains(html, "data.data.map") {
+			if _, ok := response["data"]; ok {
+				issues = append(issues, fmt.Sprintf(
+					"Markets: code uses data.forEach() but response is {category, data: [...]}, use data.data.forEach(). Actual response: %s", truncateStr(tr.Response, 300)))
+			}
+		}
+		// Also check: data.Symbol vs data.symbol (PascalCase vs snake_case)
+		if strings.Contains(html, ".Symbol") || strings.Contains(html, ".Price") || strings.Contains(html, ".Change") {
+			issues = append(issues, "Markets: fields are lowercase (symbol, price, change_24h), not PascalCase (Symbol, Price)")
+		}
+
+	case strings.Contains(tr.Path, "/news"):
+		// Response is {feed: [...]}
+		if strings.Contains(html, "data.forEach") && !strings.Contains(html, "data.feed.forEach") && !strings.Contains(html, "data.feed.map") {
+			if _, ok := response["feed"]; ok {
+				issues = append(issues, fmt.Sprintf(
+					"News: code uses data.forEach() but response is {feed: [...]}, use data.feed.forEach(). Actual response: %s", truncateStr(tr.Response, 300)))
+			}
+		}
+
+	case strings.Contains(tr.Path, "/weather"):
+		// Response is {forecast: {Current: {...}, DailyItems: [...]}}
+		if strings.Contains(html, "data.Current") && !strings.Contains(html, "data.forecast.Current") {
+			issues = append(issues, fmt.Sprintf(
+				"Weather: code uses data.Current but response is {forecast: {Current: {...}}}, use data.forecast.Current. Actual response: %s", truncateStr(tr.Response, 300)))
+		}
+	}
+
+	return issues
+}
+
+func truncateStr(s string, max int) string {
+	if len(s) <= max {
+		return s
+	}
+	return s[:max] + "…"
 }


### PR DESCRIPTION
## Summary

Server-side verification loop for generated apps:
1. Extract mu.markets/news/weather calls from generated HTML
2. Execute them server-side via internal HTTP
3. Check field access patterns match real response (data.data vs data, data.feed vs data, data.forecast.Current vs data.Current)
4. If wrong, send actual API response to Opus for auto-fix

This is the runtime feedback loop — without a browser.

https://claude.ai/code/session_01GRGLA9yj7BpqKiyi6xFwnm