### PR TITLE
Fix deadlock in DeletePostsByAuthor — was calling updateCache while h…

### DIFF
--- a/blog/blog.go
+++ b/blog/blog.go
@@ -1803,7 +1803,6 @@ func DeletePostsByAuthor(authorID string) {
 	for _, p := range posts {
 		postsMap[p.ID] = p
 	}
-	// Remove comments by this author.
 	var keptComments []*Comment
 	for _, c := range comments {
 		if c.AuthorID != authorID {
@@ -1812,8 +1811,9 @@ func DeletePostsByAuthor(authorID string) {
 	}
 	comments = keptComments
 	populateComments()
-	updateCache()
+	updateCacheUnlocked()
 	mutex.Unlock()
 	save()
 	data.SaveJSON("comments.json", comments)
+	event.Publish(event.Event{Type: "blog_updated"})
 }


### PR DESCRIPTION
…olding lock

updateCache() takes mutex.Lock(). DeletePostsByAuthor already held mutex.Lock(). Deadlock. Every page that renders blog content hung forever. Changed to updateCacheUnlocked() which expects the caller to hold the lock.