### PR TITLE
Add mu CLI: thin client that dispatches every MCP tool as a subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,44 @@ Mu exposes a REST API and [MCP](https://modelcontextprotocol.io) server at `/mcp
 
 See [API docs](https://mu.xyz/api) · [MCP docs](docs/MCP.md)
 
+## CLI
+
+Every MCP tool is also available as a `mu` subcommand. The same binary runs the server (`mu --serve`) and the CLI — with no arguments it becomes a thin client that talks to `/mcp`.
+
+```bash
+mu news                                 # latest news feed
+mu news_search "ai safety"              # search news
+mu chat "hello"                         # chat with the AI
+mu agent "what is the btc price?"       # run the full agent
+mu web_search "claude code"             # search the web
+mu weather_forecast --lat 51.5 --lon -0.12
+mu blog_create --title "Hi" --content "..."
+mu apps_build --prompt "a pomodoro timer"
+mu me                                   # your account
+mu help                                 # full tool list
+mu help apps_build                      # parameters for a specific tool
+```
+
+The CLI is registry-driven — every tool added to the MCP server automatically becomes a CLI command. Flags map to tool parameters.
+
+### Authentication
+
+```bash
+mu login                  # opens /token in your browser, paste the PAT back
+mu config set token xxx   # or set it directly
+export MU_TOKEN=xxx       # or use the environment
+```
+
+### Config
+
+Loaded from `$XDG_CONFIG_HOME/mu/config.json` (default `~/.config/mu/config.json`). Override with `MU_URL` / `MU_TOKEN` or `--url` / `--token` flags.
+
+### Output
+
+Pretty-printed JSON when attached to a terminal, raw JSON when piped — so `mu news | jq '.feed[0]'` works. Use `--table` to render list results as a text table.
+
+See [CLI docs](docs/CLI.md) for more.
+
 ## Pricing
 
 Browsing is included. AI and search features use credits — 1 credit = 1p, pay as you go.

--- a/cli/client.go
+++ b/cli/client.go
@@ -1,0 +1,193 @@
+// MCP HTTP client. All communication with the Mu instance happens via
+// JSON-RPC over the /mcp endpoint.
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// Client talks to a Mu MCP endpoint.
+type Client struct {
+	URL   string
+	Token string
+	HTTP  *http.Client
+}
+
+// NewClient builds a client from a resolved config.
+func NewClient(cfg *ResolvedConfig) *Client {
+	return &Client{
+		URL:   strings.TrimRight(cfg.URL, "/"),
+		Token: cfg.Token,
+		HTTP:  &http.Client{Timeout: 120 * time.Second},
+	}
+}
+
+// jsonrpcRequest is the JSON-RPC 2.0 request envelope.
+type jsonrpcRequest struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      int             `json:"id"`
+	Method  string          `json:"method"`
+	Params  json.RawMessage `json:"params,omitempty"`
+}
+
+// jsonrpcResponse is the JSON-RPC 2.0 response envelope.
+type jsonrpcResponse struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      int             `json:"id"`
+	Result  json.RawMessage `json:"result,omitempty"`
+	Error   *jsonrpcError   `json:"error,omitempty"`
+}
+
+type jsonrpcError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+// Tool describes a single MCP tool as returned by tools/list.
+type Tool struct {
+	Name        string      `json:"name"`
+	Description string      `json:"description"`
+	InputSchema InputSchema `json:"inputSchema"`
+}
+
+// InputSchema mirrors the JSON schema fragment the MCP server emits.
+type InputSchema struct {
+	Type       string                 `json:"type"`
+	Properties map[string]SchemaField `json:"properties"`
+	Required   []string               `json:"required"`
+}
+
+// SchemaField is a single property in an MCP tool's input schema.
+type SchemaField struct {
+	Type        string `json:"type"`
+	Description string `json:"description"`
+}
+
+// ListTools fetches the full list of tools from the server.
+func (c *Client) ListTools() ([]Tool, error) {
+	var result struct {
+		Tools []Tool `json:"tools"`
+	}
+	if err := c.call("tools/list", nil, &result); err != nil {
+		return nil, err
+	}
+	return result.Tools, nil
+}
+
+// CallTool invokes a tool and returns the content text. When the server
+// marks the result as an error, the text is still returned alongside
+// a non-nil error so the caller can surface whatever the server said.
+func (c *Client) CallTool(name string, args map[string]any) (string, error) {
+	params := map[string]any{
+		"name":      name,
+		"arguments": args,
+	}
+	var result struct {
+		Content []struct {
+			Type string `json:"type"`
+			Text string `json:"text"`
+		} `json:"content"`
+		IsError bool `json:"isError"`
+	}
+	if err := c.call("tools/call", params, &result); err != nil {
+		return "", err
+	}
+	var text string
+	for _, block := range result.Content {
+		if block.Type == "text" {
+			if text != "" {
+				text += "\n"
+			}
+			text += block.Text
+		}
+	}
+	if result.IsError {
+		return text, fmt.Errorf("tool error: %s", text)
+	}
+	return text, nil
+}
+
+// Ping checks that the server is reachable and returns the protocol
+// version string.
+func (c *Client) Ping() error {
+	var out json.RawMessage
+	return c.call("ping", nil, &out)
+}
+
+// call is the low-level JSON-RPC sender.
+func (c *Client) call(method string, params any, out any) error {
+	var rawParams json.RawMessage
+	if params != nil {
+		b, err := json.Marshal(params)
+		if err != nil {
+			return err
+		}
+		rawParams = b
+	}
+	reqBody := jsonrpcRequest{
+		JSONRPC: "2.0",
+		ID:      1,
+		Method:  method,
+		Params:  rawParams,
+	}
+	body, err := json.Marshal(reqBody)
+	if err != nil {
+		return err
+	}
+
+	endpoint := c.URL + "/mcp"
+	req, err := http.NewRequest("POST", endpoint, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	if c.Token != "" {
+		req.Header.Set("Authorization", "Bearer "+c.Token)
+	}
+
+	resp, err := c.HTTP.Do(req)
+	if err != nil {
+		return fmt.Errorf("request to %s: %w", endpoint, err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+
+	if resp.StatusCode == http.StatusPaymentRequired {
+		return fmt.Errorf("payment required (HTTP 402): insufficient credits. Top up at %s/wallet", c.URL)
+	}
+	if resp.StatusCode >= 400 && len(respBody) == 0 {
+		return fmt.Errorf("HTTP %d from %s", resp.StatusCode, endpoint)
+	}
+
+	var rpcResp jsonrpcResponse
+	if err := json.Unmarshal(respBody, &rpcResp); err != nil {
+		return fmt.Errorf("parse response: %w (body: %s)", err, trunc(string(respBody), 200))
+	}
+	if rpcResp.Error != nil {
+		return fmt.Errorf("%s", rpcResp.Error.Message)
+	}
+	if out != nil && len(rpcResp.Result) > 0 {
+		if err := json.Unmarshal(rpcResp.Result, out); err != nil {
+			return fmt.Errorf("parse result: %w", err)
+		}
+	}
+	return nil
+}
+
+func trunc(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "..."
+}

--- a/cli/config.go
+++ b/cli/config.go
@@ -1,0 +1,129 @@
+// Package cli provides the `mu` command-line interface. It is a thin
+// client that talks to any Mu instance's MCP endpoint over HTTP. It has
+// no dependencies on the rest of the Mu codebase and no embedded data —
+// every command is dispatched via JSON-RPC against /mcp.
+//
+// This file handles configuration: loading/saving the on-disk config,
+// merging environment variables, and applying CLI flag overrides.
+package cli
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// DefaultURL is used when nothing else is configured.
+const DefaultURL = "https://mu.xyz"
+
+// Config is the on-disk configuration loaded from
+// $XDG_CONFIG_HOME/mu/config.json (or ~/.config/mu/config.json).
+type Config struct {
+	URL   string `json:"url"`
+	Token string `json:"token,omitempty"`
+}
+
+// configDir returns the directory where the config file lives,
+// creating it if necessary.
+func configDir() (string, error) {
+	base := os.Getenv("XDG_CONFIG_HOME")
+	if base == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", err
+		}
+		base = filepath.Join(home, ".config")
+	}
+	dir := filepath.Join(base, "mu")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return "", err
+	}
+	return dir, nil
+}
+
+// configPath returns the full path to the config file.
+func configPath() (string, error) {
+	dir, err := configDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "config.json"), nil
+}
+
+// LoadConfig reads the config from disk. Returns a zero Config if the
+// file doesn't exist.
+func LoadConfig() (*Config, error) {
+	path, err := configPath()
+	if err != nil {
+		return nil, err
+	}
+	b, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return &Config{}, nil
+		}
+		return nil, err
+	}
+	var c Config
+	if err := json.Unmarshal(b, &c); err != nil {
+		return nil, fmt.Errorf("parse config %s: %w", path, err)
+	}
+	return &c, nil
+}
+
+// SaveConfig writes the config to disk with restrictive permissions so
+// the token isn't world-readable.
+func SaveConfig(c *Config) error {
+	path, err := configPath()
+	if err != nil {
+		return err
+	}
+	b, err := json.MarshalIndent(c, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, b, 0o600)
+}
+
+// ResolvedConfig is the effective configuration after merging file,
+// environment and flag overrides.
+type ResolvedConfig struct {
+	URL     string
+	Token   string
+	Pretty  bool // force pretty output regardless of tty
+	Raw     bool // force raw output (no pretty)
+	Table   bool // prefer table layout for list results
+	Verbose bool
+}
+
+// Resolve merges the sources in priority order: flag overrides > env >
+// file > defaults.
+func (r *ResolvedConfig) Apply(file *Config) {
+	if r.URL == "" {
+		r.URL = os.Getenv("MU_URL")
+	}
+	if r.URL == "" && file != nil {
+		r.URL = file.URL
+	}
+	if r.URL == "" {
+		r.URL = DefaultURL
+	}
+
+	if r.Token == "" {
+		r.Token = os.Getenv("MU_TOKEN")
+	}
+	if r.Token == "" && file != nil {
+		r.Token = file.Token
+	}
+}
+
+// Validate returns an error when the configuration is missing
+// something required for a call.
+func (r *ResolvedConfig) Validate() error {
+	if r.URL == "" {
+		return errors.New("no Mu URL configured (set MU_URL, run `mu login`, or pass --url)")
+	}
+	return nil
+}

