### PR TITLE
Increase LLM timeout to 120s

### DIFF
--- a/internal/ai/providers.go
+++ b/internal/ai/providers.go
@@ -18,7 +18,7 @@ import (
 var (
 	// Limit concurrent LLM requests to prevent memory bloat
 	llmSemaphore = semaphore.NewWeighted(5)
-	llmTimeout   = 60 * time.Second
+	llmTimeout   = 120 * time.Second
 
 	// Anthropic cache stats
 	cacheStatsMu        sync.Mutex


### PR DESCRIPTION
Increase LLM timeout from 60s to 120s. Opus app generation with non-Latin content (Arabic, etc) was timing out.

https://claude.ai/code/session_01GRGLA9yj7BpqKiyi6xFwnm