### PR TITLE
Disclose chat topic summary freshness

### DIFF
--- a/chat/chat.go
+++ b/chat/chat.go
@@ -54,6 +54,21 @@ func askLLM(prompt *ai.Prompt) (string, error) {
 }
 
 var summaries = map[string]string{}
+var summaryMeta = SummaryMetadata{}
+
+// SummaryMetadata describes when and how the generated topic summaries were refreshed.
+type SummaryMetadata struct {
+	GeneratedAt time.Time `json:"generated_at,omitempty"`
+	Source      string    `json:"source"`
+	Status      string    `json:"status"`
+}
+
+func currentSummaryMeta() SummaryMetadata {
+	if summaryMeta.Status == "" {
+		return SummaryMetadata{Source: "Mu indexed public content", Status: "unavailable"}
+	}
+	return summaryMeta
+}
 
 var topics = []string{}
 
@@ -1030,6 +1045,14 @@ func Load() {
 			app.Log("chat", "Error loading summaries: %v", err)
 		} else {
 			app.Log("chat", "Loaded %d summaries from disk", len(summaries))
+			if len(summaries) > 0 {
+				summaryMeta = SummaryMetadata{Source: "Mu indexed public content", Status: "cached"}
+			}
+		}
+	}
+	if b, err := data.LoadFile("chat_summaries_meta.json"); err == nil {
+		if err := json.Unmarshal(b, &summaryMeta); err != nil {
+			app.Log("chat", "Error loading summary metadata: %v", err)
 		}
 	}
 
