### PR TITLE
Report data persistence write errors

### DIFF
--- a/internal/data/data.go
+++ b/internal/data/data.go
@@ -42,9 +42,10 @@ func SaveFile(key, val string) error {
 	path := filepath.Join(dir, "data")
 	file := filepath.Join(path, key)
 	// Create all parent directories including subdirectories in key
-	os.MkdirAll(filepath.Dir(file), 0700)
-	os.WriteFile(file, []byte(val), 0600)
-	return nil
+	if err := os.MkdirAll(filepath.Dir(file), 0700); err != nil {
+		return err
+	}
+	return os.WriteFile(file, []byte(val), 0600)
 }
 
 // LoadFile loads a file from disk
@@ -74,11 +75,10 @@ func SaveJSON(key string, val interface{}) error {
 
 	// Create all parent directories
 	fileDir := filepath.Dir(file)
-	os.MkdirAll(fileDir, 0700)
-
-	os.WriteFile(file, b, 0644)
-
-	return nil
+	if err := os.MkdirAll(fileDir, 0700); err != nil {
+		return err
+	}
+	return os.WriteFile(file, b, 0644)
 }
 
 func LoadJSON(key string, val interface{}) error {
@@ -289,7 +289,6 @@ func indexWorker(id int) {
 		processIndexWork(work)
 	}
 }
-
 
 // GetByID retrieves an entry by its exact ID
 func GetByID(id string) *IndexEntry {

--- a/internal/data/save_test.go
+++ b/internal/data/save_test.go
@@ -1,0 +1,31 @@
+package data
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestSaveFileReportsDirectoryErrors(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	muPath := filepath.Join(os.Getenv("HOME"), ".mu")
+	if err := os.WriteFile(muPath, []byte("not a directory"), 0600); err != nil {
+		t.Fatalf("create blocking file: %v", err)
+	}
+
+	if err := SaveFile("example.txt", "content"); err == nil {
+		t.Fatal("SaveFile returned nil when the data directory could not be created")
+	}
+}
+
+func TestSaveJSONReportsDirectoryErrors(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	muPath := filepath.Join(os.Getenv("HOME"), ".mu")
+	if err := os.WriteFile(muPath, []byte("not a directory"), 0600); err != nil {
+		t.Fatalf("create blocking file: %v", err)
+	}
+
+	if err := SaveJSON("settings.json", map[string]string{"key": "value"}); err == nil {
+		t.Fatal("SaveJSON returned nil when the data directory could not be created")
+	}
+}


### PR DESCRIPTION
## Summary
- Return filesystem errors from data file and JSON persistence helpers instead of silently ignoring failed directory creation or writes.
- Add regression tests for blocked data directory creation paths.

## Testing
- go build ./...
- go test ./... -short
- go vet ./...

Closes #642