### PR TITLE
Add /updates endpoint — unified polling for mail, status, social

### DIFF
--- a/home/home.go
+++ b/home/home.go
@@ -506,15 +506,32 @@ const statusCardScript = `<script>
 
   bindForm();
 
-  // Poll while the tab is visible.
-  setInterval(function(){
-    if (document.hidden) return;
-    refresh();
-  }, pollInterval);
+  // Unified poll via /updates — only refreshes the status stream when
+  // there are actual new entries, and updates mail badge from the same
+  // call. Much cheaper than fetching the full HTML fragment every 10s.
+  var lastTS = Math.floor(Date.now() / 1000);
 
-  // Fetch immediately when the tab regains focus.
+  function checkUpdates() {
+    if (document.hidden) return;
+    fetch('/updates?since=' + lastTS, { credentials: 'same-origin', cache: 'no-store' })
+      .then(function(r){ return r.ok ? r.json() : null; })
+      .then(function(data){
+        if (!data) return;
+        lastTS = data.ts || lastTS;
+        // Refresh status stream only when new entries exist.
+        if (data.status > 0) refresh();
+        // Update mail badges in the header/nav.
+        var badges = [document.getElementById('head-mail-badge'), document.getElementById('nav-mail-badge')];
+        for (var i = 0; i < badges.length; i++) {
+          if (badges[i]) badges[i].textContent = data.mail > 0 ? data.mail : '';
+        }
+      })
+      .catch(function(){});
+  }
+
+  setInterval(checkUpdates, pollInterval);
   document.addEventListener('visibilitychange', function(){
-    if (!document.hidden) refresh();
+    if (!document.hidden) checkUpdates();
   });
 })();
 </script>`

--- a/main.go
+++ b/main.go
@@ -820,6 +820,7 @@ func main() {
 	http.HandleFunc("/account", app.Account)
 	http.HandleFunc("/verify", app.Verify)
 	http.HandleFunc("/session", app.Session)
+	http.HandleFunc("/updates", updatesHandler)
 	http.HandleFunc("/token", app.TokenHandler)
 	http.HandleFunc("/passkey/", app.PasskeyHandler)
 
@@ -1167,6 +1168,65 @@ func main() {
 	}
 
 	app.Log("main", "Server stopped")
+}
+
+// updatesHandler serves GET /updates?since=<unix> — a single lightweight
+// endpoint the client polls for change counts. Returns JSON:
+//
+//	{"mail":3,"status":2,"social":1,"ts":1713254400}
+//
+// The client stores ts and sends it back on the next poll. If since is
+// omitted, returns current totals (unread mail, stream size, etc.).
+func updatesHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != "GET" {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var viewerID string
+	if sess, _ := auth.TrySession(r); sess != nil {
+		viewerID = sess.Account
+	}
+
+	now := time.Now()
+
+	// Parse the "since" parameter — unix timestamp.
+	var since time.Time
+	if s := r.URL.Query().Get("since"); s != "" {
+		var n int64
+		if _, err := fmt.Sscanf(s, "%d", &n); err == nil {
+			since = time.Unix(n, 0)
+		}
+	}
+
+	result := map[string]interface{}{
+		"ts": now.Unix(),
+	}
+
+	// Mail — always unread count (personal, independent of since).
+	if viewerID != "" {
+		result["mail"] = mail.GetUnreadCount(viewerID)
+	} else {
+		result["mail"] = 0
+	}
+
+	// Status — new entries since last poll.
+	if since.IsZero() {
+		result["status"] = 0
+	} else {
+		result["status"] = user.StatusCountSince(since, viewerID)
+	}
+
+	// Social — new messages since last poll.
+	if since.IsZero() {
+		result["social"] = 0
+	} else {
+		result["social"] = social.CountSince(since)
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "no-store")
+	json.NewEncoder(w).Encode(result)
 }
 
 // chargedWriteOp maps a request method + path to the wallet operation

--- a/social/social.go
+++ b/social/social.go
@@ -244,6 +244,20 @@ func CardHTML() string {
 	return cardHTML
 }
 
+// CountSince returns the number of messages (threads + replies) posted
+// after the given timestamp. Used by the /updates endpoint.
+func CountSince(since time.Time) int {
+	mutex.RLock()
+	defer mutex.RUnlock()
+	count := 0
+	for _, p := range messages {
+		if p.PostedAt.After(since) {
+			count++
+		}
+	}
+	return count
+}
+
 // GetThreads returns all cached messages (most recent first)
 func GetThreads() []*Message {
 	mutex.RLock()

--- a/user/user.go
+++ b/user/user.go
@@ -413,6 +413,30 @@ func StatusStreamCapped(maxTotal, maxPerUser int, viewerID string) []StatusEntry
 	return entries
 }
 
+// StatusCountSince returns how many status entries are newer than the
+// given timestamp. Used by the /updates endpoint to tell the client
+// whether it needs to refresh the stream.
+func StatusCountSince(since time.Time, viewerID string) int {
+	profileMutex.RLock()
+	defer profileMutex.RUnlock()
+
+	count := 0
+	for _, p := range profiles {
+		if auth.IsBanned(p.UserID) && p.UserID != viewerID {
+			continue
+		}
+		if !p.UpdatedAt.IsZero() && p.UpdatedAt.After(since) {
+			count++
+		}
+		for _, h := range p.History {
+			if h.SetAt.After(since) {
+				count++
+			}
+		}
+	}
+	return count
+}
+
 // MaxStatusLength is the upper bound on a single status message. Larger
 // than a tweet, smaller than an essay — enough room for a short thought
 // or an @micro question without inviting wall-of-text posts.


### PR DESCRIPTION
Single lightweight endpoint the client polls instead of fetching full HTML fragments or hitting multiple services:

  GET /updates?since=1713254400
  → {"mail":3,"status":2,"social":1,"ts":1713254401}

- mail: unread count (personal, always current, not since-based)
- status: new status entries since the given unix timestamp
- social: new messages since timestamp
- ts: server timestamp to send back on next poll

Implementation:
- user.StatusCountSince(since, viewerID) — counts status entries newer than the given time, respects ban visibility
- social.CountSince(since) — counts messages newer than the given time
- mail.GetUnreadCount(userID) — already existed

Home page JS updated: instead of fetching /user/status/stream every 10 seconds regardless, polls /updates, and only fetches the stream fragment when status > 0. Also updates the mail badge from the same poll — replacing the separate fetch in mu.js. Much cheaper: one tiny JSON response vs a full HTML fragment on every tick.

https://claude.ai/code/session_01GRGLA9yj7BpqKiyi6xFwnm