### PR TITLE
Improve mixed-provider agent fallbacks

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -184,6 +184,7 @@ func QueryWithOpts(accountID, prompt string, opts QueryOpts) (string, error) {
 		Formatted string
 	}
 	var results []toolResult
+	var unavailableTools []string
 
 	for _, tc := range toolCalls {
 		if tc.Tool == "" {
@@ -194,6 +195,7 @@ func QueryWithOpts(accountID, prompt string, opts QueryOpts) (string, error) {
 		}
 		text, isErr, execErr := api.ExecuteToolAs(accountID, tc.Tool, tc.Args)
 		if execErr != nil || isErr {
+			unavailableTools = append(unavailableTools, tc.Tool)
 			continue
 		}
 		if len(text) > 8000 {
@@ -208,6 +210,9 @@ func QueryWithOpts(accountID, prompt string, opts QueryOpts) (string, error) {
 		ragText := formatToolResult(res.Name, res.Result, res.Args)
 		results[i].Formatted = ragText
 		ragParts = append(ragParts, fmt.Sprintf("### %s\n%s", res.Name, ragText))
+	}
+	for _, tool := range unavailableTools {
+		ragParts = append(ragParts, fmt.Sprintf("### %s\n%s", tool, unavailableToolMessage(tool)))
 	}
 
 	today := currentDateContext(time.Now().UTC())
@@ -875,6 +880,7 @@ func handleQuery(w http.ResponseWriter, r *http.Request) {
 		Formatted string // pre-formatted RAG text, also used for reference rendering
 	}
 	var results []toolResult
+	var unavailableTools []string
 
 	for _, tc := range toolCalls {
 		if tc.Tool == "" {
@@ -889,6 +895,7 @@ func handleQuery(w http.ResponseWriter, r *http.Request) {
 		text, isErr, execErr := api.ExecuteTool(r, tc.Tool, tc.Args)
 		if execErr != nil || isErr {
 			app.Log("agent", "Tool %s failed: err=%v isErr=%v response=%.200s", tc.Tool, execErr, isErr, text)
+			unavailableTools = append(unavailableTools, tc.Tool)
 			sse(w, map[string]any{
 				"type":    "tool_done",
 				"name":    tc.Tool,
@@ -935,6 +942,9 @@ func handleQuery(w http.ResponseWriter, r *http.Request) {
 		ragText := formatToolResult(res.Name, res.Result, res.Args)
 		results[i].Formatted = ragText
 		ragParts = append(ragParts, fmt.Sprintf("### %s\n%s", res.Name, ragText))
+	}
+	for _, tool := range unavailableTools {
+		ragParts = append(ragParts, fmt.Sprintf("### %s\n%s", tool, unavailableToolMessage(tool)))
 	}
 
 	today := currentDateContext(time.Now().UTC())
@@ -1364,6 +1374,8 @@ func formatToolResult(toolName, result string, args map[string]any) string {
 	switch toolName {
 	case "news", "news_search":
 		return withCurrentDateContext(formatNewsResult(result))
+	case "news_headlines", "news_read":
+		return withCurrentDateContext(result)
 	case "video_search":
 		return formatVideoResult(result)
 	case "reminder":

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -679,6 +679,40 @@ func TestCompleteToolAnswerNamesUnavailableSlices(t *testing.T) {
 	}
 }
 
+func TestCompleteToolAnswerUsesAvailableWebWhenNewsUnavailable(t *testing.T) {
+	rag := []string{
+		"### news\n" + unavailableToolMessage("news"),
+		`### web_search
+Web results for "latest AI news":
+Query intent: answer the user's original query "latest AI news"; do not replace it with a broader or different meaning.
+Confidence: high — synthesize only what the listed sources support.
+Sources:
+1. AI lab releases new model — Company announced a new assistant release. (https://example.com/ai-model)
+2. Chip supplier expands AI capacity — Demand for AI chips is rising. (https://example.com/ai-chips)`,
+	}
+	got := completeToolAnswer("Let me search the web for more AI stories to round this out.", rag)
+	if strings.Contains(got, `{"`) || strings.Contains(got, "Query intent:") {
+		t.Fatalf("expected readable fallback without raw/internal search context, got %q", got)
+	}
+	if !strings.Contains(got, "AI lab releases new model") || !strings.Contains(got, "https://example.com/ai-model") {
+		t.Fatalf("expected available web sources in fallback, got %q", got)
+	}
+	if !strings.Contains(got, "Unavailable: news.") {
+		t.Fatalf("expected unavailable news disclosure, got %q", got)
+	}
+}
+
+func TestFormatToolResultNewsHeadlinesStaysReadable(t *testing.T) {
+	result := "Latest headlines — 1 across 1 topics.\n\n[tech] AI lab releases a new model — Useful summary (source: Example, url: https://example.com/ai)"
+	got := formatToolResult("news_headlines", result, nil)
+	if !strings.Contains(got, "Current request date:") {
+		t.Fatalf("expected current date context, got %q", got)
+	}
+	if !strings.Contains(got, "AI lab releases a new model") || strings.Contains(got, `{"`) {
+		t.Fatalf("expected readable news_headlines context, got %q", got)
+	}
+}
+
 func TestCompleteToolAnswerKeepsSubstantiveAnswer(t *testing.T) {
 	want := "BTC is at $100,000, and the latest news says it reached a new high."
 	got := completeToolAnswer(want, []string{"### markets\nBTC: $100,000"})

--- a/agent/answer_guard.go
+++ b/agent/answer_guard.go
@@ -2,6 +2,14 @@ package agent
 
 import "strings"
 
+func unavailableToolMessage(tool string) string {
+	name := strings.TrimSpace(tool)
+	if name == "" {
+		name = "source"
+	}
+	return name + " is unavailable right now. Use any other available live results to answer, and mention this unavailable source briefly without exposing internal payloads."
+}
+
 // completeToolAnswer prevents the agent from returning only progress narration
 // after tools have already produced usable live context. LLMs occasionally stop
 // at phrases like "Let me pull that data" even though the tool calls are done;
@@ -95,7 +103,7 @@ func meaningfulLines(body string, limit int) []string {
 			continue
 		}
 		line = strings.TrimLeft(line, "-• ")
-		if line == "" {
+		if line == "" || isFallbackMetadataLine(line) {
 			continue
 		}
 		if len([]rune(line)) > 280 {
@@ -108,6 +116,21 @@ func meaningfulLines(body string, limit int) []string {
 		}
 	}
 	return lines
+}
+
+func isFallbackMetadataLine(line string) bool {
+	lower := strings.ToLower(strings.TrimSpace(line))
+	prefixes := []string{
+		"query intent:",
+		"confidence:",
+		"sources:",
+	}
+	for _, prefix := range prefixes {
+		if strings.HasPrefix(lower, prefix) {
+			return true
+		}
+	}
+	return false
 }
 
 func isUnavailableToolResult(body string) bool {


### PR DESCRIPTION
## Summary
- Track unavailable agent tools and include sanitized unavailable-source context during synthesis.
- Keep news_headlines/news_read payloads readable in tool formatting.
- Filter web-search metadata from progress fallback bullets while preserving source-linked results.

Closes #831
Closes #833

## Testing
- go test ./agent -short
- go build ./...
- go test ./... -short
- go vet ./...