### PR TITLE
Refresh product priorities after review 835

### DIFF
--- a/internal/docs/PRIORITIES.md
+++ b/internal/docs/PRIORITIES.md
@@ -21,10 +21,11 @@ and publishing marketing content. Those go to the human.
 
 ## Work queue (ranked)
 
-1. **[#831 Make news-backed agent answers user-readable when one provider is unavailable.](https://github.com/micro/mu/issues/831)** The top remaining core-loop friction is graceful mixed-provider synthesis: on 2026-06-30 the live guest `/agent` loop for “What are the latest AI news headlines today?” called news and web search, but returned raw escaped search context plus “Unavailable: news” instead of readable source-linked bullets. Keep public contracts and provider integrations unchanged, synthesize from any usable provider context, and disclose unavailable providers without exposing JSON or internal model-ready payloads.
+1. **[#836 Keep independent guest agent prompts from leaking prior topic context.](https://github.com/micro/mu/issues/836)** The top remaining core-loop friction is prompt isolation: on 2026-06-30 a fresh guest `/agent` request for “What is the weather in London today?” with empty history/context returned the weather, but also prefixed unrelated AI-news headlines from an earlier separate news request. Keep the public `/agent` contract unchanged, preserve intentional history/context behavior, and ensure fresh prompts only use the current prompt plus explicitly supplied history/context.
 
 ### Already shipped (do not re-queue)
 
+- ✅ **Mixed-provider news fallback made user-readable.** News-backed agent answers now synthesize readable output from usable provider context and disclose unavailable providers without raw internal payloads, closing #831 / PR #834.
 - ✅ **Impossible weather dates fixed.** Weather-backed synthesis now anchors forecast context to real provider dates and avoids fabricated invalid calendar dates, closing #824 / PR #827 / PR #829.
 - ✅ **Source-linked news answers.** News-backed synthesis now includes readable source names and URLs instead of opaque internal ids, closing #819 / PR #822.
 - ✅ **Grounded web-search answers.** Web-search synthesis now preserves query intent, includes source URLs in the model-ready context, and asks for refinement when weak results do not support an answer, closing #812 / #814 / PR #815.


### PR DESCRIPTION
Summary:
- Move closed #831 / PR #834 to the shipped list.
- Add #836 as the top Now-phase refinement after live guest testing found fresh prompts can leak unrelated prior topic context.

Closes #835