### PR TITLE
Mu App framework, templates, static serving

### DIFF
--- a/apps/apps.go
+++ b/apps/apps.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	htmlpkg "html"
 	"net/http"
+	"os"
 	"regexp"
 	"sort"
 	"strings"
@@ -194,6 +195,10 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 		handleCodeRun(w, r)
 	case path == "/sdk.js":
 		handleSDK(w, r)
+	case path == "/mu-app.js":
+		handleStaticFile(w, "apps/static/mu-app.js", "application/javascript")
+	case path == "/mu-app.css":
+		handleStaticFile(w, "apps/static/mu-app.css", "text/css")
 	case strings.HasSuffix(path, "/edit"):
 		slug := strings.TrimSuffix(strings.TrimPrefix(path, "/"), "/edit")
 		handleEdit(w, r, slug)
@@ -1200,6 +1205,17 @@ func handleSDK(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/javascript")
 	w.Header().Set("Cache-Control", "public, max-age=3600")
 	w.Write([]byte(sdkJS))
+}
+
+func handleStaticFile(w http.ResponseWriter, path, contentType string) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		http.Error(w, "Not found", 404)
+		return
+	}
+	w.Header().Set("Content-Type", contentType)
+	w.Header().Set("Cache-Control", "public, max-age=3600")
+	w.Write(data)
 }
 
 // handleSDKAI proxies AI requests from apps.

