### PR TITLE
Replace broken Coinbase Onramp link with copy address button

### DIFF
--- a/trade/handlers.go
+++ b/trade/handlers.go
@@ -72,12 +72,10 @@ func handlePage(w http.ResponseWriter, r *http.Request) {
 		}
 		b.WriteString(fmt.Sprintf(`<p style="font-size:13px"><a href="https://basescan.org/address/%s" target="_blank" style="font-family:monospace;word-break:break-all">%s</a></p>`, wallet.Address, shortAddr))
 
-		// Fund wallet buttons
-		onrampURL := fmt.Sprintf(`https://pay.coinbase.com/buy/select-asset?addresses={"0x%s":["base"]}&assets=["ETH","USDC"]`, strings.TrimPrefix(wallet.Address, "0x"))
 		b.WriteString(`<div style="display:flex;gap:8px;margin-top:10px;flex-wrap:wrap">`)
-		b.WriteString(fmt.Sprintf(`<a href="%s" target="_blank" class="btn" style="font-size:13px;padding:6px 14px">Buy ETH</a>`, onrampURL))
-		b.WriteString(`<button onclick="copyAddr()" class="btn btn-secondary" style="font-size:13px;padding:6px 14px">Copy Address</button>`)
+		b.WriteString(`<button onclick="copyAddr()" class="btn" style="font-size:13px;padding:6px 14px">Copy Address</button>`)
 		b.WriteString(`</div>`)
+		b.WriteString(`<p style="font-size:12px;color:#888;margin-top:8px">Send ETH to this address to fund your wallet. Works from Coinbase, Binance, MetaMask, or any wallet.</p>`)
 		b.WriteString(fmt.Sprintf(`<script>function copyAddr(){navigator.clipboard.writeText('%s');var b=event.target;b.textContent='Copied!';setTimeout(function(){b.textContent='Copy Address'},1500)}</script>`, wallet.Address))
 
 		balances := GetBalances(wallet.Address)


### PR DESCRIPTION
Coinbase Onramp requires app registration and session tokens — can't link directly. Replaced with a simple Copy Address button and clear instructions to send from any wallet or exchange.

https://claude.ai/code/session_01GRGLA9yj7BpqKiyi6xFwnm