### PR TITLE
Handle malformed Coinbase rates

### DIFF
--- a/markets/markets.go
+++ b/markets/markets.go
@@ -169,18 +169,16 @@ func fetchPrices() (map[string]float64, map[string]PriceData) {
 	defer rsp.Body.Close()
 
 	b, _ := ioutil.ReadAll(rsp.Body)
-	var res map[string]interface{}
-	json.Unmarshal(b, &res)
-	if res == nil {
+	rates, err := parseCoinbaseRates(b)
+	if err != nil {
+		app.Log("markets", "Error parsing crypto prices: %v", err)
 		return nil, nil
 	}
-
-	rates := res["data"].(map[string]interface{})["rates"].(map[string]interface{})
 	prices := map[string]float64{}
 	priceData := map[string]PriceData{}
 
 	for k, t := range rates {
-		val, err := strconv.ParseFloat(t.(string), 64)
+		val, err := strconv.ParseFloat(t, 64)
 		if err != nil {
 			continue
 		}
@@ -260,6 +258,21 @@ func fetchPrices() (map[string]float64, map[string]PriceData) {
 
 	app.Log("markets", "Finished fetching prices")
 	return prices, priceData
+}
+
+func parseCoinbaseRates(body []byte) (map[string]string, error) {
+	var res struct {
+		Data struct {
+			Rates map[string]string `json:"rates"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(body, &res); err != nil {
+		return nil, err
+	}
+	if len(res.Data.Rates) == 0 {
+		return nil, fmt.Errorf("missing rates")
+	}
+	return res.Data.Rates, nil
 }
 
 // fetchCoinGeckoChanges fetches 24h price changes from CoinGecko for all crypto assets

--- a/markets/markets_test.go
+++ b/markets/markets_test.go
@@ -145,6 +145,36 @@ func TestGetAllPrices_ReturnsDefensiveCopy(t *testing.T) {
 	}
 }
 
+func TestParseCoinbaseRates(t *testing.T) {
+	rates, err := parseCoinbaseRates([]byte(`{"data":{"rates":{"BTC":"0.000010","ETH":"0.000300"}}}`))
+	if err != nil {
+		t.Fatalf("parseCoinbaseRates returned error: %v", err)
+	}
+	if rates["BTC"] != "0.000010" {
+		t.Fatalf("BTC rate = %q, want %q", rates["BTC"], "0.000010")
+	}
+}
+
+func TestParseCoinbaseRatesRejectsMalformedPayloads(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+	}{
+		{name: "invalid json", body: `{`},
+		{name: "missing data", body: `{}`},
+		{name: "missing rates", body: `{"data":{}}`},
+		{name: "wrong rate shape", body: `{"data":{"rates":[]}}`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := parseCoinbaseRates([]byte(tt.body)); err == nil {
+				t.Fatalf("parseCoinbaseRates(%s) returned nil error", tt.body)
+			}
+		})
+	}
+}
+
 func TestGetAllPriceData_ReturnsDefensiveCopy(t *testing.T) {
 	marketsMutex.Lock()
 	cachedPriceData = map[string]PriceData{


### PR DESCRIPTION
## Summary
- Parse Coinbase exchange-rate responses into a typed shape instead of unchecked interface assertions.
- Return a logged error for malformed or missing rate payloads.
- Add regression coverage for valid and malformed Coinbase payloads.

Closes #707

## Testing
- go build ./...
- go test ./... -short
- go vet ./...