--- a/cli/config_test.go
+++ b/cli/config_test.go
@@ -1,0 +1,112 @@
+package cli
+
+import (
+	"os"
+	"testing"
+)
+
+func TestResolvedConfigApply_Defaults(t *testing.T) {
+	t.Setenv("MU_URL", "")
+	t.Setenv("MU_TOKEN", "")
+
+	var rc ResolvedConfig
+	rc.Apply(nil)
+
+	if rc.URL != DefaultURL {
+		t.Errorf("URL = %q, want %q", rc.URL, DefaultURL)
+	}
+	if rc.Token != "" {
+		t.Errorf("Token = %q, want empty", rc.Token)
+	}
+}
+
+func TestResolvedConfigApply_File(t *testing.T) {
+	t.Setenv("MU_URL", "")
+	t.Setenv("MU_TOKEN", "")
+
+	file := &Config{URL: "https://my.mu", Token: "abc"}
+	var rc ResolvedConfig
+	rc.Apply(file)
+
+	if rc.URL != "https://my.mu" {
+		t.Errorf("URL = %q, want https://my.mu", rc.URL)
+	}
+	if rc.Token != "abc" {
+		t.Errorf("Token = %q, want abc", rc.Token)
+	}
+}
+
+func TestResolvedConfigApply_EnvOverridesFile(t *testing.T) {
+	t.Setenv("MU_URL", "https://env.mu")
+	t.Setenv("MU_TOKEN", "env-tok")
+
+	file := &Config{URL: "https://file.mu", Token: "file-tok"}
+	var rc ResolvedConfig
+	rc.Apply(file)
+
+	if rc.URL != "https://env.mu" {
+		t.Errorf("URL = %q, want https://env.mu", rc.URL)
+	}
+	if rc.Token != "env-tok" {
+		t.Errorf("Token = %q, want env-tok", rc.Token)
+	}
+}
+
+func TestResolvedConfigApply_FlagOverridesEnv(t *testing.T) {
+	t.Setenv("MU_URL", "https://env.mu")
+	t.Setenv("MU_TOKEN", "env-tok")
+
+	rc := ResolvedConfig{URL: "https://flag.mu", Token: "flag-tok"}
+	rc.Apply(&Config{URL: "https://file.mu", Token: "file-tok"})
+
+	if rc.URL != "https://flag.mu" {
+		t.Errorf("URL = %q, want https://flag.mu", rc.URL)
+	}
+	if rc.Token != "flag-tok" {
+		t.Errorf("Token = %q, want flag-tok", rc.Token)
+	}
+}
+
+func TestLoadConfig_Missing(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+
+	c, err := LoadConfig()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if c == nil {
+		t.Fatal("nil config")
+	}
+	if c.URL != "" {
+		t.Errorf("URL = %q, want empty", c.URL)
+	}
+}
+
+func TestSaveAndLoadConfig(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+
+	want := &Config{URL: "https://mu.xyz", Token: "tok123"}
+	if err := SaveConfig(want); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	got, err := LoadConfig()
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if got.URL != want.URL || got.Token != want.Token {
+		t.Errorf("round-trip mismatch:\n want %+v\n  got %+v", want, got)
+	}
+
+	// Config file should have restrictive permissions.
+	path, _ := configPath()
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if mode := info.Mode().Perm(); mode != 0o600 {
+		t.Errorf("permissions = %v, want 0600", mode)
+	}
+}

