### PR TITLE
Clarify guest chat authentication

### DIFF
--- a/chat/chat.go
+++ b/chat/chat.go
@@ -29,6 +29,7 @@ var Template = `
   <div class="topic-tabs">%s</div>
 </div>
 <div id="messages"></div>
+%s
 <form id="chat-form" onsubmit="event.preventDefault(); askLLM(this);">
 <input id="context" name="context" type="hidden">
 <input id="topic" name="topic" type="hidden">
@@ -1372,11 +1373,24 @@ func handleGetChat(w http.ResponseWriter, r *http.Request, roomID string) {
 	summariesJSON, _ := json.Marshal(summariesData)
 	roomJSON, _ := json.Marshal(roomData)
 
-	tmpl := app.RenderHTMLForRequest("Chat", "Chat with AI", fmt.Sprintf(Template, topicTabs), r)
+	guestNotice := ""
+	if _, acc := auth.TrySession(r); acc == nil {
+		guestNotice = guestChatAuthNotice()
+	}
+
+	tmpl := app.RenderHTMLForRequest("Chat", "Chat with AI", fmt.Sprintf(Template, topicTabs, guestNotice), r)
 
 	tmpl = strings.Replace(tmpl, "</body>", fmt.Sprintf(`<script>var summaries = %s; var roomData = %s;</script></body>`, summariesJSON, roomJSON), 1)
 
 	w.Write([]byte(tmpl))
+}
+
+func guestChatAuthNotice() string {
+	return `<div id="chat-auth-notice" class="notice">
+  <strong>Sign in to use saved chat.</strong>
+  <p>This room keeps conversation history for your account, so sending here needs a login. You can still try Mu without an account in the public agent.</p>
+  <p><a class="link" href="/agent">Try Mu without an account</a> · <a class="link" href="/login?redirect=/chat">Log in</a> · <a class="link" href="/signup?redirect=/chat">Sign up</a></p>
+</div>`
 }
 
 // handlePostChat handles POST /chat - send a chat message

--- a/chat/chat_test.go
+++ b/chat/chat_test.go
@@ -1,6 +1,9 @@
 package chat
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestHandlePatternMatchRecognizesKnownPricePromptsWithoutData(t *testing.T) {
 	tests := []struct {
@@ -49,5 +52,21 @@ func TestHandlePatternMatchIgnoresUnsupportedPrompts(t *testing.T) {
 				t.Fatalf("handlePatternMatch(%q) = %q, want empty string", content, got)
 			}
 		})
+	}
+}
+
+func TestGuestChatAuthNoticeExplainsLoginAndAgentFallback(t *testing.T) {
+	html := guestChatAuthNotice()
+
+	for _, want := range []string{
+		"Sign in to use saved chat.",
+		"/agent",
+		"Try Mu without an account",
+		"/login?redirect=/chat",
+		"/signup?redirect=/chat",
+	} {
+		if !strings.Contains(html, want) {
+			t.Fatalf("guest chat auth notice missing %q in %s", want, html)
+		}
 	}
 }


### PR DESCRIPTION
Clarifies the guest /chat path by showing an inline sign-in explanation with links to try the public agent, log in, or sign up before a guest submits into the authenticated chat surface.\n\nCloses #870\nCloses #872