### PR TITLE
Fix SMTP domain spoofing via forged From header

### DIFF
--- a/mail/smtp.go
+++ b/mail/smtp.go
@@ -403,6 +403,20 @@ func (s *Session) Data(r io.Reader) error {
 		fromAddr = &mail.Address{Address: from}
 	}
 
+	// ANTI-SPOOFING: Reject external mail where the From header claims our domain.
+	// The envelope MAIL FROM check (in Mail()) catches direct spoofing, but attackers
+	// can use a different envelope sender and forge the From: header in the body.
+	if !s.isLocalhost {
+		headerParts := strings.Split(fromAddr.Address, "@")
+		if len(headerParts) == 2 && strings.EqualFold(headerParts[1], GetConfiguredDomain()) {
+			app.Log("mail", "Rejected header spoofing: external IP %s with From header %s", s.remoteIP, fromAddr.Address)
+			return &smtpd.SMTPError{
+				Code:    550,
+				Message: "Sender address rejected: not authorized to send from this domain",
+			}
+		}
+	}
+
 	// Parse body based on content type
 	var body string
 	if strings.Contains(contentType, "multipart/") {
@@ -917,9 +931,8 @@ func verifySPF(from string, ip string) bool {
 		}
 	}
 
-	app.Log("mail", "SPF check inconclusive for %s from IP %s (record: %s)", from, ip, spfRecord)
-	// Return true for now - we don't want to be too strict initially
-	return true
+	app.Log("mail", "SPF check failed for %s from IP %s (record: %s)", from, ip, spfRecord)
+	return false
 }
 
 // cleanupRateLimits periodically removes old rate limit entries


### PR DESCRIPTION
## Summary
- Reject external mail where the `From:` header in the email body claims our domain (uses `GetConfiguredDomain()`, not hardcoded). Attackers bypass the envelope `MAIL FROM` check by using a different envelope sender and forging the body header.
- Tighten SPF: inconclusive results now return `false` instead of `true`, so failed lookups no longer silently pass.

## Context
An external IP (34.173.133.130) sent a spoofed email as `no-reply@mu.xyz` — a non-existent account. The envelope check passed because the attacker used a different `MAIL FROM`. The email was spam-scored (7) but still saved. With this fix it would be hard-rejected at the SMTP DATA stage.

## Test plan
- [ ] Verify external mail with forged From header matching configured domain is rejected with 550
- [ ] Verify legitimate external mail (From header on other domains) still accepted
- [ ] Verify localhost/internal mail from our domain still works

https://claude.ai/code/session_01GRGLA9yj7BpqKiyi6xFwnm