### PR TITLE
Fix duplicate Discord briefing headlines

### DIFF
--- a/client/discord/briefing.go
+++ b/client/discord/briefing.go
@@ -104,14 +104,6 @@ func buildBriefing() string {
 			parts = append(parts, "**Market movers:** "+strings.Join(movers, ", "))
 		}
 	}
-	if len(feed) > 0 {
-		var headlines []string
-		for _, p := range feed {
-			headlines = append(headlines, "- "+p.Title)
-		}
-		parts = append(parts, "**Headlines:**\n"+strings.Join(headlines, "\n"))
-	}
-
 	if len(parts) == 0 {
 		return ""
 	}


### PR DESCRIPTION
## Summary
- Remove a duplicated headline section from Discord morning briefing assembly so the AI synthesis input only includes headlines once.

## Testing
- go build ./...
- go test ./... -short
- go vet ./...

Closes #663