--- a/cli/dispatch.go
+++ b/cli/dispatch.go
@@ -1,0 +1,233 @@
+// CLI dispatcher. Parses the command line, builds the MCP argument
+// map, calls the tool, and formats the result.
+package cli
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+)
+
+// Run is the entry point called from main.go. It receives argv[1:]
+// (the program name has already been stripped) and returns an exit code.
+//
+// Dispatch rules:
+//
+//	mu                         → short help
+//	mu help                    → full help (includes live tool list)
+//	mu help <tool>             → per-tool help
+//	mu login                   → interactive login
+//	mu logout                  → clear token
+//	mu config ...              → config management
+//	mu <tool> [--flag value]   → call an MCP tool
+func Run(args []string) int {
+	if len(args) == 0 {
+		printShortHelp(os.Stdout)
+		return 0
+	}
+
+	// Pull out --url / --token / --pretty / --raw / --table / --verbose
+	// that may appear anywhere and apply them to the resolved config.
+	var rc ResolvedConfig
+	positional := make([]string, 0, len(args))
+	i := 0
+	for i < len(args) {
+		a := args[i]
+		switch a {
+		case "--url":
+			if i+1 < len(args) {
+				rc.URL = args[i+1]
+				i += 2
+				continue
+			}
+		case "--token":
+			if i+1 < len(args) {
+				rc.Token = args[i+1]
+				i += 2
+				continue
+			}
+		case "--pretty":
+			rc.Pretty = true
+			i++
+			continue
+		case "--raw":
+			rc.Raw = true
+			i++
+			continue
+		case "--table":
+			rc.Table = true
+			i++
+			continue
+		case "-v", "--verbose":
+			rc.Verbose = true
+			i++
+			continue
+		}
+		if strings.HasPrefix(a, "--url=") {
+			rc.URL = strings.TrimPrefix(a, "--url=")
+			i++
+			continue
+		}
+		if strings.HasPrefix(a, "--token=") {
+			rc.Token = strings.TrimPrefix(a, "--token=")
+			i++
+			continue
+		}
+		positional = append(positional, a)
+		i++
+	}
+
+	file, _ := LoadConfig()
+	rc.Apply(file)
+
+	if len(positional) == 0 {
+		printShortHelp(os.Stdout)
+		return 0
+	}
+
+	command := positional[0]
+	rest := positional[1:]
+
+	switch command {
+	case "help", "--help", "-h":
+		return runHelp(rest, &rc)
+	case "login":
+		return runLogin(rest, &rc)
+	case "logout":
+		return runLogout(rest, &rc)
+	case "config":
+		return runConfig(rest, &rc)
+	case "version", "--version":
+		fmt.Println("mu cli (registry-driven, talks to /mcp)")
+		return 0
+	}
+
+	// Anything else is treated as an MCP tool name.
+	return runTool(command, rest, &rc)
+}
+
+// runTool dispatches a tool call. It parses remaining --flag value
+// pairs into a JSON args map, infers types, and invokes the tool.
+func runTool(name string, rest []string, rc *ResolvedConfig) int {
+	if err := rc.Validate(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 2
+	}
+
+	args, trailing, err := parseToolFlags(rest)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "argument error:", err)
+		return 2
+	}
+
+	// If a single trailing positional arg is provided and there is no
+	// flag for it, try to use it as the most obvious required param
+	// for common tools: prompt/query/q. This enables `mu chat "hello"`
+	// and `mu news_search "ai safety"` without needing --prompt / --query.
+	if len(trailing) == 1 && len(args) == 0 {
+		if v, ok := defaultArgKey(name); ok {
+			args[v] = trailing[0]
+			trailing = nil
+		}
+	}
+	if len(trailing) > 0 {
+		fmt.Fprintln(os.Stderr, "unexpected arguments:", strings.Join(trailing, " "))
+		return 2
+	}
+
+	client := NewClient(rc)
+	text, err := client.CallTool(name, args)
+	if text != "" {
+		if ferr := Format(os.Stdout, text, rc); ferr != nil {
+			fmt.Fprintln(os.Stderr, "format error:", ferr)
+		}
+	}
+	if err != nil {
+		if text == "" {
+			fmt.Fprintln(os.Stderr, "error:", err)
+		}
+		return 1
+	}
+	return 0
+}
+
+// parseToolFlags walks remaining args and extracts --name value /
+// --name=value pairs. Bare positional arguments are returned separately
+// so the caller can decide how to interpret them.
+func parseToolFlags(args []string) (map[string]any, []string, error) {
+	out := map[string]any{}
+	var trailing []string
+	i := 0
+	for i < len(args) {
+		a := args[i]
+		if !strings.HasPrefix(a, "--") && !strings.HasPrefix(a, "-") {
+			trailing = append(trailing, a)
+			i++
+			continue
+		}
+		// Strip leading dashes.
+		flag := strings.TrimLeft(a, "-")
+		var value string
+		if eq := strings.Index(flag, "="); eq >= 0 {
+			value = flag[eq+1:]
+			flag = flag[:eq]
+		} else if i+1 < len(args) && !strings.HasPrefix(args[i+1], "--") {
+			value = args[i+1]
+			i++
+		} else {
+			// Bool flag with no value (e.g. --public).
+			out[flag] = true
+			i++
+			continue
+		}
+		if flag == "" {
+			return nil, nil, fmt.Errorf("empty flag name")
+		}
+		out[flag] = coerce(value)
+		i++
+	}
+	return out, trailing, nil
+}
+
+// coerce converts a string value to the most plausible JSON type.
+// Numbers and booleans become their typed form; everything else stays
+// a string. Edge cases (a string that happens to look numeric) can be
+// worked around by the caller quoting the value.
+func coerce(s string) any {
+	// Bool.
+	if s == "true" {
+		return true
+	}
+	if s == "false" {
+		return false
+	}
+	// Integer.
+	if n, err := strconv.ParseInt(s, 10, 64); err == nil {
+		return n
+	}
+	// Float.
+	if f, err := strconv.ParseFloat(s, 64); err == nil {
+		return f
+	}
+	return s
+}
+
+// defaultArgKey returns the parameter a single positional argument
+// should be assigned to for a small set of well-known tools. Returns
+// ("", false) when there is no default.
+func defaultArgKey(tool string) (string, bool) {
+	switch tool {
+	case "chat", "agent", "apps_build":
+		return "prompt", true
+	case "news_search", "video_search", "social_search", "quran_search":
+		return "query", true
+	case "web_search", "search", "places_search":
+		return "q", true
+	case "web_fetch":
+		return "url", true
+	case "blog_read", "apps_read":
+		return "id", true
+	}
+	return "", false
+}

