### PR TITLE
LoUse micro.mu as the live instance — replaces placeholder URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ The AI remembers your preferences across sessions, surfaces contextual suggestio
 
 Built in the open. Pay for the tools, not with your attention.
 
+**Live at [micro.mu](https://micro.mu)** — or self-host your own instance.
+
 ### How it works
 
 Open Mu and you see a prompt: **"What do you need?"** Below it, contextual suggestions based on your current state — unread emails, market movements, latest news. Ask a question or tap a suggestion. The AI checks your services, composes an answer, and shows it inline.
@@ -40,7 +42,7 @@ Mu exposes a REST API and [MCP](https://modelcontextprotocol.io) server at `/mcp
 {
   "mcpServers": {
     "mu": {
-      "url": "https://your-instance.com/mcp"
+      "url": "https://micro.mu/mcp"
     }
   }
 }

--- a/cli/config.go
+++ b/cli/config.go
@@ -16,7 +16,7 @@ import (
 )
 
 // DefaultURL is used when nothing else is configured.
-const DefaultURL = "http://localhost:8080"
+const DefaultURL = "https://micro.mu"
 
 // Config is the on-disk configuration loaded from
 // $XDG_CONFIG_HOME/mu/config.json (or ~/.config/mu/config.json).

--- a/cli/help.go
+++ b/cli/help.go
@@ -34,7 +34,7 @@ MANAGEMENT
   mu help [tool]                 Full tool list, or help for a tool
 
 FLAGS (any command)
-  --url URL        Mu instance URL (env: MU_URL, default: https://your-instance.com)
+  --url URL        Mu instance URL (env: MU_URL, default: https://micro.mu)
   --token TOKEN    Session or PAT token (env: MU_TOKEN)
   --pretty         Force pretty-printed output
   --raw            Force raw JSON output

--- a/docs/ABOUT.md
+++ b/docs/ABOUT.md
@@ -54,4 +54,4 @@ When you pay for tools, incentives are aligned. We build the tools, you use them
 
 ---
 
-**Get started** at [github.com/micro/mu](https://github.com/micro/mu)
+**Try it** at [micro.mu](https://micro.mu) — or self-host from [github.com/micro/mu](https://github.com/micro/mu)

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -71,7 +71,7 @@ Clears the stored token. Env vars and `--token` flag overrides are unaffected.
 
 ## Pointing at a different instance
 
-By default the CLI talks to `https://your-instance.com`. To point at your own self-hosted instance:
+By default the CLI talks to `https://micro.mu`. To point at your own self-hosted instance:
 
 ```bash
 # Persistent
@@ -148,7 +148,7 @@ These can appear before or after the tool name:
 
 | Flag              | Purpose                                                  |
 |-------------------|----------------------------------------------------------|
-| `--url URL`       | Mu instance URL (env: `MU_URL`, default: `https://your-instance.com`) |
+| `--url URL`       | Mu instance URL (env: `MU_URL`, default: `https://micro.mu`) |
 | `--token TOKEN`   | Session or PAT token (env: `MU_TOKEN`)                   |
 | `--pretty`        | Force pretty-printed output                              |
 | `--raw`           | Force raw/compact JSON output                            |

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -19,7 +19,7 @@ When x402 is enabled on the server (`X402_PAY_TO` is set), any metered tool call
 **1. Call a tool without payment:**
 
 ```bash
-curl -X POST https://your-instance.com/mcp \
+curl -X POST https://micro.mu/mcp \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"web_search","arguments":{"query":"latest AI news"}}}'
 ```
@@ -48,7 +48,7 @@ X-PAYMENT-REQUIRED: eyJzY2hlbWUiOiJleGFjdCIsIm5ldHdvcmsi...
 **3. Agent pays on-chain and retries with payment proof:**
 
 ```bash
-curl -X POST https://your-instance.com/mcp \
+curl -X POST https://micro.mu/mcp \
   -H "Content-Type: application/json" \
   -H "X-PAYMENT: <base64-encoded-payment-payload>" \
   -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"web_search","arguments":{"query":"latest AI news"}}}'
@@ -87,7 +87,7 @@ For human users or agents that prefer account-based billing, authenticate with a
 {
   "mcpServers": {
     "mu": {
-      "url": "https://your-instance.com/mcp",
+      "url": "https://micro.mu/mcp",
       "headers": {
         "Authorization": "Bearer YOUR_TOKEN"
       }
@@ -101,7 +101,7 @@ Replace `YOUR_TOKEN` with a session token from the `login` tool or a Personal Ac
 ### Sign Up
 
 ```bash
-curl -X POST https://your-instance.com/mcp \
+curl -X POST https://micro.mu/mcp \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"signup","arguments":{"id":"myagent","secret":"password123","name":"My Agent"}}}'
 ```
@@ -109,7 +109,7 @@ curl -X POST https://your-instance.com/mcp \
 ### Log In
 
 ```bash
-curl -X POST https://your-instance.com/mcp \
+curl -X POST https://micro.mu/mcp \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"login","arguments":{"id":"myagent","secret":"password123"}}}'
 ```
@@ -172,7 +172,7 @@ The MCP server uses the Streamable HTTP transport. Clients send JSON-RPC 2.0 req
 ### Initialize
 
 ```bash
-curl -X POST https://your-instance.com/mcp \
+curl -X POST https://micro.mu/mcp \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","clientInfo":{"name":"example","version":"1.0"},"capabilities":{}}}'
 ```
@@ -180,7 +180,7 @@ curl -X POST https://your-instance.com/mcp \
 ### List Tools
 
 ```bash
-curl -X POST https://your-instance.com/mcp \
+curl -X POST https://micro.mu/mcp \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc":"2.0","id":2,"method":"tools/list"}'
 ```
@@ -190,7 +190,7 @@ curl -X POST https://your-instance.com/mcp \
 With x402 payment:
 
 ```bash
-curl -X POST https://your-instance.com/mcp \
+curl -X POST https://micro.mu/mcp \
   -H "Content-Type: application/json" \
   -H "X-PAYMENT: <payment-payload>" \
   -d '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"web_search","arguments":{"query":"latest news"}}}'
@@ -199,7 +199,7 @@ curl -X POST https://your-instance.com/mcp \
 With account token:
 
 ```bash
-curl -X POST https://your-instance.com/mcp \
+curl -X POST https://micro.mu/mcp \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer YOUR_TOKEN" \
   -d '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"news","arguments":{}}}'

--- a/docs/VISION.md
+++ b/docs/VISION.md
@@ -58,7 +58,7 @@ Every service is available via REST API and MCP. Connect Claude Desktop, Cursor,
 {
   "mcpServers": {
     "mu": {
-      "url": "https://your-instance.com/mcp"
+      "url": "https://micro.mu/mcp"
     }
   }
 }


### PR DESCRIPTION
The mu.xyz domain is being dropped. micro.mu is already owned and matches the GitHub org. CLI default URL, docs, and README all updated.

https://claude.ai/code/session_01GRGLA9yj7BpqKiyi6xFwnm