### PR TITLE
Clear stale email verification timestamps

### DIFF
--- a/internal/auth/postlimit.go
+++ b/internal/auth/postlimit.go
@@ -183,6 +183,7 @@ func SetAccountEmail(accountID, email string) error {
 	}
 	acc.Email = email
 	acc.EmailVerified = false
+	acc.EmailVerifiedAt = time.Time{}
 	return saveAccountsUnlocked()
 }
 

--- a/internal/auth/postlimit_test.go
+++ b/internal/auth/postlimit_test.go
@@ -108,3 +108,35 @@ func TestConsumeEmailVerificationTokenRejectsExpiredToken(t *testing.T) {
 		t.Fatalf("ConsumeEmailVerificationToken expired token = %v, want expired error", err)
 	}
 }
+
+func TestSetAccountEmailClearsVerificationState(t *testing.T) {
+	resetPostLimitStateForTest(t)
+
+	verifiedAt := time.Now().Add(-time.Hour)
+	mutex.Lock()
+	accounts["acct-1"] = &Account{
+		ID:              "acct-1",
+		Created:         time.Now(),
+		Email:           "old@example.com",
+		EmailVerified:   true,
+		EmailVerifiedAt: verifiedAt,
+	}
+	mutex.Unlock()
+
+	if err := SetAccountEmail("acct-1", "new@example.com"); err != nil {
+		t.Fatalf("SetAccountEmail returned error: %v", err)
+	}
+
+	mutex.Lock()
+	acc := accounts["acct-1"]
+	mutex.Unlock()
+	if acc.Email != "new@example.com" {
+		t.Fatalf("SetAccountEmail email = %q, want new@example.com", acc.Email)
+	}
+	if acc.EmailVerified {
+		t.Fatal("SetAccountEmail left EmailVerified true")
+	}
+	if !acc.EmailVerifiedAt.IsZero() {
+		t.Fatalf("SetAccountEmail EmailVerifiedAt = %v, want zero time", acc.EmailVerifiedAt)
+	}
+}


### PR DESCRIPTION
Fixes a verification-state bug in account email updates.

When an account changes its email address, clear both the verified flag and the previous verification timestamp so callers cannot observe stale verification metadata for an unverified pending address.

Closes #732

Checks:
- go build ./...
- go test ./... -short
- go vet ./...