### PR TITLE
Harden web fetch private host detection

### DIFF
--- a/search/fetch.go
+++ b/search/fetch.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"html"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"regexp"
@@ -634,27 +635,14 @@ func collapseWhitespace(s string) string {
 
 // isPrivateHost returns true if the host looks like a private/internal address.
 func isPrivateHost(host string) bool {
-	if host == "localhost" || host == "" {
+	host = strings.TrimSpace(strings.Trim(host, "[]"))
+	if host == "" || strings.EqualFold(host, "localhost") {
 		return true
 	}
-	if strings.HasPrefix(host, "127.") || strings.HasPrefix(host, "10.") ||
-		strings.HasPrefix(host, "192.168.") || host == "::1" || host == "0.0.0.0" {
-		return true
+
+	if ip := net.ParseIP(host); ip != nil {
+		return ip.IsLoopback() || ip.IsPrivate() || ip.IsLinkLocalUnicast() || ip.IsUnspecified()
 	}
-	// Block 172.16.0.0/12
-	if strings.HasPrefix(host, "172.") {
-		parts := strings.SplitN(host, ".", 3)
-		if len(parts) >= 2 {
-			var second int
-			fmt.Sscanf(parts[1], "%d", &second)
-			if second >= 16 && second <= 31 {
-				return true
-			}
-		}
-	}
-	// Block metadata endpoints
-	if host == "169.254.169.254" || host == "metadata.google.internal" {
-		return true
-	}
-	return false
+
+	return strings.EqualFold(host, "metadata.google.internal")
 }

--- a/search/fetch_test.go
+++ b/search/fetch_test.go
@@ -58,3 +58,38 @@ func TestIsProxyableLinkHandlesSchemesCaseInsensitively(t *testing.T) {
 		}
 	}
 }
+
+func TestIsPrivateHostBlocksInternalAddresses(t *testing.T) {
+	for _, host := range []string{
+		"localhost",
+		"127.0.0.1",
+		"10.1.2.3",
+		"172.16.0.1",
+		"172.31.255.255",
+		"192.168.1.10",
+		"169.254.169.254",
+		"0.0.0.0",
+		"::1",
+		"[::1]",
+		"fe80::1",
+		"::ffff:127.0.0.1",
+		"metadata.google.internal",
+	} {
+		if !isPrivateHost(host) {
+			t.Errorf("isPrivateHost(%q) = false; want true", host)
+		}
+	}
+}
+
+func TestIsPrivateHostAllowsPublicHosts(t *testing.T) {
+	for _, host := range []string{
+		"example.com",
+		"8.8.8.8",
+		"1.1.1.1",
+		"2001:4860:4860::8888",
+	} {
+		if isPrivateHost(host) {
+			t.Errorf("isPrivateHost(%q) = true; want false", host)
+		}
+	}
+}


### PR DESCRIPTION
Harden the web fetch SSRF guard by using IP classification for loopback, private, link-local, unspecified, and IPv4-mapped addresses while preserving the metadata hostname block. Add coverage for blocked internal hosts and allowed public hosts.

Closes #740