### PR TITLE
Validate trade amount parsing

### DIFF
--- a/trade/trade.go
+++ b/trade/trade.go
@@ -23,14 +23,14 @@ import (
 // Chain configuration. Defaults to Ethereum mainnet.
 // Set TRADE_CHAIN=base for Base L2.
 type ChainConfig struct {
-	Name      string
-	ChainID   int64
-	RPCURL    string
-	WETH      string
-	USDC      string
-	Router    string
-	Quoter    string
-	Explorer  string
+	Name     string
+	ChainID  int64
+	RPCURL   string
+	WETH     string
+	USDC     string
+	Router   string
+	Quoter   string
+	Explorer string
 }
 
 var chains = map[string]ChainConfig{
@@ -127,21 +127,21 @@ type Wallet struct {
 
 // Trade records a completed or pending swap.
 type Trade struct {
-	ID        string  `json:"id"`
-	Account   string  `json:"account"`
-	FromToken string  `json:"from_token"`
-	ToToken   string  `json:"to_token"`
-	AmountIn  string  `json:"amount_in"`
-	AmountOut string  `json:"amount_out"`
-	TxHash    string  `json:"tx_hash,omitempty"`
-	Status    string  `json:"status"` // pending, confirmed, failed
-	CreatedAt string  `json:"created_at"`
-	GasUsed   string  `json:"gas_used,omitempty"`
+	ID        string `json:"id"`
+	Account   string `json:"account"`
+	FromToken string `json:"from_token"`
+	ToToken   string `json:"to_token"`
+	AmountIn  string `json:"amount_in"`
+	AmountOut string `json:"amount_out"`
+	TxHash    string `json:"tx_hash,omitempty"`
+	Status    string `json:"status"` // pending, confirmed, failed
+	CreatedAt string `json:"created_at"`
+	GasUsed   string `json:"gas_used,omitempty"`
 }
 
 var (
 	walletMu sync.RWMutex
-	wallets  = map[string]*Wallet{} // accountID → wallet
+	wallets  = map[string]*Wallet{}  // accountID → wallet
 	trades   = map[string][]*Trade{} // accountID → trades
 )
 
@@ -247,6 +247,11 @@ func saveTrade(accountID string, t *Trade) {
 // ParseAmount converts a human-readable amount (e.g. "100") to the
 // token's smallest unit based on decimals.
 func ParseAmount(amount string, decimals int) (*big.Int, error) {
+	if decimals < 0 {
+		return nil, errors.New("invalid decimals")
+	}
+
+	amount = strings.TrimSpace(amount)
 	parts := strings.Split(amount, ".")
 	if len(parts) > 2 {
 		return nil, errors.New("invalid amount")
@@ -257,6 +262,12 @@ func ParseAmount(amount string, decimals int) (*big.Int, error) {
 	if len(parts) == 2 {
 		frac = parts[1]
 	}
+	if whole == "" && frac == "" {
+		return nil, errors.New("invalid amount")
+	}
+	if !allDigits(whole) || !allDigits(frac) {
+		return nil, errors.New("invalid number")
+	}
 
 	if len(frac) > decimals {
 		frac = frac[:decimals]
@@ -266,11 +277,23 @@ func ParseAmount(amount string, decimals int) (*big.Int, error) {
 	}
 
 	combined := whole + frac
+	if combined == "" {
+		combined = "0"
+	}
 	val, ok := new(big.Int).SetString(combined, 10)
 	if !ok {
 		return nil, errors.New("invalid number")
 	}
 	return val, nil
+}
+
+func allDigits(s string) bool {
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
 }
 
 // FormatAmount converts a raw token amount to human-readable form.

--- a/trade/trade_test.go
+++ b/trade/trade_test.go
@@ -16,6 +16,9 @@ func TestParseAmount(t *testing.T) {
 		{"0.5", 18, "500000000000000000"},
 		{"1.23", 6, "1230000"},
 		{"0.000001", 6, "1"},
+		{".5", 6, "500000"},
+		{"1.", 6, "1000000"},
+		{" 2.5 ", 6, "2500000"},
 	}
 	for _, tt := range tests {
 		got, err := ParseAmount(tt.amount, tt.decimals)
@@ -26,6 +29,29 @@ func TestParseAmount(t *testing.T) {
 		if got.String() != tt.want {
 			t.Errorf("ParseAmount(%q, %d) = %s, want %s", tt.amount, tt.decimals, got.String(), tt.want)
 		}
+	}
+}
+
+func TestParseAmountRejectsInvalidAmounts(t *testing.T) {
+	tests := []struct {
+		name     string
+		amount   string
+		decimals int
+	}{
+		{"empty", "", 6},
+		{"just decimal", ".", 6},
+		{"negative", "-1", 6},
+		{"positive sign", "+1", 6},
+		{"invalid fractional", "1.a", 6},
+		{"too many decimals", "1.2.3", 6},
+		{"negative decimals", "1", -1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got, err := ParseAmount(tt.amount, tt.decimals); err == nil {
+				t.Fatalf("ParseAmount(%q, %d) = %s, want error", tt.amount, tt.decimals, got)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary
- tighten trade amount parsing to reject signed, empty, malformed, and negative-decimal inputs
- add ParseAmount edge-case coverage for valid shorthand amounts and invalid inputs

Closes #649

## Testing
- go build ./...
- go test ./... -short
- go vet ./...