@@ -1244,6 +1267,7 @@ func generateSummaries() {
 
 	mutex.Lock()
 	summaries = newSummaries
+	summaryMeta = SummaryMetadata{GeneratedAt: time.Now().UTC(), Source: "Mu indexed public content", Status: "fresh"}
 	mutex.Unlock()
 
 	// Save summaries to disk
@@ -1251,6 +1275,9 @@ func generateSummaries() {
 		app.Log("chat", "Error saving summaries: %v", err)
 	} else {
 		app.Log("chat", "Saved %d summaries to disk", len(summaries))
+	}
+	if err := data.SaveJSON("chat_summaries_meta.json", summaryMeta); err != nil {
+		app.Log("chat", "Error saving summary metadata: %v", err)
 	}
 
 	// Generate topic summaries every 4 hours (not hourly) to reduce LLM calls
@@ -1353,13 +1380,15 @@ func handleGetChat(w http.ResponseWriter, r *http.Request, roomID string) {
 	mutex.RLock()
 	topicsData := topics
 	summariesData := summaries
+	summaryMetaData := currentSummaryMeta()
 	mutex.RUnlock()
 
 	// Return JSON if requested
 	if app.WantsJSON(r) {
 		response := map[string]interface{}{
-			"topics":    topicsData,
-			"summaries": summariesData,
+			"topics":       topicsData,
+			"summaries":    summariesData,
+			"summary_meta": summaryMetaData,
 		}
 		if len(roomData) > 0 {
 			response["room"] = roomData
@@ -1371,6 +1400,7 @@ func handleGetChat(w http.ResponseWriter, r *http.Request, roomID string) {
 	// Return HTML
 	topicTabs := app.Head("chat", topicsData)
 	summariesJSON, _ := json.Marshal(summariesData)
+	summaryMetaJSON, _ := json.Marshal(summaryMetaData)
 	roomJSON, _ := json.Marshal(roomData)
 
 	guestNotice := ""
@@ -1380,7 +1410,7 @@ func handleGetChat(w http.ResponseWriter, r *http.Request, roomID string) {
 
 	tmpl := app.RenderHTMLForRequest("Chat", "Chat with AI", fmt.Sprintf(Template, topicTabs, guestNotice), r)
 
-	tmpl = strings.Replace(tmpl, "</body>", fmt.Sprintf(`<script>var summaries = %s; var roomData = %s;</script></body>`, summariesJSON, roomJSON), 1)
+	tmpl = strings.Replace(tmpl, "</body>", fmt.Sprintf(`<script>var summaries = %s; var summaryMeta = %s; var roomData = %s;</script></body>`, summariesJSON, summaryMetaJSON, roomJSON), 1)
 
 	w.Write([]byte(tmpl))
 }

--- a/chat/chat_test.go
+++ b/chat/chat_test.go
@@ -70,3 +70,17 @@ func TestGuestChatAuthNoticeExplainsLoginAndAgentFallback(t *testing.T) {
 		}
 	}
 }
+
+func TestCurrentSummaryMetaDefaultsUnavailable(t *testing.T) {
+	oldMeta := summaryMeta
+	summaryMeta = SummaryMetadata{}
+	defer func() { summaryMeta = oldMeta }()
+
+	meta := currentSummaryMeta()
+	if meta.Status != "unavailable" {
+		t.Fatalf("Status = %q, want unavailable", meta.Status)
+	}
+	if meta.Source == "" {
+		t.Fatalf("Source should explain summary provenance")
+	}
+}

--- a/internal/app/html/mu.css
+++ b/internal/app/html/mu.css
@@ -1158,6 +1158,14 @@ body:has(#messages) #chat-back-link {
   user-select: none;
 }
 
+.summary-meta {
+  display: block;
+  margin-top: 4px;
+  color: #777;
+  font-size: 12px;
+  font-weight: 400;
+}
+
 .summary-header:hover {
   background: #f0f0f0;
   border-radius: 8px;

--- a/internal/app/html/mu.js
+++ b/internal/app/html/mu.js
@@ -232,6 +232,20 @@ var isAuthenticated = false;
 var context = [];
 var topic = '';
 
+
+function summaryMetaText() {
+  if (typeof summaryMeta === 'undefined' || !summaryMeta) return 'Topic summaries unavailable: no freshness metadata was provided.';
+  if (summaryMeta.status === 'unavailable') return 'Topic summaries unavailable: no fresh generated summaries are available yet.';
+  const parts = [];
+  if (summaryMeta.generated_at) {
+    const d = new Date(summaryMeta.generated_at);
+    if (!isNaN(d.getTime())) parts.push('Generated ' + d.toLocaleString());
+  }
+  if (summaryMeta.source) parts.push('Sources: ' + summaryMeta.source);
+  if (summaryMeta.status === 'cached') parts.push('cached from a previous run');
+  return parts.join(' · ') || 'Freshness metadata unavailable.';
+}
+
 // Show all topic summaries with join links (landing page)
 function showTopicSummariesOverlay() {
   const messages = document.getElementById('messages');
@@ -241,7 +255,10 @@ function showTopicSummariesOverlay() {
   if (messages.querySelector('.summary-card')) return;
   
   const topics = Object.keys(summaries).sort();
-  if (topics.length === 0) return;
+  if (topics.length === 0) {
+    messages.innerHTML = '<div class="message summary-card"><strong>Today\'s Topics</strong><p class="summary-meta">' + summaryMetaText() + '</p></div>';
+    return;
+  }
   
   // Build summaries content using existing CSS classes
   let summariesHtml = '';
@@ -261,6 +278,7 @@ function showTopicSummariesOverlay() {
   card.innerHTML = `
     <div class="summary-header" onclick="toggleAllSummaries()">
       <strong>Today's Topics</strong>
+      <span class="summary-meta">${summaryMetaText()}</span>
       <span id="summary-toggle-icon">▶</span>
     </div>
     <div id="all-summaries" class="all-summaries" style="display: none;">
@@ -324,7 +342,7 @@ function showTopicContext(t) {
     contextMsg.className = 'context-message';
     let summaryHtml = '';
     if (typeof summaries !== 'undefined' && summaries[t]) {
-      summaryHtml = `<p class="topic-summary">${summaries[t]}</p>`;
+      summaryHtml = `<p class="topic-summary">${summaries[t]}</p><p class="summary-meta">${summaryMetaText()}</p>`;
     }
     contextMsg.innerHTML = '<strong>' + t + '</strong>' + summaryHtml;
     messages.appendChild(contextMsg);


### PR DESCRIPTION
## Summary
- Adds generated-at/source/status metadata for /chat topic summaries in JSON and page bootstrap data.
- Shows freshness/source context beside guest topic summaries and an explicit unavailable state when summaries are missing.
- Covers the unavailable metadata fallback with a regression test.

## Testing
- go build ./...
- go test ./... -short
- go vet ./...

Closes #904
Closes #906