### PR TITLE
Fix SPF: handle -all hard fail and CIDR matching

### DIFF
--- a/mail/smtp.go
+++ b/mail/smtp.go
@@ -905,8 +905,24 @@ func verifySPF(from string, ip string) bool {
 		if strings.HasPrefix(token, "ip4:") {
 			allowedIP := strings.TrimPrefix(token, "ip4:")
 			if strings.Contains(allowedIP, "/") {
-				// CIDR notation - would need proper CIDR matching
-				app.Log("mail", "SPF CIDR check not fully implemented: %s", allowedIP)
+				_, cidr, err := net.ParseCIDR(allowedIP)
+				if err == nil && cidr.Contains(net.ParseIP(ip)) {
+					app.Log("mail", "SPF passed: IP %s matches CIDR %s", ip, allowedIP)
+					return true
+				}
+			} else if allowedIP == ip {
+				app.Log("mail", "SPF passed: IP %s matches %s", ip, allowedIP)
+				return true
+			}
+		}
+		if strings.HasPrefix(token, "ip6:") {
+			allowedIP := strings.TrimPrefix(token, "ip6:")
+			if strings.Contains(allowedIP, "/") {
+				_, cidr, err := net.ParseCIDR(allowedIP)
+				if err == nil && cidr.Contains(net.ParseIP(ip)) {
+					app.Log("mail", "SPF passed: IP %s matches CIDR %s", ip, allowedIP)
+					return true
+				}
 			} else if allowedIP == ip {
 				app.Log("mail", "SPF passed: IP %s matches %s", ip, allowedIP)
 				return true
@@ -924,10 +940,14 @@ func verifySPF(from string, ip string) bool {
 				}
 			}
 		}
-		// "+all" or "~all" or "?all" - permissive policies
+		// "all" mechanism - check qualifier
 		if token == "+all" || token == "~all" || token == "?all" {
 			app.Log("mail", "SPF permissive policy: %s", token)
 			return true
+		}
+		if token == "-all" || token == "all" {
+			app.Log("mail", "SPF hard fail: IP %s not authorized by %s (policy: %s)", ip, domain, token)
+			return false
 		}
 	}
 

--- a/mail/smtp.go
+++ b/mail/smtp.go
@@ -403,6 +403,20 @@ func (s *Session) Data(r io.Reader) error {
 		fromAddr = &mail.Address{Address: from}
 	}
 
+	// ANTI-SPOOFING: Reject external mail where the From header claims our domain.
+	// The envelope MAIL FROM check (in Mail()) catches direct spoofing, but attackers
+	// can use a different envelope sender and forge the From: header in the body.
+	if !s.isLocalhost {
+		headerParts := strings.Split(fromAddr.Address, "@")
+		if len(headerParts) == 2 && strings.EqualFold(headerParts[1], GetConfiguredDomain()) {
+			app.Log("mail", "Rejected header spoofing: external IP %s with From header %s", s.remoteIP, fromAddr.Address)
+			return &smtpd.SMTPError{
+				Code:    550,
+				Message: "Sender address rejected: not authorized to send from this domain",
+			}
+		}
+	}
+
 	// Parse body based on content type
 	var body string
 	if strings.Contains(contentType, "multipart/") {
@@ -917,9 +931,8 @@ func verifySPF(from string, ip string) bool {
 		}
 	}
 
-	app.Log("mail", "SPF check inconclusive for %s from IP %s (record: %s)", from, ip, spfRecord)
-	// Return true for now - we don't want to be too strict initially
-	return true
+	app.Log("mail", "SPF check failed for %s from IP %s (record: %s)", from, ip, spfRecord)
+	return false
 }
 
 // cleanupRateLimits periodically removes old rate limit entries


### PR DESCRIPTION
## Summary
- Handle `-all` (hard fail) in SPF records — previously unrecognized, so unauthorized IPs fell through as "inconclusive"
- Implement proper CIDR matching for `ip4:` and `ip6:` using `net.ParseCIDR` instead of logging "not fully implemented"
- With the previous commit (already merged), SPF now actually works: only your server's IP passes, everything else fails

## Context
The spoofed email from 34.173.133.130 should have been rejected by SPF alone since only our server IP is authorized. But SPF had three bugs: no `-all` handling, no CIDR matching, and inconclusive=pass. All three now fixed.

https://claude.ai/code/session_01GRGLA9yj7BpqKiyi6xFwnm