### PR TITLE
Update product priorities after review

### DIFF
--- a/internal/docs/PRIORITIES.md
+++ b/internal/docs/PRIORITIES.md
@@ -21,13 +21,10 @@ and publishing marketing content. Those go to the human.
 
 ## Work queue (ranked)
 
-1. **[#748 Every service degrades gracefully.](https://github.com/micro/mu/issues/748)** Audit each home card and each
-   agent-callable service for the provider-down case — no dead cards, no silent
-   failures, a clear "unavailable" instead. One service per increment.
-2. **[#749 First-run experience.](https://github.com/micro/mu/issues/749)** A new visitor understands what Mu is and gets value
+1. **[#749 First-run experience.](https://github.com/micro/mu/issues/749)** A new visitor understands what Mu is and gets value
    from one prompt without an account — tighten the guest landing, suggestions,
    and the sign-up moment (when the free limit is hit) for clarity, not friction.
-3. **[#750 Answer formatting quality.](https://github.com/micro/mu/issues/750)** Rendered answers (news, markets, weather) look
+2. **[#750 Answer formatting quality.](https://github.com/micro/mu/issues/750)** Rendered answers (news, markets, weather) look
    right everywhere they appear — web (guest + signed-in), Discord, Telegram —
    with consistent spacing, headings, and links.
 


### PR DESCRIPTION
Summary:
- Remove closed issue #748 from the active product-review queue.
- Keep Now-phase refinement ordered as #749 first-run experience, then #750 answer formatting.

Closes #758