### PR TITLE
Harden micro agent route validation

### DIFF
--- a/agent/micro/router.go
+++ b/agent/micro/router.go
@@ -194,11 +194,23 @@ func llmRoute(prompt string) []string {
 		return []string{"micro"}
 	}
 
-	// Validate agent IDs
-	var valid []string
+	return validateAgentIDs(ids)
+}
+
+func validateAgentIDs(ids []string) []string {
+	valid := make([]string, 0, min(len(ids), 3))
+	seen := map[string]bool{}
 	for _, id := range ids {
-		if _, ok := Registry[id]; ok {
-			valid = append(valid, id)
+		if seen[id] {
+			continue
+		}
+		if _, ok := Registry[id]; !ok {
+			continue
+		}
+		seen[id] = true
+		valid = append(valid, id)
+		if len(valid) == 3 {
+			break
 		}
 	}
 	if len(valid) == 0 {

--- a/agent/micro/router_test.go
+++ b/agent/micro/router_test.go
@@ -102,3 +102,19 @@ func TestAllExcludesFallbackAgent(t *testing.T) {
 		}
 	}
 }
+
+func TestValidateAgentIDsDeduplicatesAndLimits(t *testing.T) {
+	got := validateAgentIDs([]string{"markets", "bogus", "markets", "news", "weather", "mail"})
+	want := []string{"markets", "news", "weather"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("validateAgentIDs() = %v, want %v", got, want)
+	}
+}
+
+func TestValidateAgentIDsFallsBackToMicro(t *testing.T) {
+	got := validateAgentIDs([]string{"bogus"})
+	want := []string{"micro"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("validateAgentIDs() = %v, want %v", got, want)
+	}
+}


### PR DESCRIPTION
## Summary
- Deduplicate LLM-selected micro agent IDs before orchestration
- Ignore unknown agent IDs and enforce the router's three-agent limit
- Add regression tests for invalid, duplicate, and over-limit routing output

Closes #681

## Verification
- go build ./...
- go test ./... -short
- go vet ./...