### PR TITLE
Remove reminder from card prefs, redirect home gear back to home

### DIFF
--- a/home/home.go
+++ b/home/home.go
@@ -386,7 +386,7 @@ function fetchW(la,lo){
 	// Inline card preferences panel
 	if viewerAcc != nil {
 		allCardDefs := []struct{ id, label string }{
-			{"reminder", "Reminder"}, {"blog", "Blog"}, {"news", "News"},
+			{"blog", "Blog"}, {"news", "News"},
 			{"markets", "Markets"}, {"social", "Social"}, {"video", "Video"},
 		}
 		activeSet := map[string]bool{}

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -922,7 +922,13 @@ func Account(w http.ResponseWriter, r *http.Request) {
 			selected := r.Form["cards"]
 			acc.HomeCards = selected
 			auth.UpdateAccount(acc)
-			http.Redirect(w, r, "/account", http.StatusSeeOther)
+			// Redirect back to where the form was submitted from.
+			ref := r.Header.Get("Referer")
+			if ref != "" && (strings.Contains(ref, "/home") || strings.HasSuffix(ref, "/")) {
+				http.Redirect(w, r, "/home", http.StatusSeeOther)
+			} else {
+				http.Redirect(w, r, "/account", http.StatusSeeOther)
+			}
 			return
 		}
 
@@ -955,7 +961,7 @@ func Account(w http.ResponseWriter, r *http.Request) {
 
 	// Home card preferences
 	allCards := []struct{ id, label string }{
-		{"reminder", "Reminder"}, {"blog", "Blog"}, {"news", "News"},
+		{"blog", "Blog"}, {"news", "News"},
 		{"markets", "Markets"}, {"social", "Social"}, {"video", "Video"},
 	}
 	activeCards := map[string]bool{}


### PR DESCRIPTION
Reminder was still listed in the card preference checkboxes on both the home page gear panel and /account, but since it's no longer in cards.json, toggling it did nothing. Removed from both lists.

Home page card settings now redirects back to /home (was always going to /account). Checks referer — if submitted from /home, returns to /home; otherwise /account.