### PR TITLE
Restore card rendering, maintain conversation history, and rename placeholder

### DIFF
--- a/agent/run.go
+++ b/agent/run.go
@@ -15,13 +15,15 @@ import (
 
 // RunRequest is the input for the synchronous agent endpoint.
 type RunRequest struct {
-	Prompt string `json:"prompt"`
-	Model  string `json:"model"`
+	Prompt    string `json:"prompt"`
+	Model     string `json:"model"`
+	ContextID string `json:"context_id"` // prior flow ID for follow-ups
 }
 
 // RunResponse is the output of the synchronous agent endpoint.
 type RunResponse struct {
 	Answer string     `json:"answer"`
+	FlowID string     `json:"flow_id,omitempty"`
 	Tools  []ToolUsed `json:"tools,omitempty"`
 	Error  string     `json:"error,omitempty"`
 }
@@ -146,5 +148,23 @@ func RunHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	answer = app.StripLatexDollars(answer)
-	app.RespondJSON(w, RunResponse{Answer: answer, Tools: toolsUsed})
+
+	// Save as a flow so it appears in the agent history at /agent.
+	var steps []FlowStep
+	for _, tu := range toolsUsed {
+		steps = append(steps, FlowStep{Tool: tu.Name})
+	}
+	flow := &Flow{
+		ID:        newFlowID(),
+		AccountID: acc.ID,
+		Prompt:    req.Prompt,
+		Steps:     steps,
+		Answer:    answer,
+		Status:    "done",
+		ParentID:  req.ContextID,
+		CreatedAt: time.Now().UTC(),
+	}
+	saveFlow(flow)
+
+	app.RespondJSON(w, RunResponse{Answer: answer, FlowID: flow.ID, Tools: toolsUsed})
 }

--- a/home/home.go
+++ b/home/home.go
@@ -544,6 +544,7 @@ const consoleScript = `<script>
 (function(){
   var form = document.getElementById('console-form');
   var resp = document.getElementById('console-response');
+  var currentFlowId = '';
   if (!form || !resp) return;
 
   function csrfToken() {
@@ -577,12 +578,13 @@ const consoleScript = `<script>
       method: 'POST',
       credentials: 'same-origin',
       headers: headers,
-      body: JSON.stringify({ prompt: q })
+      body: JSON.stringify({ prompt: q, context_id: currentFlowId })
     }).then(function(r){
       if (!r.ok) return r.text().then(function(t){ throw new Error(t) });
       return r.json();
     }).then(function(data){
       var answer = (data && data.answer) ? data.answer : (typeof data === 'string' ? data : JSON.stringify(data));
+      if (data && data.flow_id) currentFlowId = data.flow_id;
       var ae = document.getElementById(qid+'-a'); if(ae) ae.outerHTML = '<div style="color:#555;line-height:1.6;word-wrap:break-word">' + renderMd(answer) + '</div>';
     }).catch(function(err){
       var ee = document.getElementById(qid+'-a'); if(ee) ee.outerHTML = '<p style="color:#c00;margin:0">' + escHtml(err.message || 'Something went wrong') + '</p>';


### PR DESCRIPTION
RunHandler (/agent/run) now creates a Flow on every query. The response includes flow_id so the client can chain follow-ups via context_id. Sessions appear in the agent history at /agent.

RunRequest gains context_id field. RunResponse gains flow_id field. The Flow is saved with status "done", the answer text, tool steps, and parent_id for chaining.

Console JS tracks currentFlowId — first question creates a new session, follow-ups send the previous flow_id as context_id so the agent can see the conversation chain. Refreshing the page starts a new session (currentFlowId resets). Existing sessions are browsable at /agent.