### PR TITLE
Add multi-chain support: Ethereum mainnet + Base

### DIFF
--- a/trade/handlers.go
+++ b/trade/handlers.go
@@ -65,12 +65,12 @@ func handlePage(w http.ResponseWriter, r *http.Request) {
 	} else {
 		// Wallet
 		b.WriteString(`<div class="card">`)
-		b.WriteString(`<h3>Wallet</h3>`)
+		b.WriteString(fmt.Sprintf(`<h3>Wallet <span style="font-size:12px;font-weight:400;color:#888">· %s</span></h3>`, ActiveChainName()))
 		shortAddr := wallet.Address
 		if len(shortAddr) > 10 {
 			shortAddr = shortAddr[:6] + "..." + shortAddr[len(shortAddr)-4:]
 		}
-		b.WriteString(fmt.Sprintf(`<p style="font-size:13px"><a href="https://basescan.org/address/%s" target="_blank" style="font-family:monospace;word-break:break-all">%s</a></p>`, wallet.Address, shortAddr))
+		b.WriteString(fmt.Sprintf(`<p style="font-size:13px"><a href="`+ChainExplorer()+`/address/%s" target="_blank" style="font-family:monospace;word-break:break-all">%s</a></p>`, wallet.Address, shortAddr))
 
 		b.WriteString(`<div style="display:flex;gap:8px;margin-top:10px;flex-wrap:wrap">`)
 		b.WriteString(`<button onclick="copyAddr()" class="btn" style="font-size:13px;padding:6px 14px">Copy Address</button>`)
@@ -217,7 +217,7 @@ func handlePage(w http.ResponseWriter, r *http.Request) {
 				b.WriteString(fmt.Sprintf(`<div style="display:flex;justify-content:space-between;align-items:center;padding:8px 0;border-bottom:1px solid #f0f0f0;font-size:14px">`))
 				b.WriteString(fmt.Sprintf(`<div><strong>%s → %s</strong><br><span style="font-size:12px;color:#888">%s</span></div>`, t.AmountIn, t.AmountOut, date))
 				if t.TxHash != "" {
-					b.WriteString(fmt.Sprintf(`<a href="https://basescan.org/tx/%s" target="_blank" style="color:%s;font-size:13px">%s</a>`, t.TxHash, statusColor, t.Status))
+					b.WriteString(fmt.Sprintf(`<a href="`+ChainExplorer()+`/tx/%s" target="_blank" style="color:%s;font-size:13px">%s</a>`, t.TxHash, statusColor, t.Status))
 				} else {
 					b.WriteString(fmt.Sprintf(`<span style="color:%s;font-size:13px">%s</span>`, statusColor, t.Status))
 				}

--- a/trade/swap.go
+++ b/trade/swap.go
@@ -52,12 +52,12 @@ func GetQuote(fromSymbol, toSymbol, amount string) (*Quote, error) {
 	fee := big.NewInt(3000) // 0.3% pool
 	callData := buildQuoteCalldata(fromAddr, toAddr, amountIn, fee)
 
-	result, err := ethCall(UniswapQuoterAddr, callData)
+	result, err := ethCall(UniswapQuoterAddr(), callData)
 	if err != nil {
 		// Try 0.05% pool (500) for stablecoin pairs
 		fee = big.NewInt(500)
 		callData = buildQuoteCalldata(fromAddr, toAddr, amountIn, fee)
-		result, err = ethCall(UniswapQuoterAddr, callData)
+		result, err = ethCall(UniswapQuoterAddr(), callData)
 		if err != nil {
 			return nil, fmt.Errorf("quote failed: %w", err)
 		}
@@ -168,7 +168,7 @@ func ExecuteSwap(accountID, fromSymbol, toSymbol, amount string) (*Trade, error)
 
 	// Step 1: Approve token if ERC20 (not native ETH)
 	if !from.Native {
-		if err := ensureApproval(w, from.Address, UniswapRouterAddr, amountIn); err != nil {
+		if err := ensureApproval(w, from.Address, UniswapRouterAddr(), amountIn); err != nil {
 			return nil, fmt.Errorf("approval failed: %w", err)
 		}
 	}
@@ -209,18 +209,18 @@ func ExecuteSwap(accountID, fromSymbol, toSymbol, amount string) (*Trade, error)
 		return nil, fmt.Errorf("get gas fees: %w", err)
 	}
 
-	gasLimit, err := estimateGas(w.Address, UniswapRouterAddr, txValue, callData)
+	gasLimit, err := estimateGas(w.Address, UniswapRouterAddr(), txValue, callData)
 	if err != nil {
 		return nil, fmt.Errorf("estimate gas: %w", err)
 	}
 
 	tx := &Transaction{
-		ChainID:              big.NewInt(BaseChainID),
+		ChainID:              big.NewInt(activeChain().ChainID),
 		Nonce:                nonce,
 		MaxPriorityFeePerGas: maxPriorityFee,
 		MaxFeePerGas:         maxFee,
 		GasLimit:             gasLimit,
-		To:                   UniswapRouterAddr,
+		To:                   UniswapRouterAddr(),
 		Value:                txValue,
 		Data:                 callData,
 	}
@@ -314,7 +314,7 @@ func ensureApproval(w *Wallet, tokenAddr, spender string, amount *big.Int) error
 	}
 
 	tx := &Transaction{
-		ChainID:              big.NewInt(BaseChainID),
+		ChainID:              big.NewInt(activeChain().ChainID),
 		Nonce:                nonce,
 		MaxPriorityFeePerGas: maxPriorityFee,
 		MaxFeePerGas:         maxFee,

--- a/trade/trade.go
+++ b/trade/trade.go
@@ -14,31 +14,76 @@ import (
 	"strings"
 	"sync"
 
+	"mu/internal/app"
 	"mu/internal/data"
 
 	"golang.org/x/crypto/sha3"
 )
 
-// Base chain constants.
-const (
-	BaseChainID = 8453
-	BaseRPCURL  = "https://mainnet.base.org"
-)
-
-// Well-known token addresses on Base.
-var Tokens = map[string]Token{
-	"ETH": {Symbol: "ETH", Name: "Ether", Decimals: 18, Address: "0x0000000000000000000000000000000000000000", Native: true},
-	"WETH": {Symbol: "WETH", Name: "Wrapped Ether", Decimals: 18, Address: "0x4200000000000000000000000000000000000006"},
-	"USDC": {Symbol: "USDC", Name: "USD Coin", Decimals: 6, Address: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"},
+// Chain configuration. Defaults to Ethereum mainnet.
+// Set TRADE_CHAIN=base for Base L2.
+type ChainConfig struct {
+	Name      string
+	ChainID   int64
+	RPCURL    string
+	WETH      string
+	USDC      string
+	Router    string
+	Quoter    string
+	Explorer  string
 }
 
+var chains = map[string]ChainConfig{
+	"ethereum": {
+		Name:     "Ethereum",
+		ChainID:  1,
+		RPCURL:   "https://eth.llamarpc.com",
+		WETH:     "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+		USDC:     "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+		Router:   "0xE592427A0AEce92De3Edee1F18E0157C05861564",
+		Quoter:   "0x61fFE014bA17989E743c5F6cB21bF9697530B21e",
+		Explorer: "https://etherscan.io",
+	},
+	"base": {
+		Name:     "Base",
+		ChainID:  8453,
+		RPCURL:   "https://mainnet.base.org",
+		WETH:     "0x4200000000000000000000000000000000000006",
+		USDC:     "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+		Router:   "0x2626664c2603336E57B271c5C0b26F421741e481",
+		Quoter:   "0x3d4e44Eb1374240CE5F1B871ab261CD16335B76a",
+		Explorer: "https://basescan.org",
+	},
+}
+
+func activeChain() ChainConfig {
+	name := os.Getenv("TRADE_CHAIN")
+	if name == "" {
+		name = "ethereum"
+	}
+	if c, ok := chains[name]; ok {
+		return c
+	}
+	return chains["ethereum"]
+}
+
+func ActiveChainName() string { return activeChain().Name }
+func ChainExplorer() string   { return activeChain().Explorer }
+
+var Tokens map[string]Token
 var tokenOrder = []string{"ETH", "USDC", "WETH"}
 
-// Uniswap V3 contract addresses on Base.
-const (
-	UniswapRouterAddr = "0x2626664c2603336E57B271c5C0b26F421741e481"
-	UniswapQuoterAddr = "0x3d4e44Eb1374240CE5F1B871ab261CD16335B76a"
-)
+func initTokens() {
+	c := activeChain()
+	Tokens = map[string]Token{
+		"ETH":  {Symbol: "ETH", Name: "Ether", Decimals: 18, Address: "0x0000000000000000000000000000000000000000", Native: true},
+		"WETH": {Symbol: "WETH", Name: "Wrapped Ether", Decimals: 18, Address: c.WETH},
+		"USDC": {Symbol: "USDC", Name: "USD Coin", Decimals: 6, Address: c.USDC},
+	}
+}
+
+func UniswapRouterAddr() string { return activeChain().Router }
+func UniswapQuoterAddr() string { return activeChain().Quoter }
 
 type Token struct {
 	Symbol   string `json:"symbol"`
@@ -75,10 +120,12 @@ var (
 )
 
 func Load() {
+	initTokens()
 	data.LoadJSON("trade_wallets.json", &wallets)
 	data.LoadJSON("trade_history.json", &trades)
 	loadStrategies()
 	StartSignalLoop()
+	app.Log("trade", "Trading on %s (chain ID %d)", activeChain().Name, activeChain().ChainID)
 }
 
 // Enabled returns true. Trading uses Base mainnet by default.
@@ -90,7 +137,7 @@ func rpcURL() string {
 	if v := os.Getenv("TRADE_RPC_URL"); v != "" {
 		return v
 	}
-	return BaseRPCURL
+	return activeChain().RPCURL
 }
 
 // GetWallet returns the trading wallet for a user, or nil.

--- a/trade/trade_test.go
+++ b/trade/trade_test.go
@@ -73,6 +73,7 @@ func TestAddressFromKnownKey(t *testing.T) {
 }
 
 func TestListTokens(t *testing.T) {
+	initTokens()
 	tokens := ListTokens()
 	if len(tokens) == 0 {
 		t.Error("ListTokens() returned empty")


### PR DESCRIPTION
Trading now defaults to Ethereum mainnet instead of Base. Chain is configurable via TRADE_CHAIN env var (ethereum or base).

Each chain has its own Uniswap contract addresses, WETH/USDC addresses, RPC endpoint, and block explorer. The wallet page shows which chain is active. Explorer links use the correct domain.

Default mainnet RPC: eth.llamarpc.com (free, no key required) Set TRADE_RPC_URL for a faster provider (Alchemy, Infura, etc.)

https://claude.ai/code/session_01GRGLA9yj7BpqKiyi6xFwnm