### PR TITLE
Harden app security scanning

### DIFF
--- a/apps/scan.go
+++ b/apps/scan.go
@@ -1,7 +1,14 @@
 package apps
 
 import (
+	"regexp"
 	"strings"
+)
+
+var (
+	externalRedirectRe = regexp.MustCompile(`(?i)window\.location(?:\.href)?\s*=\s*['\"]https?://`)
+	externalScriptRe   = regexp.MustCompile(`(?i)<script\b[^>]*\bsrc\s*=\s*['\"]https?://`)
+	evalCallRe         = regexp.MustCompile(`(?i)\beval\s*\(`)
 )
 
 // ScanApp checks app HTML for security issues before saving.
@@ -16,28 +23,22 @@ func ScanApp(html string) []string {
 	}
 
 	// Block credential harvesting
-	if strings.Contains(html, "XMLHttpRequest") && (strings.Contains(lower, "password") || strings.Contains(lower, "credential")) {
+	if strings.Contains(lower, "xmlhttprequest") && (strings.Contains(lower, "password") || strings.Contains(lower, "credential")) {
 		issues = append(issues, "Suspicious credential harvesting pattern")
 	}
 
-	// Block redirecting to external sites for phishing
-	if strings.Contains(lower, "window.location") && strings.Contains(html, "http") {
-		// Allow relative redirects, block absolute
-		for _, pattern := range []string{"window.location='http", `window.location="http`, "window.location.href='http", `window.location.href="http`} {
-			if strings.Contains(lower, pattern) {
-				issues = append(issues, "Redirecting to external URLs is not allowed")
-				break
-			}
-		}
+	// Block redirecting to external sites for phishing.
+	if externalRedirectRe.MatchString(html) {
+		issues = append(issues, "Redirecting to external URLs is not allowed")
 	}
 
-	// Block loading external scripts
-	if strings.Contains(lower, `<script src="http`) || strings.Contains(lower, `<script src='http`) {
+	// Block loading external scripts.
+	if externalScriptRe.MatchString(html) {
 		issues = append(issues, "Loading external scripts is not allowed")
 	}
 
-	// Block eval with string concatenation (code injection)
-	if strings.Contains(html, "eval(") && !strings.Contains(html, "// safe-eval") {
+	// Block eval with string concatenation (code injection).
+	if evalCallRe.MatchString(html) && !strings.Contains(lower, "// safe-eval") {
 		issues = append(issues, "eval() is not allowed")
 	}
 

--- a/apps/scan_test.go
+++ b/apps/scan_test.go
@@ -1,0 +1,71 @@
+package apps
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestScanAppAllowsBenignHTML(t *testing.T) {
+	issues := ScanApp(`<!doctype html><button onclick="window.location='/apps'">Apps</button><script>console.log('ok')</script>`)
+	if len(issues) != 0 {
+		t.Fatalf("expected no issues, got %v", issues)
+	}
+}
+
+func TestScanAppBlocksCookieAccessCaseInsensitive(t *testing.T) {
+	issues := ScanApp(`<script>console.log(Document.Cookie)</script>`)
+	assertScanIssue(t, issues, "document.cookie")
+}
+
+func TestScanAppBlocksCredentialHarvestingCaseInsensitive(t *testing.T) {
+	issues := ScanApp(`<script>var xhr = new xmlhttprequest(); xhr.send(password)</script>`)
+	assertScanIssue(t, issues, "credential")
+}
+
+func TestScanAppBlocksExternalRedirectsWithSpacing(t *testing.T) {
+	cases := []string{
+		`<script>window.location = "https://evil.example"</script>`,
+		`<script>window.location.href = 'http://evil.example'</script>`,
+		`<script>WINDOW.LOCATION.HREF='https://evil.example'</script>`,
+	}
+	for _, tc := range cases {
+		t.Run(tc, func(t *testing.T) {
+			issues := ScanApp(tc)
+			assertScanIssue(t, issues, "Redirecting to external URLs")
+		})
+	}
+}
+
+func TestScanAppBlocksExternalScriptSources(t *testing.T) {
+	cases := []string{
+		`<script src = "https://cdn.example/app.js"></script>`,
+		`<SCRIPT async src='http://cdn.example/app.js'></SCRIPT>`,
+	}
+	for _, tc := range cases {
+		t.Run(tc, func(t *testing.T) {
+			issues := ScanApp(tc)
+			assertScanIssue(t, issues, "Loading external scripts")
+		})
+	}
+}
+
+func TestScanAppBlocksEvalCaseInsensitiveUnlessAllowed(t *testing.T) {
+	issues := ScanApp(`<script>EVAL(userInput)</script>`)
+	assertScanIssue(t, issues, "eval()")
+
+	issues = ScanApp(`<script>// SAFE-EVAL
+	eval(trustedCode)</script>`)
+	if len(issues) != 0 {
+		t.Fatalf("expected safe-eval marker to allow eval, got %v", issues)
+	}
+}
+
+func assertScanIssue(t *testing.T, issues []string, want string) {
+	t.Helper()
+	for _, issue := range issues {
+		if strings.Contains(issue, want) {
+			return
+		}
+	}
+	t.Fatalf("expected issue containing %q, got %v", want, issues)
+}


### PR DESCRIPTION
## Summary
- Harden app security scanning for external redirects, script sources, credential harvesting, and eval detection.
- Add focused scan coverage for benign HTML and suspicious variants.

Closes #719

## Testing
- go build ./...
- go test ./... -short
- go vet ./...