### PR TITLE
Align docs with new landing page messaging

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -14,12 +14,12 @@ mu/
 │   ├── auth/               # Sessions, accounts, passkeys, presence
 │   ├── data/               # File persistence, indexing, event pub/sub
 │   └── moderation/         # Content flagging, hiding, auto-moderation
-├── admin/                  # Content moderation, flagging, admin dashboard
+├── admin/                  # Content moderation, flagging, admin panel
 ├── agent/                  # AI agent (plans + executes via MCP tools)
 ├── blog/                   # Posts, comments, opinions, ActivityPub federation
 ├── chat/                   # Real-time chat rooms with AI
 ├── docs/                   # Documentation pages
-├── home/                   # Dashboard cards (composition layer)
+├── home/                   # Home screen cards (composition layer)
 ├── mail/                   # Email inbox, SMTP server, DKIM, spam filtering
 ├── markets/                # Crypto/stock market data
 ├── news/                   # RSS feed aggregation
@@ -89,7 +89,7 @@ Most building blocks also import `wallet` for quota checking on metered operatio
 Some packages act as **composition layers** that aggregate content from multiple
 building blocks to render combined views:
 
-- **`home/`** — renders dashboard cards by importing `blog`, `news`, `markets`,
+- **`home/`** — renders home screen cards by importing `blog`, `news`, `markets`,
   `reminder`, `social`, `video`, `agent`. This is intentional: home is a
   read-only aggregation view.
 
@@ -131,7 +131,7 @@ reminder.Load()   // Daily briefing
 wallet.Load()     // Credit balances
 apps.Load()       // User apps
 social.Load()     // Social feeds
-home.Load()       // Dashboard cards
+home.Load()       // Home screen cards
 agent.Load()      // (no-op)
 digest.Load()     // Digest scheduler
 user.Load()       // Presence tracking
@@ -186,4 +186,4 @@ wallet.ConsumeQuota(accountID, wallet.OpSomeAction)
 3. **Building blocks should not import each other** — except documented composition layers
 4. **`wallet` is the one cross-cutting building block** — most blocks import it for quota
 5. **`admin` imports `mail`** — for spam filter and blocklist management in the
-   admin dashboard. This is an acceptable coupling since admin is a management UI
+   admin panel. This is an acceptable coupling since admin is a management UI

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # mu
 
-A personal app platform — blog, chat, news, mail, weather and more. No ads. No tracking. No algorithm.
+The everything app — blog, chat, news, mail, weather and more — all in one place. No ads. No tracking. No algorithm.
 
 ## Overview
 
-Mu is a self-hosted app platform that brings together the things you do every day on the internet — news, markets, weather, mail, chat — in one place, without ads, algorithms, or tracking.
+Micro is the everything app. Blog, chat, news, mail, and more — all in one place. No ads, no tracking, no algorithms. Built in the open. We call the app Mu for short.
 
 Pay for the tools, not with your attention.
 
-### What's on the dashboard
+### What's included
 
 - **News** — Headlines from RSS feeds, chronological, with AI summaries
 - **Markets** — Live crypto, futures, and commodity prices

--- a/docs/ABOUT.md
+++ b/docs/ABOUT.md
@@ -1,12 +1,12 @@
 # About Mu
 
-**Your personal dashboard. No ads. No tracking. No algorithm.**
+**The internet became addictive. Micro is the alternative.**
 
 ## What is Mu?
 
-Mu is a personal dashboard that brings together the things you check every day — news, markets, weather, mail, chat — in one place.
+Micro is the everything app — blog, chat, news, mail, and more — all in one place. No ads, no tracking, no algorithms. Built in the open. We call the app Mu for short.
 
-No infinite scroll. No algorithmic feeds. No ads. No tracking. Just the information you want, at a glance.
+Technology should serve people — not use them.
 
 ## Why Mu Exists
 
@@ -14,7 +14,7 @@ Every platform monetises your attention. Infinite scroll keeps you hooked. Algor
 
 Mu was built on a different principle: **pay for the tools, not with your attention.**
 
