### PR TITLE
Harden reminder metadata parsing

### DIFF
--- a/reminder/reminder.go
+++ b/reminder/reminder.go
@@ -83,14 +83,8 @@ func fetchReminder() {
 	event.Publish(event.Event{Type: "reminder_updated"})
 
 	// Extract message and updated for indexing
-	message := ""
-	if m, ok := val["message"]; ok {
-		message = m.(string)
-	}
-	updated := ""
-	if u, ok := val["updated"]; ok {
-		updated = u.(string)
-	}
+	message := stringField(val, "message")
+	updated := stringField(val, "updated")
 
 	// Index with just the message summary. The full content (verse, hadith, name)
 	// contains markdown that doesn't render well in chat threads, and it changes
@@ -115,6 +109,13 @@ func fetchReminder() {
 	)
 
 	app.Log("reminder", "Updated reminder")
+}
+
+func stringField(val map[string]interface{}, key string) string {
+	if s, ok := val[key].(string); ok {
+		return s
+	}
+	return ""
 }
 
 // ReminderHTML returns the rendered reminder card HTML
@@ -237,4 +238,3 @@ func deduplicateVerseName(text string) string {
 
 	return header + rest
 }
-

--- a/reminder/reminder_test.go
+++ b/reminder/reminder_test.go
@@ -1,8 +1,6 @@
 package reminder
 
-import (
-	"testing"
-)
+import "testing"
 
 func TestReminderData_Structure(t *testing.T) {
 	rd := &ReminderData{
@@ -26,3 +24,36 @@ func TestReminderData_Structure(t *testing.T) {
 	}
 }
 
+func TestStringField(t *testing.T) {
+	fields := map[string]interface{}{
+		"message": "Be mindful of Allah",
+		"updated": 1700000000,
+	}
+
+	if got := stringField(fields, "message"); got != "Be mindful of Allah" {
+		t.Fatalf("stringField(message) = %q, want %q", got, "Be mindful of Allah")
+	}
+	if got := stringField(fields, "updated"); got != "" {
+		t.Fatalf("stringField(updated) = %q, want empty string for non-string value", got)
+	}
+	if got := stringField(fields, "missing"); got != "" {
+		t.Fatalf("stringField(missing) = %q, want empty string", got)
+	}
+}
+
+func TestDeduplicateVerseName(t *testing.T) {
+	input := "Muhammad - Muhammad - 47:1\nThose who disbelieve..."
+	want := "Muhammad - 47:1\nThose who disbelieve..."
+
+	if got := deduplicateVerseName(input); got != want {
+		t.Fatalf("deduplicateVerseName() = %q, want %q", got, want)
+	}
+}
+
+func TestDeduplicateVerseNameLeavesDifferentNames(t *testing.T) {
+	input := "Al-Fatihah - The Opener - 1:1\nIn the name..."
+
+	if got := deduplicateVerseName(input); got != input {
+		t.Fatalf("deduplicateVerseName() = %q, want unchanged input", got)
+	}
+}


### PR DESCRIPTION
## Summary
- avoid panics when reminder API metadata fields are missing or non-string
- add focused reminder tests for metadata extraction and verse-name deduplication

Closes #661

## Testing
- go build ./...
- go test ./... -short
- go vet ./...