### PR TITLE
Fix malformed leading bold in agent answers

### DIFF
--- a/internal/app/answer_format.go
+++ b/internal/app/answer_format.go
@@ -1,8 +1,10 @@
 package app
 
 import (
+	"regexp"
 	"strings"
 	"unicode"
+	"unicode/utf8"
 )
 
 // NormalizeAnswerMarkdown prepares assistant answers for every Mu surface before
@@ -48,6 +50,7 @@ func NormalizeAnswerMarkdown(answer string) string {
 }
 
 func normalizeMarkdownLine(line string) string {
+	line = repairMalformedLeadingBold(line)
 	if heading, rest, ok := strings.Cut(line, " "); ok && isMarkdownHeading(heading) {
 		return heading + " " + strings.TrimSpace(rest)
 	}
@@ -62,8 +65,11 @@ func normalizeMarkdownLine(line string) string {
 		}
 	}
 
-	for _, prefix := range []string{"-", "*", "+", ">"} {
-		if rest, ok := strings.CutPrefix(line, prefix); ok {
+	if rest, ok := strings.CutPrefix(line, ">"); ok {
+		return "> " + strings.TrimSpace(rest)
+	}
+	for _, prefix := range []string{"-", "*", "+"} {
+		if rest, ok := strings.CutPrefix(line, prefix); ok && startsMarkdownListRest(rest) {
 			return prefix + " " + strings.TrimSpace(rest)
 		}
 	}
@@ -74,6 +80,20 @@ func normalizeMarkdownLine(line string) string {
 		return normalizeTableLine(line)
 	}
 	return line
+}
+
+var malformedLeadingBoldRe = regexp.MustCompile(`^\*([^*\n]+?:)\*\*(\s|$)`)
+
+func repairMalformedLeadingBold(line string) string {
+	return malformedLeadingBoldRe.ReplaceAllString(line, `**$1**$2`)
+}
+
+func startsMarkdownListRest(rest string) bool {
+	if rest == "" {
+		return false
+	}
+	r, _ := utf8.DecodeRuneInString(rest)
+	return unicode.IsSpace(r)
 }
 
 func isMarkdownHeading(s string) bool {

--- a/internal/app/answer_format_test.go
+++ b/internal/app/answer_format_test.go
@@ -31,3 +31,30 @@ func TestNormalizeAnswerMarkdownNormalizesCommonBlocks(t *testing.T) {
 		t.Fatalf("NormalizeAnswerMarkdown() = %q, want %q", got, want)
 	}
 }
+
+func TestNormalizeAnswerMarkdownRepairsMalformedLeadingBold(t *testing.T) {
+	input := "*London today:** Light rain, 17°C.\n*Wind:** 10 mph."
+	want := "**London today:** Light rain, 17°C.\n**Wind:** 10 mph."
+	if got := NormalizeAnswerMarkdown(input); got != want {
+		t.Fatalf("NormalizeAnswerMarkdown() = %q, want %q", got, want)
+	}
+}
+
+func TestRenderMalformedLeadingBoldAsCleanStrongText(t *testing.T) {
+	input := NormalizeAnswerMarkdown("*London today:** Light rain, 17°C.")
+	html := string(Render([]byte(input)))
+	if strings.Contains(html, "*") {
+		t.Fatalf("rendered HTML leaked markdown delimiter: %q", html)
+	}
+	if !strings.Contains(html, "<strong>London today:</strong>") {
+		t.Fatalf("rendered HTML did not produce strong label: %q", html)
+	}
+}
+
+func TestNormalizeAnswerMarkdownDoesNotTreatEmphasisAsList(t *testing.T) {
+	input := "*emphasis* stays inline\n* list item"
+	want := "*emphasis* stays inline\n* list item"
+	if got := NormalizeAnswerMarkdown(input); got != want {
+		t.Fatalf("NormalizeAnswerMarkdown() = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Summary
- Repair malformed leading bold labels like `*London today:**` before markdown rendering.
- Avoid treating inline emphasis that starts with `*` as a list item during answer normalization.
- Add regression coverage for clean rendered HTML output.

Closes #787
Closes #789

## Testing
- go build ./...
- go test ./... -short
- go vet ./...