### PR TITLE
Fix guest recent search query escaping

### DIFF
--- a/search/search.go
+++ b/search/search.go
@@ -404,8 +404,9 @@ var webRecentSearchesScript = `
   const STORAGE_KEY = 'mu_recent_web_searches';
 
   function escapeHTML(text) {
-    return text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
-               .replace(/"/g, '&quot;').replace(/'/g, '&#039;');
+    const div = document.createElement('div');
+    div.textContent = String(text);
+    return div.innerHTML;
   }
 
   function loadRecentSearches() {
@@ -442,7 +443,7 @@ var webRecentSearchesScript = `
     let h = '<div class="recent-searches"><h3>Recent Searches</h3><div class="recent-searches-scroll">';
     searches.forEach(function(search) {
       const escaped = escapeHTML(search);
-      h += '<span class="recent-search-item" data-query="' + escaped + '">'
+      h += '<span class="recent-search-item" data-query="' + encodeURIComponent(search) + '">'
          + '<span class="recent-search-label">' + escaped + '</span>'
          + '<span class="recent-search-close" title="Remove">&times;</span>'
          + '</span>';
@@ -456,7 +457,7 @@ var webRecentSearchesScript = `
       if (label) {
         label.addEventListener('click', function(e) {
           e.preventDefault(); e.stopPropagation();
-          var q = item.getAttribute('data-query');
+          var q = decodeURIComponent(item.getAttribute('data-query') || '');
           saveRecentSearch(q);
           window.location.href = '/web?q=' + encodeURIComponent(q);
         });
@@ -464,7 +465,7 @@ var webRecentSearchesScript = `
       if (close) {
         close.addEventListener('click', function(e) {
           e.preventDefault(); e.stopPropagation();
-          removeRecentSearch(item.getAttribute('data-query'));
+          removeRecentSearch(decodeURIComponent(item.getAttribute('data-query') || ''));
         });
       }
     });

--- a/search/search_test.go
+++ b/search/search_test.go
@@ -1,6 +1,9 @@
 package search
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestStripHTML(t *testing.T) {
 	tests := []struct {
@@ -19,5 +22,20 @@ func TestStripHTML(t *testing.T) {
 		if got != tc.want {
 			t.Errorf("stripHTML(%q) = %q; want %q", tc.input, got, tc.want)
 		}
+	}
+}
+
+func TestRecentSearchesScriptEscapesLabelsWithoutManglingSpaces(t *testing.T) {
+	if !strings.Contains(webRecentSearchesScript, "div.textContent = String(text);") {
+		t.Fatal("recent search labels should escape via textContent")
+	}
+	if strings.Contains(webRecentSearchesScript, ".replace(/ /g, '&gt;')") || strings.Contains(webRecentSearchesScript, ".replace(/\\s/g, '&gt;')") {
+		t.Fatal("recent search escaping must not convert spaces to HTML entities")
+	}
+	if !strings.Contains(webRecentSearchesScript, "encodeURIComponent(search)") {
+		t.Fatal("recent search data attributes should encode raw queries without changing label text")
+	}
+	if !strings.Contains(webRecentSearchesScript, "decodeURIComponent(item.getAttribute('data-query') || '')") {
+		t.Fatal("recent search click/remove handlers should decode stored queries")
 	}
 }


### PR DESCRIPTION
Fixes the guest Search page recent-query rendering so multi-word searches keep their spaces while HTML-sensitive characters remain escaped.\n\nCloses #861\nCloses #863