### PR TITLE
Isolate fresh guest agent requests

### DIFF
--- a/agent/native.go
+++ b/agent/native.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	gmagent "go-micro.dev/v6/agent"
@@ -17,6 +18,8 @@ import (
 	"mu/internal/service"
 	"mu/internal/settings"
 )
+
+var nativeAgentSeq atomic.Uint64
 
 // nativeEnabled reports whether the native go-micro agent path is on. mu is an
 // agent platform, so the go-micro agent is the default. Set AGENT_NATIVE to a
@@ -123,12 +126,19 @@ func buildNativeAgent(accountID, prompt string, opts QueryOpts, wrappers ...gmai
 		question = hb.String()
 	}
 
+	// Use a fresh named agent for each request. Some go-micro providers keep
+	// per-agent conversation state keyed by name, so reusing a stable "assistant"
+	// name can leak prior independent prompts into fresh guest requests.
 	toolWrappers := append([]gmai.ToolWrapper{injectAccount(accountID)}, wrappers...)
-	a = service.NewAgent("assistant", sys, "atlascloud", key, nativeServices(opts.Public),
+	a = service.NewAgent(nativeAgentInstanceName(), sys, "atlascloud", key, nativeServices(opts.Public),
 		gmagent.Model(ai.ModelDeepSeekPro),
 		gmagent.MaxSteps(6),
 		gmagent.WrapTool(toolWrappers...))
 	return a, question, true
+}
+
+func nativeAgentInstanceName() string {
+	return fmt.Sprintf("assistant-%d-%d", time.Now().UTC().UnixNano(), nativeAgentSeq.Add(1))
 }
 
 // queryNative answers using a go-micro agent wired to the registered domain

--- a/agent/native_default_test.go
+++ b/agent/native_default_test.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"strings"
 	"testing"
 
 	"mu/internal/settings"
@@ -23,5 +24,20 @@ func TestNativeEnabledDefault(t *testing.T) {
 	settings.Set("AGENT_NATIVE", "on")
 	if !nativeEnabled() {
 		t.Fatal("AGENT_NATIVE=on should keep it enabled")
+	}
+}
+
+func TestNativeAgentInstanceNameIsUnique(t *testing.T) {
+	first := nativeAgentInstanceName()
+	second := nativeAgentInstanceName()
+
+	if first == "" || second == "" {
+		t.Fatal("native agent instance names should not be empty")
+	}
+	if first == second {
+		t.Fatalf("native agent instance names should be unique, got %q twice", first)
+	}
+	if !strings.HasPrefix(first, "assistant-") || !strings.HasPrefix(second, "assistant-") {
+		t.Fatalf("native agent instance names should keep assistant prefix, got %q and %q", first, second)
 	}
 }


### PR DESCRIPTION
## Summary
- Give each native go-micro agent request a unique assistant instance name so provider-side per-agent state cannot leak across independent fresh prompts.
- Add a regression check that native assistant instance names remain unique while preserving the assistant prefix.

Closes #836
Closes #838

## Verification
- go build ./...
- go test ./... -short
- go vet ./...