-## What's on the dashboard
+## What's included
 
 - **News** — Headlines from RSS feeds, chronological, with AI summaries
 - **Markets** — Live crypto, futures, and commodity prices
@@ -37,9 +37,17 @@ Mu was built on a different principle: **pay for the tools, not with your attent
 - **No tracking** — we don't profile you
 - **No ads** — we don't sell your attention
 
+## Marketplace
+
+Tired of the walled gardens? Us too.
+
+Micro includes an app marketplace. Create an app and sell it. Builders keep 90% of everything. The platform takes 10%. No ad revenue to chase. No engagement metrics to game. Build something useful, people pay for it, you get paid.
+
 ## Technology
 
 Mu runs as a single Go binary. Self-host on your own server or use [mu.xyz](https://mu.xyz). Open source under AGPL-3.0.
+
+When you pay for tools, incentives are aligned. We build the tools, you use them. That's it.
 
 ---
 

--- a/docs/APPS.md
+++ b/docs/APPS.md
@@ -137,8 +137,8 @@ SDK calls consume credits from the user's wallet:
 |--------|------|
 | `mu.ai()` | 1 credit |
 | `mu.fetch()` | 1 credit |
-| `mu.store.*` | Free |
-| `mu.user()` | Free |
+| `mu.store.*` | Included |
+| `mu.user()` | Included |
 
 ## Discovery
 

--- a/docs/ENVIRONMENT_VARIABLES.md
+++ b/docs/ENVIRONMENT_VARIABLES.md
@@ -108,7 +108,7 @@ export X402_NETWORK="eip155:8453"  # Default: Base mainnet
 
 ## Payment Configuration (Optional)
 
-Enable donations to support your instance. All variables are optional - leave empty for a free instance.
+Enable donations to support your instance. All variables are optional - leave empty for a self-hosted instance.
 
 ```bash
 # One-time donation URL
@@ -127,7 +127,7 @@ export DONATION_URL="https://gocardless.com/your-donation-link"
 # Credit costs per operation (default values shown)
 export CREDIT_COST_NEWS="1"        # News search (1p)
 export CREDIT_COST_VIDEO="2"       # Video search (2p) - YouTube API cost
-export CREDIT_COST_VIDEO_WATCH="0" # Video watch (free) - no value added over YouTube
+export CREDIT_COST_VIDEO_WATCH="0" # Video watch (included) - no value added over YouTube
 export CREDIT_COST_CHAT="3"        # Chat AI query (3p) - LLM cost
 export CREDIT_COST_EMAIL="4"       # External email (4p) - SMTP delivery cost
 export CREDIT_COST_PLACES_SEARCH="5"  # Places text search (5p) - Google Places API cost
@@ -191,7 +191,7 @@ export MAIL_SELECTOR="default"
 | `X402_NETWORK` | `eip155:8453` | Blockchain network for x402 payments |
 | `CREDIT_COST_NEWS` | `1` | Credits per news search |
 | `CREDIT_COST_VIDEO` | `2` | Credits per video search |
-| `CREDIT_COST_VIDEO_WATCH` | `0` | Credits per video watch (free by default) |
+| `CREDIT_COST_VIDEO_WATCH` | `0` | Credits per video watch (included by default) |
 | `CREDIT_COST_CHAT` | `3` | Credits per chat query |
 | `CREDIT_COST_EMAIL` | `4` | Credits per external email |
 | `CREDIT_COST_PLACES_SEARCH` | `5` | Credits per places text search |
@@ -221,7 +221,7 @@ MAIL_SELECTOR=default
 # STRIPE_PUBLISHABLE_KEY=pk_live_...
 # STRIPE_WEBHOOK_SECRET=whsec_...
 
-# Donations (optional - leave empty for free instance)
+# Donations (optional - leave empty for self-hosted instance)
 DONATION_URL=https://gocardless.com/your-donation-link
 ```
 

--- a/docs/MARKETPLACE.md
+++ b/docs/MARKETPLACE.md
@@ -152,12 +152,12 @@ A simple split:
 
 | Recipient | Share | Rationale |
 |-----------|-------|-----------|
-| Provider  | 70%   | They built and host the service |
-| Platform  | 30%   | Registry, billing, discovery, trust |
+| Provider  | 90%   | They built and host the service |
+| Platform  | 10%   | Registry, billing, discovery, trust |
 
 Providers set their own per-call price in credits. The platform fee is transparent — no hidden charges.
 
-For the initial launch, the split could be more generous (80/20 or even 90/10) to attract providers.
+Builders keep 90% of everything. The platform takes 10%.
 
 ## Agent Integration
 
@@ -311,7 +311,7 @@ Build the community layer around services.
 
 Help providers build and test services.
 
-- Provider dashboard with call analytics and revenue
+- Provider analytics panel with call data and revenue
 - Service health monitoring
 - Test sandbox for development
 - Documentation and examples
@@ -320,7 +320,7 @@ Help providers build and test services.
 
 ### For Mu
 
-- **Revenue**: 30% of every marketplace transaction without hosting costs
+- **Revenue**: 10% of every marketplace transaction without hosting costs
 - **Network effects**: More services attract more users, more users attract more providers
 - **Differentiation**: No other platform combines MCP tools + AI agent + per-use billing in this way
 - **Aligned incentives**: We succeed when providers build useful services, not when users are addicted

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -77,7 +77,7 @@ Metered tools are priced at **1 credit = $0.01 USD** via x402:
 | `apps_build` | $0.03 |
 | `apps_run` | $0.03 |
 
-Free tools (news, blog_list, blog_read, video, markets, social, search, quran, hadith, reminder, etc.) don't require payment.
+Included tools (news, blog_list, blog_read, video, markets, social, search, quran, hadith, reminder, etc.) don't require payment.
 
 ## Account-Based Authentication
 
@@ -126,39 +126,39 @@ Accounts can top up credits with a card via Stripe.
 
 | Tool | Description | Credit Cost |
 |------|-------------|-------------|
-| `login` | Log in and get session token | Free |
-| `signup` | Create account and get session token | Free |
+| `login` | Log in and get session token | Included |
+| `signup` | Create account and get session token | Included |
 | `chat` | Chat with AI assistant | 5 credits |
-| `news` | Read the latest news feed | Free |
+| `news` | Read the latest news feed | Included |
 | `news_search` | Search for news articles | 1 credit |
-| `blog_list` | Get all blog posts | Free |
-| `blog_read` | Read a specific blog post | Free |
+| `blog_list` | Get all blog posts | Included |
+| `blog_read` | Read a specific blog post | Included |
 | `blog_create` | Create a new blog post | 1 credit |
-| `blog_update` | Update a blog post | Free |
-| `blog_delete` | Delete a blog post | Free |
-| `video` | Get the latest videos | Free |
+| `blog_update` | Update a blog post | Included |
+| `blog_delete` | Delete a blog post | Included |
+| `video` | Get the latest videos | Included |
 | `video_search` | Search for videos | 2 credits |
-| `social` | Read the social feed | Free |
+| `social` | Read the social feed | Included |
 | `social_search` | Search social posts | 1 credit |
 | `places_search` | Search for places by name or category | 5 credits |
 | `places_nearby` | Find places of interest near a location | 2 credits |
-| `mail_read` | Read mail inbox | Free |
+| `mail_read` | Read mail inbox | Included |
 | `mail_send` | Send a mail message | 4 credits |
-| `search` | Search across all content | Free |
-| `wallet_balance` | Get wallet credit balance | Free |
-| `wallet_topup` | Get wallet topup payment methods | Free |
-| `markets` | Get live market prices | Free |
-| `reminder` | Get the daily Islamic reminder | Free |
-| `quran` | Look up a Quran chapter or verse | Free |
-| `hadith` | Look up hadith from Sahih Al Bukhari | Free |
-| `quran_search` | Semantic search across Quran and Hadith | Free |
+| `search` | Search across all content | Included |
+| `wallet_balance` | Get wallet credit balance | Included |
+| `wallet_topup` | Get wallet topup payment methods | Included |
+| `markets` | Get live market prices | Included |
+| `reminder` | Get the daily Islamic reminder | Included |
+| `quran` | Look up a Quran chapter or verse | Included |
+| `hadith` | Look up hadith from Sahih Al Bukhari | Included |
+| `quran_search` | Semantic search across Quran and Hadith | Included |
 | `weather_forecast` | Get the weather forecast for a location | 1 credit |
 | `web_search` | Search the web for current information | 5 credits |
 | `web_fetch` | Fetch a web page and return cleaned readable content | 3 credits |
-| `apps_search` | Search the apps directory | Free |
-| `apps_read` | Read details of a specific app | Free |
-| `apps_create` | Create a new app | Free |
-| `apps_edit` | Edit an existing app | Free |
+| `apps_search` | Search the apps directory | Included |
+| `apps_read` | Read details of a specific app | Included |
+| `apps_create` | Create a new app | Included |
+| `apps_edit` | Edit an existing app | Included |
 | `apps_build` | AI-generate an app from a description | 3 credits |
 | `apps_run` | Run JavaScript code in a sandbox | 3 credits |
 

--- a/docs/MESSAGING_SYSTEM.md
+++ b/docs/MESSAGING_SYSTEM.md
@@ -105,7 +105,7 @@ Internet → SMTP Server (port 2525/25)
 **SMTP server always runs** - no enable flag needed. Just configure DNS to route mail.
 
 **Access Control:**
-- Internal messaging is free for all users
+- Internal messaging is included for all users
 - External email costs 4 credits per message (SMTP delivery cost)
 - Set user roles via the admin interface
 

--- a/docs/PRINCIPLES.md
+++ b/docs/PRINCIPLES.md
@@ -4,7 +4,13 @@
 
 Technology is a tool, not a destination.
 
-The core idea: **Technology should serve you, not exploit you.**
+The core idea: **Technology should serve people — not use them.**
+
+**No ads.** We don't sell your attention.
+**No algorithms.** No doomscrolling or recommendations designed to keep you addicted.
+**No tracking.** We don't profile you or sell your data.
+**Pay as you go.** Browsing is included. AI and search cost credits. No subscriptions, no hidden fees.
+**Open source.** Licensed under AGPL-3.0. Run it, modify it, share it.
 
 ## The Five Principles
 

--- a/docs/SYSTEM_DESIGN.md
+++ b/docs/SYSTEM_DESIGN.md
@@ -94,7 +94,7 @@ mu/
 ├── places/               # Location search (Google Places / OSM)
 ├── weather/              # Weather forecasts
 ├── search/               # Web search (Brave API), URL fetching
-├── home/                 # Dashboard cards
+├── home/                 # Home screen cards
 ├── user/                 # User profiles, presence tracking
 │
 │   Agents (compose building blocks)
@@ -215,7 +215,7 @@ YouTube integration without ads or tracking.
 
 Private messaging with full email capability.
 
-- **Internal messaging** - User-to-user, free
+- **Internal messaging** - User-to-user, included
 - **External email** - SMTP delivery, costs credits
 - **SMTP server** - Receives incoming internet mail
 - **DKIM signing** - Outbound authentication
@@ -243,7 +243,7 @@ Credit-based usage metering.
 Location search and discovery.
 
 - **Google Places API** - Rich results when API key configured
-- **OpenStreetMap fallback** - Free location data
+- **OpenStreetMap fallback** - Open location data
 - **Saved categories** - Configurable in `places/locations.json`
 
 ### Weather (`weather/`)
@@ -263,7 +263,7 @@ Web search without tracking.
 
 ### Home (`home/`)
 
-Dashboard overview.
+Home screen overview.
 
 - **Cards** - Configurable summary widgets via `home/cards.json`
 - **At-a-glance** - Quick access to all building blocks
@@ -328,5 +328,5 @@ All user-configurable data lives in JSON files (embedded at build time):
 ## Economic Model
 
 Users can self-host or use the hosted version at mu.xyz. Browsing is included. Searching, posting,
-and AI features use credits. 20 credits/day included, then pay as you go at 1 credit = 1p.
-This supports development while keeping the platform accessible for casual use.
+and AI features use credits. Pay as you go at 1 credit = 1p, top up from £5.
+This supports development while keeping the platform accessible.

--- a/docs/VISION.md
+++ b/docs/VISION.md
@@ -1,18 +1,18 @@
 # Vision
 
-**Your personal dashboard. No ads. No tracking. No algorithm.**
+**Pay for the tools, not with your attention.**
 
 ## The Problem
 
 The tools people use every day — news, search, email, chat, markets — are scattered across dozens of platforms, each competing for your time and data. Every platform monetises your attention. Infinite scroll keeps you hooked. Algorithms decide what you see. Ads follow you everywhere.
 
-There's no single place that brings it all together without the noise.
+The internet became addictive. There's no single place that brings it all together without the noise.
 
 ## What Mu Is
 
-Mu is a personal dashboard. News, markets, weather, mail, chat, AI — one screen, one account. Like iGoogle or Netvibes, but modern, self-hostable, and backed by an API that AI agents can use too.
+Mu is the everything app. News, markets, weather, mail, chat, AI — everything in one place. Your home on the internet. Like iGoogle or Netvibes, but modern, self-hostable, and backed by an API that AI agents can use too.
 
-Pay for the tools, not with your attention.
+Technology should serve people — not use them. When you pay for tools, incentives are aligned. We build the tools, you use them. That's it.
 
 ## Design Choices
 
@@ -26,7 +26,7 @@ Pay for the tools, not with your attention.
 
 **Single binary.** One Go binary, no external dependencies. Self-host or use [mu.xyz](https://mu.xyz).
 
-## What's on the dashboard
+## What's included
 
 | Service | What it does |
 |---------|-------------|

--- a/docs/WALLET_AND_CREDITS.md
+++ b/docs/WALLET_AND_CREDITS.md
@@ -27,7 +27,7 @@ We charge because LLMs and APIs cost money. Here's our actual cost breakdown —
 | News Search | 1 credit (1p) | Indexed search |
 | News Summary | 1 credit (1p) | AI-generated summary |
 | Video Search | 2 credits (2p) | YouTube API cost |
-| Video Watch | Free | No value added over YouTube |
+| Video Watch | Included | No value added over YouTube |
 | Chat AI Query | 5 credits (5p) | LLM inference cost |
 | Chat Room | 1 credit (1p) | Room creation |
 | Places Search | 5 credits (5p) | Google Places API cost |
@@ -36,7 +36,7 @@ We charge because LLMs and APIs cost money. Here's our actual cost breakdown —
 | Weather Forecast | 1 credit (1p) | Weather API cost |
 | Weather Pollen | 1 credit (1p) | Pollen data add-on |
 
-**Note:** Internal messages (user-to-user within Mu) are included. Only external email (to addresses outside Mu) costs credits.
+**Note:** Internal messages (user-to-user within Mu) are included at no cost. Only external email (to addresses outside Mu) costs credits.
 
 ### Who Pays What
 
@@ -52,7 +52,7 @@ Unlimited tiers create misaligned incentives. If you pay a flat fee for unlimite
 
 Pay-as-you-go keeps us honest: we want to build efficient tools that solve your problem quickly, not sticky products that maximize your screen time.
 
-If you want truly unlimited and free — self-host. The code is open source.
+If you want truly unlimited usage — self-host. The code is open source (AGPL-3.0).
 
 ---
 
@@ -67,13 +67,13 @@ When Stripe is configured (`STRIPE_SECRET_KEY`, `STRIPE_PUBLISHABLE_KEY`), users
 
 **Rate:** 1 credit = 1p — flat, no bonuses or tiers.
 
-Configure a webhook in the Stripe Dashboard pointing to `https://your-domain.com/wallet/stripe/webhook` and set `STRIPE_WEBHOOK_SECRET` to the signing secret. The webhook listens for `checkout.session.completed` events.
+Configure a webhook in the Stripe admin panel pointing to `https://your-domain.com/wallet/stripe/webhook` and set `STRIPE_WEBHOOK_SECRET` to the signing secret. The webhook listens for `checkout.session.completed` events.
 
 ---
 
 ## Crypto Payments (x402)
 
-The [x402 protocol](https://x402.org) enables account-free, per-request payments with stablecoins. This is designed for AI agents and programmatic clients that want to pay for API access without creating a Mu account.
+The [x402 protocol](https://x402.org) enables per-request payments with stablecoins without needing a Mu account. This is designed for AI agents and programmatic clients that want to pay for API access directly.
 
 ### How It Works
 

--- a/docs/WHITEPAPER.md
+++ b/docs/WHITEPAPER.md
@@ -134,9 +134,9 @@ Each operation has a fixed credit cost determined by the underlying infrastructu
 
 Read-only operations — browsing news feeds, reading blog posts, watching videos, viewing market prices — carry no cost.
 
-### 3.3 Daily Quota
+### 3.3 Pay As You Go
 
-All metered operations consume credits from the user's wallet. Browsing (news, blogs, videos, markets) is included at no cost. Operations that require infrastructure — AI inference, web search, email delivery — cost credits. This model ensures sustainability while keeping the platform accessible.
+All metered operations consume credits from the user's wallet. Browsing (news, blogs, videos, markets) is included at no cost. Operations that require infrastructure — AI inference, web search, email delivery — cost credits. Top up from £5. This model ensures sustainability while keeping the platform accessible.
 
 ### 3.4 Incentive Alignment
 
@@ -185,7 +185,7 @@ The transfer mechanism enables peer-to-peer payments between users, creator tipp
 
 The building block architecture is designed for extensibility. A third-party developer can implement an MCP-compatible service — a server that responds to `tools/list` and `tools/call` — and register it in a central marketplace directory.
 
-When a user invokes a marketplace service, the Mu instance acts as a proxy: it verifies the user's credit balance, forwards the MCP tool call to the provider's endpoint, and upon successful response, deducts credits from the user and credits the provider. The default revenue split is 70% to the provider and 30% to the platform.
+When a user invokes a marketplace service, the Mu instance acts as a proxy: it verifies the user's credit balance, forwards the MCP tool call to the provider's endpoint, and upon successful response, deducts credits from the user and credits the provider. The default revenue split is 90% to the provider and 10% to the platform.
 
 ### 5.2 Direct Settlement
 
@@ -197,7 +197,7 @@ This creates a spectrum of integration: providers who want distribution and bill
 
 Blog posts are published as ActivityPub objects with WebFinger discovery. Users on federated platforms — Mastodon, Threads, and other ActivityPub implementations — can follow Mu authors, receive posts in their feeds, and interact through the standard ActivityPub inbox/outbox mechanism.
 
-Internal messages between Mu users are included. External email is delivered via SMTP with DKIM signing, at a credit cost that reflects delivery infrastructure.
+Internal messages between Mu users are included at no cost. External email is delivered via SMTP with DKIM signing, at a credit cost that reflects delivery infrastructure.
 
 ## 9. Toward a Federated Network
 


### PR DESCRIPTION
Update all docs to use "everything app" framing from micro.mu. Replace "dashboard" with "everything app" or "home screen". Replace "free" with "included" for pricing language. Remove daily quota references, use "pay as you go". Update marketplace revenue split to 90/10.
Add principles summary (no ads, no algorithms, no tracking, AGPL). Add marketplace and closing lines to About page.

https://claude.ai/code/session_01GRGLA9yj7BpqKiyi6xFwnm