### PR TITLE
Mark CSRF cookie secure on direct TLS

### DIFF
--- a/internal/auth/csrf.go
+++ b/internal/auth/csrf.go
@@ -48,7 +48,7 @@ func SetCSRFCookie(w http.ResponseWriter, r *http.Request) {
 	if token == "" {
 		return
 	}
-	secure := r.Header.Get("X-Forwarded-Proto") == "https"
+	secure := r.TLS != nil || r.Header.Get("X-Forwarded-Proto") == "https"
 	http.SetCookie(w, &http.Cookie{
 		Name:     "csrf_token",
 		Value:    token,

--- a/internal/auth/csrf_test.go
+++ b/internal/auth/csrf_test.go
@@ -100,6 +100,23 @@ func TestValidCSRFValidatesHeaderAndFormTokens(t *testing.T) {
 	}
 }
 
+func TestSetCSRFCookieUsesSecureForDirectTLS(t *testing.T) {
+	_, sess := resetCSRFTestState(t)
+	req := httptest.NewRequest(http.MethodPost, "https://example.com/", nil)
+	req.AddCookie(&http.Cookie{Name: "session", Value: sess.Token})
+	rec := httptest.NewRecorder()
+
+	SetCSRFCookie(rec, req)
+
+	cookies := rec.Result().Cookies()
+	if len(cookies) != 1 {
+		t.Fatalf("SetCSRFCookie wrote %d cookies, want 1", len(cookies))
+	}
+	if !cookies[0].Secure {
+		t.Fatal("SetCSRFCookie did not mark cookie secure for direct TLS")
+	}
+}
+
 func TestSetCSRFCookieUsesSecureForwardedProto(t *testing.T) {
 	_, sess := resetCSRFTestState(t)
 	req := requestWithSession(t, sess)


### PR DESCRIPTION
## Summary
- mark CSRF cookies Secure for requests served directly over TLS, not only behind X-Forwarded-Proto=https
- add regression coverage for HTTPS requests generated by httptest

Closes #734