### PR TITLE
Remove all mu.xyz references — domain being shut down

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Below the AI, cards give you an at-a-glance overview of everything: news headlin
 - **Apps** — Build and use small, useful tools — any app can be pinned as a home card
 - **Stream** — Public event feed for agents and tools to subscribe to
 
-Runs as a single Go binary. Self-host or use [mu.xyz](https://mu.xyz).
+Runs as a single Go binary. Self-host your own instance.
 
 ## For developers
 
@@ -40,7 +40,7 @@ Mu exposes a REST API and [MCP](https://modelcontextprotocol.io) server at `/mcp
 {
   "mcpServers": {
     "mu": {
-      "url": "https://mu.xyz/mcp"
+      "url": "https://your-instance.com/mcp"
     }
   }
 }
@@ -48,7 +48,7 @@ Mu exposes a REST API and [MCP](https://modelcontextprotocol.io) server at `/mcp
 
 30+ tools — news, search, weather, places, video, email, markets — accessible via MCP. AI agents can pay per-request with USDC through the [x402 protocol](https://x402.org). No API keys. No accounts. Just call and pay. First 10 calls per wallet are free.
 
-See [API docs](https://mu.xyz/api) · [MCP docs](docs/MCP.md)
+See [MCP docs](docs/MCP.md)
 
 ## CLI
 
@@ -122,7 +122,7 @@ See [Environment Variables](docs/ENVIRONMENT_VARIABLES.md) for all options.
 
 ## Documentation
 
-Full docs at [mu.xyz/docs](https://mu.xyz/docs) or in the [docs](docs/) folder.
+Full docs in the [docs](docs/) folder.
 
 ## License
 

--- a/blog/activitypub.go
+++ b/blog/activitypub.go
@@ -24,7 +24,7 @@ func APDomain() string {
 	return "localhost"
 }
 
-// apBaseURL returns the base URL for the instance (e.g. "https://mu.xyz").
+// apBaseURL returns the base URL for the instance (e.g. "https://your-instance.com").
 func apBaseURL() string {
 	d := APDomain()
 	if d == "localhost" {

--- a/blog/activitypub_test.go
+++ b/blog/activitypub_test.go
@@ -45,8 +45,8 @@ func TestAPBaseURL(t *testing.T) {
 	defer os.Setenv("MU_DOMAIN", origMU)
 
 	os.Setenv("MU_DOMAIN", "mu.xyz")
-	if got := apBaseURL(); got != "https://mu.xyz" {
-		t.Errorf("apBaseURL() = %q, want %q", got, "https://mu.xyz")
+	if got := apBaseURL(); got != "https://your-instance.com" {
+		t.Errorf("apBaseURL() = %q, want %q", got, "https://your-instance.com")
 	}
 
 	os.Setenv("MU_DOMAIN", "localhost")
@@ -164,17 +164,17 @@ func TestPostToObject(t *testing.T) {
 		Name: "Alice",
 	}
 
-	obj := postToObject("https://mu.xyz", acc, post)
+	obj := postToObject("https://your-instance.com", acc, post)
 
 	// Check basic fields
 	if obj["type"] != "Note" {
 		t.Errorf("type = %v, want Note", obj["type"])
 	}
-	if obj["id"] != "https://mu.xyz/blog/post?id=123" {
-		t.Errorf("id = %v, want https://mu.xyz/blog/post?id=123", obj["id"])
+	if obj["id"] != "https://your-instance.com/blog/post?id=123" {
+		t.Errorf("id = %v, want https://your-instance.com/blog/post?id=123", obj["id"])
 	}
-	if obj["attributedTo"] != "https://mu.xyz/@alice" {
-		t.Errorf("attributedTo = %v, want https://mu.xyz/@alice", obj["attributedTo"])
+	if obj["attributedTo"] != "https://your-instance.com/@alice" {
+		t.Errorf("attributedTo = %v, want https://your-instance.com/@alice", obj["attributedTo"])
 	}
 	if obj["name"] != "Test Post" {
 		t.Errorf("name = %v, want Test Post", obj["name"])
@@ -215,7 +215,7 @@ func TestPostToObject_NoTitle(t *testing.T) {
 	}
 	acc := &auth.Account{ID: "bob", Name: "Bob"}
 
-	obj := postToObject("https://mu.xyz", acc, post)
+	obj := postToObject("https://your-instance.com", acc, post)
 
 	if _, hasName := obj["name"]; hasName {
 		t.Error("name should not be set for posts without title")

--- a/cli/config.go
+++ b/cli/config.go
@@ -16,7 +16,7 @@ import (
 )
 
 // DefaultURL is used when nothing else is configured.
-const DefaultURL = "https://mu.xyz"
+const DefaultURL = "http://localhost:8080"
 
 // Config is the on-disk configuration loaded from
 // $XDG_CONFIG_HOME/mu/config.json (or ~/.config/mu/config.json).

--- a/cli/config_test.go
+++ b/cli/config_test.go
@@ -87,7 +87,7 @@ func TestSaveAndLoadConfig(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", dir)
 
-	want := &Config{URL: "https://mu.xyz", Token: "tok123"}
+	want := &Config{URL: "https://your-instance.com", Token: "tok123"}
 	if err := SaveConfig(want); err != nil {
 		t.Fatalf("save: %v", err)
 	}

--- a/cli/help.go
+++ b/cli/help.go
@@ -34,7 +34,7 @@ MANAGEMENT
   mu help [tool]                 Full tool list, or help for a tool
 
 FLAGS (any command)
-  --url URL        Mu instance URL (env: MU_URL, default: https://mu.xyz)
+  --url URL        Mu instance URL (env: MU_URL, default: https://your-instance.com)
   --token TOKEN    Session or PAT token (env: MU_TOKEN)
   --pretty         Force pretty-printed output
   --raw            Force raw JSON output

--- a/docs/ABOUT.md
+++ b/docs/ABOUT.md
@@ -46,7 +46,7 @@ Below the AI, cards give you an at-a-glance overview. Cards are configurable —
 
 ## Technology
 
-Mu runs as a single Go binary. Self-host on your own server or use [mu.xyz](https://mu.xyz). Open source under AGPL-3.0.
+Mu runs as a single Go binary. Self-host on your own server. Open source under AGPL-3.0.
 
 Supports Anthropic Claude, Atlas Cloud (DeepSeek, Qwen), or local models via any OpenAI-compatible API (Ollama, vLLM, llama.cpp).
 
@@ -54,4 +54,4 @@ When you pay for tools, incentives are aligned. We build the tools, you use them
 
 ---
 
-**Get started** at [mu.xyz](https://mu.xyz) or read our [Principles](/docs/principles).
+**Get started** at [github.com/micro/mu](https://github.com/micro/mu)

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -71,7 +71,7 @@ Clears the stored token. Env vars and `--token` flag overrides are unaffected.
 
 ## Pointing at a different instance
 
-By default the CLI talks to `https://mu.xyz`. To point at your own self-hosted instance:
+By default the CLI talks to `https://your-instance.com`. To point at your own self-hosted instance:
 
 ```bash
 # Persistent
@@ -148,7 +148,7 @@ These can appear before or after the tool name:
 
 | Flag              | Purpose                                                  |
 |-------------------|----------------------------------------------------------|
-| `--url URL`       | Mu instance URL (env: `MU_URL`, default: `https://mu.xyz`) |
+| `--url URL`       | Mu instance URL (env: `MU_URL`, default: `https://your-instance.com`) |
 | `--token TOKEN`   | Session or PAT token (env: `MU_TOKEN`)                   |
 | `--pretty`        | Force pretty-printed output                              |
 | `--raw`           | Force raw/compact JSON output                            |

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -169,7 +169,7 @@ If you use passkeys, add the .onion origin so WebAuthn works on both domains:
 export PASSKEY_EXTRA_ORIGINS="http://your-onion-address.onion"
 ```
 
-Note: Passkeys registered on `mu.xyz` won't work on the `.onion` address (WebAuthn spec limitation). Users can register separate passkeys for each origin, or use password login over Tor.
+Note: Passkeys registered on `your-instance` won't work on the `.onion` address (WebAuthn spec limitation). Users can register separate passkeys for each origin, or use password login over Tor.
 
 ### 4. Nginx for .onion (optional)
 

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -19,7 +19,7 @@ When x402 is enabled on the server (`X402_PAY_TO` is set), any metered tool call
 **1. Call a tool without payment:**
 
 ```bash
-curl -X POST https://mu.xyz/mcp \
+curl -X POST https://your-instance.com/mcp \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"web_search","arguments":{"query":"latest AI news"}}}'
 ```
@@ -48,7 +48,7 @@ X-PAYMENT-REQUIRED: eyJzY2hlbWUiOiJleGFjdCIsIm5ldHdvcmsi...
 **3. Agent pays on-chain and retries with payment proof:**
 
 ```bash
-curl -X POST https://mu.xyz/mcp \
+curl -X POST https://your-instance.com/mcp \
   -H "Content-Type: application/json" \
   -H "X-PAYMENT: <base64-encoded-payment-payload>" \
   -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"web_search","arguments":{"query":"latest AI news"}}}'
@@ -87,7 +87,7 @@ For human users or agents that prefer account-based billing, authenticate with a
 {
   "mcpServers": {
     "mu": {
-      "url": "https://mu.xyz/mcp",
+      "url": "https://your-instance.com/mcp",
       "headers": {
         "Authorization": "Bearer YOUR_TOKEN"
       }
@@ -101,7 +101,7 @@ Replace `YOUR_TOKEN` with a session token from the `login` tool or a Personal Ac
 ### Sign Up
 
 ```bash
-curl -X POST https://mu.xyz/mcp \
+curl -X POST https://your-instance.com/mcp \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"signup","arguments":{"id":"myagent","secret":"password123","name":"My Agent"}}}'
 ```
@@ -109,7 +109,7 @@ curl -X POST https://mu.xyz/mcp \
 ### Log In
 
 ```bash
-curl -X POST https://mu.xyz/mcp \
+curl -X POST https://your-instance.com/mcp \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"login","arguments":{"id":"myagent","secret":"password123"}}}'
 ```
@@ -172,7 +172,7 @@ The MCP server uses the Streamable HTTP transport. Clients send JSON-RPC 2.0 req
 ### Initialize
 
 ```bash
-curl -X POST https://mu.xyz/mcp \
+curl -X POST https://your-instance.com/mcp \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","clientInfo":{"name":"example","version":"1.0"},"capabilities":{}}}'
 ```
@@ -180,7 +180,7 @@ curl -X POST https://mu.xyz/mcp \
 ### List Tools
 
 ```bash
-curl -X POST https://mu.xyz/mcp \
+curl -X POST https://your-instance.com/mcp \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc":"2.0","id":2,"method":"tools/list"}'
 ```
@@ -190,7 +190,7 @@ curl -X POST https://mu.xyz/mcp \
 With x402 payment:
 
 ```bash
-curl -X POST https://mu.xyz/mcp \
+curl -X POST https://your-instance.com/mcp \
   -H "Content-Type: application/json" \
   -H "X-PAYMENT: <payment-payload>" \
   -d '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"web_search","arguments":{"query":"latest news"}}}'
@@ -199,7 +199,7 @@ curl -X POST https://mu.xyz/mcp \
 With account token:
 
 ```bash
-curl -X POST https://mu.xyz/mcp \
+curl -X POST https://your-instance.com/mcp \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer YOUR_TOKEN" \
   -d '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"news","arguments":{}}}'

--- a/docs/SYSTEM_DESIGN.md
+++ b/docs/SYSTEM_DESIGN.md
@@ -327,6 +327,6 @@ All user-configurable data lives in JSON files (embedded at build time):
 
 ## Economic Model
 
-Users can self-host or use the hosted version at mu.xyz. Browsing is included. Searching, posting,
+Users can self-host or use a hosted instance. Browsing is included. Searching, posting,
 and AI features use credits. Pay as you go at 1 credit = 1p, top up from £5.
 This supports development while keeping the platform accessible.

--- a/docs/VISION.md
+++ b/docs/VISION.md
@@ -30,7 +30,7 @@ Technology should serve people — not use them. When you pay for tools, incenti
 
 **No ads, no tracking.** Revenue comes from usage credits, not attention.
 
-**Single binary.** One Go binary, no external dependencies. Self-host or use [mu.xyz](https://mu.xyz).
+**Single binary.** One Go binary, no external dependencies. Self-host your own instance.
 
 **Local models.** Self-hosters can use Ollama or any OpenAI-compatible server. No cloud dependency required.
 
@@ -58,7 +58,7 @@ Every service is available via REST API and MCP. Connect Claude Desktop, Cursor,
 {
   "mcpServers": {
     "mu": {
-      "url": "https://mu.xyz/mcp"
+      "url": "https://your-instance.com/mcp"
     }
   }
 }

--- a/docs/WHITEPAPER.md
+++ b/docs/WHITEPAPER.md
@@ -2,9 +2,9 @@
 
 Asim Aslam
 
-asim@mu.xyz
+asim@aslam.me
 
-mu.xyz
+github.com/micro/mu
 
 **Abstract.** The dominant model for internet services relies on advertising revenue, which creates a structural incentive to maximise user engagement rather than user utility. We propose Mu, a unified network of composable services — including news aggregation, web search, messaging, financial data, weather, location services, and AI — accessible through a single protocol endpoint and funded by direct per-use micropayments rather than advertising. Services are exposed via the Model Context Protocol (MCP), a JSON-RPC 2.0 interface that serves both human users and autonomous AI agents. Payments are handled through two complementary mechanisms: traditional card payments for account-holding users, and the x402 HTTP payment protocol for account-free, per-request settlement using on-chain stablecoins. The system is implemented as a single self-hostable binary. We describe the architecture, the credit-based economic model, the payment protocols, a mechanism for peer-to-peer credit transfer, and a path toward a federated network of nodes sharing a common settlement layer.
 

--- a/mail/inbound_filter.go
+++ b/mail/inbound_filter.go
@@ -149,7 +149,7 @@ var domainWhitelist = map[string]bool{
 	// Email infrastructure (DMARC reports, etc.)
 	"dmarc.yahoo.com": true,
 	// Mu
-	"mu.xyz": true, "micro.mu": true, "reminder.dev": true,
+	"micro.mu": true, "reminder.dev": true,
 }
 
 // Custom whitelist additions (persisted, managed by admin).

--- a/places/city.go
+++ b/places/city.go
@@ -153,7 +153,7 @@ out center;`, radiusM, lat, lon, radiusM, lat, lon, radiusM, lat, lon, radiusM, 
 		return nil, err
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	req.Header.Set("User-Agent", "Mu/1.0 (https://mu.xyz)")
+	req.Header.Set("User-Agent", "Mu/1.0 (https://your-instance.com)")
 
 	resp, err := client.Do(req)
 	if err != nil {
@@ -283,7 +283,7 @@ out center;`, safe, radiusM, lat, lon, safe, radiusM, lat, lon)
 		return nil, err
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	req.Header.Set("User-Agent", "Mu/1.0 (https://mu.xyz)")
+	req.Header.Set("User-Agent", "Mu/1.0 (https://your-instance.com)")
 
 	resp, err := httpClient.Do(req)
 	if err != nil {

--- a/places/places.go
+++ b/places/places.go
@@ -126,7 +126,7 @@ func searchNominatim(query string) ([]*Place, error) {
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Set("User-Agent", "Mu/1.0 (https://mu.xyz)")
+	req.Header.Set("User-Agent", "Mu/1.0 (https://your-instance.com)")
 
 	resp, err := httpClient.Do(req)
 	if err != nil {

--- a/wallet/handlers.go
+++ b/wallet/handlers.go
@@ -618,7 +618,7 @@ func handleStripeCheckout(w http.ResponseWriter, r *http.Request) {
 		baseURL = "https://" + fwdHost
 	} else {
 		scheme := "https"
-		if r.TLS == nil && !strings.Contains(r.Host, "mu.xyz") {
+		if r.TLS == nil && r.Header.Get("X-Forwarded-Proto") != "https" {
 			scheme = "http"
 		}
 		baseURL = fmt.Sprintf("%s://%s", scheme, r.Host)


### PR DESCRIPTION
Replaced all mu.xyz URLs in docs, code, and config with either generic placeholders (your-instance.com) or github.com/micro/mu.

- README: self-host only, no hosted instance reference
- MCP docs: all curl examples use your-instance.com
- CLI: default URL changed to http://localhost:8080
- Mail whitelist: removed mu.xyz, kept micro.mu
- Wallet: scheme detection uses X-Forwarded-Proto instead of hardcoded mu.xyz hostname check
- ABOUT/VISION/WHITEPAPER: github.com/micro/mu links
- INSTALLATION: generic hostname

Test files still reference mu.xyz as test fixtures — harmless.