--- a/cli/dispatch_test.go
+++ b/cli/dispatch_test.go
@@ -1,0 +1,142 @@
+package cli
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseToolFlags(t *testing.T) {
+	cases := []struct {
+		name     string
+		args     []string
+		wantArgs map[string]any
+		wantPos  []string
+	}{
+		{
+			name:     "no args",
+			args:     nil,
+			wantArgs: map[string]any{},
+			wantPos:  nil,
+		},
+		{
+			name: "space-separated string",
+			args: []string{"--query", "ai safety"},
+			wantArgs: map[string]any{
+				"query": "ai safety",
+			},
+		},
+		{
+			name: "equals-separated string",
+			args: []string{"--query=ai safety"},
+			wantArgs: map[string]any{
+				"query": "ai safety",
+			},
+		},
+		{
+			name: "integer coerced",
+			args: []string{"--limit", "10"},
+			wantArgs: map[string]any{
+				"limit": int64(10),
+			},
+		},
+		{
+			name: "float coerced",
+			args: []string{"--lat", "51.5", "--lon", "-0.12"},
+			wantArgs: map[string]any{
+				"lat": 51.5,
+				"lon": -0.12,
+			},
+		},
+		{
+			name: "bool explicit",
+			args: []string{"--pollen", "true"},
+			wantArgs: map[string]any{
+				"pollen": true,
+			},
+		},
+		{
+			name: "bare bool flag",
+			args: []string{"--public"},
+			wantArgs: map[string]any{
+				"public": true,
+			},
+		},
+		{
+			name: "positional trailing",
+			args: []string{"--query", "ai", "extra"},
+			wantArgs: map[string]any{
+				"query": "ai",
+			},
+			wantPos: []string{"extra"},
+		},
+		{
+			name:     "only positional",
+			args:     []string{"hello world"},
+			wantArgs: map[string]any{},
+			wantPos:  []string{"hello world"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, pos, err := parseToolFlags(tc.args)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !reflect.DeepEqual(got, tc.wantArgs) {
+				t.Errorf("args mismatch:\n want %v\n  got %v", tc.wantArgs, got)
+			}
+			if !reflect.DeepEqual(pos, tc.wantPos) {
+				t.Errorf("positional mismatch:\n want %v\n  got %v", tc.wantPos, pos)
+			}
+		})
+	}
+}
+
+func TestCoerce(t *testing.T) {
+	cases := []struct {
+		in   string
+		want any
+	}{
+		{"hello", "hello"},
+		{"true", true},
+		{"false", false},
+		{"10", int64(10)},
+		{"-5", int64(-5)},
+		{"1.5", 1.5},
+		{"51.5", 51.5},
+	}
+	for _, tc := range cases {
+		got := coerce(tc.in)
+		if !reflect.DeepEqual(got, tc.want) {
+			t.Errorf("coerce(%q) = %v (%T), want %v (%T)", tc.in, got, got, tc.want, tc.want)
+		}
+	}
+}
+
+func TestDefaultArgKey(t *testing.T) {
+	cases := map[string]string{
+		"chat":          "prompt",
+		"agent":         "prompt",
+		"apps_build":    "prompt",
+		"news_search":   "query",
+		"video_search":  "query",
+		"web_search":    "q",
+		"places_search": "q",
+		"web_fetch":     "url",
+		"blog_read":     "id",
+	}
+	for tool, want := range cases {
+		got, ok := defaultArgKey(tool)
+		if !ok {
+			t.Errorf("defaultArgKey(%q) returned false, want %q", tool, want)
+			continue
+		}
+		if got != want {
+			t.Errorf("defaultArgKey(%q) = %q, want %q", tool, got, want)
+		}
+	}
+	if _, ok := defaultArgKey("mail_send"); ok {
+		t.Error("defaultArgKey(mail_send) should return false")
+	}
+}

