### PR TITLE
Console, home rework, cost cuts, DKIM fix, work removal

### DIFF
--- a/home/home.go
+++ b/home/home.go
@@ -371,7 +371,7 @@ function fetchW(la,lo){
 		b.WriteString(fmt.Sprintf(`
 <div id="console-prompt" style="margin:0 0 16px">
 <form id="console-form" style="position:relative">
-<textarea id="console-input" placeholder="Ask Micro" maxlength="%d" rows="1" style="width:100%%;padding:10px 40px 10px 12px;border:1px solid #ddd;border-radius:12px;font-size:14px;font-family:inherit;resize:none;box-sizing:border-box;line-height:1.4;overflow:hidden"></textarea>
+<textarea id="console-input" placeholder="Search or look up..." maxlength="%d" rows="1" style="width:100%%;padding:10px 40px 10px 12px;border:1px solid #ddd;border-radius:12px;font-size:14px;font-family:inherit;resize:none;box-sizing:border-box;line-height:1.4;overflow:hidden"></textarea>
 <button type="submit" style="position:absolute;right:6px;top:50%%;transform:translateY(-50%%);width:28px;height:28px;background:#000;color:#fff;border:none;border-radius:6px;cursor:pointer;display:flex;align-items:center;justify-content:center;font-size:14px;padding:0">&#x2192;</button>
 </form>
 <div id="console-response" style="display:none;margin-top:12px;padding:14px;background:#f9f9f9;border-radius:10px"></div>


### PR DESCRIPTION
## Summary

### Home screen rework
- Console prompt at top of home — calls `/agent/run` directly, saves as agent sessions
- Follow-ups chain via `context_id`, conversation history preserved inline
- Sessions visible at `/agent` page
- Removed weather card (temp shown inline next to date)
- Reminder moved to first position on mobile
- Configurable cards via ⚙ gear icon on home (show/hide per user)
- Weather fetches independently of card

### Console fixes
- Calls agent API directly (no stream polling, no overlay)
- Markdown rendering in responses
- Enter key works, full width, button fits on mobile
- Placeholder: "Search or look up..." — utility framing, not oracle

### Cost reduction
- Background tasks switched to Haiku (summaries, tags, moderation, topics)
- Article summaries on-demand only
- Daily opinions 1 → was 2

### DKIM + mail
- Relaxed/relaxed canonicalization (was simple/simple — Google was rejecting)
- SMTP rejects non-FQDN sender domains (blocks "no-reply@wetransfer" spam)

### Stream package
- Public event feed at /stream for agents/tools
- MCP tools: stream, stream_post
- System event throttling (30min cooldown per type)

### Removed
- Work/tasks package (1,928 lines)
- Weather card
- Status card from home (replaced by console)
- System event auto-publishing to stream

### Other
- Invite request flow on signup page
- Admin users page with Banned tab
- App HTML content moderation
- Video + news summaries opened to logged-out users
- Various console UX iterations

https://claude.ai/code/session_01GRGLA9yj7BpqKiyi6xFwnm

---
_Generated by [Claude Code](https://claude.ai/code/session_01GRGLA9yj7BpqKiyi6xFwnm)_