### PR TITLE
Fix invite pages: mobile layout, back links, admin dashboard link

### DIFF
--- a/admin/admin.go
+++ b/admin/admin.go
@@ -29,6 +29,7 @@ func AdminHandler(w http.ResponseWriter, r *http.Request) {
 		<a href="/admin/blocklist">Blocklist</a>
 		<a href="/admin/console">Console</a>
 		<a href="/admin/env">Environment</a>
+		<a href="/admin/invite">Invites</a>
 		<a href="/admin/email">Mail Log</a>
 		<a href="/admin/moderate">Moderation</a>
 		<a href="/admin/server">Server</a>

--- a/admin/console.go
+++ b/admin/console.go
@@ -92,30 +92,28 @@ func InviteHandler(w http.ResponseWriter, r *http.Request) {
 	if len(requests) == 0 {
 		sb.WriteString(`<p class="text-muted">No requests yet.</p>`)
 	} else {
-		sb.WriteString(`<table class="admin-table"><thead><tr><th>Email</th><th>Reason</th><th>When</th><th>Status</th><th class="center">Actions</th></tr></thead><tbody>`)
 		for _, req := range requests {
-			reason := req.Reason
-			if reason == "" {
-				reason = `<span class="text-muted">—</span>`
+			reason := ""
+			if req.Reason != "" {
+				reason = fmt.Sprintf(`<p style="font-size:13px;color:#666;margin:4px 0">%s</p>`, req.Reason)
 			}
-			status := `pending`
+			status := `<span style="color:#c90;font-size:12px">pending</span>`
 			if req.Invited {
-				status = fmt.Sprintf(`invited %s`, req.InvitedAt.Format("2 Jan"))
+				status = fmt.Sprintf(`<span style="color:#22c55e;font-size:12px">invited %s</span>`, req.InvitedAt.Format("2 Jan"))
 			}
 			actions := ""
 			if !req.Invited {
 				actions = fmt.Sprintf(
-					`<form method="POST" class="d-inline"><input type="hidden" name="email" value="%s"><button type="submit" style="font-size:12px;padding:2px 8px;border-radius:4px;border:1px solid #22c55e;background:#fff;color:#22c55e;cursor:pointer">Send invite</button></form> <form method="POST" class="d-inline" onsubmit="return confirm('Reject %s?')"><input type="hidden" name="action" value="reject"><input type="hidden" name="email" value="%s"><button type="submit" class="btn-danger" style="font-size:12px;padding:2px 8px">Reject</button></form>`,
-					req.Email, req.Email, req.Email)
+					`<div style="display:flex;gap:6px;margin-top:6px"><form method="POST"><input type="hidden" name="email" value="%s"><button type="submit" style="font-size:12px;padding:4px 10px;border-radius:4px;border:1px solid #22c55e;background:#fff;color:#22c55e;cursor:pointer">Send invite</button></form><form method="POST" onsubmit="return confirm('Reject?')"><input type="hidden" name="action" value="reject"><input type="hidden" name="email" value="%s"><button type="submit" style="font-size:12px;padding:4px 10px;border-radius:4px;border:1px solid #c00;background:#fff;color:#c00;cursor:pointer">Reject</button></form></div>`,
+					req.Email, req.Email)
 			} else {
 				actions = fmt.Sprintf(
-					`<form method="POST" class="d-inline" onsubmit="return confirm('Resend invite to %s?')"><input type="hidden" name="email" value="%s"><button type="submit" style="font-size:12px;padding:2px 8px">Resend</button></form>`,
-					req.Email, req.Email)
+					`<div style="margin-top:6px"><form method="POST" onsubmit="return confirm('Resend?')"><input type="hidden" name="email" value="%s"><button type="submit" style="font-size:12px;padding:4px 10px">Resend</button></form></div>`,
+					req.Email)
 			}
-			sb.WriteString(fmt.Sprintf(`<tr><td><strong>%s</strong></td><td style="max-width:300px">%s</td><td class="text-muted text-sm">%s</td><td>%s</td><td class="center">%s</td></tr>`,
-				req.Email, reason, req.RequestedAt.Format("2 Jan 15:04"), status, actions))
+			sb.WriteString(fmt.Sprintf(`<div style="padding:10px 0;border-bottom:1px solid #f0f0f0"><div style="display:flex;align-items:baseline;gap:8px;flex-wrap:wrap"><strong style="font-size:14px">%s</strong>%s<span style="color:#bbb;font-size:12px">%s</span></div>%s%s</div>`,
+				req.Email, status, req.RequestedAt.Format("2 Jan 15:04"), reason, actions))
 		}
-		sb.WriteString(`</tbody></table>`)
 	}
 	sb.WriteString(`</div>`)
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -574,13 +574,14 @@ func InviteHandler(w http.ResponseWriter, r *http.Request) {
 		body := fmt.Sprintf(`<div class="card">
 <h4>Invite sent</h4>
 <p>Invite sent to <strong>%s</strong></p>
-<p><a href="/invite">Invite another →</a> · <a href="/home">Home →</a></p>
+<p><a href="/invite">Invite another</a> · <a href="/home">Home</a></p>
 </div>`, htmlpkg.EscapeString(email))
 		w.Write([]byte(RenderHTML("Invite Sent", "Invite sent", body)))
 		return
 	}
 
-	body := `<div class="card">
+	body := `<p><a href="/home">← Home</a></p>
+<div class="card">
 <h4>Invite someone to Mu</h4>
 <p class="text-sm">Enter their email — they'll get a signup link.</p>
 <form method="POST" action="/invite" style="margin-top:8px">


### PR DESCRIPTION
/invite page: added '← Home' back link at top.

/admin/invite: replaced table with stacked card layout — each request is a row with email, status badge, timestamp, optional reason, and action buttons. Wraps naturally on mobile instead of squishing columns off-screen.

Admin dashboard: added 'Invites' link to the admin links grid.

Back links: /invite → /home, /admin/invite → /admin (via existing ← Admin link).