### PR TITLE
Improve weather unavailable states

### DIFF
--- a/weather/agent.go
+++ b/weather/agent.go
@@ -14,7 +14,7 @@ func ForecastText(lat, lon float64) string {
 
 	wf, err := FetchWeather(lat, lon)
 	if err != nil || wf == nil {
-		return "Weather is unavailable right now."
+		return weatherUnavailableMessage
 	}
 
 	var sb strings.Builder
@@ -40,7 +40,7 @@ func ForecastText(lat, lon float64) string {
 		}
 	}
 	if sb.Len() == 0 {
-		return "Weather is unavailable right now."
+		return weatherUnavailableMessage
 	}
 	return sb.String()
 }

--- a/weather/messages.go
+++ b/weather/messages.go
@@ -1,0 +1,3 @@
+package weather
+
+const weatherUnavailableMessage = "Weather is unavailable right now. Please try again later."

--- a/weather/weather.go
+++ b/weather/weather.go
@@ -153,7 +153,7 @@ func handleJSON(w http.ResponseWriter, r *http.Request) {
 	// Fetch weather
 	forecast, err := FetchWeather(lat, lon)
 	if err != nil {
-		app.RespondError(w, http.StatusInternalServerError, fmt.Sprintf("Failed to fetch weather: %v", err))
+		app.RespondError(w, http.StatusServiceUnavailable, weatherUnavailableMessage)
 		return
 	}
 
@@ -288,7 +288,7 @@ func renderWeatherPage(r *http.Request) string {
       fetchWeather(parseFloat(data[0].lat), parseFloat(data[0].lon), name);
     }).catch(function() {
       showLoading(false);
-      showError('Failed to find location.');
+      showError('Location search is unavailable right now. Please try again later.');
     });
   }
 
@@ -307,7 +307,7 @@ func renderWeatherPage(r *http.Request) string {
       })
       .catch(function(err) {
         showLoading(false);
-        var msg = (err && err.error) ? err.error : 'Failed to load weather data.';
+        var msg = (err && err.error) ? err.error : 'Weather is unavailable right now. Please try again later.';
         if (msg.indexOf('Insufficient credits') !== -1) {
           msg += ' <a href="/wallet/topup">Top up your wallet</a>.';
         }

--- a/weather/weather_test.go
+++ b/weather/weather_test.go
@@ -1,6 +1,7 @@
 package weather
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -68,5 +69,21 @@ func TestForecastTextInvalidCoordinatesDoesNotFetch(t *testing.T) {
 	want := "Weather is unavailable because the requested coordinates are invalid."
 	if got != want {
 		t.Fatalf("ForecastText invalid coordinates = %q, want %q", got, want)
+	}
+}
+
+func TestForecastTextProviderUnavailableIsClear(t *testing.T) {
+	t.Setenv("GOOGLE_API_KEY", "")
+
+	got := ForecastText(51.5074, -0.1278)
+	if got != weatherUnavailableMessage {
+		t.Fatalf("ForecastText provider unavailable = %q, want %q", got, weatherUnavailableMessage)
+	}
+}
+
+func TestCardHTMLShowsWeatherUnavailableOnFetchFailure(t *testing.T) {
+	got := CardHTML()
+	if !strings.Contains(got, "Weather unavailable") {
+		t.Fatalf("CardHTML should show a clear unavailable state on fetch failure, got %q", got)
 	}
 }


### PR DESCRIPTION
## Summary
- Return a clear service-unavailable response when the weather provider cannot fetch a forecast.
- Reuse the same unavailable message for the weather agent summary.
- Add coverage for provider-down and home-card unavailable messaging.

Closes #748
Closes #756

## Testing
- go build ./...
- go test ./... -short
- go vet ./...