### PR TITLE
Ensure tool-backed answers are complete

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1255,7 +1255,8 @@ func handleQuery(w http.ResponseWriter, r *http.Request) {
 			"When results come from multiple sources (news, video, markets, weather, etc.), identify and highlight " +
 			"connections and correlations between them — for example, how a market move relates to a news story, " +
 			"or how videos cover the same topic appearing in the news.\n\n" +
-			"Use markdown formatting. Summarise key information from any news articles, weather data, market prices or other structured data.\n\n" +
+			"Use markdown formatting. Summarise key information from any news articles, weather data, market prices or other structured data. " +
+			"Do not answer with progress narration like 'let me check' or 'I'll pull the data'; the tools have already run, so provide the final answer or say exactly what is unavailable.\n\n" +
 			"IMPORTANT: Use plain dollar signs for currency (e.g. $69,811). Do NOT use LaTeX math delimiters like \\( or \\)."
 	}
 
@@ -1282,6 +1283,7 @@ func handleQuery(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	answer = app.StripLatexDollars(answer)
+	answer = completeToolAnswer(answer, ragParts)
 
 	rendered := app.RenderString(answer)
 	html := `<div class="card" id="agent-response">` + rendered + `</div>`

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -593,3 +593,30 @@ func TestRenderResultCard_AppsRun(t *testing.T) {
 		t.Errorf("expected iframe in result card, got %q", card)
 	}
 }
+
+func TestCompleteToolAnswerReplacesProgressOnlyWithResults(t *testing.T) {
+	rag := []string{"### markets\nBTC: $100,000", "### news\n- Bitcoin reaches new high"}
+	got := completeToolAnswer("Let me pull the latest market and news data for you.", rag)
+	if strings.Contains(strings.ToLower(got), "let me pull") {
+		t.Fatalf("expected progress narration to be replaced, got %q", got)
+	}
+	if !strings.Contains(got, "BTC: $100,000") || !strings.Contains(got, "Bitcoin reaches new high") {
+		t.Fatalf("expected fallback to include tool results, got %q", got)
+	}
+}
+
+func TestCompleteToolAnswerKeepsSubstantiveAnswer(t *testing.T) {
+	want := "BTC is at $100,000, and the latest news says it reached a new high."
+	got := completeToolAnswer(want, []string{"### markets\nBTC: $100,000"})
+	if got != want {
+		t.Fatalf("expected substantive answer unchanged, got %q", got)
+	}
+}
+
+func TestCompleteToolAnswerWithoutToolsDoesNotOverride(t *testing.T) {
+	want := "Let me think about that."
+	got := completeToolAnswer(want, nil)
+	if got != want {
+		t.Fatalf("expected no override without tool results, got %q", got)
+	}
+}

--- a/agent/answer_guard.go
+++ b/agent/answer_guard.go
@@ -1,0 +1,61 @@
+package agent
+
+import "strings"
+
+// completeToolAnswer prevents the agent from returning only progress narration
+// after tools have already produced usable live context. LLMs occasionally stop
+// at phrases like "Let me pull that data" even though the tool calls are done;
+// in that case, return the collected results directly so the user still gets a
+// complete answer or a clear unavailable state.
+func completeToolAnswer(answer string, ragParts []string) string {
+	trimmed := strings.TrimSpace(answer)
+	if len(ragParts) == 0 || !isProgressOnlyAnswer(trimmed) {
+		return answer
+	}
+
+	var b strings.Builder
+	b.WriteString("I found live results, but couldn't synthesize a full narrative. Here are the results:\n\n")
+	for i, part := range ragParts {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		if i > 0 {
+			b.WriteString("\n\n")
+		}
+		b.WriteString(part)
+	}
+	return b.String()
+}
+
+func isProgressOnlyAnswer(answer string) bool {
+	if answer == "" {
+		return true
+	}
+
+	lower := strings.ToLower(answer)
+	progressPhrases := []string{
+		"let me pull",
+		"let me fetch",
+		"let me check",
+		"i'll pull",
+		"i’ll pull",
+		"i will pull",
+		"i'll fetch",
+		"i’ll fetch",
+		"i will fetch",
+		"i'll check",
+		"i’ll check",
+		"i will check",
+		"pull that data",
+		"fetch that data",
+		"gather that information",
+		"look that up",
+	}
+	for _, phrase := range progressPhrases {
+		if strings.Contains(lower, phrase) && len([]rune(answer)) < 240 {
+			return true
+		}
+	}
+	return false
+}

--- a/agent/run.go
+++ b/agent/run.go
@@ -68,6 +68,7 @@ Examples:
 // state (unread mail, market prices, etc.) that gets injected into the
 // synthesis prompt.
 var UserContextFunc func(accountID string) string
+
 type RunRequest struct {
 	Prompt    string `json:"prompt"`
 	Model     string `json:"model"`
@@ -216,13 +217,14 @@ func RunHandler(w http.ResponseWriter, r *http.Request) {
 	} else {
 		synthSystem = "You are Micro, a personal AI assistant. Today is " + today + ". " +
 			"Answer concisely using the tool results and user context below. Use markdown. " +
+			"Do not answer with progress narration like 'let me check' or 'I'll pull the data'; the tools have already run, so provide the final answer or say exactly what is unavailable. " +
 			"If the user context already contains the answer (e.g. unread mail count), use it directly."
 	}
 	if userCtx != "" {
 		synthSystem += "\n\nUser context:\n" + userCtx
 	}
 	answer, err := ai.Ask(&ai.Prompt{
-		System: synthSystem,
+		System:   synthSystem,
 		Rag:      ragParts,
 		Question: req.Prompt,
 		Priority: ai.PriorityHigh,
@@ -236,6 +238,7 @@ func RunHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	answer = app.StripLatexDollars(answer)
+	answer = completeToolAnswer(answer, ragParts)
 
 	if isGuest {
 		app.RespondJSON(w, RunResponse{Answer: answer, Tools: toolsUsed})


### PR DESCRIPTION
Closes #763
Closes #765

## Summary
- Add a guard that replaces progress-only synthesis after successful tool calls with the collected live tool results.
- Strengthen agent synthesis prompts to return a final answer or explicit unavailable state instead of progress narration.
- Cover the fallback guard with unit tests.

## Testing
- go build ./...
- go test ./... -short
- go vet ./...