### PR TITLE
Guard native agent progress-only answers

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -832,10 +832,12 @@ func streamNativeSSE(w http.ResponseWriter, accountID, prompt string, opts Query
 	streaming := false
 	emitted := false
 	var captured strings.Builder
+	var nativeTools []string
 
 	answer, handled, err := streamNative(accountID, prompt, opts, StreamHooks{
 		ToolStart: func(label string) {
 			emitted = true
+			nativeTools = append(nativeTools, label)
 			sse(w, map[string]any{"type": "tool_start", "name": label, "message": label})
 		},
 		ToolEnd: func(label string) {
@@ -872,6 +874,7 @@ func streamNativeSSE(w http.ResponseWriter, accountID, prompt string, opts Query
 	if answer == "" {
 		answer = app.StripLatexDollars(captured.String())
 	}
+	answer = completeNativeToolAnswer(answer, nativeTools)
 	rendered := app.RenderString(answer)
 	html := `<div class="card" id="agent-response">` + rendered + `</div>`
 	if !isGuest {

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -620,3 +620,21 @@ func TestCompleteToolAnswerWithoutToolsDoesNotOverride(t *testing.T) {
 		t.Fatalf("expected no override without tool results, got %q", got)
 	}
 }
+
+func TestCompleteNativeToolAnswerReplacesProgressWithUnavailableState(t *testing.T) {
+	got := completeNativeToolAnswer("I'll check the latest market and news data now.", []string{"📈 Checking market prices", "📰 Scanning headlines"})
+	if strings.Contains(strings.ToLower(got), "i'll check") {
+		t.Fatalf("expected progress narration to be replaced, got %q", got)
+	}
+	if !strings.Contains(got, "couldn't produce a complete final answer") {
+		t.Fatalf("expected clear unavailable state, got %q", got)
+	}
+}
+
+func TestCompleteNativeToolAnswerKeepsProgressWithoutTools(t *testing.T) {
+	want := "I'll check what that means."
+	got := completeNativeToolAnswer(want, nil)
+	if got != want {
+		t.Fatalf("expected no override without native tool use, got %q", got)
+	}
+}

--- a/agent/answer_guard.go
+++ b/agent/answer_guard.go
@@ -28,6 +28,20 @@ func completeToolAnswer(answer string, ragParts []string) string {
 	return b.String()
 }
 
+// completeNativeToolAnswer provides the same safety net for the native
+// go-micro agent path. That path streams tool lifecycle events but not raw tool
+// payloads, so when it stops at progress narration after using tools we can at
+// least return a clear unavailable state instead of leaving the user with
+// “let me check” as the final answer.
+func completeNativeToolAnswer(answer string, toolLabels []string) string {
+	trimmed := strings.TrimSpace(answer)
+	if len(toolLabels) == 0 || !isProgressOnlyAnswer(trimmed) {
+		return answer
+	}
+
+	return "I checked the live sources, but couldn't produce a complete final answer from the available tool results. Please try again in a moment; if one source is unavailable, ask for the specific slice (news, markets, weather, or search) and I'll show what is reachable."
+}
+
 func isProgressOnlyAnswer(answer string) bool {
 	if answer == "" {
 		return true

--- a/agent/native.go
+++ b/agent/native.go
@@ -98,6 +98,8 @@ func buildNativeAgent(accountID, prompt string, opts QueryOpts) (a gmagent.Agent
 		"Use the available tools for live or personal data (weather, news, market prices, " +
 		"social, video, blog, web search, trading, and recall of the user's own news/mail). " +
 		"Quote exact values from tool results. Be concise and conversational. " +
+		"After using tools, always provide the final answer or state exactly what is unavailable; " +
+		"never stop at progress narration like let me check or I will pull that data. " +
 		"If the user asks about weather without a location, default to London (lat 51.5074, lon -0.1278)."
 	if !opts.Public && UserContextFunc != nil {
 		if uc := UserContextFunc(accountID); uc != "" {


### PR DESCRIPTION
## Summary
- add a native-agent answer guard so streamed tool runs that stop at progress narration return a clear unavailable state instead
- strengthen the native agent system prompt to require final answers after tool use
- cover the native progress-only fallback with unit tests

Closes #768
Closes #770

## Testing
- go build ./...
- go test ./... -short
- go vet ./...