### PR TITLE
Sonnet for edits (faster), Opus for builds

### DIFF
--- a/apps/builder.go
+++ b/apps/builder.go
@@ -364,7 +364,7 @@ func handleGenerate(w http.ResponseWriter, r *http.Request) {
 			System:   editPrompt,
 			Rag:      rag,
 			Question: question,
-			Model:    "claude-opus-4-20250514",
+			Model:    "claude-sonnet-4-20250514",
 			Priority: ai.PriorityHigh,
 			Caller:   "app-editor",
 		}


### PR DESCRIPTION
Use Sonnet for patch edits instead of Opus. Patches are small search-and-replace operations — Sonnet handles them fine and is 5x faster.

https://claude.ai/code/session_01GRGLA9yj7BpqKiyi6xFwnm