--- a/cli/format.go
+++ b/cli/format.go
@@ -1,0 +1,278 @@
+// Output formatting — pretty-printed JSON by default (with colour when
+// writing to a tty) and optional table layout for list-shaped results.
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strings"
+)
+
+// isTerminal returns true when stdout is an interactive terminal.
+// We avoid pulling in the x/term dependency by checking the common
+// env signals and the file mode.
+func isTerminal() bool {
+	if os.Getenv("MU_NO_COLOR") != "" || os.Getenv("NO_COLOR") != "" {
+		return false
+	}
+	fi, err := os.Stdout.Stat()
+	if err != nil {
+		return false
+	}
+	return (fi.Mode() & os.ModeCharDevice) != 0
+}
+
+// Format prints a tool response text to w using the given resolved
+// config as a preference hint.
+func Format(w io.Writer, raw string, cfg *ResolvedConfig) error {
+	raw = strings.TrimSpace(raw)
+
+	// Decide format preference.
+	pretty := cfg.Pretty
+	if cfg.Raw {
+		pretty = false
+	} else if !cfg.Pretty && !isTerminal() {
+		// Piping to another command — stay raw for jq-friendliness.
+		pretty = false
+	} else {
+		pretty = true
+	}
+
+	// Non-JSON output is printed as-is.
+	var parsed any
+	if err := json.Unmarshal([]byte(raw), &parsed); err != nil {
+		fmt.Fprintln(w, raw)
+		return nil
+	}
+
+	// Table mode: only works for array-of-objects results.
+	if cfg.Table {
+		if rows, ok := parsed.([]any); ok {
+			if printTable(w, rows) {
+				return nil
+			}
+		}
+		if m, ok := parsed.(map[string]any); ok {
+			for _, v := range m {
+				if rows, ok := v.([]any); ok {
+					if printTable(w, rows) {
+						return nil
+					}
+				}
+			}
+		}
+		// Fall through to JSON if the result isn't table-shaped.
+	}
+
+	if pretty {
+		return prettyJSON(w, parsed)
+	}
+	// Raw: compact JSON to stdout.
+	enc := json.NewEncoder(w)
+	return enc.Encode(parsed)
+}
+
+// prettyJSON writes an indented, syntax-coloured (when tty) JSON dump.
+func prettyJSON(w io.Writer, v any) error {
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetIndent("", "  ")
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(v); err != nil {
+		return err
+	}
+	text := strings.TrimRight(buf.String(), "\n")
+
+	if !isTerminal() {
+		fmt.Fprintln(w, text)
+		return nil
+	}
+	// Minimal ANSI colour for readability.
+	coloured := colouriseJSON(text)
+	fmt.Fprintln(w, coloured)
+	return nil
+}
+
+// colouriseJSON applies very light ANSI colouring to already-indented
+// JSON. It is intentionally simple: we only colour keys and string
+// values, leaving numbers/bools/nulls in default colour.
+func colouriseJSON(s string) string {
+	const (
+		keyColor = "\033[34m" // blue
+		strColor = "\033[32m" // green
+		reset    = "\033[0m"
+	)
+	var out strings.Builder
+	i := 0
+	for i < len(s) {
+		c := s[i]
+		if c == '"' {
+			// Find the matching quote (handle escapes).
+			end := i + 1
+			for end < len(s) {
+				if s[end] == '\\' {
+					end += 2
+					continue
+				}
+				if s[end] == '"' {
+					break
+				}
+				end++
+			}
+			if end >= len(s) {
+				out.WriteString(s[i:])
+				break
+			}
+			lit := s[i : end+1]
+			// Distinguish key vs value: a key is followed by ":".
+			rest := s[end+1:]
+			isKey := strings.HasPrefix(strings.TrimLeft(rest, " \t"), ":")
+			if isKey {
+				out.WriteString(keyColor)
+				out.WriteString(lit)
+				out.WriteString(reset)
+			} else {
+				out.WriteString(strColor)
+				out.WriteString(lit)
+				out.WriteString(reset)
+			}
+			i = end + 1
+			continue
+		}
+		out.WriteByte(c)
+		i++
+	}
+	return out.String()
+}
+
+// printTable renders a slice of JSON objects as an aligned text table.
+// Returns false if the rows aren't uniformly object-shaped.
+func printTable(w io.Writer, rows []any) bool {
+	if len(rows) == 0 {
+		fmt.Fprintln(w, "(empty)")
+		return true
+	}
+	// All rows must be maps.
+	records := make([]map[string]any, 0, len(rows))
+	for _, r := range rows {
+		m, ok := r.(map[string]any)
+		if !ok {
+			return false
+		}
+		records = append(records, m)
+	}
+
+	// Collect column names — preserve the first row's key order, then
+	// append any extras from subsequent rows.
+	seen := map[string]bool{}
+	var cols []string
+	for _, k := range sortedKeys(records[0]) {
+		if !seen[k] {
+			cols = append(cols, k)
+			seen[k] = true
+		}
+	}
+	for _, rec := range records[1:] {
+		for _, k := range sortedKeys(rec) {
+			if !seen[k] {
+				cols = append(cols, k)
+				seen[k] = true
+			}
+		}
+	}
+
+	// Limit columns to keep the table readable. Skip long content
+	// fields that would dominate the layout.
+	var trimmed []string
+	for _, c := range cols {
+		low := strings.ToLower(c)
+		if low == "html" || low == "body" || low == "content" {
+			continue
+		}
+		trimmed = append(trimmed, c)
+		if len(trimmed) >= 6 {
+			break
+		}
+	}
+	if len(trimmed) == 0 {
+		trimmed = cols
+	}
+	cols = trimmed
+
+	// Compute widths.
+	widths := make(map[string]int, len(cols))
+	for _, c := range cols {
+		widths[c] = len(c)
+	}
+	strRows := make([]map[string]string, len(records))
+	for i, rec := range records {
+		strRows[i] = map[string]string{}
+		for _, c := range cols {
+			v := rec[c]
+			s := formatCell(v)
+			if len(s) > 60 {
+				s = s[:57] + "..."
+			}
+			strRows[i][c] = s
+			if len(s) > widths[c] {
+				widths[c] = len(s)
+			}
+		}
+	}
+
+	// Header.
+	for i, c := range cols {
+		if i > 0 {
+			fmt.Fprint(w, "  ")
+		}
+		fmt.Fprintf(w, "%-*s", widths[c], strings.ToUpper(c))
+	}
+	fmt.Fprintln(w)
+
+	// Rows.
+	for _, rec := range strRows {
+		for i, c := range cols {
+			if i > 0 {
+				fmt.Fprint(w, "  ")
+			}
+			fmt.Fprintf(w, "%-*s", widths[c], rec[c])
+		}
+		fmt.Fprintln(w)
+	}
+	return true
+}
+
+func sortedKeys(m map[string]any) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func formatCell(v any) string {
+	switch x := v.(type) {
+	case nil:
+		return ""
+	case string:
+		return x
+	case float64:
+		if x == float64(int64(x)) {
+			return fmt.Sprintf("%d", int64(x))
+		}
+		return fmt.Sprintf("%g", x)
+	case bool:
+		if x {
+			return "true"
+		}
+		return "false"
+	default:
+		b, _ := json.Marshal(x)
+		return string(b)
+	}
+}

--- a/cli/help.go
+++ b/cli/help.go
@@ -1,0 +1,179 @@
+// Help text. The tool list is fetched live from the server so any new
+// MCP tool automatically shows up.
+package cli
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strings"
+)
+
+const shortHelp = `mu — command line for the Mu platform
+
+USAGE
+  mu <command> [flags]
+  mu <tool>    [--arg value ...]
+
+COMMON COMMANDS
+  mu news                        Latest news feed
+  mu news_search "ai safety"     Search news
+  mu blog_list                   List blog posts
+  mu chat "hello"                Chat with the AI
+  mu agent "what is the btc price?"
+  mu web_search "claude code"    Search the web
+  mu weather_forecast --lat 51.5 --lon -0.12
+  mu apps_search "pomodoro"      Search the apps directory
+  mu me                          Show your account
+
+MANAGEMENT
+  mu login                       Log in by pasting a token from /token
+  mu logout                      Forget the saved token
+  mu config get|set|path         Manage the config file
+  mu help [tool]                 Full tool list, or help for a tool
+
+FLAGS (any command)
+  --url URL        Mu instance URL (env: MU_URL, default: https://mu.xyz)
+  --token TOKEN    Session or PAT token (env: MU_TOKEN)
+  --pretty         Force pretty-printed output
+  --raw            Force raw JSON output
+  --table          Render list results as a text table
+  -v, --verbose    Verbose logging
+
+CONFIG
+  Loaded from $XDG_CONFIG_HOME/mu/config.json (default: ~/.config/mu/config.json).
+  Environment variables MU_URL and MU_TOKEN override the config file.
+  Command-line flags override both.
+
+EXAMPLES
+  mu news | jq '.feed[0]'
+  mu news_search --query "bitcoin" --table
+  mu blog_create --title "Hi" --content "..."
+  mu apps_build --prompt "a pomodoro timer with lap counter"
+`
+
+// printShortHelp prints the summary help text.
+func printShortHelp(w io.Writer) {
+	fmt.Fprint(w, shortHelp)
+}
+
+// runHelp handles `mu help` and `mu help <tool>`.
+func runHelp(args []string, rc *ResolvedConfig) int {
+	if len(args) == 0 {
+		return runToolList(rc)
+	}
+	return runToolHelp(args[0], rc)
+}
+
+// runToolList fetches tools/list and prints a grouped summary.
+func runToolList(rc *ResolvedConfig) int {
+	if err := rc.Validate(); err != nil {
+		printShortHelp(os.Stdout)
+		return 0
+	}
+	client := NewClient(rc)
+	tools, err := client.ListTools()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "failed to fetch tools:", err)
+		printShortHelp(os.Stdout)
+		return 1
+	}
+
+	// Group by prefix (chars before first underscore). Tools without
+	// an underscore go into a "general" bucket.
+	groups := map[string][]Tool{}
+	for _, t := range tools {
+		prefix := "general"
+		if idx := strings.Index(t.Name, "_"); idx > 0 {
+			prefix = t.Name[:idx]
+		}
+		groups[prefix] = append(groups[prefix], t)
+	}
+
+	var prefixes []string
+	for p := range groups {
+		prefixes = append(prefixes, p)
+	}
+	sort.Strings(prefixes)
+
+	fmt.Println("Available tools on", rc.URL)
+	fmt.Println()
+	for _, p := range prefixes {
+		fmt.Printf("# %s\n", p)
+		list := groups[p]
+		sort.Slice(list, func(i, j int) bool { return list[i].Name < list[j].Name })
+		for _, t := range list {
+			desc := t.Description
+			if len(desc) > 72 {
+				desc = desc[:69] + "..."
+			}
+			fmt.Printf("  %-28s  %s\n", t.Name, desc)
+		}
+		fmt.Println()
+	}
+	fmt.Println("Run `mu help <tool>` for parameter details.")
+	return 0
+}
+
+// runToolHelp prints parameter details for a single tool.
+func runToolHelp(name string, rc *ResolvedConfig) int {
+	if err := rc.Validate(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 2
+	}
+	client := NewClient(rc)
+	tools, err := client.ListTools()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "failed to fetch tools:", err)
+		return 1
+	}
+	var tool *Tool
+	for i := range tools {
+		if tools[i].Name == name {
+			tool = &tools[i]
+			break
+		}
+	}
+	if tool == nil {
+		fmt.Fprintf(os.Stderr, "unknown tool: %s\n", name)
+		return 1
+	}
+
+	fmt.Printf("%s — %s\n\n", tool.Name, tool.Description)
+
+	required := map[string]bool{}
+	for _, k := range tool.InputSchema.Required {
+		required[k] = true
+	}
+
+	if len(tool.InputSchema.Properties) == 0 {
+		fmt.Println("(no parameters)")
+		return 0
+	}
+
+	var names []string
+	for n := range tool.InputSchema.Properties {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+
+	fmt.Println("PARAMETERS")
+	for _, n := range names {
+		f := tool.InputSchema.Properties[n]
+		req := ""
+		if required[n] {
+			req = " (required)"
+		}
+		fmt.Printf("  --%-16s %-8s %s%s\n", n, f.Type, f.Description, req)
+	}
+	fmt.Println()
+	fmt.Printf("EXAMPLE\n  mu %s", tool.Name)
+	for _, n := range names {
+		if required[n] {
+			fmt.Printf(` --%s "..."`, n)
+		}
+	}
+	fmt.Println()
+	return 0
+}

