### PR TITLE
Show inline weather next to date, fix invite link layout

### DIFF
--- a/home/home.go
+++ b/home/home.go
@@ -287,14 +287,24 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 
 	var b strings.Builder
 
-	// Date header + admin actions
+	// Date header: date + inline weather summary + admin actions
 	now := time.Now()
 	_, viewerAcc := auth.TrySession(r)
-	inviteLink := ""
+	inviteHTML := ""
 	if viewerAcc != nil && viewerAcc.Admin && auth.InviteOnly() {
-		inviteLink = ` <a href="/admin/invite" style="float:right;font-size:13px;color:#555;text-decoration:none">+ Invite user</a>`
+		inviteHTML = `<span id="home-date-actions"><a href="/admin/invite" style="color:#555;text-decoration:none">+ Invite</a></span>`
 	}
-	b.WriteString(fmt.Sprintf(`<p id="home-date">%s%s</p>`, now.Format("Monday, 2 January 2006"), inviteLink))
+	b.WriteString(fmt.Sprintf(`<div id="home-date"><span id="home-date-text">%s</span><span id="home-date-weather"></span>%s</div>`, now.Format("Monday, 2 January 2006"), inviteHTML))
+	// Inline script reads cached weather summary from localStorage
+	// and renders "10°C ☁️" next to the date. No fetch — reads what
+	// the weather card already cached.
+	b.WriteString(`<script>(function(){
+var w;try{w=JSON.parse(localStorage.getItem('mu_weather_now'))}catch(e){}
+if(!w||w.temp==null)return;
+var emoji={'clear':'☀️','sunny':'☀️','cloud':'☁️','overcast':'☁️','partly':'⛅','rain':'🌧️','drizzle':'🌧️','snow':'❄️','thunder':'⛈️','storm':'⛈️','fog':'🌫️','mist':'🌫️','haze':'🌫️','wind':'💨'};
+var e='';var d=(w.desc||'').toLowerCase();for(var k in emoji){if(d.indexOf(k)>=0){e=emoji[k];break}}
+document.getElementById('home-date-weather').textContent=w.temp+'°C '+(e||'');
+})()</script>`)
 
 	// Status card content (will be prepended to left column).
 	// Built by user.RenderStatusStream so the fragment endpoint and the

--- a/internal/app/html/mu.css
+++ b/internal/app/html/mu.css
@@ -611,6 +611,21 @@ body.page-home #page-title ~ #customize-link {
 #home-date {
   color: #888;
   margin: 0 0 16px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+#home-date-text {
+  white-space: nowrap;
+}
+#home-date-weather {
+  font-size: 13px;
+  color: #999;
+}
+#home-date-actions {
+  margin-left: auto;
+  font-size: 13px;
 }
 
 #home-status-form {
@@ -2371,7 +2386,7 @@ a.highlight {
     display: contents;
   }
   #home-date {
-    text-align: center;
+    justify-content: center;
   }
 
   /* Compact cards on mobile */

--- a/weather/weather.go
+++ b/weather/weather.go
@@ -74,6 +74,7 @@ fetch('/weather?lat='+lat+'&lon='+lon,{headers:{'Accept':'application/json'}})
 var f=d.forecast;
 if(!f||!f.Current){return}
 var c=f.Current;
+try{localStorage.setItem('mu_weather_now',JSON.stringify({temp:Math.round(c.TempC),desc:c.Description||''}))}catch(e){}
 var h='<div style="display:flex;align-items:center;gap:8px">';
 h+='<span style="font-size:22px;font-weight:600;color:#333">'+Math.round(c.TempC)+'°C</span>';
 h+='<span style="color:#666">'+c.Description+'</span>';


### PR DESCRIPTION
Date header is now a flex row:
  Thursday, 10 April   10°C ☁️             + Invite

- Left: date text + weather summary (temp + emoji)
- Right: invite link (admin-only, when invite-only is on)

Weather summary reads from localStorage — the weather card JS now stores {temp, desc} to 'mu_weather_now' alongside the rendered HTML cache. The date header reads this on page load with zero fetch cost. Emoji is mapped from the description text (clear→☀️, cloud→☁️, rain→🌧️, etc.).

CSS: #home-date changed from centered text to flex row with gap. Mobile keeps justify-content:center. The invite link uses margin-left:auto to pin right.

https://claude.ai/code/session_01GRGLA9yj7BpqKiyi6xFwnm