### PR TITLE
Handle punctuated micro-agent mentions

### DIFF
--- a/agent/micro/router.go
+++ b/agent/micro/router.go
@@ -33,7 +33,7 @@ func MatchDirectAddress(prompt string) string {
 	if strings.HasPrefix(lower, "@") {
 		parts := strings.Fields(lower)
 		if len(parts) > 0 {
-			id := strings.TrimPrefix(parts[0], "@")
+			id := strings.Trim(strings.TrimPrefix(parts[0], "@"), ` .,:;!?()[]{}<>"'`)
 			if _, ok := Registry[id]; ok {
 				return id
 			}
@@ -98,21 +98,21 @@ func keywordRoute(prompt string) []string {
 
 	// Single-domain keywords
 	routes := map[string][]string{
-		"mail":      {"mail"},
-		"email":     {"mail"},
-		"inbox":     {"mail"},
-		"unread":    {"mail"},
-		"quran":     {"faith"},
-		"hadith":    {"faith"},
-		"reminder":  {"faith"},
-		"surah":     {"faith"},
-		"verse":     {"faith"},
-		"coworking": {"places"},
-		"nearby":    {"places"},
+		"mail":       {"mail"},
+		"email":      {"mail"},
+		"inbox":      {"mail"},
+		"unread":     {"mail"},
+		"quran":      {"faith"},
+		"hadith":     {"faith"},
+		"reminder":   {"faith"},
+		"surah":      {"faith"},
+		"verse":      {"faith"},
+		"coworking":  {"places"},
+		"nearby":     {"places"},
 		"restaurant": {"places"},
-		"cafe":      {"places"},
-		"blog":      {"social"},
-		"post":      {"social"},
+		"cafe":       {"places"},
+		"blog":       {"social"},
+		"post":       {"social"},
 	}
 
 	for keyword, ids := range routes {

--- a/agent/micro/router_test.go
+++ b/agent/micro/router_test.go
@@ -17,6 +17,11 @@ func TestRouteDirectAddressAvoidsLLM(t *testing.T) {
 			want:   []string{"markets"},
 		},
 		{
+			name:   "at mention with punctuation",
+			prompt: "@markets, what is ETH doing today?",
+			want:   []string{"markets"},
+		},
+		{
 			name:   "ask the agent",
 			prompt: "ask the weather agent about Lisbon tomorrow",
 			want:   []string{"weather"},


### PR DESCRIPTION
## Summary
- Trim common punctuation from @agent direct-address tokens before registry lookup.
- Add coverage for comma-punctuated micro-agent mentions.

Closes #669

## Testing
- go build ./...
- go test ./... -short
- go vet ./...