### PR TITLE
Add share button to blog posts

### DIFF
--- a/blog/blog.go
+++ b/blog/blog.go
@@ -1508,11 +1508,13 @@ func PostHandler(w http.ResponseWriter, r *http.Request) {
 		timeInfo = "Updated " + app.TimeAgo(post.UpdatedAt)
 	}
 
+	shareButton := ` · <a href="#" class="share-btn" onclick="event.preventDefault();if(navigator.share){navigator.share({title:document.title,url:location.href})}else{navigator.clipboard.writeText(location.href).then(()=>{this.textContent='Copied!';setTimeout(()=>{this.textContent='Share'},2000)})}" title="Share this post">Share</a>`
+
 	var contentSB strings.Builder
 	contentSB.WriteString(`<div id="blog">`)
 	contentSB.WriteString(tagsDisplay)
 	contentSB.WriteString(`<div class="info">`)
-	contentSB.WriteString(timeInfo + ` · ` + authorLink + editButton)
+	contentSB.WriteString(timeInfo + ` · ` + authorLink + shareButton + editButton)
 	contentSB.WriteString(`</div>`)
 	contentSB.WriteString(`<hr class="my-5 border-t">`)
 	contentSB.WriteString(`<div class="mb-5">` + contentHTML + `</div>`)


### PR DESCRIPTION
## Summary
- Add "Share" link on blog post detail page (next to time and author)
- Mobile: triggers native share sheet via Web Share API
- Desktop: copies URL to clipboard, shows "Copied!" confirmation

https://claude.ai/code/session_01GRGLA9yj7BpqKiyi6xFwnm