### PR TITLE
Refresh product priorities after review #796

### DIFF
--- a/internal/docs/PRIORITIES.md
+++ b/internal/docs/PRIORITIES.md
@@ -21,7 +21,7 @@ and publishing marketing content. Those go to the human.
 
 ## Work queue (ranked)
 
-1. **[#792 Return real weather answers instead of progress-only fallbacks.](https://github.com/micro/mu/issues/792)** The highest-value live regression is still in the core guest ask → answer loop: a common weather prompt can finish with only a progress placeholder (for example, `Let me pull the latest for you.`) instead of conditions/forecast details. Ensure weather tool results are synthesized into the final answer, or show a clear provider-unavailable message, with CI-verifiable coverage.
+1. **[#797 Return real news answers instead of progress-only search fallbacks.](https://github.com/micro/mu/issues/797)** The highest-value live regression is still in the core guest ask → answer loop: a common news prompt can finish with only search/progress narration (for example, `Let me search the web for more AI stories to round this out.`) instead of headlines, sources, or a clear provider-unavailable message. Ensure news/search tool results are synthesized into the final answer, or show an explicit graceful unavailable state, with CI-verifiable coverage.
 
 ### Already shipped (do not re-queue)
 


### PR DESCRIPTION
Summary:
- Replaced the closed weather fallback priority with newly filed issue #797 for the live news/search progress-only answer regression.

Closes #796