### PR TITLE
Refresh product priorities after review 840

### DIFF
--- a/internal/docs/PRIORITIES.md
+++ b/internal/docs/PRIORITIES.md
@@ -21,10 +21,11 @@ and publishing marketing content. Those go to the human.
 
 ## Work queue (ranked)
 
-1. **[#836 Keep independent guest agent prompts from leaking prior topic context.](https://github.com/micro/mu/issues/836)** The top remaining core-loop friction is prompt isolation: on 2026-06-30 a fresh guest `/agent` request for “What is the weather in London today?” with empty history/context returned the weather, but also prefixed unrelated AI-news headlines from an earlier separate news request. Keep the public `/agent` contract unchanged, preserve intentional history/context behavior, and ensure fresh prompts only use the current prompt plus explicitly supplied history/context.
+1. **[#841 Restore live news-backed agent answers when feeds are unavailable.](https://github.com/micro/mu/issues/841)** The top remaining core-loop friction is current-events usefulness: on 2026-06-30 fresh guest `/agent` prompts for “What are the top technology news stories today?” and “Give me the latest AI news headlines” completed quickly and gracefully, but returned only “requested data is unavailable right now” instead of useful source-linked headlines. Keep the public `/agent` contract unchanged, preserve the existing no-fabrication/degraded-state behavior, and make news prompts synthesize grounded results whenever any feed/search provider has usable context.
 
 ### Already shipped (do not re-queue)
 
+- ✅ **Fresh guest prompt isolation.** Independent guest `/agent` requests no longer leak prior topic context into unrelated prompts, closing #836 / PR #839.
 - ✅ **Mixed-provider news fallback made user-readable.** News-backed agent answers now synthesize readable output from usable provider context and disclose unavailable providers without raw internal payloads, closing #831 / PR #834.
 - ✅ **Impossible weather dates fixed.** Weather-backed synthesis now anchors forecast context to real provider dates and avoids fabricated invalid calendar dates, closing #824 / PR #827 / PR #829.
 - ✅ **Source-linked news answers.** News-backed synthesis now includes readable source names and URLs instead of opaque internal ids, closing #819 / PR #822.


### PR DESCRIPTION
Summary:
- Move closed prompt-isolation work (#836 / PR #839) to shipped.
- Rank the newly observed live news unavailable-state friction as the top open Now/seamlessness item (#841).

Closes #840