### PR TITLE
Improve social URL detection

### DIFF
--- a/social/context.go
+++ b/social/context.go
@@ -3,6 +3,8 @@ package social
 import (
 	"fmt"
 	htmlpkg "html"
+	"net/url"
+	"strings"
 
 	"mu/internal/app"
 )
@@ -63,9 +65,14 @@ func FetchContext(articleURL, articleContent string) *SocialContext {
 	return &SocialContext{Posts: ctxPosts}
 }
 
-// DetectTruthSocial checks if a URL is from Truth Social
+// DetectTruthSocial checks if a URL is from Truth Social.
 func DetectTruthSocial(u string) bool {
-	return len(u) > 0 && (len(u) > 20 && u[:20] == "https://truthsocial." || len(u) > 19 && u[:19] == "http://truthsocial.")
+	parsed, err := url.Parse(u)
+	if err != nil {
+		return false
+	}
+	host := strings.ToLower(parsed.Hostname())
+	return host == "truthsocial.com" || strings.HasSuffix(host, ".truthsocial.com")
 }
 
 // RenderContextHTML renders social context as HTML blockquotes for embedding in news articles

--- a/social/context_test.go
+++ b/social/context_test.go
@@ -1,0 +1,53 @@
+package social
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestDetectTruthSocial(t *testing.T) {
+	tests := []struct {
+		name string
+		url  string
+		want bool
+	}{
+		{name: "apex https", url: "https://truthsocial.com/@mu/posts/123", want: true},
+		{name: "www https", url: "https://www.truthsocial.com/@mu/posts/123", want: true},
+		{name: "subdomain http", url: "http://media.truthsocial.com/@mu/posts/123", want: true},
+		{name: "lookalike host", url: "https://nottruthsocial.com/@mu/posts/123", want: false},
+		{name: "invalid", url: "://truthsocial.com/@mu", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := DetectTruthSocial(tt.url); got != tt.want {
+				t.Fatalf("DetectTruthSocial(%q) = %v, want %v", tt.url, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDetectSocialURLsIncludesMobileAndDeduplicates(t *testing.T) {
+	content := strings.Join([]string{
+		"source https://mobile.twitter.com/mu/status/1,",
+		"mirror https://mobile.twitter.com/mu/status/1",
+		"x post https://www.x.com/mu/status/2)",
+		"truth https://truthsocial.com/@mu/posts/3.",
+		"ignore https://example.com/mu/status/4",
+	}, " ")
+
+	got := DetectSocialURLs(content)
+	want := []string{
+		"https://mobile.twitter.com/mu/status/1",
+		"https://www.x.com/mu/status/2",
+		"https://truthsocial.com/@mu/posts/3",
+	}
+	if len(got) != len(want) {
+		t.Fatalf("DetectSocialURLs() returned %d URLs, want %d: %#v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("DetectSocialURLs()[%d] = %q, want %q (all: %#v)", i, got[i], want[i], got)
+		}
+	}
+}

--- a/social/social.go
+++ b/social/social.go
@@ -39,12 +39,12 @@ var nitterInstance = "nitter.poast.org"
 
 // Message represents a message in a thread (or the thread-starting message itself)
 type Message struct {
-	ID        string    `json:"id"`
-	Author    string    `json:"author"`     // display name
-	AuthorID  string    `json:"author_id"`  // account ID
-	Content   string    `json:"content"`
-	ReplyTo   string    `json:"reply_to,omitempty"` // parent thread ID (empty = thread starter)
-	PostedAt  time.Time `json:"posted_at"`
+	ID       string    `json:"id"`
+	Author   string    `json:"author"`    // display name
+	AuthorID string    `json:"author_id"` // account ID
+	Content  string    `json:"content"`
+	ReplyTo  string    `json:"reply_to,omitempty"` // parent thread ID (empty = thread starter)
+	PostedAt time.Time `json:"posted_at"`
 }
 
 // addMessage adds a message to the feed (prepend, dedup, cap, save)
@@ -1156,7 +1156,6 @@ func firstSentences(text string, n int) string {
 	return text
 }
 
-
 // stripHTML removes HTML tags from a string
 func stripHTML(s string) string {
 	re := regexp.MustCompile(`<[^>]*>`)
@@ -1167,7 +1166,7 @@ func stripHTML(s string) string {
 
 // DetectSocialURLs finds social media URLs in text content
 func DetectSocialURLs(content string) []string {
-	re := regexp.MustCompile(`https?://(?:(?:www\.)?(?:twitter\.com|x\.com)|(?:truthsocial\.com))/[^\s"'<>\])+]+`)
+	re := regexp.MustCompile(`https?://(?:(?:(?:www|mobile)\.)?(?:twitter\.com|x\.com)|(?:(?:www\.)?truthsocial\.com))/[^\s"'<>\])+]+`)
 	matches := re.FindAllString(content, -1)
 
 	seen := map[string]bool{}


### PR DESCRIPTION
## Summary
- Recognize mobile Twitter/X and www Truth Social URLs when extracting social context from articles.
- Parse Truth Social hosts with net/url to avoid brittle prefix checks and reject lookalike domains.
- Add regression tests for Truth Social host detection and social URL extraction/deduplication.

Closes #640

## Verification
- go build ./...
- go test ./... -short
- go vet ./...