### PR TITLE
Handle whitespace in micro-agent addresses

### DIFF
--- a/agent/micro/router.go
+++ b/agent/micro/router.go
@@ -27,6 +27,7 @@ func Route(prompt string) []string {
 // MatchDirectAddress checks if the user explicitly addresses an agent.
 // e.g. "ask the markets agent about ETH" or "@markets ETH price"
 func MatchDirectAddress(prompt string) string {
+	prompt = strings.TrimSpace(prompt)
 	lower := strings.ToLower(prompt)
 
 	// "@agent" pattern
@@ -57,6 +58,7 @@ func MatchDirectAddress(prompt string) string {
 
 // StripAddress removes the agent address prefix from a prompt.
 func StripAddress(prompt string) string {
+	prompt = strings.TrimSpace(prompt)
 	lower := strings.ToLower(prompt)
 
 	if strings.HasPrefix(lower, "@") {

--- a/agent/micro/router_test.go
+++ b/agent/micro/router_test.go
@@ -22,6 +22,11 @@ func TestRouteDirectAddressAvoidsLLM(t *testing.T) {
 			want:   []string{"markets"},
 		},
 		{
+			name:   "at mention with leading whitespace",
+			prompt: "  @markets what is ETH doing today?",
+			want:   []string{"markets"},
+		},
+		{
 			name:   "ask the agent",
 			prompt: "ask the weather agent about Lisbon tomorrow",
 			want:   []string{"weather"},
@@ -57,6 +62,11 @@ func TestStripAddress(t *testing.T) {
 			name:   "ask agent about",
 			prompt: "ask the weather agent about Lisbon tomorrow",
 			want:   "Lisbon tomorrow",
+		},
+		{
+			name:   "at mention with leading whitespace",
+			prompt: "  @markets what is ETH doing today?",
+			want:   "what is ETH doing today?",
 		},
 		{
 			name:   "use agent",


### PR DESCRIPTION
## Summary
- Trim surrounding whitespace before matching direct micro-agent addresses.
- Add regression coverage for leading-whitespace @agent prompts.

Closes #711

## Testing
- go build ./...
- go test ./... -short
- go vet ./...