### PR TITLE
Fix avatar colors: no black fallback, better palette order

### DIFF
--- a/home/home.go
+++ b/home/home.go
@@ -277,13 +277,13 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 			// Pastel bg + darker text pairs
 			type avatarColor struct{ bg, fg string }
 			avatarColors := []avatarColor{
-				{"#fce4ec", "#c62828"}, // pink
-				{"#e3f2fd", "#1565c0"}, // blue
-				{"#e8f5e9", "#2e7d32"}, // green
-				{"#f3e5f5", "#6a1b9a"}, // purple
-				{"#fff3e0", "#e65100"}, // orange
 				{"#e0f2f1", "#00695c"}, // teal
+				{"#f3e5f5", "#6a1b9a"}, // purple
+				{"#e3f2fd", "#1565c0"}, // blue
+				{"#fff3e0", "#e65100"}, // orange
+				{"#fce4ec", "#c62828"}, // pink
 				{"#fff9c4", "#f57f17"}, // yellow
+				{"#e8f5e9", "#2e7d32"}, // green
 				{"#fce4ec", "#ad1457"}, // rose
 			}
 			sc.WriteString(`<div id="home-statuses">`)

--- a/internal/app/html/mu.css
+++ b/internal/app/html/mu.css
@@ -616,9 +616,7 @@ body.page-home #page-title ~ #customize-link {
   width: 32px;
   height: 32px;
   border-radius: 50%;
-  background: #333;
-  color: #fff;
-  border: 1.5px solid #333;
+  border: 1.5px solid;
   display: flex;
   align-items: center;
   justify-content: center;


### PR DESCRIPTION
## Summary
- Remove black fallback colors from CSS — inline styles handle everything
- Reorder palette so "asim" gets blue instead of green

https://claude.ai/code/session_01GRGLA9yj7BpqKiyi6xFwnm