### PR TITLE
Recheck failed trades on page load, rename button to Swap

### DIFF
--- a/trade/handlers.go
+++ b/trade/handlers.go
@@ -40,6 +40,8 @@ func handlePage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	RecheckTrades(acc.ID)
+
 	errMsg := r.URL.Query().Get("error")
 
 	var b strings.Builder
@@ -133,7 +135,7 @@ func handlePage(w http.ResponseWriter, r *http.Request) {
 		b.WriteString(`<input type="text" name="amount" id="swap-amount" placeholder="0.00" value="`+htmlEsc(prevAmount)+`" required style="width:100%;padding:8px 50px 8px 8px;border:1px solid #ddd;border-radius:6px;font-size:14px;box-sizing:border-box;font-family:monospace">`)
 		b.WriteString(`<button type="button" onclick="setMax()" style="position:absolute;right:6px;top:50%;transform:translateY(-50%);padding:2px 8px;font-size:12px;border:1px solid #ddd;border-radius:4px;background:#f5f5f5;cursor:pointer;color:#555">MAX</button>`)
 		b.WriteString(`</div>`)
-		b.WriteString(`<button type="submit" class="btn" style="width:100%;margin-top:12px">Get Quote</button>`)
+		b.WriteString(`<button type="submit" class="btn" style="width:100%;margin-top:12px">Swap</button>`)
 		b.WriteString(`</form>`)
 
 		// Build JS balance map for max button

--- a/trade/trade.go
+++ b/trade/trade.go
@@ -432,4 +432,29 @@ func GetWalletInfo(accountID string) *WalletInfo {
 	return &WalletInfo{Address: w.Address}
 }
 
+// RecheckTrades looks up any pending/failed trades with a tx hash
+// and corrects their status from on-chain data.
+func RecheckTrades(accountID string) int {
+	walletMu.Lock()
+	defer walletMu.Unlock()
+
+	fixed := 0
+	for _, t := range trades[accountID] {
+		if t.TxHash == "" || t.Status == "confirmed" {
+			continue
+		}
+		gasUsed, err := waitForReceiptOnce(t.TxHash)
+		if err != nil {
+			continue
+		}
+		t.Status = "confirmed"
+		t.GasUsed = gasUsed
+		fixed++
+	}
+	if fixed > 0 {
+		data.SaveJSON("trade_history.json", trades)
+	}
+	return fixed
+}
+
 var _ = json.Marshal

--- a/trade/tx.go
+++ b/trade/tx.go
@@ -326,6 +326,30 @@ func sendRawTransaction(signedTx []byte) (string, error) {
 	return strings.Trim(string(result), `"`), nil
 }
 
+func waitForReceiptOnce(txHash string) (string, error) {
+	url := rpcURL()
+	req := rpcRequest{JSONRPC: "2.0", Method: "eth_getTransactionReceipt", Params: []any{txHash}, ID: 1}
+	result, err := doRPC(url, req)
+	if err != nil {
+		return "", err
+	}
+	raw := strings.TrimSpace(string(result))
+	if raw == "null" || raw == "" {
+		return "", fmt.Errorf("no receipt yet")
+	}
+	var receipt struct {
+		Status  string `json:"status"`
+		GasUsed string `json:"gasUsed"`
+	}
+	if err := json.Unmarshal(result, &receipt); err != nil {
+		return "", err
+	}
+	if receipt.Status == "0x1" || receipt.Status == "1" {
+		return receipt.GasUsed, nil
+	}
+	return "", fmt.Errorf("transaction reverted")
+}
+
 func waitForReceipt(txHash string) (string, error) {
 	url := rpcURL()
 	for i := 0; i < 60; i++ {


### PR DESCRIPTION
- On /trade page load, recheck any pending/failed trades that have a tx hash — queries the receipt and corrects status to confirmed
- Rename "Get Quote" button to "Swap" since it actually executes

https://claude.ai/code/session_01GRGLA9yj7BpqKiyi6xFwnm