### PR TITLE
Anchor weather tool context dates

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1370,7 +1370,7 @@ func formatToolResult(toolName, result string, args map[string]any) string {
 		return formatReminderResult(result)
 	case "search":
 		return withCurrentDateContext(formatSearchResult(result))
-	case "web_search":
+	case "web_search", "weather_forecast":
 		return withCurrentDateContext(result)
 	case "web_fetch":
 		return formatWebFetchResult(result)

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -244,13 +244,34 @@ func TestCurrentDateContextIncludesISORequestDate(t *testing.T) {
 }
 
 func TestFormatToolResultAddsCurrentDateToLiveResults(t *testing.T) {
-	newsResult := `{"feed":[{"title":"Test headline","category":"tech"}]}`
-	got := formatToolResult("news", newsResult, nil)
-	if !strings.Contains(got, "Current request date:") {
-		t.Fatalf("expected current request date in news tool context, got %q", got)
+	for _, tt := range []struct {
+		name   string
+		tool   string
+		result string
+	}{
+		{name: "news", tool: "news", result: `{"feed":[{"title":"Test headline","category":"tech"}]}`},
+		{name: "weather", tool: "weather_forecast", result: "Weather for London.\nNow: 18°C, cloudy."},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got := formatToolResult(tt.tool, tt.result, nil)
+			if !strings.Contains(got, "Current request date:") {
+				t.Fatalf("expected current request date in %s tool context, got %q", tt.tool, got)
+			}
+			if !strings.Contains(got, time.Now().UTC().Format("2006-01-02")) {
+				t.Fatalf("expected today's ISO date in %s tool context, got %q", tt.tool, got)
+			}
+		})
 	}
-	if !strings.Contains(got, time.Now().UTC().Format("2006-01-02")) {
-		t.Fatalf("expected today's ISO date in news tool context, got %q", got)
+}
+
+func TestFormatToolResultKeepsExistingCurrentDateContext(t *testing.T) {
+	result := "Current request date: Tuesday, 30 June 2026 (2026-06-30, UTC).\nWeather for London."
+	got := formatToolResult("weather_forecast", result, nil)
+	if strings.Count(got, "Current request date:") != 1 {
+		t.Fatalf("expected one current request date context, got %q", got)
+	}
+	if !strings.Contains(got, "2026-06-30") {
+		t.Fatalf("expected existing request date to be preserved, got %q", got)
 	}
 }
 

--- a/agent/date_context.go
+++ b/agent/date_context.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"fmt"
+	"strings"
 	"time"
 )
 
@@ -16,6 +17,9 @@ func currentDateContext(now time.Time) string {
 func withCurrentDateContext(text string) string {
 	if text == "" {
 		return "Current request date: " + currentDateContext(time.Now().UTC()) + "."
+	}
+	if strings.Contains(text, "Current request date:") {
+		return text
 	}
 	return "Current request date: " + currentDateContext(time.Now().UTC()) + ".\n" + text
 }


### PR DESCRIPTION
Continuous-improvement increment #828. The queued priority issue #824 is already closed, so this applies the fallback charter path with a small reliability/test-coverage refinement for date-sensitive weather-backed synthesis.

Changes:
- Adds request-date context to weather_forecast tool results before synthesis when absent.
- Preserves existing weather summaries that already include a request-date anchor to avoid duplicate instructions.
- Expands agent formatter tests for weather date anchoring.

Verification:
- go build ./...
- go test ./... -short
- go vet ./...

Closes #828
Refs #824