### PR TITLE
Harden settings load

### DIFF
--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -16,7 +16,14 @@ var (
 )
 
 func Load() {
-	data.LoadJSON("settings.json", &values)
+	loaded := map[string]string{}
+	if err := data.LoadJSON("settings.json", &loaded); err != nil {
+		return
+	}
+
+	mu.Lock()
+	values = loaded
+	mu.Unlock()
 }
 
 // Get returns the value for a key. Environment variable takes precedence

--- a/internal/settings/settings_test.go
+++ b/internal/settings/settings_test.go
@@ -77,6 +77,22 @@ func TestLoadReadsPersistedSettings(t *testing.T) {
 	}
 }
 
+func TestLoadKeepsExistingSettingsOnInvalidJSON(t *testing.T) {
+	resetForTest(t)
+
+	Set("MU_TEST_SETTING", "saved-value")
+	path := filepath.Join(os.Getenv("HOME"), ".mu", "data", "settings.json")
+	if err := os.WriteFile(path, []byte(`{"MU_TEST_SETTING":`), 0600); err != nil {
+		t.Fatalf("write invalid settings: %v", err)
+	}
+
+	Load()
+
+	if got := Get("MU_TEST_SETTING"); got != "saved-value" {
+		t.Fatalf("Get after invalid Load = %q, want saved-value", got)
+	}
+}
+
 func TestAllReturnsCopyOfSavedSettings(t *testing.T) {
 	resetForTest(t)
 


### PR DESCRIPTION
Harden settings loading so malformed persisted settings do not partially mutate the in-memory settings map, and cover the behavior with a regression test.

Closes #678