### PR TITLE
Fix SQLite partial content search

### DIFF
--- a/internal/data/sqlite.go
+++ b/internal/data/sqlite.go
@@ -250,7 +250,8 @@ func searchSQLiteFallback(query string, limit int, options *SearchOptions) ([]*I
 			if len(word) < 2 {
 				continue
 			}
-			likeConds = append(likeConds, "LOWER(title) LIKE ?")
+			likeConds = append(likeConds, "(LOWER(title) LIKE ? OR LOWER(content) LIKE ?)")
+			likeArgs = append(likeArgs, "%"+word+"%")
 			likeArgs = append(likeArgs, "%"+word+"%")
 		}
 		if len(likeConds) > 0 {
@@ -489,8 +490,6 @@ func GetByTypeSQLite(entryType string, limit int) ([]*IndexEntry, error) {
 
 	return results, nil
 }
-
-
 
 // MigrateFromJSON migrates existing JSON data to SQLite
 func MigrateFromJSON() error {

--- a/internal/data/sqlite_test.go
+++ b/internal/data/sqlite_test.go
@@ -131,6 +131,34 @@ func TestSQLiteSearch(t *testing.T) {
 	}
 }
 
+func TestSQLiteSearchFindsPartialContentMatches(t *testing.T) {
+	tempDir := t.TempDir()
+	os.Setenv("HOME", tempDir)
+
+	dbOnce = sync.Once{}
+	db = nil
+
+	err := IndexSQLite("partial1", "news", "Space Telescope", "Astronomers photographed galaxies in ultraviolet light.", "", nil)
+	if err != nil {
+		t.Fatalf("IndexSQLite failed: %v", err)
+	}
+	err = IndexSQLite("partial2", "news", "Garden Notes", "Tomatoes need steady watering.", "", nil)
+	if err != nil {
+		t.Fatalf("IndexSQLite failed: %v", err)
+	}
+
+	results, err := SearchSQLite("ultravio", 10)
+	if err != nil {
+		t.Fatalf("SearchSQLite failed: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("Expected 1 partial content match, got %d", len(results))
+	}
+	if results[0].ID != "partial1" {
+		t.Fatalf("Expected partial1, got %s", results[0].ID)
+	}
+}
+
 func TestSQLiteIndexUpdate(t *testing.T) {
 	tempDir := t.TempDir()
 	os.Setenv("HOME", tempDir)


### PR DESCRIPTION
## Summary
- Search SQLite LIKE fallback now checks both titles and content for partial terms.
- Added regression coverage for partial content matches.

Closes #722

## Testing
- go build ./...
- go test ./... -short
- go vet ./...