### PR TITLE
Anchor live answers to request date

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -210,7 +210,7 @@ func QueryWithOpts(accountID, prompt string, opts QueryOpts) (string, error) {
 		ragParts = append(ragParts, fmt.Sprintf("### %s\n%s", res.Name, ragText))
 	}
 
-	today := time.Now().UTC().Format("Monday, 2 January 2006 (UTC)")
+	today := currentDateContext(time.Now().UTC())
 
 	// Include conversation history in RAG context
 	if len(opts.History) > 0 {
@@ -937,7 +937,7 @@ func handleQuery(w http.ResponseWriter, r *http.Request) {
 		ragParts = append(ragParts, fmt.Sprintf("### %s\n%s", res.Name, ragText))
 	}
 
-	today := time.Now().UTC().Format("Monday, 2 January 2006 (UTC)")
+	today := currentDateContext(time.Now().UTC())
 
 	var synthSystem string
 	if len(results) == 0 {
@@ -950,7 +950,7 @@ func handleQuery(w http.ResponseWriter, r *http.Request) {
 			"IMPORTANT: Use plain dollar signs for currency (e.g. $69,811). Do NOT use LaTeX math delimiters like \\( or \\)."
 	} else {
 		synthSystem = "You are a helpful assistant. Today's date is " + today + ". " +
-			"The tool results below come from live data feeds — treat them as current information and use the article publication dates when reasoning about recency.\n\n" +
+			"The tool results below come from live data feeds. For prompts about today, latest, current, or now, anchor the answer to the current date above; do not label today as a different date unless a provider timestamp explicitly proves staleness, and disclose that staleness. Use article publication dates when reasoning about recency.\n\n" +
 			"Answer the user's question using the tool results provided below.\n\n" +
 			"IMPORTANT: For any prices, market values, weather conditions, or other real-time data, you MUST use " +
 			"the exact values from the tool results. Do NOT use your training knowledge for current prices or live data — " +
@@ -1362,13 +1362,13 @@ func placesMapURL(args map[string]any, items []placeItem) string {
 func formatToolResult(toolName, result string, args map[string]any) string {
 	switch toolName {
 	case "news", "news_search":
-		return formatNewsResult(result)
+		return withCurrentDateContext(formatNewsResult(result))
 	case "video_search":
 		return formatVideoResult(result)
 	case "reminder":
 		return formatReminderResult(result)
 	case "search":
-		return formatSearchResult(result)
+		return withCurrentDateContext(formatSearchResult(result))
 	case "web_fetch":
 		return formatWebFetchResult(result)
 	case "places_search", "places_nearby":

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -233,6 +233,27 @@ func TestFormatSearchResult_JSON(t *testing.T) {
 	}
 }
 
+func TestCurrentDateContextIncludesISORequestDate(t *testing.T) {
+	got := currentDateContext(time.Date(2026, 6, 30, 23, 59, 0, 0, time.FixedZone("BST", 3600)))
+	if !strings.Contains(got, "Tuesday, 30 June 2026") {
+		t.Fatalf("expected human-readable UTC date, got %q", got)
+	}
+	if !strings.Contains(got, "2026-06-30") {
+		t.Fatalf("expected ISO date anchor, got %q", got)
+	}
+}
+
+func TestFormatToolResultAddsCurrentDateToLiveResults(t *testing.T) {
+	newsResult := `{"feed":[{"title":"Test headline","category":"tech"}]}`
+	got := formatToolResult("news", newsResult, nil)
+	if !strings.Contains(got, "Current request date:") {
+		t.Fatalf("expected current request date in news tool context, got %q", got)
+	}
+	if !strings.Contains(got, time.Now().UTC().Format("2006-01-02")) {
+		t.Fatalf("expected today's ISO date in news tool context, got %q", got)
+	}
+}
+
 func TestFormatToolResult_Dispatch(t *testing.T) {
 	// Ensure the dispatcher calls the right formatter
 	newsResult := `{"feed":[{"title":"Test headline","category":"tech"}]}`

--- a/agent/date_context.go
+++ b/agent/date_context.go
@@ -1,0 +1,21 @@
+package agent
+
+import (
+	"fmt"
+	"time"
+)
+
+// currentDateContext gives synthesis prompts one canonical request date to use
+// for today/latest/current answers. It includes an ISO date so model output is
+// anchored even when weekday or locale formatting would otherwise drift.
+func currentDateContext(now time.Time) string {
+	now = now.UTC()
+	return fmt.Sprintf("%s (%s, UTC)", now.Format("Monday, 2 January 2006"), now.Format("2006-01-02"))
+}
+
+func withCurrentDateContext(text string) string {
+	if text == "" {
+		return "Current request date: " + currentDateContext(time.Now().UTC()) + "."
+	}
+	return "Current request date: " + currentDateContext(time.Now().UTC()) + ".\n" + text
+}

--- a/agent/run.go
+++ b/agent/run.go
@@ -206,7 +206,7 @@ func RunHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Step 3: Synthesise with user context.
-	today := time.Now().UTC().Format("Monday, 2 January 2006 (UTC)")
+	today := currentDateContext(time.Now().UTC())
 	var synthSystem string
 	if len(ragParts) == 0 && userCtx == "" {
 		synthSystem = "You are Micro, the agent on Mu at micro.mu. Today is " + today + ". " +

--- a/markets/agent.go
+++ b/markets/agent.go
@@ -3,6 +3,7 @@ package markets
 import (
 	"fmt"
 	"strings"
+	"time"
 )
 
 // MarketsText returns a compact, model-ready snapshot of live prices for the
@@ -19,6 +20,7 @@ func MarketsText(category string) string {
 	assets := getAssetsForCategory(category)
 
 	var sb strings.Builder
+	fmt.Fprintf(&sb, "Current request date: %s.\n", time.Now().UTC().Format("Monday, 2 January 2006 (2006-01-02, UTC)"))
 	fmt.Fprintf(&sb, "Live %s prices:\n", category)
 	found := 0
 	for _, symbol := range assets {

--- a/news/agent.go
+++ b/news/agent.go
@@ -82,6 +82,7 @@ func HeadlinesText(topic string, limit int) string {
 	}
 
 	var sb strings.Builder
+	fmt.Fprintf(&sb, "Current request date: %s.\n", time.Now().UTC().Format("Monday, 2 January 2006 (2006-01-02, UTC)"))
 	if topic != "" {
 		fmt.Fprintf(&sb, "Latest %q headlines (%d). Use news_read with an id to read one in full.\n\n", topic, len(picked))
 	} else {

--- a/weather/agent.go
+++ b/weather/agent.go
@@ -3,6 +3,7 @@ package weather
 import (
 	"fmt"
 	"strings"
+	"time"
 )
 
 // ForecastText returns a compact, model-ready weather summary for a location.
@@ -18,6 +19,7 @@ func ForecastText(lat, lon float64) string {
 	}
 
 	var sb strings.Builder
+	fmt.Fprintf(&sb, "Current request date: %s.\n", time.Now().UTC().Format("Monday, 2 January 2006 (2006-01-02, UTC)"))
 	if wf.Location != "" {
 		fmt.Fprintf(&sb, "Weather for %s.\n", wf.Location)
 	}


### PR DESCRIPTION
Closes #802
Closes #804

## Summary
- Anchor agent synthesis prompts to the current request date with both human-readable and ISO UTC formats.
- Add current request date context to live news/search/weather/markets tool results so today/latest/current answers do not drift to stale labels.
- Add tests covering the date anchor used in live result context.

## Testing
- go build ./...
- go test ./... -short
- go vet ./...