### PR TITLE
Guard trade history limits

### DIFF
--- a/trade/trade.go
+++ b/trade/trade.go
@@ -227,6 +227,10 @@ func GetTrades(accountID string, limit int) []*Trade {
 	walletMu.RLock()
 	defer walletMu.RUnlock()
 
+	if limit <= 0 {
+		return nil
+	}
+
 	t := trades[accountID]
 	if len(t) <= limit {
 		return t

--- a/trade/trade_test.go
+++ b/trade/trade_test.go
@@ -6,6 +6,24 @@ import (
 	"testing"
 )
 
+func TestGetTradesHandlesNonPositiveLimit(t *testing.T) {
+	walletMu.Lock()
+	trades = map[string][]*Trade{
+		"acct": {
+			{ID: "oldest"},
+			{ID: "newest"},
+		},
+	}
+	walletMu.Unlock()
+
+	if got := GetTrades("acct", 0); len(got) != 0 {
+		t.Fatalf("GetTrades limit 0 returned %d trades, want 0", len(got))
+	}
+	if got := GetTrades("acct", -1); len(got) != 0 {
+		t.Fatalf("GetTrades negative limit returned %d trades, want 0", len(got))
+	}
+}
+
 func TestParseAmount(t *testing.T) {
 	tests := []struct {
 		amount   string


### PR DESCRIPTION
Fix GetTrades so non-positive limits return an empty result instead of slicing with an invalid index.\n\nCloses #699