### PR TITLE
Refresh product priorities after review #772

### DIFF
--- a/internal/docs/PRIORITIES.md
+++ b/internal/docs/PRIORITIES.md
@@ -21,13 +21,8 @@ and publishing marketing content. Those go to the human.
 
 ## Work queue (ranked)
 
-1. **[#768 Fix live multi-tool answers that stop after progress narration.](https://github.com/micro/mu/issues/768)** The live core ask → answer loop returns
-   a complete, useful answer for multi-tool prompts (markets/news/search) or a
-   clear unavailable-state for any unavailable slice — never just progress
-   narration like “let me pull data.”
-2. **[#750 Answer formatting quality.](https://github.com/micro/mu/issues/750)** Rendered answers (news, markets, weather) look
-   right everywhere they appear — web (guest + signed-in), Discord, Telegram —
-   with consistent spacing, headings, and links.
+1. **[#773 Produce complete synthesized answers from successful tool calls.](https://github.com/micro/mu/issues/773)** When the live agent successfully calls tools for a prompt, it synthesizes a useful final answer from those results instead of returning the generic incomplete-answer fallback; unavailable slices are named clearly.
+2. **[#750 Normalize answer formatting across web and chat clients.](https://github.com/micro/mu/issues/750)** Rendered answers (news, markets, weather, search) look right everywhere they appear — guest web, signed-in web, Discord, Telegram — with consistent spacing, headings, links, and readable list/table fallbacks.
 
 ### Already shipped (do not re-queue)
 


### PR DESCRIPTION
Summary:\n- Drop closed #768 from the active product queue.\n- Add #773 as the top refinement item for complete synthesized answers from successful tool calls.\n- Keep #750 next for cross-client answer formatting quality.\n\nCloses #772