### PR TITLE
Fold Trade under Markets as a tab

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -324,7 +324,6 @@ var Template = `
           <a href="/video"><img src="/video.png?` + Version + `"><span class="label">Video</span></a>
           <a href="/web"><img src="/search.svg?` + Version + `"><span class="label">Web</span></a>
           <a id="nav-wallet" href="/wallet"><img src="/wallet.png?` + Version + `"><span class="label">Wallet</span></a>
-          <a href="/trade"><img src="/trade.svg?` + Version + `"><span class="label">Trade</span></a>
 
         </div>
         <div class="nav-bottom">

--- a/main.go
+++ b/main.go
@@ -720,7 +720,7 @@ func main() {
 	}, func(args map[string]any, accountID string) (string, error) {
 		info := trade.GetWalletInfo(accountID)
 		if info == nil {
-			return `{"error":"No trading wallet. Create one at /trade."}`, nil
+			return `{"error":"No trading wallet. Create one at /markets?category=trade"}`, nil
 		}
 		result := map[string]any{"address": info.Address}
 		if trade.Enabled() {
@@ -788,7 +788,6 @@ func main() {
 		"/admin/delete":  true,
 		"/admin/console": true,
 		"/admin/invite": true,
-		"/trade":           true,  // Require auth for trading
 		"/wallet":          false, // Public - shows wallet info; auth checked in handler
 
 		"/apps":      false, // Public - apps directory; auth checked in handler for create/edit
@@ -898,8 +897,7 @@ func main() {
 	http.HandleFunc("/wallet/", wallet.Handler) // Handle sub-routes like /wallet/topup
 
 	// serve trading page
-	http.HandleFunc("/trade", trade.Handler)
-	http.HandleFunc("/trade/", trade.Handler)
+	http.HandleFunc("/trade/", trade.Handler) // form submissions (swap, wallet, strategy)
 
 	// serve search page (local + Brave web search)
 	http.HandleFunc("/search", search.Handler)
@@ -930,6 +928,7 @@ func main() {
 	http.HandleFunc("/mail", mail.Handler)
 
 	// serve markets page
+	markets.TradeHandler = trade.Handler
 	http.HandleFunc("/markets", markets.Handler)
 
 	// serve social page

--- a/markets/markets.go
+++ b/markets/markets.go
@@ -469,6 +469,12 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 		category = CategoryCrypto
 	}
 
+	// Route to trade page
+	if category == "trade" {
+		TradeHandler(w, r)
+		return
+	}
+
 	// Validate category
 	if category != CategoryCrypto && category != CategoryFutures && category != CategoryCommodities && category != CategoryCurrencies {
 		category = CategoryCrypto
@@ -483,6 +489,9 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 	// HTML response for browser
 	handleHTML(w, r, category)
 }
+
+// TradeHandler is set by the trade package to handle /markets?category=trade.
+var TradeHandler http.HandlerFunc
 
 // handleJSON returns market data as JSON
 func handleJSON(w http.ResponseWriter, r *http.Request, category string) {
@@ -552,6 +561,7 @@ func generateMarketsPage(priceData map[string]PriceData, activeCategory string) 
 	sb.WriteString(generateTab("Futures", CategoryFutures, activeCategory))
 	sb.WriteString(generateTab("Commodities", CategoryCommodities, activeCategory))
 	sb.WriteString(generateTab("Currencies", CategoryCurrencies, activeCategory))
+	sb.WriteString(generateTab("Trade", "trade", activeCategory))
 	sb.WriteString(`</div>`)
 
 	// Market data table

--- a/trade/handlers.go
+++ b/trade/handlers.go
@@ -15,6 +15,8 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 
 	switch {
 	case path == "/trade" && r.Method == "GET":
+		http.Redirect(w, r, "/markets?category=trade", http.StatusSeeOther)
+	case (path == "/trade" || path == "/markets") && r.Method == "GET":
 		handlePage(w, r)
 	case path == "/trade/wallet" && r.Method == "POST":
 		handleCreateWallet(w, r)
@@ -261,7 +263,7 @@ func handlePage(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	html := app.RenderHTMLForRequest("Trade", "DEX trading via Uniswap on Base", b.String(), r)
+	html := app.RenderHTMLForRequest("Markets", "DEX trading via Uniswap", b.String(), r)
 	w.Write([]byte(html))
 }
 
@@ -275,17 +277,17 @@ func handleCreateWallet(w http.ResponseWriter, r *http.Request) {
 	privKey := strings.TrimSpace(r.FormValue("private_key"))
 	if privKey != "" {
 		if _, err := ImportWallet(sess.Account, privKey); err != nil {
-			http.Redirect(w, r, "/trade?error="+err.Error(), http.StatusSeeOther)
+			http.Redirect(w, r, "/markets?category=trade&error="+err.Error(), http.StatusSeeOther)
 			return
 		}
 	} else {
 		if _, err := CreateWallet(sess.Account); err != nil {
-			http.Redirect(w, r, "/trade?error="+err.Error(), http.StatusSeeOther)
+			http.Redirect(w, r, "/markets?category=trade&error="+err.Error(), http.StatusSeeOther)
 			return
 		}
 	}
 
-	http.Redirect(w, r, "/trade", http.StatusSeeOther)
+	http.Redirect(w, r, "/markets?category=trade", http.StatusSeeOther)
 }
 
 func handleQuote(w http.ResponseWriter, r *http.Request) {
@@ -320,11 +322,12 @@ func handleSwap(w http.ResponseWriter, r *http.Request) {
 	trade, err := ExecuteSwap(sess.Account, from, to, amount)
 	if err != nil {
 		q := url.Values{}
+		q.Set("category", "trade")
 		q.Set("error", err.Error())
 		q.Set("from", from)
 		q.Set("to", to)
 		q.Set("amount", amount)
-		http.Redirect(w, r, "/trade?"+q.Encode(), http.StatusSeeOther)
+		http.Redirect(w, r, "/markets?"+q.Encode(), http.StatusSeeOther)
 		return
 	}
 
@@ -339,7 +342,7 @@ func handleSwap(w http.ResponseWriter, r *http.Request) {
 	b.WriteString(`<h3>Swap Quote</h3>`)
 	b.WriteString(fmt.Sprintf(`<p><strong>%s</strong> → <strong>%s</strong></p>`, trade.AmountIn, trade.AmountOut))
 	b.WriteString(fmt.Sprintf(`<p class="text-sm text-muted">Status: %s</p>`, trade.Status))
-	b.WriteString(`<p style="margin-top:12px"><a href="/trade">← Back to Trade</a></p>`)
+	b.WriteString(`<p style="margin-top:12px"><a href="/markets?category=trade">← Back to Markets</a></p>`)
 	b.WriteString(`</div>`)
 
 	html := app.RenderHTMLForRequest("Swap Quote", "Trade result", b.String(), r)
@@ -359,11 +362,11 @@ func handleCreateStrategy(w http.ResponseWriter, r *http.Request) {
 	maxPerWeek := r.FormValue("max_per_week")
 
 	if _, err := CreateStrategy(sess.Account, desc, mode, maxPerTrade, maxPerWeek); err != nil {
-		http.Redirect(w, r, "/trade?error="+err.Error(), http.StatusSeeOther)
+		http.Redirect(w, r, "/markets?category=trade&error="+err.Error(), http.StatusSeeOther)
 		return
 	}
 
-	http.Redirect(w, r, "/trade", http.StatusSeeOther)
+	http.Redirect(w, r, "/markets?category=trade", http.StatusSeeOther)
 }
 
 func handleToggleStrategy(w http.ResponseWriter, r *http.Request) {
@@ -373,7 +376,7 @@ func handleToggleStrategy(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	PauseStrategy(sess.Account, r.FormValue("id"))
-	http.Redirect(w, r, "/trade", http.StatusSeeOther)
+	http.Redirect(w, r, "/markets?category=trade", http.StatusSeeOther)
 }
 
 func handleDeleteStrategy(w http.ResponseWriter, r *http.Request) {
@@ -383,7 +386,7 @@ func handleDeleteStrategy(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	DeleteStrategy(sess.Account, r.FormValue("id"))
-	http.Redirect(w, r, "/trade", http.StatusSeeOther)
+	http.Redirect(w, r, "/markets?category=trade", http.StatusSeeOther)
 }
 
 func htmlEsc(s string) string {


### PR DESCRIPTION
Trade is now accessible via /markets?category=trade instead of a separate /trade page. Removed Trade from the sidebar nav. Markets page now has Crypto, Futures, Commodities, Currencies, and Trade tabs.

/trade redirects to /markets?category=trade. Form submissions still use /trade/ paths (swap, wallet, strategy).

https://claude.ai/code/session_01GRGLA9yj7BpqKiyi6xFwnm