### PR TITLE
Disclose markets data freshness

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1422,12 +1422,18 @@ func formatMarketsResult(result string) string {
 	}
 
 	var data struct {
-		Category string `json:"category"`
-		Data     []struct {
+		Category  string `json:"category"`
+		UpdatedAt string `json:"updated_at"`
+		Stale     bool   `json:"stale"`
+		Partial   bool   `json:"partial"`
+		Freshness string `json:"freshness"`
+		Data      []struct {
 			Symbol    string  `json:"symbol"`
 			Price     float64 `json:"price"`
 			Change24h float64 `json:"change_24h"`
 			Type      string  `json:"type"`
+			UpdatedAt string  `json:"updated_at"`
+			Source    string  `json:"source"`
 		} `json:"data"`
 	}
 	if err := json.Unmarshal([]byte(result), &data); err != nil {
@@ -1443,6 +1449,17 @@ func formatMarketsResult(result string) string {
 	}
 
 	var b strings.Builder
+	if strings.TrimSpace(data.Freshness) != "" {
+		fmt.Fprintf(&b, "%s.\n", strings.TrimSuffix(strings.TrimSpace(data.Freshness), "."))
+	} else if strings.TrimSpace(data.UpdatedAt) != "" {
+		fmt.Fprintf(&b, "Last refresh: %s.\n", strings.TrimSpace(data.UpdatedAt))
+	}
+	if data.Stale {
+		b.WriteString("Disclosure: market data may be stale.\n")
+	}
+	if data.Partial {
+		b.WriteString("Disclosure: some requested symbols are unavailable from the current source.\n")
+	}
 	fmt.Fprintf(&b, "Live %s prices:\n", category)
 	count := 0
 	for _, item := range data.Data {

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -304,6 +304,16 @@ func TestFormatToolResultMarketsRESTDataStaysReadable(t *testing.T) {
 	}
 }
 
+func TestFormatToolResultMarketsRESTDataIncludesFreshnessDisclosure(t *testing.T) {
+	result := `{"category":"crypto","updated_at":"2026-07-01T12:00:00Z","stale":true,"partial":true,"freshness":"Last refresh: 2026-07-01 12:00 UTC; data may be stale; some symbols are unavailable from the current source","data":[{"symbol":"BTC","price":97000,"change_24h":1.23,"source":"Coinbase + CoinGecko"}]}`
+	got := formatToolResult("markets", result, nil)
+	for _, want := range []string{"Last refresh: 2026-07-01 12:00 UTC", "market data may be stale", "some requested symbols are unavailable", "BTC: $97000.00 (+1.23% 24h)"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("expected %q in readable markets context, got %q", want, got)
+		}
+	}
+}
+
 func TestFormatToolResult_Dispatch(t *testing.T) {
 	// Ensure the dispatcher calls the right formatter
 	newsResult := `{"feed":[{"title":"Test headline","category":"tech"}]}`

--- a/markets/agent.go
+++ b/markets/agent.go
@@ -21,6 +21,8 @@ func MarketsText(category string) string {
 
 	var sb strings.Builder
 	fmt.Fprintf(&sb, "Current request date: %s.\n", time.Now().UTC().Format("Monday, 2 January 2006 (2006-01-02, UTC)"))
+	updatedAt, stale, missing := marketsFreshness(priceData, assets)
+	fmt.Fprintf(&sb, "%s.\n", marketsFreshnessText(updatedAt, stale, missing))
 	fmt.Fprintf(&sb, "Live %s prices:\n", category)
 	found := 0
 	for _, symbol := range assets {

--- a/markets/markets.go
+++ b/markets/markets.go
@@ -26,15 +26,18 @@ var cardSnap *snapshot.Snapshot
 
 // PriceData holds price and 24h change for an asset
 type PriceData struct {
-	Price     float64 `json:"price"`
-	Change24h float64 `json:"change_24h"`
+	Price     float64   `json:"price"`
+	Change24h float64   `json:"change_24h"`
+	UpdatedAt time.Time `json:"updated_at,omitempty"`
+	Source    string    `json:"source,omitempty"`
 }
 
 var (
-	marketsMutex    sync.RWMutex
-	marketsHTML     string
-	cachedPrices    map[string]float64
-	cachedPriceData map[string]PriceData
+	marketsMutex     sync.RWMutex
+	marketsHTML      string
+	cachedPrices     map[string]float64
+	cachedPriceData  map[string]PriceData
+	lastPriceRefresh time.Time
 )
 
 // cryptoGeckoIDs maps ticker symbols to CoinGecko asset IDs
@@ -93,6 +96,7 @@ func Load() {
 		if json.Unmarshal(b, &pd) == nil {
 			marketsMutex.Lock()
 			cachedPriceData = pd
+			lastPriceRefresh = latestPriceUpdate(pd)
 			marketsMutex.Unlock()
 		}
 	}
@@ -165,6 +169,7 @@ func refreshMarkets() {
 			marketsMutex.Lock()
 			cachedPrices = prices
 			cachedPriceData = priceData
+			lastPriceRefresh = time.Now().UTC()
 			marketsHTML = html
 			marketsMutex.Unlock()
 
@@ -218,6 +223,8 @@ func fetchPrices() (map[string]float64, map[string]PriceData) {
 			if change, ok := geckoChanges[geckoID]; ok {
 				pd.Change24h = change
 			}
+			pd.UpdatedAt = time.Now().UTC()
+			pd.Source = "Coinbase + CoinGecko"
 			priceData[symbol] = pd
 		}
 	}
@@ -246,6 +253,8 @@ func fetchPrices() (map[string]float64, map[string]PriceData) {
 				priceData[key] = PriceData{
 					Price:     price,
 					Change24h: f.Quote.RegularMarketChangePercent,
+					UpdatedAt: time.Now().UTC(),
+					Source:    "Yahoo Finance",
 				}
 			}
 		}()
@@ -275,6 +284,8 @@ func fetchPrices() (map[string]float64, map[string]PriceData) {
 				priceData[currency] = PriceData{
 					Price:     price,
 					Change24h: q.RegularMarketChangePercent,
+					UpdatedAt: time.Now().UTC(),
+					Source:    "Yahoo Finance",
 				}
 			}
 		}()
@@ -425,10 +436,58 @@ func GetAllPriceData() map[string]PriceData {
 	// Fall back to plain prices for any symbol not in priceData
 	for k, price := range cachedPrices {
 		if _, ok := result[k]; !ok {
-			result[k] = PriceData{Price: price}
+			result[k] = PriceData{Price: price, UpdatedAt: lastPriceRefresh, Source: "cached price"}
 		}
 	}
 	return result
+}
+
+func latestPriceUpdate(priceData map[string]PriceData) time.Time {
+	var latest time.Time
+	for _, pd := range priceData {
+		if pd.UpdatedAt.After(latest) {
+			latest = pd.UpdatedAt
+		}
+	}
+	return latest
+}
+
+func marketsFreshness(priceData map[string]PriceData, assets []string) (time.Time, bool, bool) {
+	var latest time.Time
+	missing := false
+	for _, symbol := range assets {
+		pd, ok := priceData[symbol]
+		if !ok || pd.Price == 0 {
+			missing = true
+			continue
+		}
+		if pd.UpdatedAt.After(latest) {
+			latest = pd.UpdatedAt
+		}
+	}
+	if latest.IsZero() {
+		marketsMutex.RLock()
+		latest = lastPriceRefresh
+		marketsMutex.RUnlock()
+	}
+	stale := latest.IsZero() || time.Since(latest) > 2*time.Hour
+	return latest, stale, missing
+}
+
+func marketsFreshnessText(updatedAt time.Time, stale, missing bool) string {
+	parts := []string{}
+	if updatedAt.IsZero() {
+		parts = append(parts, "Last refresh: unavailable (cached fallback may be stale)")
+	} else {
+		parts = append(parts, fmt.Sprintf("Last refresh: %s UTC", updatedAt.UTC().Format("2006-01-02 15:04")))
+		if stale {
+			parts = append(parts, "data may be stale")
+		}
+	}
+	if missing {
+		parts = append(parts, "some symbols are unavailable from the current source")
+	}
+	return strings.Join(parts, "; ")
 }
 
 // Categories for market data
@@ -501,6 +560,8 @@ type MarketData struct {
 	Price     float64 `json:"price"`
 	Change24h float64 `json:"change_24h"`
 	Type      string  `json:"type"`
+	UpdatedAt string  `json:"updated_at,omitempty"`
+	Source    string  `json:"source,omitempty"`
 }
 
 // Handler handles /markets requests
@@ -552,12 +613,25 @@ func handleJSON(w http.ResponseWriter, r *http.Request, category string) {
 			Price:     pd.Price,
 			Change24h: pd.Change24h,
 			Type:      category,
+			Source:    pd.Source,
 		})
+		if !pd.UpdatedAt.IsZero() {
+			data[len(data)-1].UpdatedAt = pd.UpdatedAt.UTC().Format(time.RFC3339)
+		}
+	}
+	updatedAt, stale, missing := marketsFreshness(priceData, assets)
+	updatedAtText := ""
+	if !updatedAt.IsZero() {
+		updatedAtText = updatedAt.UTC().Format(time.RFC3339)
 	}
 
 	app.RespondJSON(w, map[string]interface{}{
-		"category": category,
-		"data":     data,
+		"category":   category,
+		"data":       data,
+		"updated_at": updatedAtText,
+		"stale":      stale,
+		"partial":    missing,
+		"freshness":  marketsFreshnessText(updatedAt, stale, missing),
 	})
 }
 
