### PR TITLE
Harden guest micro-agent tool access

### DIFF
--- a/agent/micro/execute.go
+++ b/agent/micro/execute.go
@@ -30,7 +30,7 @@ func (a *Agent) Execute(accountID, prompt string, public bool) (string, error) {
 	app.Log("micro", "Agent %s handling: %.80s", a.ID, prompt)
 
 	// Build tool list description for planning
-	toolsDesc := a.buildToolsDesc()
+	toolsDesc := a.buildToolsDesc(public)
 
 	// User context (skip for public/guest queries)
 	userCtx := ""
@@ -87,6 +87,9 @@ func (a *Agent) Execute(accountID, prompt string, public bool) (string, error) {
 		if !a.hasTool(tc.Tool) {
 			continue
 		}
+		if public && !isGuestAllowedTool(tc.Tool) {
+			continue
+		}
 		text, isErr, execErr := api.ExecuteToolAs(accountID, tc.Tool, tc.Args)
 		if execErr != nil || isErr {
 			continue
@@ -126,16 +129,14 @@ func (a *Agent) Execute(accountID, prompt string, public bool) (string, error) {
 	return app.StripLatexDollars(answer), nil
 }
 
-func (a *Agent) buildToolsDesc() string {
+func (a *Agent) buildToolsDesc(public bool) string {
 	// All tools descriptions from the MCP registry
 	allDescs := api.ToolDescriptions()
-	if a.Tools == nil {
-		return allDescs // "micro" agent gets everything
-	}
-
 	allowed := map[string]bool{}
-	for _, t := range a.Tools {
-		allowed[t] = true
+	if a.Tools != nil {
+		for _, t := range a.Tools {
+			allowed[t] = true
+		}
 	}
 
 	var sb strings.Builder
@@ -152,11 +153,47 @@ func (a *Agent) buildToolsDesc() string {
 			continue
 		}
 		name := strings.TrimSpace(rest[:colonIdx])
-		if allowed[name] {
-			sb.WriteString(line + "\n")
+		if a.Tools != nil && !allowed[name] {
+			continue
 		}
+		if public && !isGuestAllowedTool(name) {
+			continue
+		}
+		sb.WriteString(line + "\n")
 	}
 	return sb.String()
+}
+
+var guestAllowedTools = map[string]bool{
+	"news":             true,
+	"news_headlines":   true,
+	"news_read":        true,
+	"news_search":      true,
+	"recall":           true,
+	"markets":          true,
+	"weather_forecast": true,
+	"video":            true,
+	"video_search":     true,
+	"web_search":       true,
+	"web_fetch":        true,
+	"social":           true,
+	"social_search":    true,
+	"blog_list":        true,
+	"blog_read":        true,
+	"apps_search":      true,
+	"apps_read":        true,
+	"search":           true,
+	"reminder":         true,
+	"quran":            true,
+	"hadith":           true,
+	"quran_search":     true,
+	"stream":           true,
+	"places_search":    true,
+	"places_nearby":    true,
+}
+
+func isGuestAllowedTool(name string) bool {
+	return guestAllowedTools[name]
 }
 
 func (a *Agent) hasTool(name string) bool {

--- a/agent/micro/execute_test.go
+++ b/agent/micro/execute_test.go
@@ -1,0 +1,41 @@
+package micro
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildToolsDescFiltersPrivateToolsForGuests(t *testing.T) {
+	mail := Get("mail")
+	if mail == nil {
+		t.Fatal("mail agent is not registered")
+	}
+
+	privateTools := mail.buildToolsDesc(false)
+	if !strings.Contains(privateTools, "mail_read") {
+		t.Fatalf("private mail tools should include mail_read, got %q", privateTools)
+	}
+
+	guestTools := mail.buildToolsDesc(true)
+	if strings.Contains(guestTools, "mail_read") || strings.Contains(guestTools, "mail_send") {
+		t.Fatalf("guest mail tools should exclude private mail tools, got %q", guestTools)
+	}
+}
+
+func TestGuestAllowedToolsCoverPublicCoreServices(t *testing.T) {
+	for _, tool := range []string{"weather_forecast", "news_headlines", "markets", "web_search", "search"} {
+		t.Run(tool, func(t *testing.T) {
+			if !isGuestAllowedTool(tool) {
+				t.Fatalf("%s should be allowed for guest ask-answer smoke paths", tool)
+			}
+		})
+	}
+
+	for _, tool := range []string{"mail_read", "mail_send"} {
+		t.Run(tool, func(t *testing.T) {
+			if isGuestAllowedTool(tool) {
+				t.Fatalf("%s should stay private for guest ask-answer smoke paths", tool)
+			}
+		})
+	}
+}

--- a/agent/micro/router_test.go
+++ b/agent/micro/router_test.go
@@ -155,3 +155,25 @@ func TestKeywordRouteSingleDomainPriorityIsDeterministic(t *testing.T) {
 		}
 	}
 }
+
+func TestKeywordRouteCoreAskAnswerSmokeCoverage(t *testing.T) {
+	tests := []struct {
+		name   string
+		prompt string
+		want   []string
+	}{
+		{name: "weather", prompt: "what's the weather in London?", want: []string{"weather"}},
+		{name: "news", prompt: "what's happening in the news today?", want: []string{"news"}},
+		{name: "markets", prompt: "what is the BTC price?", want: []string{"markets"}},
+		{name: "mail", prompt: "do I have unread mail?", want: []string{"mail"}},
+		{name: "search", prompt: "search the web for go-micro agents", want: []string{"search"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := keywordRoute(tt.prompt); !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("keywordRoute(%q) = %v, want %v", tt.prompt, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Keep public micro-agent planning and execution constrained to guest-safe tools.
- Add smoke coverage for core ask-answer routing across weather, news, markets, mail, and search.
- Add tests that guest paths keep public core tools available while excluding private mail tools.

Closes #747
Closes #752