### PR TITLE
Mobile mail indicator in header, softer badge color

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -215,6 +215,7 @@ var Template = `
       <div id="brand">
         <a href="/">Mu</a>
       </div>
+      <a id="head-mail" href="/mail" aria-label="Mail"></a>
     </div>
 
     <div id="nav-overlay" onclick="toggleMenu()"></div>

--- a/internal/app/html/mu.css
+++ b/internal/app/html/mu.css
@@ -473,22 +473,50 @@ td {
 }
 
 #nav-mail-badge {
-  background: #e53935;
+  background: #555;
   color: white;
   font-size: 11px;
-  min-width: 18px;
-  height: 18px;
-  line-height: 18px;
+  min-width: 16px;
+  height: 16px;
+  line-height: 16px;
   text-align: center;
-  padding: 0 5px;
-  border-radius: 9px;
-  font-weight: bold;
+  padding: 0 4px;
+  border-radius: 8px;
+  font-weight: 600;
   margin-left: auto;
   display: none;
 }
 
 #nav-mail-badge:not(:empty) {
   display: inline-block;
+}
+
+/* Header mail indicator — hidden on desktop, visible on mobile */
+#head-mail {
+  display: none;
+  position: absolute;
+  right: 15px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 20px;
+  height: 20px;
+  text-decoration: none;
+}
+#head-mail[data-count]::after {
+  content: attr(data-count);
+  position: absolute;
+  top: 0;
+  right: 0;
+  background: #555;
+  color: white;
+  font-size: 11px;
+  min-width: 16px;
+  height: 16px;
+  line-height: 16px;
+  text-align: center;
+  padding: 0 4px;
+  border-radius: 8px;
+  font-weight: 600;
 }
 
 #nav-logged-out {
@@ -2103,7 +2131,7 @@ a.highlight {
   #menu-toggle {
     display: flex;
   }
-  
+
   #head {
     padding: 6px 15px;
     border-bottom: 1px solid #ddd;
@@ -2111,6 +2139,10 @@ a.highlight {
     position: fixed;
     height: 44px;
     box-sizing: border-box;
+  }
+
+  #head-mail {
+    display: block;
   }
   
   #brand a {

--- a/internal/app/html/mu.js
+++ b/internal/app/html/mu.js
@@ -665,11 +665,13 @@ function setSession() {
         navUsername.style.display = 'block';
       }
       // Fetch unread mail count for badge
+      var headMail = document.getElementById("head-mail");
       fetch('/mail?unread=count')
         .then(res => res.json())
         .then(data => {
-          if (data.count > 0 && navMailBadge) {
-            navMailBadge.textContent = data.count > 9 ? '9+' : data.count;
+          if (data.count > 0) {
+            if (navMailBadge) navMailBadge.textContent = data.count > 9 ? '9+' : data.count;
+            if (headMail) headMail.setAttribute('data-count', data.count > 9 ? '9+' : data.count);
           }
         })
         .catch(() => {});


### PR DESCRIPTION
## Summary
- Mail count badge in mobile header bar (right side) — no need to open the menu to see new mail
- Badge color softened from harsh red to muted dark grey (#555)
- Hidden on desktop (sidebar badge is enough), shown on mobile only

https://claude.ai/code/session_01GRGLA9yj7BpqKiyi6xFwnm