### PR TITLE
Anchor weather answers to real forecast dates

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -950,7 +950,7 @@ func handleQuery(w http.ResponseWriter, r *http.Request) {
 			"IMPORTANT: Use plain dollar signs for currency (e.g. $69,811). Do NOT use LaTeX math delimiters like \\( or \\)."
 	} else {
 		synthSystem = "You are a helpful assistant. Today's date is " + today + ". " +
-			"The tool results below come from live data feeds. For prompts about today, latest, current, or now, anchor the answer to the current date above; do not label today as a different date unless a provider timestamp explicitly proves staleness, and disclose that staleness. Use article publication dates when reasoning about recency.\n\n" +
+			"The tool results below come from live data feeds. For prompts about today, latest, current, or now, anchor the answer to the current date above; do not label today as a different date unless a provider timestamp explicitly proves staleness, and disclose that staleness. Use article publication dates when reasoning about recency. For weather, use the dated forecast rows exactly and never invent calendar dates or weekdays; if the date is ambiguous or absent, say so.\n\n" +
 			"Answer the user's question using the tool results provided below.\n\n" +
 			"For web_search results, preserve the user's query intent exactly, cite the listed source URLs, and if confidence is low say the results do not clearly support the requested answer and ask for a refinement.\n\n" +
 			"IMPORTANT: For any prices, market values, weather conditions, or other real-time data, you MUST use " +

--- a/weather/agent.go
+++ b/weather/agent.go
@@ -18,8 +18,17 @@ func ForecastText(lat, lon float64) string {
 		return weatherUnavailableMessage
 	}
 
+	return formatForecastText(wf, time.Now().UTC())
+}
+
+func formatForecastText(wf *WeatherForecast, now time.Time) string {
+	if wf == nil {
+		return weatherUnavailableMessage
+	}
+
 	var sb strings.Builder
-	fmt.Fprintf(&sb, "Current request date: %s.\n", time.Now().UTC().Format("Monday, 2 January 2006 (2006-01-02, UTC)"))
+	fmt.Fprintf(&sb, "Current request date: %s.\n", now.UTC().Format("Monday, 2 January 2006 (2006-01-02, UTC)"))
+	sb.WriteString("Calendar rule: anchor relative words like today/tomorrow to the request date above, use only the dated forecast rows below, and do not invent dates. If a requested day is not listed, say it is unavailable.\n")
 	if wf.Location != "" {
 		fmt.Fprintf(&sb, "Weather for %s.\n", wf.Location)
 	}
@@ -28,7 +37,7 @@ func ForecastText(lat, lon float64) string {
 			c.TempC, c.FeelsLikeC, c.Description, c.Humidity, c.WindKph)
 	}
 	if len(wf.DailyItems) > 0 {
-		sb.WriteString("Next days:\n")
+		sb.WriteString("Dated daily forecast (provider timestamps):\n")
 		for i, d := range wf.DailyItems {
 			if i >= 5 {
 				break
@@ -38,7 +47,7 @@ func ForecastText(lat, lon float64) string {
 				rain = fmt.Sprintf(", rain %.0fmm", d.RainMM)
 			}
 			fmt.Fprintf(&sb, "%s: %.0f–%.0f°C, %s%s\n",
-				d.Date.Format("Mon 2 Jan"), d.MinTempC, d.MaxTempC, d.Description, rain)
+				d.Date.Format("Monday, 2 January 2006 (2006-01-02)"), d.MinTempC, d.MaxTempC, d.Description, rain)
 		}
 	}
 	if sb.Len() == 0 {

--- a/weather/weather_test.go
+++ b/weather/weather_test.go
@@ -3,6 +3,7 @@ package weather
 import (
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestToCelsius_Fahrenheit(t *testing.T) {
@@ -85,5 +86,37 @@ func TestCardHTMLShowsWeatherUnavailableOnFetchFailure(t *testing.T) {
 	got := CardHTML()
 	if !strings.Contains(got, "Weather unavailable") {
 		t.Fatalf("CardHTML should show a clear unavailable state on fetch failure, got %q", got)
+	}
+}
+
+func TestFormatForecastTextAnchorsDatesToRealCalendarRows(t *testing.T) {
+	wf := &WeatherForecast{
+		Location: "London",
+		Current: &CurrentConditions{
+			TempC:       18,
+			FeelsLikeC:  17,
+			Description: "cloudy",
+			Humidity:    70,
+			WindKph:     12,
+		},
+		DailyItems: []DailyItem{
+			{Date: time.Date(2026, time.June, 30, 0, 0, 0, 0, time.UTC), MinTempC: 13, MaxTempC: 21, Description: "showers", RainMM: 2, WillRain: true},
+			{Date: time.Date(2026, time.July, 1, 0, 0, 0, 0, time.UTC), MinTempC: 12, MaxTempC: 20, Description: "bright spells"},
+		},
+	}
+
+	got := formatForecastText(wf, time.Date(2026, time.June, 30, 9, 0, 0, 0, time.UTC))
+	for _, want := range []string{
+		"Current request date: Tuesday, 30 June 2026 (2026-06-30, UTC).",
+		"Calendar rule: anchor relative words like today/tomorrow to the request date above",
+		"Tuesday, 30 June 2026 (2026-06-30): 13–21°C, showers, rain 2mm",
+		"Wednesday, 1 July 2026 (2026-07-01): 12–20°C, bright spells",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("formatForecastText missing %q in:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, "31 June") {
+		t.Fatalf("formatForecastText invented impossible calendar date in:\n%s", got)
 	}
 }


### PR DESCRIPTION
## Summary
- Make weather tool context list provider forecast rows with full weekday/date/ISO values.
- Add an explicit calendar rule for weather-backed synthesis so relative weather answers do not invent impossible dates.
- Cover the 30 June 2026 boundary with a unit test.

Closes #824
Closes #826

## Verification
- go build ./...
- go test ./... -short
- go vet ./...