### PR TITLE
Compact single-row status entries

### DIFF
--- a/home/home.go
+++ b/home/home.go
@@ -288,8 +288,8 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 					clearBtn = ` <a href="/user/status" onclick="event.preventDefault();fetch('/user/status',{method:'POST',headers:{'Content-Type':'application/x-www-form-urlencoded'},body:'status='}).then(()=>location.reload())" class="home-status-clear" title="Clear status">✕</a>`
 				}
 				sc.WriteString(fmt.Sprintf(
-					`<div class="%s"><div class="home-status-avatar">%s</div><div class="home-status-body"><div class="home-status-header"><a href="/@%s" class="home-status-name">%s</a>%s</div><div class="home-status-text">%s</div><div class="home-status-time">%s</div></div></div>`,
-					entryClass, initial, htmlEsc(s.UserID), htmlEsc(s.Name), clearBtn, htmlEsc(s.Status), app.TimeAgo(s.UpdatedAt)))
+					`<div class="%s"><div class="home-status-avatar">%s</div><div class="home-status-body"><a href="/@%s" class="home-status-name">%s</a> <span class="home-status-text">%s</span>%s</div><span class="home-status-time">%s</span></div>`,
+					entryClass, initial, htmlEsc(s.UserID), htmlEsc(s.Name), htmlEsc(s.Status), clearBtn, app.TimeAgo(s.UpdatedAt)))
 			}
 			sc.WriteString(`</div>`)
 		}

--- a/internal/app/html/mu.css
+++ b/internal/app/html/mu.css
@@ -600,8 +600,9 @@ body.page-home #page-title ~ #customize-link {
 }
 .home-status-entry {
   display: flex;
-  gap: 10px;
-  padding: 10px 0;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 0;
   border-bottom: 1px solid #f0f0f0;
 }
 .home-status-entry:last-child {
@@ -612,15 +613,15 @@ body.page-home #page-title ~ #customize-link {
   padding-top: 0;
 }
 .home-status-avatar {
-  width: 32px;
-  height: 32px;
+  width: 26px;
+  height: 26px;
   border-radius: 50%;
   background: #333;
   color: #fff;
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 13px;
+  font-size: 12px;
   font-weight: 600;
   flex-shrink: 0;
 }
@@ -630,15 +631,12 @@ body.page-home #page-title ~ #customize-link {
 .home-status-body {
   flex: 1;
   min-width: 0;
-}
-.home-status-header {
-  display: flex;
-  align-items: center;
-  gap: 6px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 .home-status-name {
   font-weight: 600;
-  font-size: 13px;
   color: #333;
   text-decoration: none;
 }
@@ -649,6 +647,7 @@ body.page-home #page-title ~ #customize-link {
   text-decoration: none;
   color: #ccc;
   font-size: 11px;
+  margin-left: 4px;
   opacity: 0;
   transition: opacity 0.15s;
 }
@@ -660,14 +659,12 @@ body.page-home #page-title ~ #customize-link {
 }
 .home-status-text {
   color: #555;
-  font-size: 14px;
-  margin-top: 2px;
-  word-break: break-word;
 }
 .home-status-time {
   color: #bbb;
   font-size: 12px;
-  margin-top: 2px;
+  flex-shrink: 0;
+  white-space: nowrap;
 }
 
 #home {


### PR DESCRIPTION
## Summary
- Status entries now single row: avatar | name + status text | time ago
- Row height matches 26px avatar circle
- Long statuses truncate with ellipsis instead of wrapping
- No custom font sizes — inherits from card defaults
- Much more compact on mobile

https://claude.ai/code/session_01GRGLA9yj7BpqKiyi6xFwnm