### PR TITLE
Security: require Stripe webhook signature, blog admin override

### DIFF
--- a/blog/blog.go
+++ b/blog/blog.go
@@ -1303,8 +1303,8 @@ func PostHandler(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		// Check if user is the author
-		if post.AuthorID != acc.ID {
+		// Check if user is the author or admin
+		if post.AuthorID != acc.ID && !acc.Admin {
 			app.Forbidden(w, r, "You can only edit your own posts")
 			return
 		}
@@ -1377,8 +1377,8 @@ func PostHandler(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		// Check if user is the author
-		if post.AuthorID != acc.ID {
+		// Check if user is the author or admin
+		if post.AuthorID != acc.ID && !acc.Admin {
 			app.Forbidden(w, r, "You can only delete your own posts")
 			return
 		}

--- a/wallet/stripe.go
+++ b/wallet/stripe.go
@@ -182,14 +182,17 @@ func HandleStripeWebhook(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Verify webhook signature if secret is configured
-	if stripeWebhookSecret != "" {
-		sig := r.Header.Get("Stripe-Signature")
-		if !verifyStripeSignature(body, sig, stripeWebhookSecret) {
-			app.Log("stripe", "webhook signature verification failed")
-			http.Error(w, "invalid signature", http.StatusBadRequest)
-			return
-		}
+	// Verify webhook signature — REQUIRED for security
+	if stripeWebhookSecret == "" {
+		app.Log("stripe", "CRITICAL: STRIPE_WEBHOOK_SECRET not configured, rejecting webhook")
+		http.Error(w, "webhook not configured", http.StatusServiceUnavailable)
+		return
+	}
+	sig := r.Header.Get("Stripe-Signature")
+	if !verifyStripeSignature(body, sig, stripeWebhookSecret) {
+		app.Log("stripe", "webhook signature verification failed")
+		http.Error(w, "invalid signature", http.StatusBadRequest)
+		return
 	}
 
 	// Parse event


### PR DESCRIPTION
## Security Audit Fixes

### 1. Stripe webhook signature now REQUIRED (HIGH)
Previously if `STRIPE_WEBHOOK_SECRET` wasn't set, webhooks were accepted without verification. An attacker could forge events to credit any account. Now rejects with 503 if secret isn't configured.

### 2. Blog edit/delete admin override (MEDIUM)
Blog post edit and delete only checked author ownership. Unlike apps (`&& !acc.Admin`) and social, admins couldn't moderate blog posts. Fixed to match the same pattern.

### Audit results (no action needed)
- Mail: All endpoints scoped to authenticated user ✓
- Wallet transfers: Source always from session ✓
- Admin routes: All 14 double-protected ✓
- Apps/Social: Ownership + admin override ✓
- Account IDs: Enforced lowercase at signup ✓

https://claude.ai/code/session_01GRGLA9yj7BpqKiyi6xFwnm