### PR TITLE
Fix Telegram account ID collisions

### DIFF
--- a/client/telegram/telegram.go
+++ b/client/telegram/telegram.go
@@ -28,8 +28,8 @@ import (
 )
 
 var (
-	linkMu   sync.RWMutex
-	links    = map[string]string{} // telegram user ID → mu account ID
+	linkMu sync.RWMutex
+	links  = map[string]string{} // telegram user ID → mu account ID
 
 	historyMu sync.RWMutex
 	histories = map[string][]agent.QueryMessage{} // telegram user ID → recent messages
@@ -375,7 +375,7 @@ func DeleteLinks(muAccount string) {
 	data.SaveJSON("telegram_links.json", links)
 }
 
-func autoCreateAccount(telegramID, username, displayName string) string {
+func sanitizeAccountID(telegramID, username string) string {
 	id := strings.ToLower(username)
 	id = strings.Map(func(r rune) rune {
 		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '_' {
@@ -389,20 +389,46 @@ func autoCreateAccount(telegramID, username, displayName string) string {
 	if len(id) > 24 {
 		id = id[:24]
 	}
+	return id
+}
 
-	baseID := id
-	for i := 0; i < 100; i++ {
-		if _, err := auth.GetAccount(id); err != nil {
-			break
+func uniqueAccountID(baseID string, exists func(string) bool) string {
+	if !exists(baseID) {
+		return baseID
+	}
+	for i := 1; i < 100; i++ {
+		suffix := fmt.Sprintf("%d", i)
+		prefixLen := 24 - len(suffix)
+		if prefixLen <= 0 {
+			return ""
 		}
-		id = fmt.Sprintf("%s%d", baseID, i+1)
-		if len(id) > 24 {
-			id = id[:24]
+		candidate := baseID
+		if len(candidate) > prefixLen {
+			candidate = candidate[:prefixLen]
 		}
+		candidate += suffix
+		if !exists(candidate) {
+			return candidate
+		}
+	}
+	return ""
+}
+
+func autoCreateAccount(telegramID, username, displayName string) string {
+	id := uniqueAccountID(sanitizeAccountID(telegramID, username), func(id string) bool {
+		_, err := auth.GetAccount(id)
+		return err == nil
+	})
+	if id == "" {
+		app.Log("telegram", "Auto-create failed for %s: no available account ID", username)
+		return ""
 	}
 
 	passBytes := make([]byte, 16)
-	rand.Read(passBytes)
+	if _, err := rand.Read(passBytes); err != nil {
+		app.Log("telegram", "Auto-create failed for %s: %v", username, err)
+		return ""
+	}
 	pass := hex.EncodeToString(passBytes)
 
 	acc := &auth.Account{
@@ -424,7 +450,7 @@ func autoCreateAccount(telegramID, username, displayName string) string {
 func getHistory(telegramID string) []agent.QueryMessage {
 	historyMu.RLock()
 	defer historyMu.RUnlock()
-	return histories[telegramID]
+	return append([]agent.QueryMessage(nil), histories[telegramID]...)
 }
 
 func addHistory(telegramID string, role, text string) {

--- a/client/telegram/telegram_test.go
+++ b/client/telegram/telegram_test.go
@@ -1,0 +1,85 @@
+package telegram
+
+import (
+	"testing"
+
+	"mu/agent"
+)
+
+func TestSanitizeAccountID(t *testing.T) {
+	tests := []struct {
+		name       string
+		telegramID string
+		username   string
+		want       string
+	}{
+		{
+			name:       "lowercases and removes unsupported characters",
+			telegramID: "123456789",
+			username:   "Mu.User-Name!",
+			want:       "muusername",
+		},
+		{
+			name:       "pads short usernames with telegram suffix",
+			telegramID: "123456789",
+			username:   "Al",
+			want:       "al6789",
+		},
+		{
+			name:       "caps account IDs at auth limit",
+			telegramID: "123456789",
+			username:   "averyveryverylongtelegramusername",
+			want:       "averyveryverylongtelegra",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := sanitizeAccountID(tt.telegramID, tt.username); got != tt.want {
+				t.Fatalf("sanitizeAccountID(%q, %q) = %q, want %q", tt.telegramID, tt.username, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestUniqueAccountIDPreservesSuffixForLongBase(t *testing.T) {
+	base := "averyveryverylongtelegra"
+	existing := map[string]bool{base: true}
+
+	got := uniqueAccountID(base, func(id string) bool { return existing[id] })
+	want := "averyveryverylongtelegr1"
+	if got != want {
+		t.Fatalf("uniqueAccountID() = %q, want %q", got, want)
+	}
+	if len(got) > 24 {
+		t.Fatalf("uniqueAccountID() length = %d, want <= 24", len(got))
+	}
+}
+
+func TestUniqueAccountIDExhaustion(t *testing.T) {
+	base := "taken"
+	got := uniqueAccountID(base, func(id string) bool { return true })
+	if got != "" {
+		t.Fatalf("uniqueAccountID() = %q, want empty string when exhausted", got)
+	}
+}
+
+func TestGetHistoryReturnsCopy(t *testing.T) {
+	telegramID := "history-copy-test"
+	historyMu.Lock()
+	histories[telegramID] = []agent.QueryMessage{{Role: "user", Text: "original"}}
+	historyMu.Unlock()
+	defer func() {
+		historyMu.Lock()
+		delete(histories, telegramID)
+		historyMu.Unlock()
+	}()
+
+	got := getHistory(telegramID)
+	got[0].Text = "mutated"
+
+	again := getHistory(telegramID)
+	if again[0].Text != "original" {
+		t.Fatalf("getHistory returned mutable backing storage; got %q", again[0].Text)
+	}
+}


### PR DESCRIPTION
Fix Telegram auto-created account ID collision handling for long usernames and add focused tests for ID sanitization, suffixing, and history copy behavior.

Closes #674