### PR TITLE
Reject over-precise trade amounts

### DIFF
--- a/trade/trade.go
+++ b/trade/trade.go
@@ -270,7 +270,7 @@ func ParseAmount(amount string, decimals int) (*big.Int, error) {
 	}
 
 	if len(frac) > decimals {
-		frac = frac[:decimals]
+		return nil, errors.New("too many decimal places")
 	}
 	for len(frac) < decimals {
 		frac += "0"

--- a/trade/trade_test.go
+++ b/trade/trade_test.go
@@ -43,7 +43,8 @@ func TestParseAmountRejectsInvalidAmounts(t *testing.T) {
 		{"negative", "-1", 6},
 		{"positive sign", "+1", 6},
 		{"invalid fractional", "1.a", 6},
-		{"too many decimals", "1.2.3", 6},
+		{"too many decimal separators", "1.2.3", 6},
+		{"too many fractional digits", "0.0000001", 6},
 		{"negative decimals", "1", -1},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary
- Reject trade amount inputs with more fractional digits than the token supports instead of silently truncating them.
- Add coverage for over-precise amount parsing.

## Testing
- go build ./...
- go test ./... -short
- go vet ./...

Closes #696