### PR TITLE
Open video watching and news AI summaries to logged-out users

### DIFF
--- a/news/news.go
+++ b/news/news.go
@@ -1521,55 +1521,9 @@ func handleArticleView(w http.ResponseWriter, r *http.Request, articleID string)
 
 	title := entry.Title
 
-	// Check if user is authenticated
-	sess, _ := auth.TrySession(r)
-	isGuest := sess == nil
-
-	// For guests: show article preview but hide AI summary
-	if isGuest {
-		imageSection := ""
-		if image != "" {
-			imageSection = fmt.Sprintf(`<img src="%s" class="article-image" referrerpolicy="no-referrer" onerror="this.style.display='none'">`, image)
-		}
-
-		categoryBadge := ""
-		if category != "" {
-			categoryBadge = fmt.Sprintf(` · <a href="/news#%s" class="category">%s</a>`, category, category)
-		}
-
-		descriptionSection := ""
-		if description != "" {
-			descriptionSection = fmt.Sprintf(`<div class="article-description"><p>%s</p></div>`, description)
-		}
-
-		// Show login prompt instead of AI summary
-		summarySection := `
-			<div class="article-summary bg-light" style="border: 1px dashed #ddd;">
-				<h3>AI Summary</h3>
-				<p class="text-muted"><a href="/login?redirect=/news?id=` + articleID + `">Login</a> to read the AI-generated summary.</p>
-			</div>`
-
-		articleHtml := fmt.Sprintf(`
-			<div id="news-article">
-				%s
-				<div class="article-meta">
-					<span><span data-timestamp="%d">%s</span> · Source: <i>%s</i>%s</span>
-				</div>
-				%s
-				%s
-				<div class="article-actions">
-					<a href="%s" target="_blank" rel="noopener noreferrer">Read Original →</a>
-				</div>
-				<div class="article-back">
-					<a href="/news">← Back to news</a>
-				</div>
-			</div>
-		`, imageSection, postedAt.Unix(), app.TimeAgo(postedAt), getDomain(articleURL), categoryBadge, descriptionSection, summarySection, articleURL)
-
-		pageHTML := app.RenderHTML(title, title, articleHtml)
-		w.Write([]byte(pageHTML))
-		return
-	}
+	// Previously gated AI summaries behind login, but summaries are
+	// pre-generated and cached — no cost to serve. Open to all so
+	// content can be shared and discovered.
 
 	// Debug logging
 	app.Log("news", "Article view: ID=%s, Title='%s', URL='%s'", articleID, title, articleURL)

--- a/video/video.go
+++ b/video/video.go
@@ -1078,32 +1078,6 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 
 	// render watch page
 	if len(id) > 0 {
-		youtubeURL := "https://www.youtube.com/watch?v=" + id
-		thumbnailURL := "https://img.youtube.com/vi/" + id + "/maxresdefault.jpg"
-
-		// Check if user is authenticated
-		sess, _ := auth.TrySession(r)
-		isGuest := sess == nil
-
-		// For guests: show thumbnail with options to login or go to YouTube
-		if isGuest {
-			guestHtml := fmt.Sprintf(`
-				<div class="card text-center p-10" style="max-width: 640px; margin: 40px auto;">
-					<img src="%s" class="w-full rounded mb-5" onerror="this.src='https://img.youtube.com/vi/%s/hqdefault.jpg'">
-					<h2>Watch Video</h2>
-					<p class="text-muted my-5">Login to watch ad-free, or view on YouTube.</p>
-					<p class="my-5">
-						<a href="/login?redirect=/video?id=%s" class="btn btn-primary mr-3">Login to watch</a>
-						<a href="%s" target="_blank" rel="noopener noreferrer" class="btn btn-outline">Watch on YouTube →</a>
-					</p>
-					<p class="mt-5"><a href="/video">← Back to videos</a></p>
-				</div>
-			`, thumbnailURL, id, id, youtubeURL)
-			pageHTML := app.RenderHTML("Video", "Video", guestHtml)
-			w.Write([]byte(pageHTML))
-			return
-		}
-
 		// Check if autoplay is requested
 		autoplay := r.Form.Get("autoplay") == "1"
 


### PR DESCRIPTION
Both were gated behind login for no reason — the video is a YouTube iframe (zero cost) and the AI summary is pre-generated and cached (zero cost to serve). Gating them just blocked sharing and discovery with no upside, especially now that signup is invite-only.

video/video.go: removed the guest block that showed a thumbnail with 'Login to watch' instead of the actual player. Everyone now gets the full embed.

news/news.go: removed the guest branch that duplicated the entire article template just to hide the summary behind a login prompt. Everyone now sees the same article page with the AI summary.