### PR TITLE
Normalize assistant bullet glyphs

### DIFF
--- a/internal/app/answer_format.go
+++ b/internal/app/answer_format.go
@@ -73,6 +73,9 @@ func normalizeMarkdownLine(line string) string {
 			return prefix + " " + strings.TrimSpace(rest)
 		}
 	}
+	if rest, ok := strings.CutPrefix(line, "•"); ok && startsMarkdownListRest(rest) {
+		return "- " + strings.TrimSpace(rest)
+	}
 	if numbered := normalizeNumberedListLine(line); numbered != "" {
 		return numbered
 	}

--- a/internal/app/answer_format_test.go
+++ b/internal/app/answer_format_test.go
@@ -58,3 +58,11 @@ func TestNormalizeAnswerMarkdownDoesNotTreatEmphasisAsList(t *testing.T) {
 		t.Fatalf("NormalizeAnswerMarkdown() = %q, want %q", got, want)
 	}
 }
+
+func TestNormalizeAnswerMarkdownConvertsBulletGlyphs(t *testing.T) {
+	input := "•   Weather is clear\n• Bring sunglasses"
+	want := "- Weather is clear\n- Bring sunglasses"
+	if got := NormalizeAnswerMarkdown(input); got != want {
+		t.Fatalf("NormalizeAnswerMarkdown() = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Summary
- Normalize common bullet glyphs in assistant answers to standard markdown list markers so web and chat rendering stays consistent.
- Add coverage for bullet glyph normalization.

Closes #867