### PR TITLE
Handle missing weather observations

### DIFF
--- a/weather/agent.go
+++ b/weather/agent.go
@@ -2,6 +2,7 @@ package weather
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -33,8 +34,23 @@ func formatForecastText(wf *WeatherForecast, now time.Time) string {
 		fmt.Fprintf(&sb, "Weather for %s.\n", wf.Location)
 	}
 	if c := wf.Current; c != nil {
-		fmt.Fprintf(&sb, "Now: %.0f°C (feels %.0f°C), %s, humidity %d%%, wind %.0f km/h.\n",
-			c.TempC, c.FeelsLikeC, c.Description, c.Humidity, c.WindKph)
+		details := []string{fmt.Sprintf("%.0f°C", c.TempC)}
+		if c.FeelsLikeC != 0 || c.TempC == 0 {
+			details = append(details, fmt.Sprintf("feels %.0f°C", c.FeelsLikeC))
+		}
+		if c.Description != "" {
+			details = append(details, c.Description)
+		}
+		if c.HumidityAvailable {
+			details = append(details, "humidity "+strconv.Itoa(c.Humidity)+"%")
+		}
+		if c.WindKphAvailable {
+			details = append(details, fmt.Sprintf("wind %.0f km/h", c.WindKph))
+		}
+		if !c.HumidityAvailable || !c.WindKphAvailable {
+			details = append(details, "some current observations unavailable")
+		}
+		fmt.Fprintf(&sb, "Now: %s.\n", strings.Join(details, ", "))
 	}
 	if len(wf.DailyItems) > 0 {
 		sb.WriteString("Dated daily forecast (provider timestamps):\n")

--- a/weather/google.go
+++ b/weather/google.go
@@ -35,12 +35,14 @@ type WeatherForecast struct {
 
 // CurrentConditions holds current weather values.
 type CurrentConditions struct {
-	TempC       float64
-	FeelsLikeC  float64
-	Description string
-	Humidity    int
-	WindKph     float64
-	IconCode    string
+	TempC             float64
+	FeelsLikeC        float64
+	Description       string
+	Humidity          int
+	HumidityAvailable bool
+	WindKph           float64
+	WindKphAvailable  bool
+	IconCode          string
 }
 
 // HourlyItem holds one hour of forecast data.

--- a/weather/weather_test.go
+++ b/weather/weather_test.go
@@ -111,11 +111,13 @@ func TestFormatForecastTextAnchorsDatesToRealCalendarRows(t *testing.T) {
 	wf := &WeatherForecast{
 		Location: "London",
 		Current: &CurrentConditions{
-			TempC:       18,
-			FeelsLikeC:  17,
-			Description: "cloudy",
-			Humidity:    70,
-			WindKph:     12,
+			TempC:             18,
+			FeelsLikeC:        17,
+			Description:       "cloudy",
+			Humidity:          70,
+			HumidityAvailable: true,
+			WindKph:           12,
+			WindKphAvailable:  true,
 		},
 		DailyItems: []DailyItem{
 			{Date: time.Date(2026, time.June, 30, 0, 0, 0, 0, time.UTC), MinTempC: 13, MaxTempC: 21, Description: "showers", RainMM: 2, WillRain: true},
@@ -136,5 +138,26 @@ func TestFormatForecastTextAnchorsDatesToRealCalendarRows(t *testing.T) {
 	}
 	if strings.Contains(got, "31 June") {
 		t.Fatalf("formatForecastText invented impossible calendar date in:\n%s", got)
+	}
+}
+
+func TestFormatForecastTextTreatsMissingCurrentObservationsAsUnavailable(t *testing.T) {
+	wf := &WeatherForecast{
+		Location: "New York",
+		Current: &CurrentConditions{
+			TempC:       24,
+			FeelsLikeC:  24,
+			Description: "partly cloudy",
+		},
+	}
+
+	got := formatForecastText(wf, time.Date(2026, time.July, 1, 12, 0, 0, 0, time.UTC))
+	for _, notWant := range []string{"humidity 0%", "wind 0 km/h"} {
+		if strings.Contains(got, notWant) {
+			t.Fatalf("formatForecastText presented missing reading %q as fact in:\n%s", notWant, got)
+		}
+	}
+	if !strings.Contains(got, "some current observations unavailable") {
+		t.Fatalf("formatForecastText should disclose missing current observations in:\n%s", got)
 	}
 }


### PR DESCRIPTION
## Summary
- Mark optional current-condition readings as unavailable unless explicitly present.
- Update weather agent context to avoid presenting missing humidity or wind as factual zeroes.
- Add regression coverage for missing current observations.

Closes #894
Closes #896

## Testing
- git diff --check
- go build ./...
- go test ./... -short
- go vet ./...