### PR TITLE
Unify guest + assistant into one inline streaming chat

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -291,8 +291,11 @@ func servePage(w http.ResponseWriter, r *http.Request) {
 		_ = preFillPrompt // keep zero
 	}
 
-	// Pre-fill from query params (e.g. home page agent card).
+	// Pre-fill from query params (e.g. home page agent card). Accept both
+	// ?prompt= and the shorter ?q= alias used by external entry points.
 	if p := r.URL.Query().Get("prompt"); p != "" {
+		preFillPrompt = htmlEsc(p)
+	} else if p := r.URL.Query().Get("q"); p != "" {
 		preFillPrompt = htmlEsc(p)
 	}
 	preSelectModel := r.URL.Query().Get("model") // "standard" or "premium"
@@ -896,6 +899,13 @@ func handleQuery(w http.ResponseWriter, r *http.Request) {
 		Prompt    string `json:"prompt"`
 		Model     string `json:"model"`
 		ContextID string `json:"context_id"` // optional: prior flow to continue from
+		// History is an optional client-supplied conversation thread used by
+		// the inline chat (landing + assistant). It gives multi-turn context
+		// without server-side persistence, so guests get follow-up memory too.
+		History []struct {
+			Prompt string `json:"prompt"`
+			Answer string `json:"answer"`
+		} `json:"history"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil || strings.TrimSpace(req.Prompt) == "" {
 		http.Error(w, `{"error":"prompt required"}`, http.StatusBadRequest)
@@ -938,10 +948,29 @@ func handleQuery(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// Load conversation history when continuing a conversation.
+	// Load conversation history when continuing a conversation. A saved flow
+	// (context_id) takes precedence; otherwise fall back to the client-supplied
+	// inline history used by the stateless inline chat.
 	var conversationHistory []*Flow
 	if req.ContextID != "" {
 		conversationHistory = getConversationHistory(req.ContextID, 5)
+	}
+	if len(conversationHistory) == 0 && len(req.History) > 0 {
+		const maxTurns = 6
+		hist := req.History
+		if len(hist) > maxTurns {
+			hist = hist[len(hist)-maxTurns:]
+		}
+		for _, h := range hist {
+			if strings.TrimSpace(h.Prompt) == "" {
+				continue
+			}
+			ans := h.Answer
+			if len(ans) > 1500 {
+				ans = ans[:1500] + "…"
+			}
+			conversationHistory = append(conversationHistory, &Flow{Prompt: h.Prompt, Answer: ans})
+		}
 	}
 
 	// Create flow early so progress is saved server-side even if the

--- a/home/assistant.go
+++ b/home/assistant.go
@@ -8,155 +8,17 @@ import (
 
 func AssistantHandler(w http.ResponseWriter, r *http.Request) {
 	prefill := r.URL.Query().Get("q")
+	if prefill == "" {
+		prefill = r.URL.Query().Get("prompt")
+	}
 
-	content := `<div>
-<div style="margin-bottom:24px">
-  <form id="ask-form" style="display:flex;align-items:center;gap:0;border:1px solid #ddd;border-radius:6px;padding:4px 4px 4px 12px">
-    <textarea id="ask-input" placeholder="Ask anything..." maxlength="1024" rows="1"
-      style="flex:1;padding:10px 0;border:none;font-size:16px;font-family:inherit;resize:none;line-height:1.4;overflow:hidden;background:transparent;outline:none"
-      onkeydown="if(event.key==='Enter'&&!event.shiftKey){event.preventDefault();document.getElementById('ask-form').dispatchEvent(new Event('submit'))}"
-      oninput="this.style.height='auto';this.style.height=Math.min(this.scrollHeight,120)+'px'"></textarea>
-    <button type="submit" style="flex-shrink:0;width:36px;height:36px;background:#111;color:#fff;border:none;border-radius:6px;cursor:pointer;display:flex;align-items:center;justify-content:center;font-size:18px">&#x2192;</button>
-  </form>
-</div>
-<div id="suggestions"></div>
-<div id="conversation" style="font-size:15px;line-height:1.7"></div>
-</div>
+	content := `<div style="margin-bottom:24px">` + chatComponent(false) + `</div>`
 
-<style>
-.msg-user{margin-bottom:16px;padding:10px 14px;background:#f5f5f5;border-radius:8px;font-size:14px;color:#333}
-.msg-agent{margin-bottom:24px}
-.stream-cursor{display:inline-block;width:2px;height:1em;background:#000;vertical-align:text-bottom;animation:blink 0.8s step-end infinite;margin-left:2px}
-@keyframes blink{0%,100%{opacity:1}50%{opacity:0}}
-.suggest-pills{display:flex;gap:8px;flex-wrap:wrap;margin-bottom:24px}
-.suggest-pills a{padding:8px 14px;border:1px solid #e0e0e0;border-radius:6px;font-size:13px;color:#555;text-decoration:none}
-.suggest-pills a:hover{background:#f5f5f5}
-</style>
-
-<script>
-(function(){
-var form=document.getElementById('ask-form');
-var input=document.getElementById('ask-input');
-var conv=document.getElementById('conversation');
-var sugDiv=document.getElementById('suggestions');
-var KEY='mu_assistant_conv';
-
-// Restore previous conversation from sessionStorage
-try{
-  var saved=sessionStorage.getItem(KEY);
-  if(saved)conv.innerHTML=saved;
-}catch(e){}
-
-// Show suggestions only when conversation is empty
-function showSuggestions(){
-  if(conv.innerHTML.trim())return;
-  sugDiv.innerHTML='<div class="suggest-pills">'
-    +'<a href="#" data-q="What\'s happening today?">What\'s happening today?</a>'
-    +'<a href="#" data-q="Check my email">Check my email</a>'
-    +'<a href="#" data-q="Bitcoin price">Bitcoin price</a>'
-    +'<a href="#" data-q="Latest news">Latest news</a>'
-    +'<a href="#" data-q="Weather forecast">Weather forecast</a>'
-    +'</div>';
-  sugDiv.querySelectorAll('a').forEach(function(a){
-    a.addEventListener('click',function(e){
-      e.preventDefault();
-      input.value=a.dataset.q;
-      form.dispatchEvent(new Event('submit'));
-    });
-  });
-}
-showSuggestions();
-
-function saveConv(){
-  try{sessionStorage.setItem(KEY,conv.innerHTML)}catch(e){}
-}
-
-function ask(q){
-  sugDiv.innerHTML='';
-
-  var userDiv=document.createElement('div');
-  userDiv.className='msg-user';
-  userDiv.textContent=q;
-  conv.appendChild(userDiv);
-
-  var agentDiv=document.createElement('div');
-  agentDiv.className='msg-agent';
-  agentDiv.innerHTML='<div style="color:#888;font-size:14px">Thinking...</div>';
-  conv.appendChild(agentDiv);
-
-  input.value='';
-  input.focus();
-  saveConv();
-  agentDiv.scrollIntoView({behavior:'smooth',block:'end'});
-
-  var body=JSON.stringify({prompt:q,model:'standard'});
-  fetch('/agent',{method:'POST',headers:{'Content-Type':'application/json'},body:body,credentials:'same-origin'})
-  .then(function(resp){
-    if(!resp.ok){
-      agentDiv.innerHTML='<div style="color:#c00">Something went wrong.</div>';
-      saveConv();
-      return;
-    }
-    var reader=resp.body.getReader();
-    var decoder=new TextDecoder();
-    var buf='';
-    var streamText='';
-
-    function read(){
-      return reader.read().then(function(chunk){
-        if(chunk.done){saveConv();return}
-        buf+=decoder.decode(chunk.value,{stream:true});
-        var lines=buf.split('\n');
-        buf=lines.pop();
-        lines.forEach(function(line){
-          if(!line.startsWith('data: '))return;
-          try{
-            var ev=JSON.parse(line.slice(6));
-            if(ev.type==='thinking'){
-              agentDiv.innerHTML='<div style="color:#888;font-size:14px">'+ev.message+'</div>';
-            } else if(ev.type==='stream_start'){
-              streamText='';
-              agentDiv.innerHTML='<div style="white-space:pre-wrap"><span id="stream-out"></span><span class="stream-cursor"></span></div>';
-            } else if(ev.type==='stream_token'){
-              streamText+=ev.token;
-              var el=document.getElementById('stream-out');
-              if(el)el.textContent=streamText;
-              agentDiv.scrollIntoView({behavior:'smooth',block:'end'});
-            } else if(ev.type==='response'){
-              agentDiv.innerHTML=ev.html;
-              saveConv();
-            } else if(ev.type==='error'){
-              agentDiv.innerHTML='<div style="color:#c00">'+ev.message+'</div>';
-              saveConv();
-            }
-          }catch(ex){}
-        });
-        return read();
-      });
-    }
-    return read();
-  })
-  .catch(function(err){
-    agentDiv.innerHTML='<div style="color:#c00">Error: '+err.message+'</div>';
-    saveConv();
-  });
-}
-
-form.addEventListener('submit',function(e){
-  e.preventDefault();
-  var q=input.value.trim();
-  if(!q)return;
-  ask(q);
-});
-})();
-</script>`
-
-	// Auto-submit if query param provided
+	// Auto-submit if a query param was provided (e.g. from a deep link).
 	if prefill != "" {
-		escaped := htmlEsc(prefill)
 		content += `<script>(function(){
-var input=document.getElementById('ask-input');
-if(input){input.value="` + escaped + `";document.getElementById('ask-form').dispatchEvent(new Event('submit'));}
+var input=document.getElementById('mu-chat-input');
+if(input&&window.muChatAsk){input.value=` + jsString(prefill) + `;window.muChatAsk(input.value);}
 history.replaceState(null,'','/');
 })()</script>`
 	}

--- a/home/chat.go
+++ b/home/chat.go
@@ -1,0 +1,186 @@
+package home
+
+import "encoding/json"
+
+// jsString returns s as a safely-quoted JavaScript string literal (with
+// surrounding quotes) for embedding in inline scripts.
+func jsString(s string) string {
+	b, err := json.Marshal(s)
+	if err != nil {
+		return `""`
+	}
+	return string(b)
+}
+
+// chatComponent returns the shared inline-streaming chat UI used on both the
+// guest landing page (`/` logged out) and the assistant page (`/` logged in).
+//
+// It is intentionally self-contained: one <div id="mu-chat"> with the input,
+// suggestion pills, and a conversation log, plus scoped styles and a small
+// script. The script POSTs to /agent and renders the SSE stream inline, keeps
+// the conversation in the DOM + sessionStorage so a reload restores it, and
+// threads the most recent turns back to the server (the `history` field) so
+// follow-up questions keep context — for guests too, with no server-side
+// persistence required.
+//
+// When `guest` is true and the server returns 401 (free query limit reached),
+// the chat shows an inline sign-up call-to-action instead of a generic error.
+func chatComponent(guest bool) string {
+	guestJS := "false"
+	if guest {
+		guestJS = "true"
+	}
+
+	html := `<div id="mu-chat">
+  <form id="mu-chat-form">
+    <textarea id="mu-chat-input" placeholder="Ask anything..." maxlength="1024" rows="1"
+      onkeydown="if(event.key==='Enter'&&!event.shiftKey){event.preventDefault();document.getElementById('mu-chat-form').dispatchEvent(new Event('submit'))}"
+      oninput="this.style.height='auto';this.style.height=Math.min(this.scrollHeight,140)+'px'"></textarea>
+    <button type="submit" aria-label="Send">&#x2192;</button>
+  </form>
+  <div id="mu-chat-suggest"></div>
+  <div id="mu-chat-conv"></div>
+</div>
+
+<style>
+#mu-chat{max-width:750px;margin:0 auto;width:100%}
+#mu-chat-form{display:flex;align-items:center;gap:0;border:1px solid #ddd;border-radius:6px;background:#fff;padding:4px 4px 4px 12px;transition:border-color .2s}
+#mu-chat-form:focus-within{border-color:#999}
+#mu-chat-input{flex:1;padding:10px 0;border:none;font-size:16px;font-family:inherit;resize:none;line-height:1.4;overflow:hidden;background:transparent;outline:none}
+#mu-chat-form button{flex-shrink:0;width:36px;height:36px;background:#111;color:#fff;border:none;border-radius:6px;cursor:pointer;display:flex;align-items:center;justify-content:center;font-size:18px}
+#mu-chat-suggest{margin-top:16px}
+.mu-pills{display:flex;gap:8px;flex-wrap:wrap;justify-content:center}
+.mu-pills a{padding:8px 14px;border:1px solid #e0e0e0;border-radius:6px;font-size:13px;color:#555;text-decoration:none;cursor:pointer}
+.mu-pills a:hover{background:#f5f5f5}
+#mu-chat-conv{margin-top:24px;font-size:15px;line-height:1.7;text-align:left}
+#mu-chat-conv:empty{margin-top:0}
+.mu-user{margin:0 0 12px;padding:10px 14px;background:#f5f5f5;border-radius:8px;font-size:14px;color:#333}
+.mu-agent{margin-bottom:24px}
+.mu-think{color:#888;font-size:14px}
+.mu-err{color:#c00}
+.mu-cta{padding:12px 14px;border:1px solid #e0e0e0;border-radius:8px;background:#fafafa;font-size:14px}
+.mu-cta a{color:#111;font-weight:600;text-decoration:none}
+.mu-cursor{display:inline-block;width:2px;height:1em;background:#000;vertical-align:text-bottom;animation:mublink .8s step-end infinite;margin-left:2px}
+@keyframes mublink{0%,100%{opacity:1}50%{opacity:0}}
+#mu-chat .card{max-width:100%;border:1px solid #e0e0e0;border-radius:8px;padding:14px 16px;margin-bottom:12px;background:#fff;box-shadow:0 1px 2px rgba(0,0,0,.04)}
+#mu-chat .card h4{margin:0 0 8px;font-size:1em;font-weight:600}
+#mu-chat .card a,#mu-chat .link,#mu-chat a.link{color:#111}
+</style>
+
+<script>
+(function(){
+var GUEST=` + guestJS + `;
+var form=document.getElementById('mu-chat-form');
+var input=document.getElementById('mu-chat-input');
+var conv=document.getElementById('mu-chat-conv');
+var sugDiv=document.getElementById('mu-chat-suggest');
+if(!form)return;
+var CKEY='mu_chat_conv';
+var HKEY='mu_chat_hist';
+var history=[];
+
+try{
+  var savedConv=sessionStorage.getItem(CKEY);
+  if(savedConv)conv.innerHTML=savedConv;
+  var savedHist=sessionStorage.getItem(HKEY);
+  if(savedHist)history=JSON.parse(savedHist)||[];
+}catch(e){}
+
+function esc(s){return String(s||'').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');}
+
+var SUGGEST=['Today\'s news','Bitcoin price','Weather forecast','What is Mu?'];
+function showSuggestions(){
+  if(conv.innerHTML.trim()){sugDiv.innerHTML='';return;}
+  var h='<div class="mu-pills">';
+  SUGGEST.forEach(function(s){h+='<a href="#" data-q="'+esc(s)+'">'+esc(s)+'</a>';});
+  h+='</div>';
+  sugDiv.innerHTML=h;
+  sugDiv.querySelectorAll('a').forEach(function(a){
+    a.addEventListener('click',function(e){e.preventDefault();input.value=a.dataset.q;ask(a.dataset.q);});
+  });
+}
+
+function save(){
+  try{
+    sessionStorage.setItem(CKEY,conv.innerHTML);
+    sessionStorage.setItem(HKEY,JSON.stringify(history.slice(-6)));
+  }catch(e){}
+}
+
+function ask(q){
+  q=String(q||'').trim();
+  if(!q)return;
+  sugDiv.innerHTML='';
+  var u=document.createElement('div');u.className='mu-user';u.textContent=q;conv.appendChild(u);
+  var a=document.createElement('div');a.className='mu-agent';a.innerHTML='<div class="mu-think">Thinking…</div>';conv.appendChild(a);
+  input.value='';input.style.height='auto';input.focus();
+  save();
+  a.scrollIntoView({behavior:'smooth',block:'end'});
+  var streamText='';
+  var body=JSON.stringify({prompt:q,model:'standard',history:history.slice(-6)});
+  fetch('/agent',{method:'POST',headers:{'Content-Type':'application/json'},body:body,credentials:'same-origin'})
+  .then(function(resp){
+    if(resp.status===401){
+      return resp.json().catch(function(){return {};}).then(function(j){
+        var msg=esc(j.error||'Sign up to keep using the AI agent.');
+        a.innerHTML='<div class="mu-cta">'+msg+' <a href="/signup">Sign up free →</a></div>';
+        save();
+        throw 'handled';
+      });
+    }
+    if(!resp.ok||!resp.body){a.innerHTML='<div class="mu-err">Something went wrong. Please try again.</div>';save();throw 'handled';}
+    var reader=resp.body.getReader();
+    var decoder=new TextDecoder();
+    var buf='';
+    function read(){
+      return reader.read().then(function(chunk){
+        if(chunk.done){save();return;}
+        buf+=decoder.decode(chunk.value,{stream:true});
+        var lines=buf.split('\n');
+        buf=lines.pop();
+        lines.forEach(function(line){
+          if(line.indexOf('data: ')!==0)return;
+          try{
+            var ev=JSON.parse(line.slice(6));
+            if(ev.type==='thinking'){
+              a.innerHTML='<div class="mu-think">'+esc(ev.message)+'</div>';
+            }else if(ev.type==='stream_start'){
+              streamText='';
+              a.innerHTML='<div style="white-space:pre-wrap"><span id="mu-stream-out"></span><span class="mu-cursor"></span></div>';
+            }else if(ev.type==='stream_token'){
+              streamText+=ev.token;
+              var el=document.getElementById('mu-stream-out');
+              if(el)el.textContent=streamText;
+              a.scrollIntoView({behavior:'smooth',block:'end'});
+            }else if(ev.type==='response'){
+              a.innerHTML=ev.html;
+              history.push({prompt:q,answer:streamText});
+              save();
+            }else if(ev.type==='error'){
+              a.innerHTML='<div class="mu-err">'+esc(ev.message)+'</div>';
+              save();
+            }
+          }catch(ex){}
+        });
+        return read();
+      });
+    }
+    return read();
+  })
+  .catch(function(err){
+    if(err==='handled')return;
+    a.innerHTML='<div class="mu-err">Error: '+esc(err&&err.message||err)+'</div>';
+    save();
+  });
+}
+
+form.addEventListener('submit',function(e){e.preventDefault();ask(input.value);});
+showSuggestions();
+
+// Exposed so server-rendered prefill (?q= / ?prompt=) can auto-submit.
+window.muChatAsk=ask;
+})();
+</script>`
+
+	return html
+}

--- a/home/landing.go
+++ b/home/landing.go
@@ -1,13 +1,24 @@
 package home
 
 import (
-	"fmt"
 	"net/http"
-	"net/url"
-
 )
 
 func LandingHandler(w http.ResponseWriter, r *http.Request) {
+	// Prefill + auto-submit from a deep link, e.g. /?q=... or /?prompt=...
+	prefill := r.URL.Query().Get("q")
+	if prefill == "" {
+		prefill = r.URL.Query().Get("prompt")
+	}
+	var prefillScript string
+	if prefill != "" {
+		prefillScript = `<script>(function(){
+var input=document.getElementById('mu-chat-input');
+if(input&&window.muChatAsk){input.value=` + jsString(prefill) + `;window.muChatAsk(input.value);}
+history.replaceState(null,'','/');
+})()</script>`
+	}
+
 	page := `<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -24,19 +35,12 @@ func LandingHandler(w http.ResponseWriter, r *http.Request) {
 <style>
 *{margin:0;padding:0;box-sizing:border-box}
 body{font-family:'Nunito Sans',sans-serif;background:#fff;color:#111;min-height:100vh;display:flex;flex-direction:column}
-.landing{flex:1;display:flex;flex-direction:column;align-items:center;justify-content:center;padding:0 20px;position:relative}
+.landing{flex:1;display:flex;flex-direction:column;align-items:center;justify-content:flex-start;padding:14vh 20px 40px;position:relative}
 .brand{font-size:2.5rem;font-weight:800;letter-spacing:-1px;margin-bottom:8px}
 .tagline{color:#666;font-size:16px;margin-bottom:32px}
 .login-link{position:absolute;top:20px;right:20px}
 .login-link a{color:#555;text-decoration:none;font-size:14px;font-weight:600}
-.prompt-wrap{width:100%%;max-width:720px;margin-bottom:12px}
-.prompt-wrap form{display:flex;align-items:center;gap:0;border:1px solid #ddd;border-radius:6px;background:#fff;padding:4px 4px 4px 12px;transition:border-color 0.2s}
-.prompt-wrap form:focus-within{border-color:#999}
-.prompt-wrap textarea{flex:1;padding:10px 0;border:none;font-size:16px;font-family:inherit;resize:none;line-height:1.4;overflow:hidden;background:transparent;outline:none}
-.prompt-wrap button{flex-shrink:0;width:36px;height:36px;background:#111;color:#fff;border:none;border-radius:6px;cursor:pointer;display:flex;align-items:center;justify-content:center;font-size:18px}
-.pills{display:flex;gap:8px;flex-wrap:wrap;justify-content:center;margin-bottom:40px}
-.pills a{padding:8px 16px;border:1px solid #e0e0e0;border-radius:6px;font-size:13px;color:#555;text-decoration:none;white-space:nowrap;transition:background 0.15s}
-.pills a:hover{background:#f5f5f5}
+.also{text-align:center;margin:32px 0;font-size:14px;color:#888}
 .footer{padding:20px;text-align:center;font-size:13px;color:#999}
 .footer a{color:#555;text-decoration:none;margin:0 10px}
 .footer a:hover{text-decoration:underline}
@@ -47,18 +51,8 @@ body{font-family:'Nunito Sans',sans-serif;background:#fff;color:#111;min-height:
   <div class="login-link"><a href="/login">Log in</a></div>
   <div class="brand">Mu</div>
   <div class="tagline">Your personal AI agent</div>
-  <div class="prompt-wrap">
-    <form action="/agent" method="GET">
-      <textarea name="prompt" placeholder="Ask anything..." maxlength="512" rows="1"
-        onkeydown="if(event.key==='Enter'&&!event.shiftKey){event.preventDefault();this.form.submit()}"
-        oninput="this.style.height='auto';this.style.height=Math.min(this.scrollHeight,120)+'px'"></textarea>
-      <button type="submit">&#x2192;</button>
-    </form>
-  </div>
-  <div class="pills">` +
-		landingPills() + `
-  </div>
-  <div style="text-align:center;margin-bottom:32px;font-size:14px;color:#888">
+  ` + chatComponent(true) + `
+  <div class="also">
     <span>Also available on</span>
     <a href="https://discord.gg/WeMU5AGxD" style="color:#5865F2;text-decoration:none;margin-left:8px;font-weight:600">Discord</a>
     <span style="margin:0 4px">·</span>
@@ -73,19 +67,11 @@ body{font-family:'Nunito Sans',sans-serif;background:#fff;color:#111;min-height:
   <a href="/docs">Docs</a>
   <a href="/login">Log in</a>
 </div>
+` + prefillScript + `
 </body>
 </html>`
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	w.Header().Set("Cache-Control", "no-store")
 	w.Write([]byte(page))
-}
-
-func landingPills() string {
-	suggestions := []string{"Today's news", "Bitcoin price", "What is Mu?"}
-	var out string
-	for _, s := range suggestions {
-		out += fmt.Sprintf(`<a href="/agent?prompt=%s">%s</a>`, htmlEsc(url.QueryEscape(s)), htmlEsc(s))
-	}
-	return out
 }


### PR DESCRIPTION
The landing page (`/` logged out) redirected the query box to the heavy `/agent` flow page, while the logged-in assistant (`/`) used a separate inline chat that kept no server-side memory, and the `/agent` page used a third "continue=flow" model. Guest follow-ups lost all context because guest flows are never persisted, so the continue lookup found nothing.

Collapse the two `/` surfaces onto one shared inline streaming chat:

- home/chat.go: new self-contained `chatComponent(guest)` — streams the SSE response from POST /agent inline, keeps the thread in the DOM + sessionStorage, threads recent turns back to the server for context, and shows an inline sign-up CTA when a guest hits the free limit.
- home/landing.go: guest `/` now uses the inline chat in its branded hero instead of redirecting to /agent; accepts ?q= and ?prompt= prefill.
- home/assistant.go: logged-in `/` uses the same component.
- agent/agent.go: handleQuery accepts an optional client-supplied `history` array, giving multi-turn memory to guests and the inline chat without server-side persistence. Also accept ?q= as a prompt alias on the /agent page.


Claude-Session: https://claude.ai/code/session_01KdcPjN9ndJwMGKQSRrAGPE