### PR TITLE
Ground news answers with source URLs

### DIFF
--- a/news/agent.go
+++ b/news/agent.go
@@ -97,7 +97,16 @@ func HeadlinesText(topic string, limit int) string {
 		if desc := strings.TrimSpace(p.Description); desc != "" {
 			line += " — " + desc
 		}
-		fmt.Fprintf(&sb, "%s (id: %s)\n", line, p.ID)
+		if p.URL != "" {
+			line += fmt.Sprintf(" (source: %s, url: %s", getDomain(p.URL), p.URL)
+			if p.ID != "" {
+				line += fmt.Sprintf(", id: %s", p.ID)
+			}
+			line += ")"
+		} else if p.ID != "" {
+			line += fmt.Sprintf(" (id: %s)", p.ID)
+		}
+		fmt.Fprintln(&sb, line)
 	}
 	return sb.String()
 }

--- a/news/news.go
+++ b/news/news.go
@@ -1768,7 +1768,7 @@ func newsSearchArticles(query string, indexed []*data.IndexEntry, limit int) []m
 			"id":          post.ID,
 			"title":       post.Title,
 			"description": htmlToText(post.Description),
-			"url":         postURL(post),
+			"url":         post.URL,
 			"category":    post.Category,
 			"image":       post.Image,
 			"posted_at":   post.PostedAt,

--- a/news/news_test.go
+++ b/news/news_test.go
@@ -248,8 +248,36 @@ func TestNewsSearchArticlesFallsBackToLiveFeed(t *testing.T) {
 	if got[0]["title"] != "Open model lab ships safer AI assistant" {
 		t.Fatalf("expected AI headline, got %#v", got[0])
 	}
-	if got[0]["url"] != "/news?id=ai-1" {
-		t.Fatalf("expected local news URL for agent grounding, got %#v", got[0]["url"])
+	if got[0]["url"] != "https://example.com/ai" {
+		t.Fatalf("expected source URL for agent citations, got %#v", got[0]["url"])
+	}
+}
+
+func TestHeadlinesTextIncludesSourceURLWithID(t *testing.T) {
+	oldFeed := feed
+	defer func() {
+		mutex.Lock()
+		feed = oldFeed
+		mutex.Unlock()
+	}()
+
+	mutex.Lock()
+	feed = []*Post{{
+		ID:          "ai-1",
+		Title:       "Open model lab ships safer AI assistant",
+		Description: "New evaluations and rollout notes for the assistant.",
+		URL:         "https://example.com/ai",
+		Category:    "Tech",
+		PostedAt:    time.Date(2026, 6, 30, 12, 0, 0, 0, time.UTC),
+	}}
+	mutex.Unlock()
+
+	got := HeadlinesText("tech", 10)
+	if !strings.Contains(got, "source: example.com, url: https://example.com/ai") {
+		t.Fatalf("expected source domain and URL in headline context, got %q", got)
+	}
+	if !strings.Contains(got, "id: ai-1") {
+		t.Fatalf("expected id to remain available for news_read, got %q", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Include source domains and article URLs in news headline context while preserving ids for news_read.
- Return original source URLs from live-feed-backed news search results so synthesized answers can cite readable links instead of internal /news?id=... links.
- Add regression coverage for headline and search grounding.

## Testing
- go test ./news ./agent -short
- go build ./...
- go test ./... -short
- go vet ./...

Closes #819
Closes #821