### PR TITLE
Validate username format in shared auth helper

### DIFF
--- a/internal/auth/username.go
+++ b/internal/auth/username.go
@@ -16,9 +16,13 @@ var bannedWords = []string{
 
 // ValidateUsername returns an error string if the username is not
 // allowed, or "" if it's fine. Called from both web signup and MCP
-// signup. This is in addition to the regex format check — a username
-// can be well-formed but still banned.
+// signup, so it enforces the shared username format as well as the
+// blocklist and reserved names.
 func ValidateUsername(username string) string {
+	if !validUsernameFormat(username) {
+		return "Invalid username format. Must start with a letter, be 4-24 characters, and contain only lowercase letters, numbers, and underscores"
+	}
+
 	lower := strings.ToLower(username)
 	for _, w := range bannedWords {
 		if strings.Contains(lower, w) {
@@ -31,4 +35,23 @@ func ValidateUsername(username string) string {
 		return "That username is reserved."
 	}
 	return ""
+}
+
+func validUsernameFormat(username string) bool {
+	if len(username) < 4 || len(username) > 24 {
+		return false
+	}
+	for i, r := range username {
+		if i == 0 {
+			if r < 'a' || r > 'z' {
+				return false
+			}
+			continue
+		}
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '_' {
+			continue
+		}
+		return false
+	}
+	return true
 }

--- a/internal/auth/username_test.go
+++ b/internal/auth/username_test.go
@@ -1,0 +1,52 @@
+package auth
+
+import "testing"
+
+func TestValidateUsernameFormat(t *testing.T) {
+	tests := []struct {
+		name     string
+		username string
+		wantErr  bool
+	}{
+		{name: "valid minimum length", username: "abcd"},
+		{name: "valid maximum length", username: "abcdefghijklmnopqrstuvwx"},
+		{name: "valid with digits and underscores", username: "agent_007"},
+		{name: "too short", username: "abc", wantErr: true},
+		{name: "too long", username: "abcdefghijklmnopqrstuvwxy", wantErr: true},
+		{name: "must start with letter", username: "1agent", wantErr: true},
+		{name: "uppercase rejected", username: "Agent", wantErr: true},
+		{name: "hyphen rejected", username: "agent-name", wantErr: true},
+		{name: "non ascii rejected", username: "ågent", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ValidateUsername(tt.username)
+			if tt.wantErr && got == "" {
+				t.Fatalf("ValidateUsername(%q) returned no error", tt.username)
+			}
+			if !tt.wantErr && got != "" {
+				t.Fatalf("ValidateUsername(%q) = %q, want no error", tt.username, got)
+			}
+		})
+	}
+}
+
+func TestValidateUsernameReservedAndBlockedNames(t *testing.T) {
+	tests := []struct {
+		name     string
+		username string
+		want     string
+	}{
+		{name: "reserved", username: "admin", want: "That username is reserved."},
+		{name: "blocked substring", username: "pornbot", want: "That username is not allowed."},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ValidateUsername(tt.username); got != tt.want {
+				t.Fatalf("ValidateUsername(%q) = %q, want %q", tt.username, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- enforce the documented username format in the shared auth validator used by MCP signup
- add username validation coverage for accepted formats, rejected formats, reserved names, and blocked substrings

Closes #676

## Tests
- go build ./...
- go test ./... -short
- go vet ./...