### PR TITLE
Harden weather coordinate handling

### DIFF
--- a/weather/agent.go
+++ b/weather/agent.go
@@ -8,6 +8,10 @@ import (
 // ForecastText returns a compact, model-ready weather summary for a location.
 // It is the AI-first accessor behind the weather_forecast agent tool.
 func ForecastText(lat, lon float64) string {
+	if !validCoordinates(lat, lon) {
+		return "Weather is unavailable because the requested coordinates are invalid."
+	}
+
 	wf, err := FetchWeather(lat, lon)
 	if err != nil || wf == nil {
 		return "Weather is unavailable right now."
@@ -35,5 +39,13 @@ func ForecastText(lat, lon float64) string {
 				d.Date.Format("Mon 2 Jan"), d.MinTempC, d.MaxTempC, d.Description, rain)
 		}
 	}
+	if sb.Len() == 0 {
+		return "Weather is unavailable right now."
+	}
 	return sb.String()
+}
+
+func validCoordinates(lat, lon float64) bool {
+	return lat == lat && lon == lon &&
+		lat >= -90 && lat <= 90 && lon >= -180 && lon <= 180
 }

--- a/weather/weather.go
+++ b/weather/weather.go
@@ -95,7 +95,7 @@ h+='<span>'+name+' '+Math.round(day.MaxTempC)+'°/'+Math.round(day.MinTempC)+'°
 h+='</div>';
 }
 renderWeather(h);
-}).catch(function(){});
+}).catch(function(){if(!cached){el.innerHTML='<span style="color:#888">Weather unavailable</span>';}});
 }
 })();
 </script>
@@ -134,6 +134,10 @@ func handleJSON(w http.ResponseWriter, r *http.Request) {
 	lon, err := strconv.ParseFloat(lonStr, 64)
 	if err != nil {
 		app.RespondError(w, http.StatusBadRequest, "invalid lon")
+		return
+	}
+	if !validCoordinates(lat, lon) {
+		app.RespondError(w, http.StatusBadRequest, "lat must be between -90 and 90 and lon must be between -180 and 180")
 		return
 	}
 

--- a/weather/weather_test.go
+++ b/weather/weather_test.go
@@ -37,3 +37,36 @@ func TestToCelsius_UnknownUnit(t *testing.T) {
 		t.Errorf("toCelsius(100, KELVIN) = %v, want 100", got)
 	}
 }
+
+func TestValidCoordinates(t *testing.T) {
+	tests := []struct {
+		name string
+		lat  float64
+		lon  float64
+		want bool
+	}{
+		{name: "origin", lat: 0, lon: 0, want: true},
+		{name: "north edge", lat: 90, lon: 180, want: true},
+		{name: "south edge", lat: -90, lon: -180, want: true},
+		{name: "lat too high", lat: 90.1, lon: 0, want: false},
+		{name: "lat too low", lat: -90.1, lon: 0, want: false},
+		{name: "lon too high", lat: 0, lon: 180.1, want: false},
+		{name: "lon too low", lat: 0, lon: -180.1, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := validCoordinates(tt.lat, tt.lon); got != tt.want {
+				t.Fatalf("validCoordinates(%v, %v) = %v, want %v", tt.lat, tt.lon, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestForecastTextInvalidCoordinatesDoesNotFetch(t *testing.T) {
+	got := ForecastText(91, 0)
+	want := "Weather is unavailable because the requested coordinates are invalid."
+	if got != want {
+		t.Fatalf("ForecastText invalid coordinates = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Summary
- Validate weather coordinates before API calls so invalid agent/tool requests degrade with a clear unavailable message.
- Return a 400 for out-of-range weather API coordinates.
- Show the weather card as unavailable when a provider fetch fails without cached data.
- Add short tests for coordinate validation and invalid forecast requests.

Closes #744