### PR TITLE
Improve news topic headline matching

### DIFF
--- a/news/agent.go
+++ b/news/agent.go
@@ -35,7 +35,7 @@ func HeadlinesText(topic string, limit int) string {
 		if p == nil || strings.TrimSpace(p.Title) == "" {
 			continue
 		}
-		if topic != "" && !strings.Contains(strings.ToLower(p.Category), topic) {
+		if topic != "" && !postMatchesNewsTopic(p, topic) {
 			continue
 		}
 		if _, ok := byCat[p.Category]; !ok {
@@ -109,6 +109,44 @@ func HeadlinesText(topic string, limit int) string {
 		fmt.Fprintln(&sb, line)
 	}
 	return sb.String()
+}
+
+func postMatchesNewsTopic(p *Post, topic string) bool {
+	if p == nil {
+		return false
+	}
+	haystack := strings.ToLower(strings.Join([]string{
+		p.Category,
+		p.Title,
+		p.Description,
+		p.Content,
+	}, " "))
+	for _, term := range newsTopicTerms(topic) {
+		if strings.Contains(haystack, term) {
+			return true
+		}
+	}
+	return false
+}
+
+func newsTopicTerms(topic string) []string {
+	topic = strings.TrimSpace(strings.ToLower(topic))
+	if topic == "" {
+		return nil
+	}
+	terms := []string{topic}
+	for _, field := range strings.Fields(topic) {
+		if field != topic {
+			terms = append(terms, field)
+		}
+	}
+	if strings.Contains(topic, "technology") {
+		terms = append(terms, "tech", "ai", "artificial intelligence", "machine learning", "model", "software")
+	}
+	if topic == "ai" || strings.Contains(topic, "artificial intelligence") {
+		terms = append(terms, "ai", "artificial intelligence", "machine learning", "model", "llm")
+	}
+	return terms
 }
 
 // ArticleText returns a single news article in full — title, source, summary

--- a/news/news_test.go
+++ b/news/news_test.go
@@ -281,6 +281,44 @@ func TestHeadlinesTextIncludesSourceURLWithID(t *testing.T) {
 	}
 }
 
+func TestHeadlinesTextTopicMatchesArticleTextAndSynonyms(t *testing.T) {
+	oldFeed := feed
+	defer func() {
+		mutex.Lock()
+		feed = oldFeed
+		mutex.Unlock()
+	}()
+
+	mutex.Lock()
+	feed = []*Post{
+		{
+			ID:          "ai-1",
+			Title:       "Open model lab ships safer AI assistant",
+			Description: "New evaluations and rollout notes for the assistant.",
+			URL:         "https://example.com/ai",
+			Category:    "Dev",
+			PostedAt:    time.Date(2026, 6, 30, 12, 0, 0, 0, time.UTC),
+		},
+		{
+			ID:          "sports-1",
+			Title:       "Club wins cup final",
+			Description: "A late goal settled the match.",
+			URL:         "https://example.com/sports",
+			Category:    "Sports",
+			PostedAt:    time.Date(2026, 6, 30, 11, 0, 0, 0, time.UTC),
+		},
+	}
+	mutex.Unlock()
+
+	got := HeadlinesText("technology", 10)
+	if !strings.Contains(got, "Open model lab ships safer AI assistant") {
+		t.Fatalf("expected technology topic to match tech/AI headline text, got %q", got)
+	}
+	if strings.Contains(got, "Club wins cup final") {
+		t.Fatalf("expected unrelated headline to stay out of topic-filtered results, got %q", got)
+	}
+}
+
 func TestNewsSearchArticlesReturnsExplicitEmptyResults(t *testing.T) {
 	oldFeed := feed
 	defer func() {


### PR DESCRIPTION
## Summary
- Match news headline topics against category, title, description, and content instead of category only.
- Expand common technology/AI topic terms so prompts like latest technology news can return grounded AI/tech headlines when feeds categorize them as Dev or similar.
- Add regression coverage for topic synonym matching.

Closes #841
Closes #843

## Testing
- go build ./...
- go test ./... -short
- go vet ./...