### PR TITLE
Render markets agent results readably

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1385,6 +1385,8 @@ func formatToolResult(toolName, result string, args map[string]any) string {
 		return withCurrentDateContext(formatSearchResult(result))
 	case "web_search", "weather_forecast":
 		return withCurrentDateContext(result)
+	case "markets":
+		return withCurrentDateContext(formatMarketsResult(result))
 	case "web_fetch":
 		return formatWebFetchResult(result)
 	case "places_search", "places_nearby":
@@ -1405,6 +1407,71 @@ func formatToolResult(toolName, result string, args map[string]any) string {
 		return formatAppsRunResult(result)
 	}
 	return result
+}
+
+// formatMarketsResult converts raw markets tool JSON into readable price context
+// for synthesis. The go-micro markets tool usually returns {"text":"..."},
+// while the REST endpoint returns {"category":"...","data":[...]}; handle both so
+// market-moving prompts never expose raw JSON to users or the model fallback.
+func formatMarketsResult(result string) string {
+	var textData struct {
+		Text string `json:"text"`
+	}
+	if err := json.Unmarshal([]byte(result), &textData); err == nil && strings.TrimSpace(textData.Text) != "" {
+		return strings.TrimSpace(textData.Text)
+	}
+
+	var data struct {
+		Category string `json:"category"`
+		Data     []struct {
+			Symbol    string  `json:"symbol"`
+			Price     float64 `json:"price"`
+			Change24h float64 `json:"change_24h"`
+			Type      string  `json:"type"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal([]byte(result), &data); err != nil {
+		return result
+	}
+	if len(data.Data) == 0 {
+		return "No market prices available right now."
+	}
+
+	category := strings.TrimSpace(data.Category)
+	if category == "" {
+		category = "market"
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "Live %s prices:\n", category)
+	count := 0
+	for _, item := range data.Data {
+		symbol := strings.TrimSpace(item.Symbol)
+		if symbol == "" || item.Price == 0 {
+			continue
+		}
+		if item.Change24h != 0 {
+			fmt.Fprintf(&b, "%s: $%s (%+.2f%% 24h)\n", symbol, formatMarketPrice(item.Price), item.Change24h)
+		} else {
+			fmt.Fprintf(&b, "%s: $%s\n", symbol, formatMarketPrice(item.Price))
+		}
+		count++
+	}
+	if count == 0 {
+		return fmt.Sprintf("No %s prices available right now.", category)
+	}
+	return strings.TrimSpace(b.String())
+}
+
+func formatMarketPrice(price float64) string {
+	switch {
+	case price >= 100:
+		return fmt.Sprintf("%.2f", price)
+	case price >= 1:
+		return fmt.Sprintf("%.3f", price)
+	default:
+		return fmt.Sprintf("%.6f", price)
+	}
 }
 
 // formatNewsResult converts a raw JSON news feed or search result into

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -275,6 +275,35 @@ func TestFormatToolResultKeepsExistingCurrentDateContext(t *testing.T) {
 	}
 }
 
+func TestFormatToolResultMarketsTextStaysReadable(t *testing.T) {
+	result := `{"text":"Current request date: Tuesday, 30 June 2026 (2026-06-30, UTC).\nLive crypto prices:\nBTC: $100000.00 (+2.50% 24h)\nETH: $3000.00 (-1.25% 24h)"}`
+	got := formatToolResult("markets", result, nil)
+	if strings.Contains(got, `{"text"`) {
+		t.Fatalf("expected readable markets context instead of raw JSON, got %q", got)
+	}
+	if strings.Count(got, "Current request date:") != 1 {
+		t.Fatalf("expected one current request date context, got %q", got)
+	}
+	for _, want := range []string{"BTC: $100000.00 (+2.50% 24h)", "ETH: $3000.00 (-1.25% 24h)"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("expected %q in readable markets context, got %q", want, got)
+		}
+	}
+}
+
+func TestFormatToolResultMarketsRESTDataStaysReadable(t *testing.T) {
+	result := `{"category":"crypto","data":[{"symbol":"BTC","price":100000,"change_24h":2.5},{"symbol":"DOGE","price":0.1234567,"change_24h":-4}]}`
+	got := formatToolResult("markets", result, nil)
+	if strings.Contains(got, `{"category"`) {
+		t.Fatalf("expected readable markets context instead of raw JSON, got %q", got)
+	}
+	for _, want := range []string{"Current request date:", "Live crypto prices:", "BTC: $100000.00 (+2.50% 24h)", "DOGE: $0.123457 (-4.00% 24h)"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("expected %q in readable markets context, got %q", want, got)
+		}
+	}
+}
+
 func TestFormatToolResult_Dispatch(t *testing.T) {
 	// Ensure the dispatcher calls the right formatter
 	newsResult := `{"feed":[{"title":"Test headline","category":"tech"}]}`


### PR DESCRIPTION
## Summary
- Format markets tool payloads into readable price lines before agent synthesis.
- Preserve request-date anchoring and unavailable-state behavior for markets context.
- Add regression tests for go-micro and REST-style markets payloads.

Closes #880
Closes #886

## Testing
- go build ./...
- go test ./... -short
- go vet ./...