### PR TITLE
Fix blog cache panic, add API & MCP playgrounds

### DIFF
--- a/blog/blog.go
+++ b/blog/blog.go
@@ -411,10 +411,12 @@ func updateCacheUnlocked() {
 			lastSpace := 300
 			// Don't cut inside a markdown link [text](url)
 			openBracket := strings.LastIndex(content[:300], "[")
-			closeParen := strings.Index(content[openBracket:], ")")
-			if openBracket > 0 && (closeParen < 0 || openBracket+closeParen > 300) {
-				// We'd cut inside a link — truncate before the link
-				lastSpace = openBracket
+			if openBracket > 0 {
+				closeParen := strings.Index(content[openBracket:], ")")
+				if closeParen < 0 || openBracket+closeParen > 300 {
+					// We'd cut inside a link — truncate before the link
+					lastSpace = openBracket
+				}
 			} else {
 				for i := 299; i >= 0 && i < len(content); i-- {
 					if content[i] == ' ' {

--- a/internal/api/api_page.go
+++ b/internal/api/api_page.go
@@ -29,23 +29,12 @@ func APIPageHandler(w http.ResponseWriter, r *http.Request) {
 	b.WriteString(`<select id="api-endpoint" onchange="apiSelectEndpoint()" style="width:100%;padding:8px;font-size:14px;border:1px solid #ddd;border-radius:4px;margin-bottom:12px">`)
 	b.WriteString(`<option value="">Select an endpoint...</option>`)
 	for i, ep := range Endpoints {
-		methodColor := "#1a7f37"
-		switch ep.Method {
-		case "POST":
-			methodColor = "#cf8e00"
-		case "PATCH":
-			methodColor = "#8250df"
-		case "DELETE":
-			methodColor = "#cf222e"
-		}
-		b.WriteString(fmt.Sprintf(`<option value="%d" data-method="%s">%s %s — %s</option>`,
+		b.WriteString(fmt.Sprintf(`<option value="%d">%s %s — %s</option>`,
 			i,
-			html.EscapeString(ep.Method),
 			html.EscapeString(ep.Method),
 			html.EscapeString(ep.Path),
 			html.EscapeString(ep.Name),
 		))
-		_ = methodColor
 	}
 	b.WriteString(`</select>`)
 

--- a/internal/api/api_page.go
+++ b/internal/api/api_page.go
@@ -1,0 +1,291 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"html"
+	"net/http"
+	"strings"
+
+	"mu/internal/app"
+)
+
+// APIPageHandler renders the API documentation page with interactive playground
+func APIPageHandler(w http.ResponseWriter, r *http.Request) {
+	var b strings.Builder
+
+	b.WriteString(`<div class="card">`)
+	b.WriteString(`<h2>API</h2>`)
+	b.WriteString(`<p class="card-desc">REST API for programmatic access to Mu.</p>`)
+	b.WriteString(`<p>Authentication: <code>Authorization: Bearer YOUR_TOKEN</code> &mdash; <a href="/token">Get a token</a> | <a href="/mcp">MCP Server</a></p>`)
+	b.WriteString(`</div>`)
+
+	// Playground
+	b.WriteString(`<div class="card">`)
+	b.WriteString(`<h3>Playground</h3>`)
+	b.WriteString(`<p class="card-desc">Pick an endpoint, fill in parameters, and send the request.</p>`)
+
+	// Endpoint selector
+	b.WriteString(`<select id="api-endpoint" onchange="apiSelectEndpoint()" style="width:100%;padding:8px;font-size:14px;border:1px solid #ddd;border-radius:4px;margin-bottom:12px">`)
+	b.WriteString(`<option value="">Select an endpoint...</option>`)
+	for i, ep := range Endpoints {
+		methodColor := "#1a7f37"
+		switch ep.Method {
+		case "POST":
+			methodColor = "#cf8e00"
+		case "PATCH":
+			methodColor = "#8250df"
+		case "DELETE":
+			methodColor = "#cf222e"
+		}
+		b.WriteString(fmt.Sprintf(`<option value="%d" data-method="%s">%s %s — %s</option>`,
+			i,
+			html.EscapeString(ep.Method),
+			html.EscapeString(ep.Method),
+			html.EscapeString(ep.Path),
+			html.EscapeString(ep.Name),
+		))
+		_ = methodColor
+	}
+	b.WriteString(`</select>`)
+
+	// Endpoint description
+	b.WriteString(`<p id="api-desc" style="color:#666;font-size:13px;margin:0 0 12px 0;display:none"></p>`)
+
+	// Method + path display
+	b.WriteString(`<div id="api-method-path" style="display:none;margin-bottom:12px">`)
+	b.WriteString(`<span id="api-method-badge" style="display:inline-block;padding:2px 8px;border-radius:3px;font-size:12px;font-weight:600;color:#fff;margin-right:8px"></span>`)
+	b.WriteString(`<code id="api-path-display" style="font-size:14px"></code>`)
+	b.WriteString(`</div>`)
+
+	// Path params
+	b.WriteString(`<div id="api-path-params"></div>`)
+
+	// Body params form
+	b.WriteString(`<div id="api-params"></div>`)
+
+	// curl preview
+	b.WriteString(`<details id="api-curl-wrap" style="display:none;margin-top:8px">`)
+	b.WriteString(`<summary style="cursor:pointer;font-size:12px;color:#888">curl command</summary>`)
+	b.WriteString(`<pre id="api-curl" style="background:#f5f5f5;padding:8px;font-size:12px;overflow-x:auto;margin-top:6px;border-radius:4px;cursor:pointer" onclick="navigator.clipboard&&navigator.clipboard.writeText(this.textContent)"></pre>`)
+	b.WriteString(`</details>`)
+
+	// Send button
+	b.WriteString(`<button id="api-send" onclick="apiSend()" disabled style="margin-top:10px;padding:8px 20px;font-size:14px">Send Request</button>`)
+
+	// Output
+	b.WriteString(`<div id="api-output" style="display:none;margin-top:12px">`)
+	b.WriteString(`<div style="display:flex;justify-content:space-between;align-items:center">`)
+	b.WriteString(`<span><strong style="font-size:13px;color:#666">Response</strong> <span id="api-status" style="font-size:12px;margin-left:8px"></span></span>`)
+	b.WriteString(`<span id="api-time" style="font-size:12px;color:#999"></span>`)
+	b.WriteString(`</div>`)
+	b.WriteString(`<pre id="api-result" style="white-space:pre-wrap;word-break:break-all;background:#f5f5f5;padding:10px;margin-top:6px;font-size:12px;max-height:400px;overflow-y:auto;border-radius:4px"></pre>`)
+	b.WriteString(`</div>`)
+
+	// Endpoint metadata as JSON
+	b.WriteString(`<script>`)
+	epJSON := apiEndpointsJSON()
+	b.WriteString(`var apiEndpoints=` + epJSON + `;`)
+
+	b.WriteString(`function apiSelectEndpoint(){`)
+	b.WriteString(`var sel=document.getElementById('api-endpoint');`)
+	b.WriteString(`var idx=sel.value;`)
+	b.WriteString(`var desc=document.getElementById('api-desc');`)
+	b.WriteString(`var mp=document.getElementById('api-method-path');`)
+	b.WriteString(`var pp=document.getElementById('api-path-params');`)
+	b.WriteString(`var params=document.getElementById('api-params');`)
+	b.WriteString(`var btn=document.getElementById('api-send');`)
+	b.WriteString(`var curl=document.getElementById('api-curl-wrap');`)
+	b.WriteString(`if(idx===''){desc.style.display='none';mp.style.display='none';pp.innerHTML='';params.innerHTML='';btn.disabled=true;curl.style.display='none';return;}`)
+	b.WriteString(`var ep=apiEndpoints[idx];`)
+	b.WriteString(`desc.textContent=ep.description;desc.style.display='block';`)
+	b.WriteString(`mp.style.display='block';`)
+	// Method badge color
+	b.WriteString(`var badge=document.getElementById('api-method-badge');`)
+	b.WriteString(`badge.textContent=ep.method;`)
+	b.WriteString(`var colors={GET:'#1a7f37',POST:'#cf8e00',PATCH:'#8250df',DELETE:'#cf222e',PUT:'#cf8e00'};`)
+	b.WriteString(`badge.style.background=colors[ep.method]||'#555';`)
+	b.WriteString(`document.getElementById('api-path-display').textContent=ep.path;`)
+	b.WriteString(`btn.disabled=false;curl.style.display='block';`)
+
+	// Path params (e.g. {id}, {username})
+	b.WriteString(`var pathParams=ep.path.match(/\{(\w+)\}/g)||[];`)
+	b.WriteString(`var ph='';`)
+	b.WriteString(`for(var i=0;i<pathParams.length;i++){`)
+	b.WriteString(`var pn=pathParams[i].replace(/[{}]/g,'');`)
+	b.WriteString(`ph+='<div style="margin-bottom:8px">';`)
+	b.WriteString(`ph+='<label style="display:block;font-size:13px;font-weight:500;margin-bottom:2px">'+pn+' <span style=\"color:#e55\">*</span></label>';`)
+	b.WriteString(`ph+='<div style="font-size:12px;color:#888;margin-bottom:4px">Path parameter</div>';`)
+	b.WriteString(`ph+='<input name="path_'+pn+'" class="api-path-param" data-param="'+pn+'" style="width:100%;padding:6px 8px;font-size:13px;border:1px solid #ddd;border-radius:4px;box-sizing:border-box" placeholder="'+pn+'">';`)
+	b.WriteString(`ph+='</div>';}`)
+	b.WriteString(`pp.innerHTML=ph;`)
+
+	// Body params
+	b.WriteString(`var h='';`)
+	b.WriteString(`if(ep.params&&ep.params.length){`)
+	b.WriteString(`for(var i=0;i<ep.params.length;i++){var p=ep.params[i];`)
+	b.WriteString(`h+='<div style="margin-bottom:8px">';`)
+	b.WriteString(`h+='<label style="display:block;font-size:13px;font-weight:500;margin-bottom:2px">'+p.name+'</label>';`)
+	b.WriteString(`h+='<div style="font-size:12px;color:#888;margin-bottom:4px">'+p.type+' — '+p.description+'</div>';`)
+	b.WriteString(`if(p.name==='prompt'||p.name==='content'||p.name==='body'||p.name==='message'||p.name==='text'){`)
+	b.WriteString(`h+='<textarea name="'+p.name+'" class="api-body-param" rows="3" style="width:100%;padding:6px 8px;font-size:13px;border:1px solid #ddd;border-radius:4px;box-sizing:border-box;font-family:inherit;resize:vertical" placeholder="'+p.name+'"></textarea>';`)
+	b.WriteString(`}else{`)
+	b.WriteString(`h+='<input name="'+p.name+'" class="api-body-param" type="'+(p.type==='number'||p.type==='integer'?'number':'text')+'" style="width:100%;padding:6px 8px;font-size:13px;border:1px solid #ddd;border-radius:4px;box-sizing:border-box" placeholder="'+p.name+'">';`)
+	b.WriteString(`}`)
+	b.WriteString(`h+='</div>';}`)
+	b.WriteString(`}`)
+	b.WriteString(`params.innerHTML=h;`)
+	b.WriteString(`apiUpdateCurl();`)
+	// Update curl on input change
+	b.WriteString(`document.querySelectorAll('.api-body-param,.api-path-param').forEach(function(el){el.addEventListener('input',apiUpdateCurl)});`)
+	b.WriteString(`}`)
+
+	// Update curl preview
+	b.WriteString(`function apiUpdateCurl(){`)
+	b.WriteString(`var sel=document.getElementById('api-endpoint').value;if(sel==='')return;`)
+	b.WriteString(`var ep=apiEndpoints[sel];`)
+	b.WriteString(`var path=ep.path;`)
+	// Replace path params
+	b.WriteString(`document.querySelectorAll('.api-path-param').forEach(function(el){`)
+	b.WriteString(`if(el.value)path=path.replace('{'+el.dataset.param+'}',el.value);`)
+	b.WriteString(`});`)
+	b.WriteString(`var cmd='curl';`)
+	b.WriteString(`if(ep.method!=='GET')cmd+=' -X '+ep.method;`)
+	b.WriteString(`cmd+=' -H \"Authorization: Bearer YOUR_TOKEN\"';`)
+	// Body
+	b.WriteString(`var body={};var hasBody=false;`)
+	b.WriteString(`document.querySelectorAll('.api-body-param').forEach(function(el){`)
+	b.WriteString(`if(el.value){body[el.name]=el.value;hasBody=true}`)
+	b.WriteString(`});`)
+	b.WriteString(`if(hasBody){cmd+=' -H \"Content-Type: application/json\"';cmd+=' -d \''+JSON.stringify(body)+'\''}`)
+	b.WriteString(`cmd+=' '+location.origin+path;`)
+	b.WriteString(`document.getElementById('api-curl').textContent=cmd;`)
+	b.WriteString(`}`)
+
+	// Send request
+	b.WriteString(`function apiSend(){`)
+	b.WriteString(`var sel=document.getElementById('api-endpoint').value;if(sel==='')return;`)
+	b.WriteString(`var ep=apiEndpoints[sel];`)
+	b.WriteString(`var path=ep.path;`)
+	b.WriteString(`document.querySelectorAll('.api-path-param').forEach(function(el){`)
+	b.WriteString(`if(el.value)path=path.replace('{'+el.dataset.param+'}',el.value);`)
+	b.WriteString(`});`)
+	b.WriteString(`var body=null;`)
+	b.WriteString(`var hasBody=false;var data={};`)
+	b.WriteString(`document.querySelectorAll('.api-body-param').forEach(function(el){`)
+	b.WriteString(`if(el.value){data[el.name]=el.value;hasBody=true}`)
+	b.WriteString(`});`)
+	b.WriteString(`if(hasBody)body=JSON.stringify(data);`)
+	b.WriteString(`var out=document.getElementById('api-output');`)
+	b.WriteString(`var res=document.getElementById('api-result');`)
+	b.WriteString(`var tm=document.getElementById('api-time');`)
+	b.WriteString(`var st=document.getElementById('api-status');`)
+	b.WriteString(`var btn=document.getElementById('api-send');`)
+	b.WriteString(`out.style.display='block';res.textContent='Sending...';res.style.color='';tm.textContent='';st.textContent='';btn.disabled=true;`)
+	b.WriteString(`var t0=Date.now();`)
+	b.WriteString(`var opts={method:ep.method,headers:{'Accept':'application/json'}};`)
+	b.WriteString(`if(body){opts.headers['Content-Type']='application/json';opts.body=body;}`)
+	b.WriteString(`fetch(path,opts)`)
+	b.WriteString(`.then(function(r){`)
+	b.WriteString(`var ms=Date.now()-t0;tm.textContent=ms+'ms';btn.disabled=false;`)
+	b.WriteString(`var code=r.status;`)
+	b.WriteString(`st.textContent=code+' '+r.statusText;`)
+	b.WriteString(`st.style.color=code>=200&&code<300?'#1a7f37':code>=400?'#cf222e':'#cf8e00';`)
+	b.WriteString(`return r.text();`)
+	b.WriteString(`}).then(function(t){`)
+	b.WriteString(`try{res.textContent=JSON.stringify(JSON.parse(t),null,2)}catch(e){res.textContent=t}`)
+	b.WriteString(`}).catch(function(err){btn.disabled=false;res.textContent='Error: '+err;res.style.color='#c00';});`)
+	b.WriteString(`}`)
+	b.WriteString(`</script>`)
+	b.WriteString(`</div>`)
+
+	// Endpoint reference list
+	b.WriteString(app.List(apiEndpointsHTML()))
+
+	app.Respond(w, r, app.Response{
+		Title:       "API",
+		Description: "API documentation",
+		HTML:        b.String(),
+	})
+}
+
+// apiEndpointsJSON returns endpoint metadata as JSON for the playground JS
+func apiEndpointsJSON() string {
+	var eps []map[string]any
+	for _, ep := range Endpoints {
+		params := []map[string]any{}
+		for _, p := range ep.Params {
+			params = append(params, map[string]any{
+				"name":        p.Name,
+				"type":        p.Value,
+				"description": p.Description,
+			})
+		}
+		eps = append(eps, map[string]any{
+			"name":        ep.Name,
+			"path":        ep.Path,
+			"method":      ep.Method,
+			"description": ep.Description,
+			"params":      params,
+		})
+	}
+	b, _ := json.Marshal(eps)
+	return string(b)
+}
+
+// apiEndpointsHTML generates the reference listing of all API endpoints
+func apiEndpointsHTML() string {
+	var b strings.Builder
+	for _, ep := range Endpoints {
+		methodColor := "#1a7f37"
+		switch ep.Method {
+		case "POST":
+			methodColor = "#cf8e00"
+		case "PATCH":
+			methodColor = "#8250df"
+		case "DELETE":
+			methodColor = "#cf222e"
+		}
+
+		b.WriteString(`<div class="card">`)
+		b.WriteString(fmt.Sprintf(`<span class="card-title"><span style="display:inline-block;padding:1px 6px;border-radius:3px;font-size:11px;font-weight:600;color:#fff;background:%s;margin-right:6px">%s</span> %s</span>`,
+			methodColor,
+			html.EscapeString(ep.Method),
+			html.EscapeString(ep.Path),
+		))
+		b.WriteString(app.Desc(ep.Name + " — " + ep.Description))
+
+		if len(ep.Params) > 0 {
+			b.WriteString(`<table style="width:100%;border-collapse:collapse;font-size:13px;margin:8px 0">`)
+			b.WriteString(`<tr><th style="text-align:left;padding:4px 8px;border-bottom:1px solid #eee">Param</th><th style="text-align:left;padding:4px 8px;border-bottom:1px solid #eee">Type</th><th style="text-align:left;padding:4px 8px;border-bottom:1px solid #eee">Description</th></tr>`)
+			for _, p := range ep.Params {
+				b.WriteString(fmt.Sprintf(`<tr><td style="padding:4px 8px">%s</td><td style="padding:4px 8px;color:#888">%s</td><td style="padding:4px 8px">%s</td></tr>`,
+					html.EscapeString(p.Name),
+					html.EscapeString(p.Value),
+					html.EscapeString(p.Description),
+				))
+			}
+			b.WriteString(`</table>`)
+		}
+
+		if len(ep.Response) > 0 {
+			for _, resp := range ep.Response {
+				if len(resp.Params) > 0 {
+					b.WriteString(`<p style="font-size:12px;color:#888;margin:8px 0 4px 0">Response: ` + html.EscapeString(resp.Type) + `</p>`)
+					b.WriteString(`<table style="width:100%;border-collapse:collapse;font-size:13px;margin:0 0 8px 0">`)
+					b.WriteString(`<tr><th style="text-align:left;padding:4px 8px;border-bottom:1px solid #eee">Field</th><th style="text-align:left;padding:4px 8px;border-bottom:1px solid #eee">Type</th><th style="text-align:left;padding:4px 8px;border-bottom:1px solid #eee">Description</th></tr>`)
+					for _, p := range resp.Params {
+						b.WriteString(fmt.Sprintf(`<tr><td style="padding:4px 8px">%s</td><td style="padding:4px 8px;color:#888">%s</td><td style="padding:4px 8px">%s</td></tr>`,
+							html.EscapeString(p.Name),
+							html.EscapeString(p.Value),
+							html.EscapeString(p.Description),
+						))
+					}
+					b.WriteString(`</table>`)
+				}
+			}
+		}
+		b.WriteString(`</div>`)
+	}
+	return b.String()
+}

--- a/internal/api/mcp_page.go
+++ b/internal/api/mcp_page.go
@@ -52,18 +52,116 @@ func mcpPageHandler(w http.ResponseWriter, r *http.Request) {
 	b.WriteString(`</ol>`)
 	b.WriteString(`</div>`)
 
-	// Test panel
+	// Interactive playground
 	b.WriteString(`<div class="card">`)
-	b.WriteString(`<h3>Test</h3>`)
+	b.WriteString(`<h3>Playground</h3>`)
+	b.WriteString(`<p class="card-desc">Pick a tool, fill in parameters, and run it.</p>`)
+
+	// Tool selector
+	b.WriteString(`<select id="mcp-tool" onchange="mcpSelectTool()" style="width:100%;padding:8px;font-size:14px;border:1px solid #ddd;border-radius:4px;margin-bottom:12px">`)
+	b.WriteString(`<option value="">Select a tool...</option>`)
+	for _, t := range tools {
+		metered := ""
+		if t.WalletOp != "" {
+			metered = " (metered)"
+		}
+		b.WriteString(`<option value="` + html.EscapeString(t.Name) + `">` + html.EscapeString(t.Name) + metered + `</option>`)
+	}
+	b.WriteString(`</select>`)
+
+	// Tool description
+	b.WriteString(`<p id="mcp-tool-desc" style="color:#666;font-size:13px;margin:0 0 12px 0;display:none"></p>`)
+
+	// Dynamic params form
+	b.WriteString(`<div id="mcp-params"></div>`)
+
+	// Run button
+	b.WriteString(`<button id="mcp-run" onclick="mcpRun()" disabled style="margin-top:8px;padding:8px 20px;font-size:14px">Run</button>`)
+
+	// Output area
+	b.WriteString(`<div id="mcp-output" style="display:none;margin-top:12px">`)
+	b.WriteString(`<div style="display:flex;justify-content:space-between;align-items:center">`)
+	b.WriteString(`<strong style="font-size:13px;color:#666">Response</strong>`)
+	b.WriteString(`<span id="mcp-time" style="font-size:12px;color:#999"></span>`)
+	b.WriteString(`</div>`)
+	b.WriteString(`<pre id="mcp-result" style="white-space:pre-wrap;word-break:break-all;background:#f5f5f5;padding:10px;margin-top:6px;font-size:12px;max-height:400px;overflow-y:auto;border-radius:4px"></pre>`)
+	b.WriteString(`</div>`)
+
+	// Tool metadata as JSON for JS
+	b.WriteString(`<script>`)
+	toolsJSON := mcpToolsJSON()
+	b.WriteString(`var mcpTools=` + toolsJSON + `;`)
+	b.WriteString(`function mcpSelectTool(){`)
+	b.WriteString(`var sel=document.getElementById('mcp-tool').value;`)
+	b.WriteString(`var desc=document.getElementById('mcp-tool-desc');`)
+	b.WriteString(`var params=document.getElementById('mcp-params');`)
+	b.WriteString(`var btn=document.getElementById('mcp-run');`)
+	b.WriteString(`if(!sel){desc.style.display='none';params.innerHTML='';btn.disabled=true;return;}`)
+	b.WriteString(`var t=mcpTools[sel];`)
+	b.WriteString(`desc.textContent=t.description;desc.style.display='block';`)
+	b.WriteString(`btn.disabled=false;`)
+	b.WriteString(`var h='';`)
+	b.WriteString(`if(t.params&&t.params.length){`)
+	b.WriteString(`for(var i=0;i<t.params.length;i++){var p=t.params[i];`)
+	b.WriteString(`h+='<div style="margin-bottom:8px">';`)
+	b.WriteString(`h+='<label style="display:block;font-size:13px;font-weight:500;margin-bottom:2px">'+p.name+(p.required?' <span style=\"color:#e55\">*</span>':'')+'</label>';`)
+	b.WriteString(`h+='<div style="font-size:12px;color:#888;margin-bottom:4px">'+p.description+'</div>';`)
+	b.WriteString(`if(p.type==='string'&&(p.name==='prompt'||p.name==='body'||p.name==='content'||p.name==='message'||p.name==='text')){`)
+	b.WriteString(`h+='<textarea name="'+p.name+'" rows="3" style="width:100%;padding:6px 8px;font-size:13px;border:1px solid #ddd;border-radius:4px;box-sizing:border-box;font-family:inherit;resize:vertical" placeholder="'+p.name+'"></textarea>';`)
+	b.WriteString(`}else{`)
+	b.WriteString(`h+='<input name="'+p.name+'" type="'+(p.type==='number'||p.type==='integer'?'number':'text')+'" style="width:100%;padding:6px 8px;font-size:13px;border:1px solid #ddd;border-radius:4px;box-sizing:border-box" placeholder="'+p.name+'">';`)
+	b.WriteString(`}`)
+	b.WriteString(`h+='</div>';}`)
+	b.WriteString(`}else{h='<p style="color:#999;font-size:13px">No parameters needed</p>';}`)
+	b.WriteString(`params.innerHTML=h;`)
+	b.WriteString(`}`)
+
+	b.WriteString(`function mcpRun(){`)
+	b.WriteString(`var name=document.getElementById('mcp-tool').value;if(!name)return;`)
+	b.WriteString(`var args={};`)
+	b.WriteString(`var inputs=document.getElementById('mcp-params').querySelectorAll('input,textarea');`)
+	b.WriteString(`for(var i=0;i<inputs.length;i++){var v=inputs[i].value;if(v){`)
+	b.WriteString(`var t=mcpTools[name].params.find(function(p){return p.name===inputs[i].name});`)
+	b.WriteString(`if(t&&(t.type==='number'||t.type==='integer')){args[inputs[i].name]=Number(v)}else{args[inputs[i].name]=v}`)
+	b.WriteString(`}}`)
+	b.WriteString(`var body=JSON.stringify({jsonrpc:'2.0',id:1,method:'tools/call',params:{name:name,arguments:args}});`)
+	b.WriteString(`var out=document.getElementById('mcp-output');`)
+	b.WriteString(`var res=document.getElementById('mcp-result');`)
+	b.WriteString(`var tm=document.getElementById('mcp-time');`)
+	b.WriteString(`var btn=document.getElementById('mcp-run');`)
+	b.WriteString(`out.style.display='block';res.textContent='Running...';tm.textContent='';btn.disabled=true;`)
+	b.WriteString(`var t0=Date.now();`)
+	b.WriteString(`fetch('/mcp',{method:'POST',headers:{'Content-Type':'application/json'},body:body})`)
+	b.WriteString(`.then(function(r){return r.json()})`)
+	b.WriteString(`.then(function(j){`)
+	b.WriteString(`var ms=Date.now()-t0;tm.textContent=ms+'ms';btn.disabled=false;`)
+	b.WriteString(`if(j.error){res.textContent='Error: '+j.error.message;res.style.color='#c00';return;}`)
+	b.WriteString(`res.style.color='';`)
+	b.WriteString(`if(j.result&&j.result.content&&j.result.content.length){`)
+	b.WriteString(`var txt=j.result.content.map(function(c){return c.text||JSON.stringify(c)}).join('\n');`)
+	b.WriteString(`try{var parsed=JSON.parse(txt);res.textContent=JSON.stringify(parsed,null,2)}catch(e){res.textContent=txt}`)
+	b.WriteString(`}else{res.textContent=JSON.stringify(j.result||j,null,2)}`)
+	b.WriteString(`}).catch(function(err){btn.disabled=false;res.textContent='Error: '+err;res.style.color='#c00';});`)
+	b.WriteString(`}`)
+	b.WriteString(`</script>`)
+	b.WriteString(`</div>`)
+
+	// Raw JSON-RPC panel (collapsed)
+	b.WriteString(`<div class="card">`)
+	b.WriteString(`<details>`)
+	b.WriteString(`<summary style="cursor:pointer;font-weight:500">Raw JSON-RPC</summary>`)
+	b.WriteString(`<div style="margin-top:10px">`)
 	b.WriteString(`<form id="mcp-test-form" onsubmit="return sendMCP(event)">`)
 	b.WriteString(`<textarea id="mcp-input" rows="5" style="width:100%;font-family:monospace;font-size:13px;padding:8px;box-sizing:border-box;" placeholder='{"jsonrpc":"2.0","id":1,"method":"tools/list"}'></textarea>`)
 	b.WriteString(`<button type="submit" style="margin-top:8px">Send</button>`)
 	b.WriteString(`</form>`)
-	b.WriteString(`<pre id="mcp-output" style="display:none;white-space:pre-wrap;word-break:break-all;background:#f5f5f5;padding:10px;margin-top:10px;font-size:12px;max-height:300px;overflow-y:auto;"></pre>`)
+	b.WriteString(`<pre id="mcp-raw-output" style="display:none;white-space:pre-wrap;word-break:break-all;background:#f5f5f5;padding:10px;margin-top:10px;font-size:12px;max-height:300px;overflow-y:auto;"></pre>`)
+	b.WriteString(`</div>`)
 	b.WriteString(`<script>`)
-	b.WriteString(`function sendMCP(e){e.preventDefault();var inp=document.getElementById('mcp-input');var out=document.getElementById('mcp-output');out.style.display='block';out.textContent='Sending...';fetch('/mcp',{method:'POST',headers:{'Content-Type':'application/json'},body:inp.value}).then(function(r){return r.text();}).then(function(t){try{out.textContent=JSON.stringify(JSON.parse(t),null,2);}catch(ex){out.textContent=t;}}).catch(function(err){out.textContent='Error: '+err;});return false;}`)
+	b.WriteString(`function sendMCP(e){e.preventDefault();var inp=document.getElementById('mcp-input');var out=document.getElementById('mcp-raw-output');out.style.display='block';out.textContent='Sending...';fetch('/mcp',{method:'POST',headers:{'Content-Type':'application/json'},body:inp.value}).then(function(r){return r.text();}).then(function(t){try{out.textContent=JSON.stringify(JSON.parse(t),null,2);}catch(ex){out.textContent=t;}}).catch(function(err){out.textContent='Error: '+err;});return false;}`)
 	b.WriteString(`function fillAndSend(json){document.getElementById('mcp-input').value=json;}`)
 	b.WriteString(`</script>`)
+	b.WriteString(`</details>`)
 	b.WriteString(`</div>`)
 
 	// Tools list
@@ -74,6 +172,29 @@ func mcpPageHandler(w http.ResponseWriter, r *http.Request) {
 		Description: "Model Context Protocol server for AI tool integration",
 		HTML:        b.String(),
 	})
+}
+
+// mcpToolsJSON returns a JSON object keyed by tool name with description and params
+func mcpToolsJSON() string {
+	m := map[string]any{}
+	for _, t := range tools {
+		params := []map[string]any{}
+		for _, p := range t.Params {
+			params = append(params, map[string]any{
+				"name":        p.Name,
+				"type":        p.Type,
+				"description": p.Description,
+				"required":    p.Required,
+			})
+		}
+		m[t.Name] = map[string]any{
+			"description": t.Description,
+			"params":      params,
+			"metered":     t.WalletOp != "",
+		}
+	}
+	b, _ := json.Marshal(m)
+	return string(b)
 }
 
 // mcpToolsHTML generates HTML listing all registered MCP tools

--- a/main.go
+++ b/main.go
@@ -51,10 +51,7 @@ func main() {
 		return
 	}
 
-	// render the api markdwon
-	md := api.Markdown()
-	apiDoc := app.Render([]byte(md))
-	apiHTML := app.RenderHTML("API", "API documentation", string(apiDoc))
+	// api page is now dynamic (rendered in api.APIPageHandler)
 
 	// load the data index
 	data.Load()
@@ -750,7 +747,7 @@ func main() {
 	})
 
 	// serve the api doc
-	http.Handle("/api", app.ServeHTML(apiHTML))
+	http.HandleFunc("/api", api.APIPageHandler)
 
 	// serve the MCP page and server (GET = HTML page, POST = JSON-RPC)
 	http.HandleFunc("/mcp", api.MCPHandler)


### PR DESCRIPTION
## Summary
- **Fix blog cache panic**: `strings.LastIndex` returns -1 when `[` not found, causing `content[-1:]` slice bounds panic during `blog.Load()` on startup
- **API playground**: Interactive endpoint selector with form fields, curl preview, and send button on `/api`
- **MCP playground**: Tool picker with auto-generated param forms and formatted results on `/mcp`

## Test plan
- [ ] Server starts without panic (blog cache truncation fix)
- [ ] `/api` page loads with endpoint dropdown and playground
- [ ] `/mcp` page loads with tool selector and playground
- [ ] Raw JSON-RPC still available under collapsed details on `/mcp`

https://claude.ai/code/session_01GRGLA9yj7BpqKiyi6xFwnm