### PR TITLE
Fix card layout — revert global touch changes, fix card wrapper clash

### DIFF
--- a/home/home.go
+++ b/home/home.go
@@ -409,7 +409,7 @@ func Handler(w http.ResponseWriter, r *http.Request) {
       cards.forEach(function(c){
         var el = document.getElementById(c.id);
         if(el){
-          var content = el.querySelector('.card-content');
+          var content = el.querySelector('.card-body');
           if(content) content.innerHTML = c.html;
         }
       });

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -283,7 +283,7 @@ var CardTemplate = `
 <!-- %s -->
 <div id="%s" class="card">
   <h4>%s</h4>
-  <div class="card-content">%s</div>
+  <div class="card-body">%s</div>
 </div>
 `
 

--- a/internal/app/html/mu.css
+++ b/internal/app/html/mu.css
@@ -112,12 +112,11 @@ button {
   color: #fff;
   border: 1px solid var(--btn-primary);
   border-radius: var(--border-radius);
-  padding: 10px 16px;
+  padding: 6px 12px;
   cursor: pointer;
   font-size: 14px;
   line-height: 1.4;
   text-decoration: none;
-  min-height: 44px;
   transition: all var(--transition-fast);
 }
 
@@ -135,9 +134,8 @@ a.btn {
   color: #fff !important;
   border: 1px solid var(--btn-primary);
   border-radius: var(--border-radius);
-  padding: 10px 16px;
+  padding: 6px 12px;
   cursor: pointer;
-  min-height: 44px;
   font-size: 14px;
   font-weight: normal;
   line-height: 1.4;
@@ -393,11 +391,10 @@ td {
   color: var(--text-primary);
   font-weight: var(--font-weight-medium);
   text-decoration: none;
-  padding: 12px 14px;
+  padding: 10px 14px;
   border-radius: var(--border-radius);
   display: flex;
   align-items: center;
-  min-height: 44px;
   transition: all var(--transition-fast);
 }
 
@@ -2197,9 +2194,8 @@ a.highlight {
   }
 
   #nav a {
-    padding: 12px 14px;
+    padding: 8px 14px;
     flex-direction: row;
-    min-height: 44px;
   }
 
   #nav img {


### PR DESCRIPTION
Reverted global button/nav padding increases that were breaking card layouts. Renamed card template wrapper from card-content to card-body to avoid clash with existing .card-content CSS (which applies font-size, color, and white-space: pre-wrap).

https://claude.ai/code/session_01GRGLA9yj7BpqKiyi6xFwnm