### PR TITLE
Harden reminder MCP API calls

### DIFF
--- a/internal/api/mcp.go
+++ b/internal/api/mcp.go
@@ -16,6 +16,47 @@ import (
 // MCP protocol version
 const MCPVersion = "2025-03-26"
 
+var (
+	reminderHTTPClient = &http.Client{Timeout: 10 * time.Second}
+	reminderAPIBase    = "https://reminder.dev/api"
+)
+
+func reminderAPIURL(path string) string {
+	return strings.TrimRight(reminderAPIBase, "/") + path
+}
+
+func getReminderAPI(path string) (string, error) {
+	resp, err := reminderHTTPClient.Get(reminderAPIURL(path))
+	if err != nil {
+		return "", fmt.Errorf("reminder API error: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return "", fmt.Errorf("reminder API returned status %d", resp.StatusCode)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("reading reminder response: %w", err)
+	}
+	return string(body), nil
+}
+
+func postReminderAPI(path, contentType, body string) (string, error) {
+	resp, err := reminderHTTPClient.Post(reminderAPIURL(path), contentType, strings.NewReader(body))
+	if err != nil {
+		return "", fmt.Errorf("reminder API error: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return "", fmt.Errorf("reminder API returned status %d", resp.StatusCode)
+	}
+	b, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("reading reminder response: %w", err)
+	}
+	return string(b), nil
+}
+
 // JSON-RPC types
 type jsonrpcRequest struct {
 	JSONRPC string          `json:"jsonrpc"`
@@ -108,9 +149,9 @@ type Tool struct {
 	Method      string
 	Path        string
 	Params      []ToolParam
-	WalletOp    string                                          // Wallet operation for credit gating (empty = included)
-	Handle      func(map[string]any) (string, error)            // Optional direct handler (bypasses HTTP dispatch)
-	HandleAuth  func(map[string]any, string) (string, error)    // Like Handle but receives the account ID
+	WalletOp    string                                       // Wallet operation for credit gating (empty = included)
+	Handle      func(map[string]any) (string, error)         // Optional direct handler (bypasses HTTP dispatch)
+	HandleAuth  func(map[string]any, string) (string, error) // Like Handle but receives the account ID
 }
 
 // QuotaCheck is called before executing a metered tool.
@@ -503,17 +544,7 @@ var tools = []Tool{
 		Name:        "reminder",
 		Description: "Get today's daily Islamic reminder with verse, hadith, and name of Allah",
 		Handle: func(args map[string]any) (string, error) {
-			client := &http.Client{Timeout: 10 * time.Second}
-			resp, err := client.Get("https://reminder.dev/api/daily")
-			if err != nil {
-				return "", fmt.Errorf("reminder API error: %v", err)
-			}
-			defer resp.Body.Close()
-			body, err := io.ReadAll(resp.Body)
-			if err != nil {
-				return "", fmt.Errorf("reading reminder response: %v", err)
-			}
-			return string(body), nil
+			return getReminderAPI("/daily")
 		},
 	},
 	{
@@ -531,17 +562,11 @@ var tools = []Tool{
 			if chapter == "" {
 				return "", fmt.Errorf("chapter is required")
 			}
-			url := "https://reminder.dev/api/quran/" + chapter
+			path := "/quran/" + chapter
 			if v, ok := args["verse"].(float64); ok && v > 0 {
-				url += fmt.Sprintf("/%d", int(v))
+				path += fmt.Sprintf("/%d", int(v))
 			}
-			resp, err := http.Get(url)
-			if err != nil {
-				return "", err
-			}
-			defer resp.Body.Close()
-			b, _ := io.ReadAll(resp.Body)
-			return string(b), nil
+			return getReminderAPI(path)
 		},
 	},
 	{
@@ -551,17 +576,11 @@ var tools = []Tool{
 			{Name: "book", Type: "number", Description: "Book number", Required: false},
 		},
 		Handle: func(args map[string]any) (string, error) {
-			url := "https://reminder.dev/api/hadith"
+			path := "/hadith"
 			if b, ok := args["book"].(float64); ok && b > 0 {
-				url += fmt.Sprintf("/%d", int(b))
+				path += fmt.Sprintf("/%d", int(b))
 			}
-			resp, err := http.Get(url)
-			if err != nil {
-				return "", err
-			}
-			defer resp.Body.Close()
-			b, _ := io.ReadAll(resp.Body)
-			return string(b), nil
+			return getReminderAPI(path)
 		},
 	},
 	{
@@ -577,13 +596,7 @@ var tools = []Tool{
 				return "", fmt.Errorf("query is required")
 			}
 			body := fmt.Sprintf(`{"q":%q}`, q)
-			resp, err := http.Post("https://reminder.dev/api/search", "application/json", strings.NewReader(body))
-			if err != nil {
-				return "", err
-			}
-			defer resp.Body.Close()
-			b, _ := io.ReadAll(resp.Body)
-			return string(b), nil
+			return postReminderAPI("/search", "application/json", body)
 		},
 	},
 }

--- a/internal/api/mcp_test.go
+++ b/internal/api/mcp_test.go
@@ -567,3 +567,63 @@ func TestRegisterTool(t *testing.T) {
 		t.Error("Registered tool not found in tools list")
 	}
 }
+
+func TestReminderAPIHelpersRejectNonSuccessStatus(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/daily" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		http.Error(w, "upstream unavailable", http.StatusBadGateway)
+	}))
+	defer server.Close()
+
+	origBase := reminderAPIBase
+	origClient := reminderHTTPClient
+	reminderAPIBase = server.URL + "/"
+	reminderHTTPClient = server.Client()
+	defer func() {
+		reminderAPIBase = origBase
+		reminderHTTPClient = origClient
+	}()
+
+	_, err := getReminderAPI("/daily")
+	if err == nil {
+		t.Fatal("expected non-success status to return an error")
+	}
+	if !strings.Contains(err.Error(), "status 502") {
+		t.Fatalf("expected status code in error, got %v", err)
+	}
+}
+
+func TestReminderAPIHelpersUseConfiguredBaseAndClient(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+		if r.URL.Path != "/api/search" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if got := r.Header.Get("Content-Type"); got != "application/json" {
+			t.Fatalf("unexpected content type: %s", got)
+		}
+		w.Write([]byte(`{"ok":true}`))
+	}))
+	defer server.Close()
+
+	origBase := reminderAPIBase
+	origClient := reminderHTTPClient
+	reminderAPIBase = server.URL + "/api/"
+	reminderHTTPClient = server.Client()
+	defer func() {
+		reminderAPIBase = origBase
+		reminderHTTPClient = origClient
+	}()
+
+	got, err := postReminderAPI("/search", "application/json", `{"q":"test"}`)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != `{"ok":true}` {
+		t.Fatalf("unexpected body: %s", got)
+	}
+}


### PR DESCRIPTION
## Summary
- Add shared Reminder API helpers with timeout-aware client reuse and non-2xx status handling.
- Route reminder, quran, hadith, and quran_search MCP tools through the helpers.
- Add unit coverage for upstream status errors and configurable Reminder API request handling.

Closes #684

## Testing
- go build ./...
- go test ./... -short
- go vet ./...