### PR TITLE
Preserve news article URLs in agent answers

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -963,6 +963,7 @@ func handleQuery(w http.ResponseWriter, r *http.Request) {
 			"The tool results below come from live data feeds. For prompts about today, latest, current, or now, anchor the answer to the current date above; do not label today as a different date unless a provider timestamp explicitly proves staleness, and disclose that staleness. Use article publication dates when reasoning about recency. For weather, use the dated forecast rows exactly and never invent calendar dates or weekdays; if the date is ambiguous or absent, say so.\n\n" +
 			"Answer the user's question using the tool results provided below.\n\n" +
 			"For web_search results, preserve the user's query intent exactly, cite the listed source URLs, and if confidence is low say the results do not clearly support the requested answer and ask for a refinement.\n\n" +
+			"For news results, include the article URL next to each headline whenever the tool result provides one; if a headline has no URL, do not invent one.\n\n" +
 			"IMPORTANT: For any prices, market values, weather conditions, or other real-time data, you MUST use " +
 			"the exact values from the tool results. Do NOT use your training knowledge for current prices or live data — " +
 			"it will be outdated. If no tool result contains the requested real-time data, say it is unavailable.\n\n" +

--- a/agent/micro/execute.go
+++ b/agent/micro/execute.go
@@ -109,7 +109,7 @@ func (a *Agent) Execute(accountID, prompt string, public bool) (string, error) {
 	today := time.Now().UTC().Format("Monday, 2 January 2006 (UTC)")
 	synthSystem := a.SystemPrompt + "\n\nToday is " + today + "."
 	if len(results) > 0 {
-		synthSystem += "\n\nUse the tool results below to answer. Be concise."
+		synthSystem += "\n\nUse the tool results below to answer. Be concise. For news results, include the article URL next to each headline whenever the tool result provides one; if a headline has no URL, do not invent one."
 	}
 	if !public && userCtx != "" {
 		synthSystem += "\n\nUser context:\n" + userCtx

--- a/agent/native.go
+++ b/agent/native.go
@@ -102,6 +102,7 @@ func buildNativeAgent(accountID, prompt string, opts QueryOpts, wrappers ...gmai
 		"Use the available tools for live or personal data (weather, news, market prices, " +
 		"social, video, blog, web search, trading, and recall of the user's own news/mail). " +
 		"Quote exact values from tool results. Be concise and conversational. " +
+		"For news results, include the article URL next to each headline whenever the tool result provides one; if a headline has no URL, do not invent one. " +
 		"After using tools, always provide the final answer or state exactly what is unavailable; " +
 		"never stop at progress narration like let me check or I will pull that data. " +
 		"If the user asks about weather without a location, default to London (lat 51.5074, lon -0.1278)."

--- a/agent/run.go
+++ b/agent/run.go
@@ -218,6 +218,7 @@ func RunHandler(w http.ResponseWriter, r *http.Request) {
 		synthSystem = "You are Micro, a personal AI assistant. Today is " + today + ". " +
 			"Answer concisely using the tool results and user context below. Use markdown. " +
 			"For web_search results, preserve the user's query intent exactly, cite the listed source URLs, and if confidence is low say the results do not clearly support the requested answer and ask for a refinement. " +
+			"For news results, include the article URL next to each headline whenever the tool result provides one; if a headline has no URL, do not invent one. " +
 			"Do not answer with progress narration like 'let me check' or 'I'll pull the data'; the tools have already run, so provide the final answer or say exactly what is unavailable. " +
 			"If the user context already contains the answer (e.g. unread mail count), use it directly."
 	}


### PR DESCRIPTION
## Summary
- Instruct all agent synthesis paths to keep article URLs with news headlines whenever tool results provide them.
- Avoid inventing links when a news result has no URL.

Closes #846
Closes #848

## Testing
- go build ./...
- go test ./... -short
- go vet ./...