### PR TITLE
Delete all user data when account is deleted

### DIFF
--- a/apps/apps.go
+++ b/apps/apps.go
@@ -1820,3 +1820,15 @@ const sdkJS = `// Mu App SDK
   });
 })();
 `
+
+// DeleteAppsByAuthor removes all apps by a user.
+func DeleteAppsByAuthor(authorID string) {
+	mutex.Lock()
+	for slug, a := range apps {
+		if a.AuthorID == authorID {
+			delete(apps, slug)
+		}
+	}
+	mutex.Unlock()
+	save()
+}

--- a/blog/blog.go
+++ b/blog/blog.go
@@ -1787,3 +1787,33 @@ func CommentHandler(w http.ResponseWriter, r *http.Request) {
 	// Redirect back to the post
 	http.Redirect(w, r, "/blog/post?id="+postID, http.StatusSeeOther)
 }
+
+// DeletePostsByAuthor removes all posts and comments by a user.
+// Called when an account is deleted.
+func DeletePostsByAuthor(authorID string) {
+	mutex.Lock()
+	var kept []*Post
+	for _, p := range posts {
+		if p.AuthorID != authorID {
+			kept = append(kept, p)
+		}
+	}
+	posts = kept
+	postsMap = make(map[string]*Post)
+	for _, p := range posts {
+		postsMap[p.ID] = p
+	}
+	// Remove comments by this author.
+	var keptComments []*Comment
+	for _, c := range comments {
+		if c.AuthorID != authorID {
+			keptComments = append(keptComments, c)
+		}
+	}
+	comments = keptComments
+	populateComments()
+	updateCache()
+	mutex.Unlock()
+	save()
+	data.SaveJSON("comments.json", comments)
+}

--- a/internal/app/prefs.go
+++ b/internal/app/prefs.go
@@ -146,3 +146,11 @@ func GetBlockedUsers(userID string) map[string]time.Time {
 	}
 	return p.Blocked
 }
+
+// ClearUserPrefs removes all preferences for a deleted user.
+func ClearUserPrefs(userID string) {
+	prefsMu.Lock()
+	defer prefsMu.Unlock()
+	delete(prefs, userID)
+	savePrefs()
+}

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -159,6 +159,11 @@ func GetAccountByName(name string) (*Account, error) {
 	return nil, errors.New("account not found")
 }
 
+// AccountDeleteHooks are called when an account is deleted. Each
+// building block registers a hook to clean up its own data. This
+// avoids auth importing every other package.
+var AccountDeleteHooks []func(accountID string)
+
 func DeleteAccount(id string) error {
 	mutex.Lock()
 	defer mutex.Unlock()
@@ -169,15 +174,30 @@ func DeleteAccount(id string) error {
 
 	delete(accounts, id)
 
-	// Also delete any sessions for this account
+	// Delete sessions for this account.
 	for sid, sess := range sessions {
 		if sess.Account == id {
 			delete(sessions, sid)
 		}
 	}
 
+	// Delete PATs for this account.
+	for tid, tok := range tokens {
+		if tok.Account == id {
+			delete(tokens, tid)
+		}
+	}
+
 	data.SaveJSON("accounts.json", accounts)
 	data.SaveJSON("sessions.json", sessions)
+	data.SaveJSON("tokens.json", tokens)
+
+	// Run all registered cleanup hooks outside the lock.
+	go func() {
+		for _, hook := range AccountDeleteHooks {
+			hook(id)
+		}
+	}()
 
 	return nil
 }

--- a/mail/mail.go
+++ b/mail/mail.go
@@ -1922,3 +1922,12 @@ func GetRecentMessages(limit int) []*Message {
 	copy(result, messages[:limit])
 	return result
 }
+
+// DeleteInbox removes all mail for a user.
+func DeleteInbox(userID string) {
+	mutex.Lock()
+	delete(inboxes, userID)
+	mutex.Unlock()
+	// Re-save all mail data.
+	save()
+}

--- a/main.go
+++ b/main.go
@@ -254,6 +254,18 @@ func main() {
 	admin.GetNewAccountBlog = blog.GetNewAccountBlogPosts
 	admin.RefreshBlogCache = blog.RefreshCache
 
+	// Register account deletion hooks — each package cleans up its own data.
+	auth.AccountDeleteHooks = append(auth.AccountDeleteHooks,
+		blog.DeletePostsByAuthor,
+		social.DeleteByAuthor,
+		apps.DeleteAppsByAuthor,
+		stream.ClearByAuthor,
+		user.ClearStatusHistory,
+		mail.DeleteInbox,
+		func(id string) { wallet.DeleteWallet(id) },
+		func(id string) { app.ClearUserPrefs(id) },
+	)
+
 	// Enable indexing after all content is loaded
 	// This allows the priority queue to process new items first
 	data.StartIndexing()

--- a/social/social.go
+++ b/social/social.go
@@ -1236,3 +1236,18 @@ func FetchExternalPost(rawURL string) (*Message, error) {
 		PostedAt: time.Now(),
 	}, nil
 }
+
+// DeleteByAuthor removes all messages by a user.
+func DeleteByAuthor(authorID string) {
+	mutex.Lock()
+	var kept []*Message
+	for _, m := range messages {
+		if m.AuthorID != authorID {
+			kept = append(kept, m)
+		}
+	}
+	messages = kept
+	updateCacheLocked()
+	mutex.Unlock()
+	save()
+}

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -752,3 +752,13 @@ func FormatCredits(credits int) string {
 	pence := credits % 100
 	return fmt.Sprintf("£%d.%02d", pounds, pence)
 }
+
+// DeleteWallet removes a user's wallet and transaction history.
+func DeleteWallet(userID string) {
+	mutex.Lock()
+	defer mutex.Unlock()
+	delete(wallets, userID)
+	delete(transactions, userID)
+	data.SaveJSON("wallets.json", wallets)
+	data.SaveJSON("transactions.json", transactions)
+}


### PR DESCRIPTION
Previously only the account and sessions were removed. Now DeleteAccount runs cleanup hooks that each package registers:

- Blog: delete all posts + comments by author
- Social: delete all messages by author
- Apps: delete all apps by author
- Stream: clear all events by author
- User: clear profile + status history
- Mail: delete entire inbox
- Wallet: delete wallet + transaction history
- Prefs: clear saved/blocked/dismissed items

Hooks run asynchronously after the account is deleted. Also deletes PATs for the account.

Prevents the privacy issue where a deleted user's content remains and a new user with the same username inherits it.

https://claude.ai/code/session_01GRGLA9yj7BpqKiyi6xFwnm