### PR TITLE
Avoid duplicate admin moderation flaggers

### DIFF
--- a/internal/flag/flag.go
+++ b/internal/flag/flag.go
@@ -220,11 +220,12 @@ func AdminFlag(contentType, contentID, username string) error {
 	key := contentType + ":" + contentID
 
 	mutex.Lock()
+	adminFlagger := username + " (admin)"
 	if item, exists := flags[key]; exists {
 		item.FlagCount = 3
 		item.Flagged = true
-		if !contains(item.FlaggedBy, username) {
-			item.FlaggedBy = append(item.FlaggedBy, username+" (admin)")
+		if !contains(item.FlaggedBy, adminFlagger) {
+			item.FlaggedBy = append(item.FlaggedBy, adminFlagger)
 		}
 	} else {
 		flags[key] = &FlaggedItem{
@@ -232,7 +233,7 @@ func AdminFlag(contentType, contentID, username string) error {
 			ContentID:   contentID,
 			FlagCount:   3,
 			Flagged:     true,
-			FlaggedBy:   []string{username + " (admin)"},
+			FlaggedBy:   []string{adminFlagger},
 			FlaggedAt:   time.Now(),
 		}
 	}

--- a/internal/flag/flag_test.go
+++ b/internal/flag/flag_test.go
@@ -181,6 +181,24 @@ func TestAdminFlag(t *testing.T) {
 	}
 }
 
+func TestAdminFlag_SameAdminDoesNotDuplicateFlagger(t *testing.T) {
+	resetFlags()
+
+	AdminFlag("post", "admin-flag", "admin_user")
+	AdminFlag("post", "admin-flag", "admin_user")
+
+	item := GetItem("post", "admin-flag")
+	if item == nil {
+		t.Fatal("expected item after admin flag")
+	}
+	if got, want := len(item.FlaggedBy), 1; got != want {
+		t.Fatalf("expected %d flagger, got %d: %v", want, got, item.FlaggedBy)
+	}
+	if got, want := item.FlaggedBy[0], "admin_user (admin)"; got != want {
+		t.Errorf("expected admin flagger %q, got %q", want, got)
+	}
+}
+
 func TestAdminFlag_ExistingItem(t *testing.T) {
 	resetFlags()
 


### PR DESCRIPTION
## Summary
- Keep admin moderation flagger labels consistent so repeated admin flags from the same user are not recorded multiple times.
- Add regression coverage for repeated admin flagging.

Closes #636

## Testing
- go build ./...
- go test ./... -short
- go vet ./...