### PR TITLE
Normalize agent answer markdown

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -82,7 +82,7 @@ func QueryWithOpts(accountID, prompt string, opts QueryOpts) (string, error) {
 	// Check for direct agent addressing
 	if agentID := micro.MatchDirectAddress(prompt); agentID != "" {
 		cleanPrompt := micro.StripAddress(prompt)
-		return micro.Orchestrate(accountID, cleanPrompt, []string{agentID}, opts.Public)
+		return normalizeQueryAnswer(micro.Orchestrate(accountID, cleanPrompt, []string{agentID}, opts.Public))
 	}
 
 	// Route to specialist agent(s)
@@ -90,7 +90,7 @@ func QueryWithOpts(accountID, prompt string, opts QueryOpts) (string, error) {
 
 	// If router picks specialist(s), use the multi-agent system
 	if len(agentIDs) > 0 && agentIDs[0] != "micro" {
-		return micro.Orchestrate(accountID, prompt, agentIDs, opts.Public)
+		return normalizeQueryAnswer(micro.Orchestrate(accountID, prompt, agentIDs, opts.Public))
 	}
 
 	// Native go-micro agent path (default for this agent platform; set
@@ -101,7 +101,7 @@ func QueryWithOpts(accountID, prompt string, opts QueryOpts) (string, error) {
 	if nativeEnabled() {
 		if answer, handled, err := queryNative(accountID, prompt, opts); handled {
 			if err == nil {
-				return answer, nil
+				return app.NormalizeAnswerMarkdown(answer), nil
 			}
 			app.Log("agent", "native agent failed, falling back to planner: %v", err)
 		}
@@ -260,7 +260,14 @@ func QueryWithOpts(accountID, prompt string, opts QueryOpts) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("synthesis failed: %w", err)
 	}
-	return app.StripLatexDollars(answer), nil
+	return app.NormalizeAnswerMarkdown(app.StripLatexDollars(answer)), nil
+}
+
+func normalizeQueryAnswer(answer string, err error) (string, error) {
+	if err != nil {
+		return "", err
+	}
+	return app.NormalizeAnswerMarkdown(answer), nil
 }
 
 // Handler dispatches GET (page) and POST (query) at /agent and /agent/*.
@@ -568,6 +575,7 @@ func streamNativeSSE(w http.ResponseWriter, accountID, prompt string, opts Query
 		answer = app.StripLatexDollars(captured.String())
 	}
 	answer = completeNativeToolAnswer(answer, nativeTools)
+	answer = app.NormalizeAnswerMarkdown(answer)
 	rendered := app.RenderString(answer)
 	html := `<div class="card" id="agent-response">` + rendered + `</div>`
 	updateFlow(flow.ID, func(f *Flow) {
@@ -974,8 +982,9 @@ func handleQuery(w http.ResponseWriter, r *http.Request) {
 		sse(w, map[string]any{"type": "done"})
 		return
 	}
-	answer = app.StripLatexDollars(answer)
+	answer = app.NormalizeAnswerMarkdown(app.StripLatexDollars(answer))
 	answer = completeToolAnswer(answer, ragParts)
+	answer = app.NormalizeAnswerMarkdown(answer)
 
 	rendered := app.RenderString(answer)
 	html := `<div class="card" id="agent-response">` + rendered + `</div>`

--- a/internal/app/answer_format.go
+++ b/internal/app/answer_format.go
@@ -1,0 +1,54 @@
+package app
+
+import "strings"
+
+// NormalizeAnswerMarkdown prepares assistant answers for every Mu surface before
+// they are rendered as HTML or sent to chat clients. It keeps markdown intact,
+// but removes accidental spacing drift that makes the same answer look different
+// across web, Discord, Telegram, and WhatsApp.
+func NormalizeAnswerMarkdown(answer string) string {
+	answer = strings.ReplaceAll(answer, "\r\n", "\n")
+	answer = strings.ReplaceAll(answer, "\r", "\n")
+
+	lines := strings.Split(answer, "\n")
+	out := make([]string, 0, len(lines))
+	blank := 0
+	inFence := false
+
+	for _, line := range lines {
+		trimmedRight := strings.TrimRight(line, " \t")
+		if strings.HasPrefix(strings.TrimSpace(trimmedRight), "```") {
+			inFence = !inFence
+			out = append(out, trimmedRight)
+			blank = 0
+			continue
+		}
+		if inFence {
+			out = append(out, trimmedRight)
+			continue
+		}
+
+		trimmed := strings.TrimSpace(trimmedRight)
+		if trimmed == "" {
+			blank++
+			if blank <= 1 {
+				out = append(out, "")
+			}
+			continue
+		}
+
+		blank = 0
+		out = append(out, normalizeMarkdownLine(trimmed))
+	}
+
+	return strings.TrimSpace(strings.Join(out, "\n"))
+}
+
+func normalizeMarkdownLine(line string) string {
+	for _, prefix := range []string{"-", "*", "+"} {
+		if rest, ok := strings.CutPrefix(line, prefix); ok {
+			return prefix + " " + strings.TrimSpace(rest)
+		}
+	}
+	return line
+}

--- a/internal/app/answer_format_test.go
+++ b/internal/app/answer_format_test.go
@@ -1,0 +1,25 @@
+package app
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestNormalizeAnswerMarkdownCollapsesSpacing(t *testing.T) {
+	input := "  ### Weather  \r\n\r\n\r\n-  Sunny today  \n*   Bring sunglasses\n\n\nDone.  "
+	want := "### Weather\n\n- Sunny today\n* Bring sunglasses\n\nDone."
+	if got := NormalizeAnswerMarkdown(input); got != want {
+		t.Fatalf("NormalizeAnswerMarkdown() = %q, want %q", got, want)
+	}
+}
+
+func TestNormalizeAnswerMarkdownPreservesCodeFenceSpacing(t *testing.T) {
+	input := "Before\n\n```\n  keep indentation  \n\nnext\n```\n\n\nAfter"
+	got := NormalizeAnswerMarkdown(input)
+	if !strings.Contains(got, "```\n  keep indentation\n\nnext\n```") {
+		t.Fatalf("code fence content was not preserved: %q", got)
+	}
+	if strings.Contains(got, "After\n\n\n") {
+		t.Fatalf("extra blank lines leaked outside code fence: %q", got)
+	}
+}


### PR DESCRIPTION
Normalize assistant answer markdown before rendering or sending responses so web, Discord, Telegram, and other chat clients receive consistent spacing, headings, lists, and code-fence handling.\n\nCloses #750\nCloses #781