### PR TITLE
Harden web fetch URL validation

### DIFF
--- a/search/fetch.go
+++ b/search/fetch.go
@@ -27,6 +27,9 @@ var fetchClient = &http.Client{
 		if len(via) >= 5 {
 			return fmt.Errorf("too many redirects")
 		}
+		if err := validateFetchURL(req.URL); err != nil {
+			return err
+		}
 		return nil
 	},
 }
@@ -147,6 +150,9 @@ func FetchHandler(w http.ResponseWriter, r *http.Request) {
 func FetchAndExtract(rawURL string) (string, string, error) {
 	// Rewrite Twitter/X URLs to Nitter for static HTML
 	fetchURL, _ := rewriteTwitterURL(rawURL)
+	if err := validateRawFetchURL(fetchURL); err != nil {
+		return "", "", err
+	}
 
 	req, err := http.NewRequest("GET", fetchURL, nil)
 	if err != nil {
@@ -208,6 +214,9 @@ func FetchAndExtractHTMLProxied(rawURL string) (string, string, error) {
 func fetchAndSanitize(rawURL string, proxy bool) (string, string, error) {
 	// Rewrite Twitter/X URLs to Nitter for static HTML
 	fetchURL, _ := rewriteTwitterURL(rawURL)
+	if err := validateRawFetchURL(fetchURL); err != nil {
+		return "", "", err
+	}
 
 	req, err := http.NewRequest("GET", fetchURL, nil)
 	if err != nil {
@@ -631,6 +640,24 @@ func stripTags(s string) string {
 // collapseWhitespace replaces runs of whitespace with a single space.
 func collapseWhitespace(s string) string {
 	return multiSpaceRe.ReplaceAllString(s, " ")
+}
+
+func validateRawFetchURL(rawURL string) error {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return err
+	}
+	return validateFetchURL(parsed)
+}
+
+func validateFetchURL(parsed *url.URL) error {
+	if parsed == nil || (parsed.Scheme != "http" && parsed.Scheme != "https") {
+		return fmt.Errorf("invalid URL: must use http or https")
+	}
+	if isPrivateHost(strings.ToLower(parsed.Hostname())) {
+		return fmt.Errorf("cannot fetch private or internal URL")
+	}
+	return nil
 }
 
 // isPrivateHost returns true if the host looks like a private/internal address.

--- a/search/fetch_test.go
+++ b/search/fetch_test.go
@@ -1,7 +1,9 @@
 package search
 
 import (
+	"net/http"
 	"net/url"
+	"strings"
 	"testing"
 )
 
@@ -91,5 +93,36 @@ func TestIsPrivateHostAllowsPublicHosts(t *testing.T) {
 		if isPrivateHost(host) {
 			t.Errorf("isPrivateHost(%q) = true; want false", host)
 		}
+	}
+}
+
+func TestFetchAndExtractRejectsPrivateURLsBeforeRequest(t *testing.T) {
+	for _, rawURL := range []string{
+		"http://127.0.0.1/private",
+		"http://169.254.169.254/latest/meta-data/",
+		"http://metadata.google.internal/computeMetadata/v1/",
+	} {
+		_, _, err := FetchAndExtract(rawURL)
+		if err == nil || !strings.Contains(strings.ToLower(err.Error()), "private or internal") {
+			t.Fatalf("FetchAndExtract(%q) error = %v; want private/internal rejection", rawURL, err)
+		}
+	}
+}
+
+func TestFetchClientRejectsRedirectsToPrivateURLs(t *testing.T) {
+	redirectURL, err := url.Parse("http://127.0.0.1/admin")
+	if err != nil {
+		t.Fatal(err)
+	}
+	publicURL, err := url.Parse("https://example.com/start")
+	if err != nil {
+		t.Fatal(err)
+	}
+	req := &http.Request{URL: redirectURL}
+	via := []*http.Request{{URL: publicURL}}
+
+	err = fetchClient.CheckRedirect(req, via)
+	if err == nil || !strings.Contains(strings.ToLower(err.Error()), "private or internal") {
+		t.Fatalf("CheckRedirect() error = %v; want private/internal rejection", err)
 	}
 }


### PR DESCRIPTION
Harden the web fetch path so service-level fetches and redirects reject private/internal URLs, matching the browser handler guard. Adds regression tests for direct private URL rejection and redirect rejection.

Closes #742

Checks:
- go build ./...
- go test ./... -short
- go vet ./...