@@ -611,7 +685,7 @@ func generateMarketsPage(priceData map[string]PriceData, activeCategory string) 
 	sb.WriteString(`<thead><tr><th>Symbol</th><th>Price</th><th>24h Change</th><th>Chart</th></tr></thead>`)
 	sb.WriteString(`<tbody>`)
 
-	assets := getAssetsForCategory(activeCategory)
+	assets := append([]string{}, getAssetsForCategory(activeCategory)...)
 
 	// Sort assets alphabetically
 	sort.Strings(assets)
@@ -626,7 +700,8 @@ func generateMarketsPage(priceData map[string]PriceData, activeCategory string) 
 	// Data source information
 	sb.WriteString(`<div class="markets-footer">`)
 	sb.WriteString(`<p class="markets-source">Data sources: Coinbase, CoinGecko, Yahoo Finance</p>`)
-	sb.WriteString(`<p class="markets-note">Prices update hourly. For real-time trading, visit official exchanges.</p>`)
+	updatedAt, stale, missing := marketsFreshness(priceData, assets)
+	fmt.Fprintf(&sb, `<p class="markets-note">%s. Prices update hourly. For real-time trading, visit official exchanges.</p>`, marketsFreshnessText(updatedAt, stale, missing))
 	sb.WriteString(`</div>`)
 
 	sb.WriteString(`</div>`)