--- a/apps/builder.go
+++ b/apps/builder.go
@@ -188,7 +188,7 @@ func handleGenerate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	_, acc, err := auth.RequireSession(r)
+	_, _, err := auth.RequireSession(r)
 	if err != nil {
 		app.Unauthorized(w, r)
 		return
@@ -274,52 +274,6 @@ func handleGenerate(w http.ResponseWriter, r *http.Request) {
 	}
 	if generated.HTML == "" {
 		generated.HTML = cleanGeneratedHTML(result)
-	}
-
-	// Test the generated HTML — check SDK calls work and field access is correct
-	testResult := TestHTML(generated.HTML, acc.ID)
-	if !testResult.OK && len(testResult.Issues) > 0 {
-		// Build a fix prompt with the real issues and actual API responses
-		var fixContext strings.Builder
-		fixContext.WriteString("The generated app has issues that need fixing:\n\n")
-		for _, issue := range testResult.Issues {
-			fixContext.WriteString("- " + issue + "\n")
-		}
-		for _, t := range testResult.APITests {
-			if t.Response != "" {
-				fixContext.WriteString(fmt.Sprintf("\nActual response from %s:\n%s\n", t.Call, t.Response))
-			}
-		}
-		fixContext.WriteString("\nFix the code to work with the actual response shapes shown above.")
-
-		fixPrompt := &ai.Prompt{
-			System:   builderSystemPromptWithDocs(),
-			Rag:      []string{"Original app HTML that needs fixing:\n```html\n" + generated.HTML + "\n```"},
-			Question: fixContext.String(),
-			Model:    "claude-opus-4-20250514",
-			Priority: ai.PriorityHigh,
-			Caller:   "app-builder-fix",
-		}
-		fixResult, fixErr := ai.Ask(fixPrompt)
-		if fixErr == nil {
-			fixResult = cleanGeneratedJSON(fixResult)
-			var fixed struct {
-				HTML string `json:"html"`
-				Name string `json:"name"`
-				Icon string `json:"icon"`
-			}
-			if json.Unmarshal([]byte(fixResult), &fixed) == nil && fixed.HTML != "" {
-				generated.HTML = fixed.HTML
-				if fixed.Name != "" {
-					generated.Name = fixed.Name
-				}
-				if fixed.Icon != "" {
-					generated.Icon = fixed.Icon
-				}
-			} else if h := cleanGeneratedHTML(fixResult); h != "" {
-				generated.HTML = h
-			}
-		}
 	}
 
 	resp := map[string]string{"html": generated.HTML}

--- a/apps/static/mu-app.css
+++ b/apps/static/mu-app.css
@@ -1,0 +1,56 @@
+/* mu-app runtime styles */
+* { margin: 0; padding: 0; box-sizing: border-box; }
+body { font-family: 'Nunito Sans', -apple-system, BlinkMacSystemFont, sans-serif; background: #fff; color: #333; }
+
+/* Shell */
+.mu-app-shell { max-width: 640px; margin: 0 auto; padding: 16px; }
+.mu-app-header { font-size: 20px; font-weight: 600; margin-bottom: 16px; }
+.mu-app-tabs { display: flex; gap: 8px; margin-bottom: 16px; }
+.mu-tab { padding: 6px 16px; border: 1px solid #e0e0e0; border-radius: 6px; background: #fff; cursor: pointer; font-family: inherit; font-size: 13px; }
+.mu-tab.active { background: #000; color: #fff; border-color: #000; }
+.mu-app-search { display: none; gap: 8px; margin-bottom: 16px; }
+.mu-app-search input { flex: 1; padding: 10px 14px; border: 1px solid #e0e0e0; border-radius: 6px; font-size: 15px; font-family: inherit; }
+
+/* Sections */
+.mu-section { margin-bottom: 20px; }
+.mu-section-title { font-size: 14px; font-weight: 600; color: #555; margin-bottom: 10px; }
+
+/* Cards */
+.mu-card { display: flex; align-items: center; justify-content: space-between; padding: 12px; border: 1px solid #eee; border-radius: 6px; margin-bottom: 8px; gap: 12px; }
+.mu-card-icon { font-size: 20px; flex-shrink: 0; }
+.mu-card-body { flex: 1; min-width: 0; }
+.mu-card-title { font-weight: 600; font-size: 14px; }
+.mu-card-subtitle { font-size: 13px; color: #666; }
+.mu-card-desc { font-size: 13px; color: #888; margin-top: 2px; line-height: 1.4; }
+.mu-card-right { text-align: right; flex-shrink: 0; }
+.mu-card-value { font-weight: 500; font-variant-numeric: tabular-nums; }
+
+/* Badges */
+.mu-badge { font-size: 12px; font-weight: 500; margin-top: 2px; }
+.mu-badge-green { color: #16a34a; }
+.mu-badge-red { color: #dc2626; }
+.mu-badge-gray { color: #888; }
+.mu-badge-blue { color: #2563eb; }
+
+/* Stats */
+.mu-stats-row { display: flex; gap: 12px; flex-wrap: wrap; margin-bottom: 16px; }
+.mu-stat { flex: 1; min-width: 100px; padding: 16px; background: #f8f8f8; border-radius: 8px; text-align: center; }
+.mu-stat-value { font-size: 24px; font-weight: 700; }
+.mu-stat-label { font-size: 12px; color: #888; margin-top: 2px; }
+.mu-stat-change { font-size: 13px; font-weight: 500; margin-top: 4px; }
+.mu-up { color: #16a34a; }
+.mu-down { color: #dc2626; }
+
+/* Table */
+.mu-table { width: 100%; border-collapse: collapse; font-size: 14px; }
+.mu-table th { text-align: left; padding: 8px 12px; border-bottom: 2px solid #eee; font-weight: 600; font-size: 13px; color: #555; }
+.mu-table td { padding: 8px 12px; border-bottom: 1px solid #f5f5f5; }
+
+/* Grid layout */
+.mu-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
+@media (max-width: 640px) { .mu-grid { grid-template-columns: 1fr; } }
+.mu-grid-cell { min-width: 0; }
+
+/* States */
+.mu-loading { text-align: center; color: #999; padding: 24px; font-size: 14px; }
+.mu-error { text-align: center; color: #c00; padding: 16px; font-size: 14px; }

--- a/apps/static/mu-app.js
+++ b/apps/static/mu-app.js
@@ -1,0 +1,217 @@
+// mu-app runtime — provides standard layouts, components, and lifecycle
+// Apps declare config + data functions, the runtime handles everything else
+(function() {
+  'use strict';
+
+  // --- Component library ---
+
+  function esc(s) {
+    var d = document.createElement('div');
+    d.textContent = s == null ? '' : String(s);
+    return d.innerHTML;
+  }
+
+  function renderCard(item) {
+    var html = '<div class="mu-card">';
+    if (item.icon) html += '<div class="mu-card-icon">' + esc(item.icon) + '</div>';
+    html += '<div class="mu-card-body">';
+    if (item.title) html += '<div class="mu-card-title">' + esc(item.title) + '</div>';
+    if (item.subtitle) html += '<div class="mu-card-subtitle">' + esc(item.subtitle) + '</div>';
+    if (item.description) html += '<div class="mu-card-desc">' + esc(item.description) + '</div>';
+    if (item.html) html += '<div class="mu-card-custom">' + item.html + '</div>';
+    html += '</div>';
+    if (item.value != null) {
+      html += '<div class="mu-card-right">';
+      html += '<div class="mu-card-value">' + esc(item.value) + '</div>';
+      if (item.badge != null) {
+        var color = item.badgeColor || 'gray';
+        html += '<div class="mu-badge mu-badge-' + color + '">' + esc(item.badge) + '</div>';
+      }
+      html += '</div>';
+    }
+    html += '</div>';
+    return html;
+  }
+
+  function renderStat(item) {
+    var html = '<div class="mu-stat">';
+    html += '<div class="mu-stat-value">' + esc(item.value) + '</div>';
+    html += '<div class="mu-stat-label">' + esc(item.label) + '</div>';
+    if (item.change != null) {
+      var cls = parseFloat(item.change) >= 0 ? 'mu-up' : 'mu-down';
+      html += '<div class="mu-stat-change ' + cls + '">' + esc(item.change) + '</div>';
+    }
+    html += '</div>';
+    return html;
+  }
+
+  function renderTable(data) {
+    if (!data || !data.columns || !data.rows) return '';
+    var html = '<table class="mu-table"><thead><tr>';
+    data.columns.forEach(function(col) {
+      html += '<th>' + esc(typeof col === 'string' ? col : col.label || col.key) + '</th>';
+    });
+    html += '</tr></thead><tbody>';
+    data.rows.forEach(function(row) {
+      html += '<tr>';
+      data.columns.forEach(function(col) {
+        var key = typeof col === 'string' ? col : col.key;
+        var val = row[key];
+        html += '<td>' + esc(val == null ? '' : val) + '</td>';
+      });
+      html += '</tr>';
+    });
+    html += '</tbody></table>';
+    return html;
+  }
+
+  // --- Layouts ---
+
+  function renderLayout(layout, sections) {
+    var html = '';
+    switch (layout) {
+      case 'grid':
+        html += '<div class="mu-grid">';
+        sections.forEach(function(s) { html += '<div class="mu-grid-cell">' + renderSection(s) + '</div>'; });
+        html += '</div>';
+        break;
+      case 'dashboard':
+        var stats = sections.filter(function(s) { return s.type === 'stats'; });
+        var rest = sections.filter(function(s) { return s.type !== 'stats'; });
+        if (stats.length) html += renderSection(stats[0]);
+        html += '<div class="mu-grid">';
+        rest.forEach(function(s) { html += '<div class="mu-grid-cell">' + renderSection(s) + '</div>'; });
+        html += '</div>';
+        break;
+      default: // list, single column
+        sections.forEach(function(s) { html += renderSection(s); });
+    }
+    return html;
+  }
+
+  function renderSection(section) {
+    var html = '<div class="mu-section" id="section-' + (section.id || '') + '">';
+    if (section.title) html += '<h3 class="mu-section-title">' + esc(section.title) + '</h3>';
+    html += '<div class="mu-section-content">';
+
+    if (section.loading) {
+      html += '<div class="mu-loading">Loading...</div>';
+    } else if (section.error) {
+      html += '<div class="mu-error">' + esc(section.error) + '</div>';
+    } else if (section.type === 'stats' && section.items) {
+      html += '<div class="mu-stats-row">';
+      section.items.forEach(function(item) { html += renderStat(item); });
+      html += '</div>';
+    } else if (section.type === 'table' && section.data) {
+      html += renderTable(section.data);
+    } else if (section.type === 'html' && section.html) {
+      html += section.html;
+    } else if (section.items) {
+      section.items.forEach(function(item) { html += renderCard(item); });
+    }
+
+    html += '</div></div>';
+    return html;
+  }
+
+  // --- Runtime ---
+
+  var appConfig = null;
+  var appSections = {};
+
+  function render() {
+    var root = document.getElementById('mu-app');
+    if (!root) return;
+    var sections = Object.keys(appSections).map(function(k) { return appSections[k]; });
+    // Sort by order if specified
+    sections.sort(function(a, b) { return (a.order || 0) - (b.order || 0); });
+    root.innerHTML = renderLayout(appConfig.layout || 'list', sections);
+  }
+
+  // Public API for apps
+  window.app = {
+    // Configure the app
+    config: function(cfg) {
+      appConfig = cfg;
+      // Set page title
+      if (cfg.name) document.title = cfg.name;
+      // Render header
+      var header = document.getElementById('mu-app-header');
+      if (header && cfg.name) header.textContent = cfg.name;
+      // Set up tabs if specified
+      if (cfg.tabs) {
+        var tabBar = document.getElementById('mu-app-tabs');
+        if (tabBar) {
+          var html = '';
+          cfg.tabs.forEach(function(tab, i) {
+            html += '<button class="mu-tab' + (i === 0 ? ' active' : '') + '" onclick="app.switchTab(\'' + esc(tab.id) + '\')">' + esc(tab.label) + '</button>';
+          });
+          tabBar.innerHTML = html;
+        }
+      }
+      // Set up search if specified
+      if (cfg.search) {
+        var searchBar = document.getElementById('mu-app-search');
+        if (searchBar) searchBar.style.display = 'flex';
+      }
+    },
+
+    // Define a section with loading state, then load data
+    section: function(id, opts) {
+      appSections[id] = {
+        id: id,
+        title: opts.title || '',
+        type: opts.type || 'list',
+        loading: true,
+        order: opts.order || 0,
+      };
+      render();
+
+      if (opts.load) {
+        Promise.resolve(opts.load()).then(function(result) {
+          appSections[id].loading = false;
+          if (result.items) appSections[id].items = result.items;
+          if (result.data) appSections[id].data = result.data;
+          if (result.html) { appSections[id].html = result.html; appSections[id].type = 'html'; }
+          if (result.error) appSections[id].error = result.error;
+          render();
+        }).catch(function(err) {
+          appSections[id].loading = false;
+          appSections[id].error = err.message || 'Failed to load';
+          render();
+        });
+      }
+    },
+
+    // Update a section
+    update: function(id, data) {
+      if (!appSections[id]) return;
+      Object.keys(data).forEach(function(k) { appSections[id][k] = data[k]; });
+      appSections[id].loading = false;
+      render();
+    },
+
+    // Switch tab
+    switchTab: function(tabId) {
+      document.querySelectorAll('.mu-tab').forEach(function(el) { el.className = 'mu-tab'; });
+      event.target.className = 'mu-tab active';
+      if (appConfig && appConfig.onTab) appConfig.onTab(tabId);
+    },
+
+    // Handle search
+    onSearch: null,
+  };
+
+  // Search handler
+  document.addEventListener('DOMContentLoaded', function() {
+    var searchInput = document.getElementById('mu-search-input');
+    if (searchInput) {
+      searchInput.addEventListener('keydown', function(e) {
+        if (e.key === 'Enter' && app.onSearch) {
+          app.onSearch(searchInput.value.trim());
+        }
+      });
+    }
+  });
+
+})();

--- a/apps/templates.go
+++ b/apps/templates.go
@@ -89,6 +89,13 @@ var Templates = []Template{
 		HTML:        templateNews,
 	},
 	{
+		ID:          "mu-app",
+		Name:        "Mu App",
+		Description: "Mini app framework — declare data, the runtime handles everything else",
+		Category:    "Framework",
+		HTML:        templateMuApp,
+	},
+	{
 		ID:          "dashboard",
 		Name:        "Dashboard",
 		Description: "Markets + news + weather in a single view",
@@ -1043,6 +1050,106 @@ mu.news().then(function(data) {
     html += '<div class="news-item"><a href="' + esc(a.url || '#') + '" target="_blank">' + esc(a.title) + '</a><div class="meta">' + esc(a.category || '') + '</div></div>';
   });
   document.getElementById('news').innerHTML = html;
+});
+</script>
+</body>
+</html>`
+
+const templateMuApp = `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<link rel="stylesheet" href="/apps/mu-app.css">
+</head>
+<body>
+<div class="mu-app-shell">
+  <h2 class="mu-app-header" id="mu-app-header"></h2>
+  <div class="mu-app-tabs" id="mu-app-tabs"></div>
+  <div class="mu-app-search" id="mu-app-search">
+    <input type="text" id="mu-search-input" placeholder="Search...">
+  </div>
+  <div id="mu-app"></div>
+</div>
+<script src="/apps/mu-app.js"></script>
+<script>
+// --- Configure your app ---
+app.config({
+  name: 'My App',
+  layout: 'dashboard',
+  tabs: [
+    {id: 'crypto', label: 'Crypto'},
+    {id: 'futures', label: 'Futures'},
+  ],
+  onTab: function(tabId) {
+    loadMarkets(tabId);
+  }
+});
+
+// --- Stats section ---
+app.section('stats', {
+  type: 'stats',
+  order: 0,
+  load: function() {
+    return mu.markets({category: 'crypto'}).then(function(data) {
+      if (!data || !data.data) return {error: 'No data'};
+      var btc = data.data.find(function(c) { return c.symbol === 'BTC'; });
+      var eth = data.data.find(function(c) { return c.symbol === 'ETH'; });
+      return {
+        items: [
+          {label: 'BTC', value: '$' + (btc ? btc.price.toLocaleString(undefined,{maximumFractionDigits:0}) : '-'), change: btc ? (btc.change_24h >= 0 ? '+' : '') + btc.change_24h.toFixed(1) + '%' : ''},
+          {label: 'ETH', value: '$' + (eth ? eth.price.toLocaleString(undefined,{maximumFractionDigits:0}) : '-'), change: eth ? (eth.change_24h >= 0 ? '+' : '') + eth.change_24h.toFixed(1) + '%' : ''},
+          {label: 'Coins', value: String(data.data.length)},
+        ]
+      };
+    });
+  }
+});
+
+// --- Markets list ---
+function loadMarkets(category) {
+  app.section('markets', {
+    title: 'Prices',
+    order: 1,
+    load: function() {
+      return mu.markets({category: category || 'crypto'}).then(function(data) {
+        if (!data || !data.data) return {error: 'Failed to load'};
+        return {
+          items: data.data.map(function(coin) {
+            var price = coin.price >= 1 ? '$' + coin.price.toLocaleString(undefined,{maximumFractionDigits:2}) : '$' + coin.price.toFixed(4);
+            return {
+              title: coin.symbol,
+              subtitle: coin.type,
+              value: price,
+              badge: (coin.change_24h >= 0 ? '+' : '') + coin.change_24h.toFixed(1) + '%',
+              badgeColor: coin.change_24h >= 0 ? 'green' : 'red',
+            };
+          })
+        };
+      });
+    }
+  });
+}
+loadMarkets('crypto');
+
+// --- News section ---
+app.section('news', {
+  title: 'Headlines',
+  order: 2,
+  load: function() {
+    return mu.news().then(function(data) {
+      if (!data || !data.feed) return {error: 'No news'};
+      return {
+        items: data.feed.slice(0, 5).map(function(a) {
+          return {
+            title: a.title,
+            subtitle: a.category,
+            description: (a.description || '').slice(0, 100),
+          };
+        })
+      };
+    });
+  }
 });
 </script>
 </body>


### PR DESCRIPTION
## Summary

- Mu App framework runtime (mu-app.js + mu-app.css) with standard layouts and components
- Mu App template showing the framework in action
- Static file serving for framework assets
- Configurable slugs on edit page
- All remaining changes from the apps-builder-fix branch

https://claude.ai/code/session_01GRGLA9yj7BpqKiyi6xFwnm