### PR TITLE
Normalize answer markdown across chat surfaces

### DIFF
--- a/client/discord/rich.go
+++ b/client/discord/rich.go
@@ -90,25 +90,25 @@ func NewButton(label, customID string, style int) Button {
 }
 
 const (
-	ButtonPrimary = 1
-	ButtonDanger  = 4
+	ButtonPrimary   = 1
+	ButtonDanger    = 4
 	ButtonSecondary = 2
 )
 
 // ── Slash Commands ──
 
 type SlashCommand struct {
-	Name        string              `json:"name"`
-	Description string              `json:"description"`
+	Name        string               `json:"name"`
+	Description string               `json:"description"`
 	Options     []SlashCommandOption `json:"options,omitempty"`
 }
 
 type SlashCommandOption struct {
-	Name        string                `json:"name"`
-	Description string                `json:"description"`
-	Type        int                   `json:"type"`
-	Required    bool                  `json:"required,omitempty"`
-	Choices     []SlashCommandChoice  `json:"choices,omitempty"`
+	Name        string               `json:"name"`
+	Description string               `json:"description"`
+	Type        int                  `json:"type"`
+	Required    bool                 `json:"required,omitempty"`
+	Choices     []SlashCommandChoice `json:"choices,omitempty"`
 }
 
 type SlashCommandChoice struct {
@@ -117,8 +117,8 @@ type SlashCommandChoice struct {
 }
 
 const (
-	OptionString  = 3
-	OptionNumber  = 10
+	OptionString = 3
+	OptionNumber = 10
 )
 
 var slashCommands = []SlashCommand{
@@ -333,7 +333,7 @@ func formatAsEmbed(prompt, answer string) Embed {
 		color = ColorGray
 	}
 
-	desc := answer
+	desc := app.NormalizeAnswerMarkdown(answer)
 	if len(desc) > 4096 {
 		desc = desc[:4093] + "…"
 	}

--- a/internal/app/answer_format.go
+++ b/internal/app/answer_format.go
@@ -1,6 +1,9 @@
 package app
 
-import "strings"
+import (
+	"strings"
+	"unicode"
+)
 
 // NormalizeAnswerMarkdown prepares assistant answers for every Mu surface before
 // they are rendered as HTML or sent to chat clients. It keeps markdown intact,
@@ -45,10 +48,73 @@ func NormalizeAnswerMarkdown(answer string) string {
 }
 
 func normalizeMarkdownLine(line string) string {
-	for _, prefix := range []string{"-", "*", "+"} {
+	if heading, rest, ok := strings.Cut(line, " "); ok && isMarkdownHeading(heading) {
+		return heading + " " + strings.TrimSpace(rest)
+	}
+	if isMarkdownHeading(line) {
+		return line
+	}
+	if strings.HasPrefix(line, "#") {
+		trimmed := strings.TrimLeft(line, "#")
+		level := len(line) - len(trimmed)
+		if level > 0 && level <= 6 {
+			return strings.Repeat("#", level) + " " + strings.TrimSpace(trimmed)
+		}
+	}
+
+	for _, prefix := range []string{"-", "*", "+", ">"} {
 		if rest, ok := strings.CutPrefix(line, prefix); ok {
 			return prefix + " " + strings.TrimSpace(rest)
 		}
 	}
+	if numbered := normalizeNumberedListLine(line); numbered != "" {
+		return numbered
+	}
+	if strings.Contains(line, "|") {
+		return normalizeTableLine(line)
+	}
 	return line
+}
+
+func isMarkdownHeading(s string) bool {
+	if s == "" || len(s) > 6 {
+		return false
+	}
+	for _, r := range s {
+		if r != '#' {
+			return false
+		}
+	}
+	return true
+}
+
+func normalizeNumberedListLine(line string) string {
+	dot := strings.IndexByte(line, '.')
+	if dot <= 0 {
+		return ""
+	}
+	for _, r := range line[:dot] {
+		if !unicode.IsDigit(r) {
+			return ""
+		}
+	}
+	return line[:dot+1] + " " + strings.TrimSpace(line[dot+1:])
+}
+
+func normalizeTableLine(line string) string {
+	leadingPipe := strings.HasPrefix(line, "|")
+	trailingPipe := strings.HasSuffix(line, "|")
+	body := strings.Trim(line, "|")
+	cells := strings.Split(body, "|")
+	for i, cell := range cells {
+		cells[i] = strings.TrimSpace(cell)
+	}
+	out := strings.Join(cells, " | ")
+	if leadingPipe {
+		out = "| " + out
+	}
+	if trailingPipe {
+		out += " |"
+	}
+	return out
 }

--- a/internal/app/answer_format_test.go
+++ b/internal/app/answer_format_test.go
@@ -23,3 +23,11 @@ func TestNormalizeAnswerMarkdownPreservesCodeFenceSpacing(t *testing.T) {
 		t.Fatalf("extra blank lines leaked outside code fence: %q", got)
 	}
 }
+
+func TestNormalizeAnswerMarkdownNormalizesCommonBlocks(t *testing.T) {
+	input := "##Weather\n1.Sunny today\n>quoted\n| City | Temp|Notes |\n|---| --- |---|"
+	want := "## Weather\n1. Sunny today\n> quoted\n| City | Temp | Notes |\n| --- | --- | --- |"
+	if got := NormalizeAnswerMarkdown(input); got != want {
+		t.Fatalf("NormalizeAnswerMarkdown() = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Summary
- Normalize headings, numbered lists, blockquotes, and markdown table spacing in the shared answer formatter.
- Route Discord embed descriptions through the shared answer formatter before truncation.
- Add coverage for common markdown block normalization.

## Testing
- go build ./...
- go test ./... -short
- go vet ./...

Closes #750
Closes #784