### PR TITLE
Fix token form expiration parsing

### DIFF
--- a/internal/app/token.go
+++ b/internal/app/token.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -209,7 +210,6 @@ async function createToken(e) {
 	w.Write([]byte(html))
 }
 
-
 func handleListTokensJSON(w http.ResponseWriter, r *http.Request, accountID string) {
 	tokens := auth.ListTokens(accountID)
 
@@ -241,6 +241,42 @@ func handleListTokensJSON(w http.ResponseWriter, r *http.Request, accountID stri
 	})
 }
 
+func parseTokenPermissions(permStr string) []string {
+	if permStr == "" {
+		return nil
+	}
+
+	parts := strings.Split(permStr, ",")
+	permissions := make([]string, 0, len(parts))
+	for _, part := range parts {
+		perm := strings.TrimSpace(part)
+		if perm != "" {
+			permissions = append(permissions, perm)
+		}
+	}
+	return permissions
+}
+
+func parseTokenExpiresIn(exp string) int {
+	exp = strings.TrimSpace(exp)
+	if exp == "" {
+		return 0
+	}
+
+	if days, err := strconv.Atoi(exp); err == nil {
+		if days > 0 {
+			return days
+		}
+		return 0
+	}
+
+	if _, err := time.Parse("2006-01-02", exp); err == nil {
+		return 365
+	}
+
+	return 0
+}
+
 func handleCreateToken(w http.ResponseWriter, r *http.Request, accountID string) {
 	var name string
 	var permissions []string
@@ -265,21 +301,8 @@ func handleCreateToken(w http.ResponseWriter, r *http.Request, accountID string)
 			return
 		}
 		name = strings.TrimSpace(r.FormValue("name"))
-		permStr := r.FormValue("permissions")
-		if permStr != "" {
-			permissions = strings.Split(permStr, ",")
-			for i := range permissions {
-				permissions[i] = strings.TrimSpace(permissions[i])
-			}
-		}
-		// Parse expires_in from form
-		if exp := r.FormValue("expires_in"); exp != "" {
-			var err error
-			_, err = time.Parse("2006-01-02", exp)
-			if err == nil {
-				expiresIn = 365 // Default to 1 year if date format provided
-			}
-		}
+		permissions = parseTokenPermissions(r.FormValue("permissions"))
+		expiresIn = parseTokenExpiresIn(r.FormValue("expires_in"))
 	}
 
 	// Validate

--- a/internal/app/token_test.go
+++ b/internal/app/token_test.go
@@ -1,0 +1,40 @@
+package app
+
+import "testing"
+
+func TestParseTokenExpiresIn(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want int
+	}{
+		{name: "empty", in: "", want: 0},
+		{name: "never", in: "0", want: 0},
+		{name: "negative", in: "-1", want: 0},
+		{name: "numeric days", in: "90", want: 90},
+		{name: "numeric days trimmed", in: " 365 ", want: 365},
+		{name: "legacy date", in: "2026-12-31", want: 365},
+		{name: "invalid", in: "soon", want: 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := parseTokenExpiresIn(tt.in); got != tt.want {
+				t.Fatalf("parseTokenExpiresIn(%q) = %d, want %d", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseTokenPermissions(t *testing.T) {
+	got := parseTokenPermissions(" read, write, ,admin ")
+	want := []string{"read", "write", "admin"}
+	if len(got) != len(want) {
+		t.Fatalf("parseTokenPermissions returned %d values, want %d: %#v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("parseTokenPermissions()[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}


### PR DESCRIPTION
Fix PAT form parsing so numeric expires_in values are honored and comma-separated permissions are normalized.

Closes #724

Checks:
- go build ./...
- go test ./... -short
- go vet ./...