### PR TITLE
Fix LaTeX dollar signs and markdown links in digest

### DIFF
--- a/blog/blog.go
+++ b/blog/blog.go
@@ -406,13 +406,21 @@ func updateCacheUnlocked() {
 		// Use pre-rendered HTML, truncate for preview
 		content := post.Content
 
-		// Truncate plain text before rendering
+		// Truncate plain text before rendering, but avoid breaking markdown links
 		if len(content) > 300 {
 			lastSpace := 300
-			for i := 299; i >= 0 && i < len(content); i-- {
-				if content[i] == ' ' {
-					lastSpace = i
-					break
+			// Don't cut inside a markdown link [text](url)
+			openBracket := strings.LastIndex(content[:300], "[")
+			closeParen := strings.Index(content[openBracket:], ")")
+			if openBracket > 0 && (closeParen < 0 || openBracket+closeParen > 300) {
+				// We'd cut inside a link — truncate before the link
+				lastSpace = openBracket
+			} else {
+				for i := 299; i >= 0 && i < len(content); i-- {
+					if content[i] == ' ' {
+						lastSpace = i
+						break
+					}
 				}
 			}
 			content = content[:lastSpace] + "..."

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -785,13 +785,23 @@ func StripLatexDollars(s string) string {
 	s = strings.ReplaceAll(s, `&#x5c;[`, "")
 	s = strings.ReplaceAll(s, `&#x5c;]`, "")
 	s = strings.ReplaceAll(s, `&#x5c;$`, "$")
-	// Raw backslash variants: \( \) \[ \] are math delimiters — strip them
+	// Escaped dollar sign: \$ → $ (do this BEFORE stripping \( \) to avoid
+	// consuming the backslash from \$ and leaving a bare $)
+	s = strings.ReplaceAll(s, `\$`, "$")
+	// \( or \) before a digit is a dollar sign: \(112 → $112, \)4,703 → $4,703
+	s = regexp.MustCompile(`\\\((\d)`).ReplaceAllString(s, "$$$1")
+	s = regexp.MustCompile(`\\\)(\d)`).ReplaceAllString(s, "$$$1")
+	// \) after a digit is just a closing delimiter: 4,703\) → 4,703
+	s = regexp.MustCompile(`(\d)\\\)`).ReplaceAllString(s, "$1")
+	// Remaining \( \) \[ \] are math delimiters — strip them
 	s = strings.ReplaceAll(s, `\(`, "")
 	s = strings.ReplaceAll(s, `\)`, "")
 	s = strings.ReplaceAll(s, `\[`, "")
 	s = strings.ReplaceAll(s, `\]`, "")
-	// Escaped dollar sign: \$ → $
-	s = strings.ReplaceAll(s, `\$`, "$")
+	// \text{...} → content (LaTeX text command)
+	s = regexp.MustCompile(`\\text\{([^}]*)\}`).ReplaceAllString(s, "$1")
+	// \mathrm{...} → content
+	s = regexp.MustCompile(`\\mathrm\{([^}]*)\}`).ReplaceAllString(s, "$1")
 	// LaTeX display math around prices: $$94.63$$ → $94.63 (keep one $ as currency)
 	s = displayPriceRe.ReplaceAllString(s, `$$$1`)
 	// General display math: $$content$$ → content


### PR DESCRIPTION
## Summary
Fixes two issues with the daily digest rendering:

1. **LaTeX dollar signs**: AI writes `\(112` and `\)4,703` using LaTeX math delimiters as dollar signs. Previously these were stripped to empty, losing the `$`. Now `\(` and `\)` before a digit become `$` — so `\(112` → `$112`, `\)4,703` → `$4,703`.

2. **Markdown link truncation**: Blog preview truncated at 300 chars which could cut inside a `[text](url)` link, breaking rendering. Now detects open markdown links and truncates before them.

Also added `\text{}` and `\mathrm{}` LaTeX command stripping.

https://claude.ai/code/session_01GRGLA9yj7BpqKiyi6xFwnm