### PR TITLE
Fix status update counts for expired entries

### DIFF
--- a/user/status_test.go
+++ b/user/status_test.go
@@ -229,3 +229,41 @@ func TestUpdateProfile_AlwaysAppendsHistory(t *testing.T) {
 		t.Errorf("after third update, history = %+v, want ['world', 'hello']", p3.History)
 	}
 }
+
+func TestStatusCountSince_IgnoresExpiredEntries(t *testing.T) {
+	profileMutex.Lock()
+	saved := profiles
+	profiles = map[string]*Profile{}
+	profileMutex.Unlock()
+	t.Cleanup(func() {
+		profileMutex.Lock()
+		profiles = saved
+		profileMutex.Unlock()
+	})
+
+	now := time.Now()
+	expired := now.Add(-statusMaxAge - time.Hour)
+	profileMutex.Lock()
+	profiles["alice"] = &Profile{
+		UserID:    "alice",
+		Status:    "expired current",
+		UpdatedAt: expired,
+		History: []StatusHistory{
+			{Status: "expired history", SetAt: expired.Add(-time.Minute)},
+		},
+	}
+	profiles["bob"] = &Profile{
+		UserID:    "bob",
+		Status:    "fresh current",
+		UpdatedAt: now,
+		History: []StatusHistory{
+			{Status: "fresh history", SetAt: now.Add(-time.Minute)},
+		},
+	}
+	profileMutex.Unlock()
+
+	count := StatusCountSince(now.Add(-2*statusMaxAge), "")
+	if count != 2 {
+		t.Fatalf("StatusCountSince counted %d entries, want only the 2 fresh entries", count)
+	}
+}

--- a/user/user.go
+++ b/user/user.go
@@ -52,7 +52,7 @@ var profiles = map[string]*Profile{}
 type Profile struct {
 	UserID    string          `json:"user_id"`
 	Status    string          `json:"status"`     // User's custom status message
-	History   []StatusHistory `json:"history"`     // Past statuses, newest first
+	History   []StatusHistory `json:"history"`    // Past statuses, newest first
 	UpdatedAt time.Time       `json:"updated_at"` // When the profile was last updated
 }
 
@@ -420,16 +420,17 @@ func StatusCountSince(since time.Time, viewerID string) int {
 	profileMutex.RLock()
 	defer profileMutex.RUnlock()
 
+	cutoff := time.Now().Add(-statusMaxAge)
 	count := 0
 	for _, p := range profiles {
 		if auth.IsBanned(p.UserID) && p.UserID != viewerID {
 			continue
 		}
-		if !p.UpdatedAt.IsZero() && p.UpdatedAt.After(since) {
+		if !p.UpdatedAt.IsZero() && !p.UpdatedAt.Before(cutoff) && p.UpdatedAt.After(since) {
 			count++
 		}
 		for _, h := range p.History {
-			if h.SetAt.After(since) {
+			if !h.SetAt.Before(cutoff) && h.SetAt.After(since) {
 				count++
 			}
 		}


### PR DESCRIPTION
## Summary
- Keep status update counts aligned with the visible status stream by ignoring entries older than the status max age.
- Add regression coverage for expired current and historical status entries.

## Testing
- go build ./...
- go test ./... -short
- go vet ./...

Closes #705