### PR TITLE
Ground web search answers in query intent

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -952,6 +952,7 @@ func handleQuery(w http.ResponseWriter, r *http.Request) {
 		synthSystem = "You are a helpful assistant. Today's date is " + today + ". " +
 			"The tool results below come from live data feeds. For prompts about today, latest, current, or now, anchor the answer to the current date above; do not label today as a different date unless a provider timestamp explicitly proves staleness, and disclose that staleness. Use article publication dates when reasoning about recency.\n\n" +
 			"Answer the user's question using the tool results provided below.\n\n" +
+			"For web_search results, preserve the user's query intent exactly, cite the listed source URLs, and if confidence is low say the results do not clearly support the requested answer and ask for a refinement.\n\n" +
 			"IMPORTANT: For any prices, market values, weather conditions, or other real-time data, you MUST use " +
 			"the exact values from the tool results. Do NOT use your training knowledge for current prices or live data — " +
 			"it will be outdated. If no tool result contains the requested real-time data, say it is unavailable.\n\n" +
@@ -1369,6 +1370,8 @@ func formatToolResult(toolName, result string, args map[string]any) string {
 		return formatReminderResult(result)
 	case "search":
 		return withCurrentDateContext(formatSearchResult(result))
+	case "web_search":
+		return withCurrentDateContext(result)
 	case "web_fetch":
 		return formatWebFetchResult(result)
 	case "places_search", "places_nearby":

--- a/agent/run.go
+++ b/agent/run.go
@@ -217,6 +217,7 @@ func RunHandler(w http.ResponseWriter, r *http.Request) {
 	} else {
 		synthSystem = "You are Micro, a personal AI assistant. Today is " + today + ". " +
 			"Answer concisely using the tool results and user context below. Use markdown. " +
+			"For web_search results, preserve the user's query intent exactly, cite the listed source URLs, and if confidence is low say the results do not clearly support the requested answer and ask for a refinement. " +
 			"Do not answer with progress narration like 'let me check' or 'I'll pull the data'; the tools have already run, so provide the final answer or say exactly what is unavailable. " +
 			"If the user context already contains the answer (e.g. unread mail count), use it directly."
 	}

--- a/search/agent.go
+++ b/search/agent.go
@@ -2,7 +2,9 @@ package search
 
 import (
 	"fmt"
+	"net/url"
 	"strings"
+	"unicode"
 )
 
 // WebSearchText runs a cached web search and returns model-ready results.
@@ -23,14 +25,85 @@ func WebSearchText(query string, limit int) string {
 		return fmt.Sprintf("No web results for %q.", query)
 	}
 
+	return formatWebSearchResults(query, results)
+}
+
+func formatWebSearchResults(query string, results []BraveResult) string {
+	confidence := webSearchConfidence(query, results)
+
 	var sb strings.Builder
 	fmt.Fprintf(&sb, "Web results for %q:\n", query)
-	for _, r := range results {
+	fmt.Fprintf(&sb, "Query intent: answer the user's original query %q; do not replace it with a broader or different meaning.\n", query)
+	if confidence == "low" {
+		fmt.Fprintf(&sb, "Confidence: low — the returned snippets only partially match the query intent. Say that the search results do not clearly support an answer and ask the user to refine the query before making unsupported claims.\n")
+	} else {
+		fmt.Fprintf(&sb, "Confidence: %s — synthesize only what the listed sources support.\n", confidence)
+	}
+	fmt.Fprintf(&sb, "Sources:\n")
+	for i, r := range results {
 		desc := strings.Join(strings.Fields(r.Description), " ")
-		if len(desc) > 200 {
-			desc = desc[:200] + "…"
+		if len(desc) > 220 {
+			desc = desc[:220] + "…"
 		}
-		fmt.Fprintf(&sb, "%s — %s (%s)\n", strings.TrimSpace(r.Title), desc, r.URL)
+		title := strings.TrimSpace(r.Title)
+		if title == "" {
+			title = sourceHost(r.URL)
+		}
+		fmt.Fprintf(&sb, "%d. %s — %s (%s)\n", i+1, title, desc, r.URL)
 	}
 	return sb.String()
+}
+
+func webSearchConfidence(query string, results []BraveResult) string {
+	terms := meaningfulQueryTerms(query)
+	if len(terms) == 0 || len(results) == 0 {
+		return "low"
+	}
+	matches := 0
+	for term := range terms {
+		for _, r := range results {
+			haystack := strings.ToLower(r.Title + " " + r.Description + " " + r.URL)
+			if strings.Contains(haystack, term) {
+				matches++
+				break
+			}
+		}
+	}
+	ratio := float64(matches) / float64(len(terms))
+	switch {
+	case ratio >= 0.75:
+		return "high"
+	case ratio >= 0.67:
+		return "medium"
+	default:
+		return "low"
+	}
+}
+
+func meaningfulQueryTerms(query string) map[string]struct{} {
+	stop := map[string]struct{}{
+		"a": {}, "an": {}, "and": {}, "are": {}, "for": {}, "from": {}, "how": {}, "is": {}, "me": {}, "of": {}, "on": {}, "or": {}, "search": {}, "show": {}, "the": {}, "to": {}, "web": {}, "what": {}, "whats": {}, "with": {},
+	}
+	terms := make(map[string]struct{})
+	for _, field := range strings.FieldsFunc(strings.ToLower(query), func(r rune) bool {
+		return !unicode.IsLetter(r) && !unicode.IsDigit(r)
+	}) {
+		field = strings.TrimSpace(field)
+		if len(field) < 2 {
+			continue
+		}
+		if _, ok := stop[field]; ok {
+			continue
+		}
+		terms[field] = struct{}{}
+	}
+	return terms
+}
+
+func sourceHost(raw string) string {
+	u, err := url.Parse(raw)
+	if err != nil || u.Host == "" {
+		return strings.TrimSpace(raw)
+	}
+	return u.Host
 }

--- a/search/agent_test.go
+++ b/search/agent_test.go
@@ -1,0 +1,42 @@
+package search
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestFormatWebSearchResultsPreservesIntentAndSources(t *testing.T) {
+	got := formatWebSearchResults("micro mu", []BraveResult{
+		{Title: "Mu — an everyday agent", Description: "Mu is built by Micro as an agent for everyday internet tasks.", URL: "https://micro.mu/"},
+		{Title: "GitHub - micro/mu", Description: "Source repository for Mu.", URL: "https://github.com/micro/mu"},
+	})
+
+	for _, want := range []string{
+		`Web results for "micro mu"`,
+		`Query intent: answer the user's original query "micro mu"`,
+		"Confidence: high",
+		"Sources:",
+		"1. Mu — an everyday agent",
+		"https://micro.mu/",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("expected %q in formatted web search results:\n%s", want, got)
+		}
+	}
+}
+
+func TestFormatWebSearchResultsFlagsLowConfidenceMismatch(t *testing.T) {
+	got := formatWebSearchResults("micro mu", []BraveResult{
+		{Title: "Micro-", Description: "Micro is a metric prefix meaning one millionth.", URL: "https://example.com/micro-prefix"},
+	})
+
+	for _, want := range []string{
+		"Confidence: low",
+		"only partially match the query intent",
+		"ask the user to refine the query before making unsupported claims",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("expected %q in low-confidence web search results:\n%s", want, got)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Preserve web search query intent in model-ready search context.
- Add confidence guidance so weak search-result matches produce explicit refinement requests instead of unsupported answers.
- Require web_search synthesis to cite listed source URLs.

Closes #812
Closes #814

## Testing
- go build ./...
- go test ./... -short
- go vet ./...