--- a/markets/markets_test.go
+++ b/markets/markets_test.go
@@ -3,6 +3,7 @@ package markets
 import (
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestFormatPrice(t *testing.T) {
@@ -190,6 +191,41 @@ func TestGetAllPriceData_ReturnsDefensiveCopy(t *testing.T) {
 	// BTC should fall back to plain price
 	if data["BTC"].Price != 97000 {
 		t.Errorf("expected BTC fallback price 97000, got %v", data["BTC"].Price)
+	}
+}
+
+func TestMarketsTextIncludesFreshnessDisclosure(t *testing.T) {
+	updated := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+	marketsMutex.Lock()
+	cachedPriceData = map[string]PriceData{
+		"BTC": {Price: 97000, Change24h: 1.5, UpdatedAt: updated, Source: "Coinbase + CoinGecko"},
+	}
+	cachedPrices = nil
+	lastPriceRefresh = updated
+	marketsMutex.Unlock()
+
+	got := MarketsText(CategoryCrypto)
+	if !strings.Contains(got, "Last refresh: 2026-07-01 12:00 UTC") {
+		t.Fatalf("expected freshness disclosure, got %q", got)
+	}
+	if !strings.Contains(got, "some symbols are unavailable") {
+		t.Fatalf("expected partial-data disclosure, got %q", got)
+	}
+}
+
+func TestGenerateMarketsPageIncludesFreshnessDisclosure(t *testing.T) {
+	updated := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+	priceData := map[string]PriceData{
+		"BTC": {Price: 97000, UpdatedAt: updated, Source: "Coinbase + CoinGecko"},
+		"ETH": {Price: 3500, UpdatedAt: updated, Source: "Coinbase + CoinGecko"},
+	}
+
+	html := generateMarketsPage(priceData, CategoryCrypto)
+	if !strings.Contains(html, "Last refresh: 2026-07-01 12:00 UTC") {
+		t.Fatalf("expected last-refresh metadata in markets page, got %q", html)
+	}
+	if !strings.Contains(html, "some symbols are unavailable") {
+		t.Fatalf("expected partial-source disclosure in markets page, got %q", html)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add refresh timestamps, source labels, stale/partial flags, and freshness text to markets JSON/page data.
- Include markets freshness disclosure in model-ready markets context and REST tool formatting.
- Add regression tests for markets page, agent context, and tool formatting.

Closes #899
Closes #901