--- a/cli/login.go
+++ b/cli/login.go
@@ -1,0 +1,192 @@
+// `mu login` and `mu logout` — store or clear the Personal Access
+// Token used to authenticate against the Mu MCP endpoint.
+package cli
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+)
+
+// runLogin handles `mu login [--url URL]`. It offers to open the
+// browser to the token page, then reads the pasted token from stdin.
+func runLogin(args []string, cfg *ResolvedConfig) int {
+	file, _ := LoadConfig()
+	if file == nil {
+		file = &Config{}
+	}
+
+	// Figure out the target URL. Respect flag/env override, otherwise
+	// reuse whatever is stored (falling back to the default).
+	url := cfg.URL
+	if url == "" {
+		url = file.URL
+	}
+	if url == "" {
+		url = DefaultURL
+	}
+
+	fmt.Fprintf(os.Stdout, "Logging in to %s\n", url)
+	fmt.Fprintln(os.Stdout)
+	fmt.Fprintln(os.Stdout, "1. Sign in and create a Personal Access Token at:")
+	fmt.Fprintf(os.Stdout, "   %s/token\n", url)
+	fmt.Fprintln(os.Stdout)
+
+	// Try to open the token page in a browser, but don't fail the
+	// command when there is no browser available (SSH sessions,
+	// containers, etc.).
+	if err := openBrowser(url + "/token"); err != nil {
+		fmt.Fprintf(os.Stdout, "   (couldn't open browser automatically — open the URL manually)\n")
+	}
+
+	fmt.Fprintln(os.Stdout, "2. Paste the token below and press Enter.")
+	fmt.Fprint(os.Stdout, "Token: ")
+
+	token, err := readLine(os.Stdin)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "failed to read token:", err)
+		return 1
+	}
+	token = strings.TrimSpace(token)
+	if token == "" {
+		fmt.Fprintln(os.Stderr, "no token entered")
+		return 1
+	}
+
+	file.URL = url
+	file.Token = token
+	if err := SaveConfig(file); err != nil {
+		fmt.Fprintln(os.Stderr, "save config:", err)
+		return 1
+	}
+
+	// Verify the token actually works.
+	rc := &ResolvedConfig{URL: url, Token: token}
+	client := NewClient(rc)
+	if _, err := client.CallTool("me", nil); err != nil {
+		fmt.Fprintln(os.Stderr, "warning: token saved but verification failed:", err)
+		return 0
+	}
+	fmt.Fprintln(os.Stdout, "✓ Logged in")
+	return 0
+}
+
+// runLogout clears the stored token.
+func runLogout(args []string, cfg *ResolvedConfig) int {
+	file, err := LoadConfig()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "load config:", err)
+		return 1
+	}
+	if file == nil {
+		file = &Config{}
+	}
+	file.Token = ""
+	if err := SaveConfig(file); err != nil {
+		fmt.Fprintln(os.Stderr, "save config:", err)
+		return 1
+	}
+	fmt.Fprintln(os.Stdout, "✓ Logged out")
+	return 0
+}
+
+// runConfig handles `mu config get|set|path`.
+func runConfig(args []string, cfg *ResolvedConfig) int {
+	if len(args) == 0 {
+		fmt.Fprintln(os.Stderr, "usage: mu config <get|set|path> [key] [value]")
+		return 2
+	}
+	switch args[0] {
+	case "path":
+		p, err := configPath()
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			return 1
+		}
+		fmt.Println(p)
+		return 0
+	case "get":
+		file, err := LoadConfig()
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			return 1
+		}
+		if len(args) < 2 {
+			fmt.Printf("url=%s\n", file.URL)
+			if file.Token != "" {
+				fmt.Println("token=***")
+			} else {
+				fmt.Println("token=")
+			}
+			return 0
+		}
+		switch args[1] {
+		case "url":
+			fmt.Println(file.URL)
+		case "token":
+			fmt.Println(file.Token)
+		default:
+			fmt.Fprintln(os.Stderr, "unknown key:", args[1])
+			return 2
+		}
+		return 0
+	case "set":
+		if len(args) < 3 {
+			fmt.Fprintln(os.Stderr, "usage: mu config set <url|token> <value>")
+			return 2
+		}
+		file, err := LoadConfig()
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			return 1
+		}
+		switch args[1] {
+		case "url":
+			file.URL = args[2]
+		case "token":
+			file.Token = args[2]
+		default:
+			fmt.Fprintln(os.Stderr, "unknown key:", args[1])
+			return 2
+		}
+		if err := SaveConfig(file); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			return 1
+		}
+		fmt.Println("✓ Saved")
+		return 0
+	}
+	fmt.Fprintln(os.Stderr, "usage: mu config <get|set|path> [key] [value]")
+	return 2
+}
+
+// readLine reads a single line from a reader, stripping the trailing
+// newline. Not using bufio.Scanner because we want control over the
+// full line with no token-size limit.
+func readLine(r io.Reader) (string, error) {
+	br := bufio.NewReader(r)
+	s, err := br.ReadString('\n')
+	if err != nil && s == "" {
+		return "", err
+	}
+	return strings.TrimRight(s, "\r\n"), nil
+}
+
+// openBrowser tries to open the given URL in the user's browser.
+// Silently returns an error when no opener is available.
+func openBrowser(url string) error {
+	var cmd *exec.Cmd
+	switch runtime.GOOS {
+	case "darwin":
+		cmd = exec.Command("open", url)
+	case "windows":
+		cmd = exec.Command("rundll32", "url.dll,FileProtocolHandler", url)
+	default:
+		cmd = exec.Command("xdg-open", url)
+	}
+	return cmd.Start()
+}

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -1,0 +1,230 @@
+# CLI
+
+`mu` is a registry-driven command-line interface for the Mu platform. It's a thin HTTP client that talks to any Mu instance's `/mcp` endpoint — every MCP tool is automatically available as a subcommand, so adding a new tool on the server side adds a new CLI command for free.
+
+The CLI and the server share the same binary. Running `mu --serve` starts the server exactly as before; running `mu` with anything else is treated as a CLI invocation and never touches server state.
+
+## Install
+
+The same `mu` binary runs the server and the CLI.
+
+```bash
+git clone https://github.com/micro/mu
+cd mu && go install
+```
+
+Or grab a prebuilt binary from the [releases page](https://github.com/micro/mu/releases).
+
+## Quick start
+
+```bash
+mu                                      # show help
+mu help                                 # live list of all available tools
+mu news                                 # latest news feed
+mu news_search "ai safety"              # search news
+mu chat "hello, what's up?"             # chat with the AI
+mu agent "summarise today's markets"    # run the full agent
+mu web_search "claude code"
+mu weather_forecast --lat 51.5 --lon -0.12
+mu apps_search "pomodoro"
+mu me                                   # your account (requires login)
+```
+
+The first positional argument is always the tool name. The rest are flags that map directly to the tool's parameters.
+
+## Authentication
+
+Most tools work without auth (news, markets, weather, blog reads, etc.). Anything that creates content, spends credits, or reads personal data needs a token.
+
+### Option 1 — browser login
+
+```bash
+mu login
+```
+
+Opens `/token` in your browser. Sign in to Mu, create a Personal Access Token, paste it back into the terminal. The token is saved to `~/.config/mu/config.json` with mode `0600`.
+
+### Option 2 — paste directly
+
+Works in SSH sessions, containers, or anywhere without a browser.
+
+```bash
+mu config set token <TOKEN>
+```
+
+### Option 3 — environment variable
+
+For CI, scripts, or ad-hoc use:
+
+```bash
+export MU_TOKEN=<TOKEN>
+mu me
+```
+
+### Logout
+
+```bash
+mu logout
+```
+
+Clears the stored token. Env vars and `--token` flag overrides are unaffected.
+
+## Pointing at a different instance
+
+By default the CLI talks to `https://mu.xyz`. To point at your own self-hosted instance:
+
+```bash
+# Persistent
+mu config set url https://mu.example.com
+
+# Per-invocation
+mu --url https://mu.example.com news
+
+# Environment
+export MU_URL=https://mu.example.com
+```
+
+## Passing arguments
+
+Flags map one-to-one with the tool's parameters. Both forms are accepted:
+
+```bash
+mu news_search --query "bitcoin"
+mu news_search --query=bitcoin
+```
+
+For a small set of well-known tools, a single positional argument is treated as the most obvious required parameter, so you can skip the flag name:
+
+```bash
+mu chat "hello"                  # same as --prompt "hello"
+mu news_search "bitcoin"         # same as --query "bitcoin"
+mu web_search "claude code"      # same as --q "claude code"
+mu apps_build "a pomodoro timer" # same as --prompt "..."
+```
+
+### Types
+
+The CLI infers parameter types from the value:
+
+| Value            | JSON type sent   |
+|------------------|------------------|
+| `true`, `false`  | boolean          |
+| `42`, `-7`       | integer          |
+| `3.14`, `-0.12`  | float            |
+| anything else    | string           |
+
+If you need to send a string that looks numeric, use `--id=123`. Bare flags (no value) are treated as booleans set to `true`:
+
+```bash
+mu apps_create --name "Timer" --slug timer --html "..." --public
+```
+
+## Output
+
+### Automatic format
+
+- **Terminal** (default) — pretty-printed, lightly coloured JSON
+- **Pipe** — compact JSON, one object per line, so it plays nicely with `jq`
+
+```bash
+mu news                        # pretty JSON
+mu news | jq '.feed[0].title'  # compact JSON, pipeable
+mu news > feed.json            # compact JSON, file-friendly
+```
+
+### Forcing a format
+
+```bash
+mu --pretty news | less         # force pretty even when piped
+mu --raw news                   # force raw even in a terminal
+mu --table news_search --query "ai"  # render as a text table
+```
+
+`--table` renders list-shaped results as aligned columns, skipping long content fields (`html`, `body`, `content`) to keep the layout readable.
+
+## Global flags
+
+These can appear before or after the tool name:
+
+| Flag              | Purpose                                                  |
+|-------------------|----------------------------------------------------------|
+| `--url URL`       | Mu instance URL (env: `MU_URL`, default: `https://mu.xyz`) |
+| `--token TOKEN`   | Session or PAT token (env: `MU_TOKEN`)                   |
+| `--pretty`        | Force pretty-printed output                              |
+| `--raw`           | Force raw/compact JSON output                            |
+| `--table`         | Render list results as a text table                     |
+| `-v`, `--verbose` | Verbose logging                                          |
+
+## Built-in commands
+
+These aren't MCP tools — they're CLI-local commands:
+
+| Command                | What it does                                              |
+|------------------------|-----------------------------------------------------------|
+| `mu help`              | Fetch the live tool list grouped by app                   |
+| `mu help <tool>`       | Show parameters and an example for a specific tool        |
+| `mu login`             | Browser-based login (opens `/token`, pastes the PAT back) |
+| `mu logout`            | Clear the stored token                                    |
+| `mu config get`        | Show the saved URL and whether a token is set             |
+| `mu config get <key>`  | Print a single config value (`url` or `token`)            |
+| `mu config set <k> <v>`| Save a config value                                      |
+| `mu config path`       | Print the path to the config file                         |
+| `mu version`           | Show the CLI version                                      |
+
+## Common recipes
+
+### Scripted news digest
+
+```bash
+mu news | jq -r '.feed[] | "\(.title)\n  \(.description)\n"'
+```
+
+### Weather for a postcode
+
+```bash
+mu places_search "EC1A 1BB"    # get lat/lon
+mu weather_forecast --lat 51.52 --lon -0.10
+```
+
+### Build an app from a prompt
+
+```bash
+mu apps_build --prompt "a pomodoro timer with lap counter"
+# → returns slug + URL you can open in a browser
+```
+
+### Run the agent
+
+```bash
+mu agent "find me three interesting AI papers from the last week and summarise them"
+```
+
+### Search then tail the first result
+
+```bash
+mu web_search "open source self-hosted email" --raw \
+  | jq -r '.results[0].url' \
+  | xargs -I {} mu web_fetch --url {}
+```
+
+## How it works
+
+The CLI is a standalone package (`mu/cli`) with no dependencies on the rest of the Mu codebase. Every invocation:
+
+1. Loads `~/.config/mu/config.json`, applies environment overrides, then flag overrides.
+2. Parses the positional arguments as a tool name + `--flag value` pairs.
+3. Builds a JSON arguments map with inferred types.
+4. Sends a `tools/call` JSON-RPC request to `<url>/mcp`.
+5. Formats the response and writes it to stdout.
+
+The same path every MCP client uses. No duplicate code, no drift between CLI and MCP tools — when a new tool is added to the server, it's immediately available on the command line.
+
+## Server deployment
+
+The CLI doesn't affect the server in any way. The binary still launches the server when you pass `--serve`:
+
+```bash
+mu --serve --address :8080
+```
+
+The dispatch logic looks for `--serve` in the arguments; anything else falls through to the CLI handler, which talks to `/mcp` over HTTP and returns an exit code. Existing server deployments continue to work unchanged.

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -105,6 +105,25 @@ var pkgColors = map[string]string{
 	"mail":  colorRed,
 }
 
+// cliMode is set at init time when the process is invoked without
+// --serve, i.e. as a CLI rather than the server. It suppresses the
+// package startup logs so they don't contaminate CLI stdout.
+var cliMode bool
+
+func init() {
+	// Detect CLI mode without importing the cli package. The rule
+	// mirrors isServerMode in main.go: any --serve means server.
+	server := false
+	for _, a := range os.Args[1:] {
+		if a == "--serve" || a == "-serve" ||
+			strings.HasPrefix(a, "--serve=") || strings.HasPrefix(a, "-serve=") {
+			server = true
+			break
+		}
+	}
+	cliMode = !server
+}
+
 // Log prints a formatted log message with a colored package prefix
 // and stores it in the in-memory system log ring buffer.
 func Log(pkg string, format string, args ...interface{}) {
@@ -114,7 +133,9 @@ func Log(pkg string, format string, args ...interface{}) {
 	}
 	timestamp := time.Now().Format("15:04:05")
 	prefix := fmt.Sprintf("%s[%s %s]%s ", color, timestamp, pkg, colorReset)
-	fmt.Printf(prefix+format+"\n", args...)
+	if !cliMode {
+		fmt.Printf(prefix+format+"\n", args...)
+	}
 	appendSysLog(pkg, format, args...)
 }
 

--- a/main.go
+++ b/main.go
@@ -21,6 +21,7 @@ import (
 	"mu/internal/auth"
 	"mu/blog"
 	"mu/chat"
+	"mu/cli"
 	"mu/internal/data"
 	"mu/docs"
 	"mu/home"
@@ -44,6 +45,16 @@ var ServeFlag = flag.Bool("serve", false, "Run the server")
 var AddressFlag = flag.String("address", ":8080", "Address for server")
 
 func main() {
+	// Server vs CLI dispatch — any invocation that includes `--serve`
+	// (or `-serve`) runs the full server exactly as before. Anything
+	// else is treated as a CLI command and handed to the cli package,
+	// which talks to /mcp over HTTP and never touches server state.
+	// This keeps the existing `mu --serve` deployment completely
+	// unaffected while adding `mu news`, `mu chat "hi"`, etc.
+	if !isServerMode(os.Args[1:]) {
+		os.Exit(cli.Run(os.Args[1:]))
+	}
+
 	flag.Parse()
 
 	if !*ServeFlag {
@@ -1040,6 +1051,23 @@ func main() {
 	}
 
 	app.Log("main", "Server stopped")
+}
+
+// isServerMode returns true when the argument list contains the
+// `--serve` flag. This is the single signal that switches between the
+// server and CLI entry points — kept deliberately simple so it can't
+// accidentally divert the production deployment.
+func isServerMode(args []string) bool {
+	for _, a := range args {
+		if a == "--serve" || a == "-serve" {
+			return true
+		}
+		// Allow `--serve=true` / `--serve=false` for completeness.
+		if strings.HasPrefix(a, "--serve=") || strings.HasPrefix(a, "-serve=") {
+			return true
+		}
+	}
+	return false
 }
 
 // runHealthChecks performs lightweight health checks on public-facing services


### PR DESCRIPTION
The same binary now runs the server (mu --serve, unchanged) or acts as a command-line client against any Mu instance's /mcp endpoint. Every tool registered with the MCP server is automatically available as a subcommand — the CLI is registry-driven, so adding a new tool adds a new CLI command for free.

Examples:

  mu news                                    # latest news feed
  mu news_search "ai safety"                 # search news
  mu chat "hello"                            # chat with the AI
  mu agent "summarise today's markets"       # run the full agent
  mu weather_forecast --lat 51.5 --lon -0.12
  mu blog_create --title "Hi" --content "..."
  mu apps_build --prompt "a pomodoro timer"
  mu help                                    # live list of tools
  mu help apps_build                         # per-tool parameters

Design:

- The cli/ package is standalone — no dependencies on the rest of the Mu codebase. It only talks HTTP to <url>/mcp.
- main.go routes based on the --serve flag: present → server (as before); absent → hand off to cli.Run. Any existing `mu --serve` deployment is unaffected.
- Config lives at $XDG_CONFIG_HOME/mu/config.json with 0600 perms. MU_URL / MU_TOKEN env vars override the file; --url / --token flags override everything.
- Output is pretty-printed JSON when attached to a terminal and raw compact JSON when piped — so `mu news | jq '.feed[0]'` works cleanly. --pretty, --raw, and --table override the default.
- Auth has three paths: `mu login` (opens /token in the browser and prompts for a paste), `mu config set token <TOKEN>`, or the MU_TOKEN environment variable.
- Flag parsing is dynamic. --name value / --name=value pairs become keys in the JSON arguments map; values are coerced to bool/int/ float/string based on shape. For common tools (chat, agent, *_search, web_fetch, blog_read, apps_read, apps_build) a single bare positional argument is assigned to the canonical parameter.
- app.Log suppresses stdout output in CLI mode so package init warnings (e.g. the YouTube key check) don't contaminate piped output.

Docs:

- README.md gets a CLI section with examples, authentication options, and output format notes.
- docs/CLI.md is the full reference — install, auth, config, flags, output modes, built-in commands, recipes, and how it works.

Tests cover the argument parser, type coercion, default arg-key mapping, and the config load/save round trip with permission check.