### PR TITLE
Clarify guest weather access

### DIFF
--- a/weather/weather.go
+++ b/weather/weather.go
@@ -201,7 +201,11 @@ func renderWeatherPage(r *http.Request) string {
 	var sb strings.Builder
 
 	if !isAuthed {
-		sb.WriteString(`<p>Please <a href="/login">log in</a> to use Weather.</p>`)
+		sb.WriteString(`<div class="card">
+  <p class="card-desc">Weather forecasts are available through Mu's agent for guests, while saved location forecasts, pollen, and credit-backed refreshes require an account.</p>
+  <p>Try asking the agent: <a href="/agent?q=Weather%20in%20San%20Francisco">Weather in San Francisco</a>.</p>
+  <p class="card-meta">Want the full weather page with location search and pollen? <a href="/login">Log in</a> to continue.</p>
+</div>`)
 		return sb.String()
 	}
 

--- a/weather/weather_test.go
+++ b/weather/weather_test.go
@@ -1,6 +1,7 @@
 package weather
 
 import (
+	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
@@ -86,6 +87,23 @@ func TestCardHTMLShowsWeatherUnavailableOnFetchFailure(t *testing.T) {
 	got := CardHTML()
 	if !strings.Contains(got, "Weather unavailable") {
 		t.Fatalf("CardHTML should show a clear unavailable state on fetch failure, got %q", got)
+	}
+}
+
+func TestRenderWeatherPageGuestShowsAgentPathAndLoginScope(t *testing.T) {
+	got := renderWeatherPage(httptest.NewRequest("GET", "/weather", nil))
+	for _, want := range []string{
+		"Weather forecasts are available through Mu's agent for guests",
+		`href="/agent?q=Weather%20in%20San%20Francisco"`,
+		"saved location forecasts, pollen, and credit-backed refreshes require an account",
+		`href="/login"`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("guest weather page missing %q in:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, "Please <a href=\"/login\">log in</a> to use Weather") {
+		t.Fatalf("guest weather page should not be a dead-end login prompt:\n%s", got)
 	}
 }
 


### PR DESCRIPTION
Clarifies the signed-out /weather page so guests see an actionable agent path instead of a dead-end login prompt, while preserving the signed-in weather flow and JSON API access controls.

Closes #856
Closes #858

Checks:
- go build ./...
- go test ./... -short
- go vet ./...