### PR TITLE
Improve tool answer fallback synthesis

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -600,8 +600,22 @@ func TestCompleteToolAnswerReplacesProgressOnlyWithResults(t *testing.T) {
 	if strings.Contains(strings.ToLower(got), "let me pull") {
 		t.Fatalf("expected progress narration to be replaced, got %q", got)
 	}
-	if !strings.Contains(got, "BTC: $100,000") || !strings.Contains(got, "Bitcoin reaches new high") {
-		t.Fatalf("expected fallback to include tool results, got %q", got)
+	if strings.Contains(strings.ToLower(got), "couldn't synthesize") {
+		t.Fatalf("expected synthesized fallback instead of generic incomplete-answer copy, got %q", got)
+	}
+	if !strings.Contains(got, "**markets**") || !strings.Contains(got, "BTC: $100,000") || !strings.Contains(got, "**news**") || !strings.Contains(got, "Bitcoin reaches new high") {
+		t.Fatalf("expected fallback to include organized tool results, got %q", got)
+	}
+}
+
+func TestCompleteToolAnswerNamesUnavailableSlices(t *testing.T) {
+	rag := []string{"### weather\nNo weather data unavailable right now.", "### news\nLatest news:\n1. Useful headline"}
+	got := completeToolAnswer("I'll check that now.", rag)
+	if !strings.Contains(got, "Useful headline") {
+		t.Fatalf("expected available slice in fallback, got %q", got)
+	}
+	if !strings.Contains(got, "Unavailable: weather.") {
+		t.Fatalf("expected unavailable slice to be named clearly, got %q", got)
 	}
 }
 

--- a/agent/answer_guard.go
+++ b/agent/answer_guard.go
@@ -5,27 +5,129 @@ import "strings"
 // completeToolAnswer prevents the agent from returning only progress narration
 // after tools have already produced usable live context. LLMs occasionally stop
 // at phrases like "Let me pull that data" even though the tool calls are done;
-// in that case, return the collected results directly so the user still gets a
-// complete answer or a clear unavailable state.
+// in that case, synthesize a compact answer directly from the collected results
+// so the user still gets useful output and unavailable slices are explicit.
 func completeToolAnswer(answer string, ragParts []string) string {
 	trimmed := strings.TrimSpace(answer)
 	if len(ragParts) == 0 || !isProgressOnlyAnswer(trimmed) {
 		return answer
 	}
 
-	var b strings.Builder
-	b.WriteString("I found live results, but couldn't synthesize a full narrative. Here are the results:\n\n")
-	for i, part := range ragParts {
-		part = strings.TrimSpace(part)
-		if part == "" {
+	return synthesizeToolFallback(ragParts)
+}
+
+func synthesizeToolFallback(ragParts []string) string {
+	var sections []string
+	var unavailable []string
+	for _, part := range ragParts {
+		title, body := splitRAGPart(part)
+		if body == "" {
 			continue
 		}
-		if i > 0 {
+		if isUnavailableToolResult(body) {
+			unavailable = append(unavailable, title)
+			continue
+		}
+		if section := formatFallbackSection(title, body); section != "" {
+			sections = append(sections, section)
+		}
+	}
+
+	var b strings.Builder
+	if len(sections) > 0 {
+		b.WriteString("Here's what I found from the live results:\n\n")
+		b.WriteString(strings.Join(sections, "\n\n"))
+	} else {
+		b.WriteString("I checked the live sources, but the requested data is unavailable right now.")
+	}
+	if len(unavailable) > 0 {
+		if b.Len() > 0 {
 			b.WriteString("\n\n")
 		}
-		b.WriteString(part)
+		b.WriteString("Unavailable: ")
+		b.WriteString(strings.Join(unavailable, ", "))
+		b.WriteString(".")
 	}
 	return b.String()
+}
+
+func splitRAGPart(part string) (string, string) {
+	part = strings.TrimSpace(part)
+	if part == "" {
+		return "results", ""
+	}
+	if strings.HasPrefix(part, "### ") {
+		line, rest, ok := strings.Cut(part, "\n")
+		title := strings.TrimSpace(strings.TrimPrefix(line, "### "))
+		if title == "" {
+			title = "results"
+		}
+		if !ok {
+			return title, ""
+		}
+		return title, strings.TrimSpace(rest)
+	}
+	return "results", part
+}
+
+func formatFallbackSection(title, body string) string {
+	lines := meaningfulLines(body, 6)
+	if len(lines) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString("**")
+	b.WriteString(title)
+	b.WriteString("**\n")
+	for _, line := range lines {
+		b.WriteString("- ")
+		b.WriteString(line)
+		b.WriteString("\n")
+	}
+	return strings.TrimSpace(b.String())
+}
+
+func meaningfulLines(body string, limit int) []string {
+	var lines []string
+	for _, raw := range strings.Split(body, "\n") {
+		line := strings.TrimSpace(raw)
+		if line == "" {
+			continue
+		}
+		line = strings.TrimLeft(line, "-• ")
+		if line == "" {
+			continue
+		}
+		if len([]rune(line)) > 280 {
+			r := []rune(line)
+			line = string(r[:280]) + "…"
+		}
+		lines = append(lines, line)
+		if len(lines) >= limit {
+			break
+		}
+	}
+	return lines
+}
+
+func isUnavailableToolResult(body string) bool {
+	lower := strings.ToLower(strings.TrimSpace(body))
+	unavailablePhrases := []string{
+		"unavailable",
+		"no news available",
+		"no news headlines available",
+		"no news headlines found",
+		"no videos found",
+		"no places found",
+		"no topup methods available",
+		"data unavailable",
+	}
+	for _, phrase := range unavailablePhrases {
+		if strings.Contains(lower, phrase) {
+			return true
+		}
+	}
+	return false
 }
 
 // completeNativeToolAnswer provides the same safety net for the native


### PR DESCRIPTION
## Summary
- Replace generic incomplete-answer copy with a compact synthesized fallback from successful tool results.
- Keep unavailable tool slices explicit when some live data is missing.
- Add regression coverage for organized fallback output and unavailable slice naming.

Closes #773
Closes #777

## Testing
- go build ./...
- go test ./... -short
- go vet ./...