### PR TITLE
Fix deterministic micro keyword routing

### DIFF
--- a/agent/micro/router.go
+++ b/agent/micro/router.go
@@ -96,28 +96,33 @@ func StripAddress(prompt string) string {
 func keywordRoute(prompt string) []string {
 	lower := strings.ToLower(prompt)
 
-	// Single-domain keywords
-	routes := map[string][]string{
-		"mail":       {"mail"},
-		"email":      {"mail"},
-		"inbox":      {"mail"},
-		"unread":     {"mail"},
-		"quran":      {"faith"},
-		"hadith":     {"faith"},
-		"reminder":   {"faith"},
-		"surah":      {"faith"},
-		"verse":      {"faith"},
-		"coworking":  {"places"},
-		"nearby":     {"places"},
-		"restaurant": {"places"},
-		"cafe":       {"places"},
-		"blog":       {"social"},
-		"post":       {"social"},
+	// Single-domain keywords are checked in a fixed order so prompts that
+	// contain more than one keyword route predictably instead of depending on
+	// Go's randomized map iteration order.
+	routes := []struct {
+		keyword string
+		ids     []string
+	}{
+		{keyword: "mail", ids: []string{"mail"}},
+		{keyword: "email", ids: []string{"mail"}},
+		{keyword: "inbox", ids: []string{"mail"}},
+		{keyword: "unread", ids: []string{"mail"}},
+		{keyword: "quran", ids: []string{"faith"}},
+		{keyword: "hadith", ids: []string{"faith"}},
+		{keyword: "reminder", ids: []string{"faith"}},
+		{keyword: "surah", ids: []string{"faith"}},
+		{keyword: "verse", ids: []string{"faith"}},
+		{keyword: "coworking", ids: []string{"places"}},
+		{keyword: "nearby", ids: []string{"places"}},
+		{keyword: "restaurant", ids: []string{"places"}},
+		{keyword: "cafe", ids: []string{"places"}},
+		{keyword: "blog", ids: []string{"social"}},
+		{keyword: "post", ids: []string{"social"}},
 	}
 
-	for keyword, ids := range routes {
-		if strings.Contains(lower, keyword) {
-			return ids
+	for _, route := range routes {
+		if strings.Contains(lower, route.keyword) {
+			return route.ids
 		}
 	}
 

--- a/agent/micro/router_test.go
+++ b/agent/micro/router_test.go
@@ -118,3 +118,14 @@ func TestValidateAgentIDsFallsBackToMicro(t *testing.T) {
 		t.Fatalf("validateAgentIDs() = %v, want %v", got, want)
 	}
 }
+
+func TestKeywordRouteSingleDomainPriorityIsDeterministic(t *testing.T) {
+	prompt := "summarize unread email about the team lunch restaurant"
+	want := []string{"mail"}
+
+	for i := 0; i < 100; i++ {
+		if got := keywordRoute(prompt); !reflect.DeepEqual(got, want) {
+			t.Fatalf("keywordRoute() iteration %d = %v, want %v", i, got, want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Make micro-agent single-domain keyword routing deterministic by replacing randomized map iteration with ordered route checks.
- Add a regression test for prompts with overlapping single-domain keywords.

Closes #709

## Testing
- go build ./...
- go test ./... -short
- go vet ./...