### PR TITLE
Disclose weather freshness in agent summaries

### DIFF
--- a/weather/agent.go
+++ b/weather/agent.go
@@ -27,13 +27,28 @@ func formatForecastText(wf *WeatherForecast, now time.Time) string {
 		return weatherUnavailableMessage
 	}
 
+	now = now.UTC()
 	var sb strings.Builder
-	fmt.Fprintf(&sb, "Current request date: %s.\n", now.UTC().Format("Monday, 2 January 2006 (2006-01-02, UTC)"))
+	fmt.Fprintf(&sb, "Current request date: %s.\n", now.Format("Monday, 2 January 2006 (2006-01-02, UTC)"))
 	sb.WriteString("Calendar rule: anchor relative words like today/tomorrow to the request date above, use only the dated forecast rows below, and do not invent dates. If a requested day is not listed, say it is unavailable.\n")
 	if wf.Location != "" {
 		fmt.Fprintf(&sb, "Weather for %s.\n", wf.Location)
 	}
-	if c := wf.Current; c != nil {
+	source := strings.TrimSpace(wf.Source)
+	if source == "" {
+		source = "weather provider"
+	}
+	generatedAt := wf.GeneratedAt.UTC()
+	if generatedAt.IsZero() {
+		generatedAt = now
+	}
+	fmt.Fprintf(&sb, "Freshness/source: source %s; generated at %s.\n", source, generatedAt.Format("2006-01-02 15:04 UTC"))
+	if wf.ObservedAt.IsZero() {
+		sb.WriteString("Current conditions status: unavailable — provider did not return a current/hourly observation timestamp, so do not present a current-weather claim.\n")
+	} else {
+		fmt.Fprintf(&sb, "Current conditions observed at %s.\n", wf.ObservedAt.UTC().Format("2006-01-02 15:04 UTC"))
+	}
+	if c := wf.Current; c != nil && !wf.ObservedAt.IsZero() {
 		details := []string{fmt.Sprintf("%.0f°C", c.TempC)}
 		if c.FeelsLikeC != 0 || c.TempC == 0 {
 			details = append(details, fmt.Sprintf("feels %.0f°C", c.FeelsLikeC))
@@ -66,7 +81,7 @@ func formatForecastText(wf *WeatherForecast, now time.Time) string {
 				d.Date.Format("Monday, 2 January 2006 (2006-01-02)"), d.MinTempC, d.MaxTempC, d.Description, rain)
 		}
 	}
-	if sb.Len() == 0 {
+	if len(wf.DailyItems) == 0 && (wf.Current == nil || wf.ObservedAt.IsZero()) {
 		return weatherUnavailableMessage
 	}
 	return sb.String()

--- a/weather/google.go
+++ b/weather/google.go
@@ -28,6 +28,9 @@ var httpClient = &http.Client{Timeout: 15 * time.Second}
 // WeatherForecast holds the parsed forecast data returned by the Google Weather API.
 type WeatherForecast struct {
 	Location    string
+	Source      string
+	GeneratedAt time.Time
+	ObservedAt  time.Time
 	Current     *CurrentConditions
 	HourlyItems []HourlyItem
 	DailyItems  []DailyItem
@@ -198,7 +201,10 @@ func FetchWeather(lat, lon float64) (*WeatherForecast, error) {
 		return nil, fmt.Errorf("failed to parse hourly weather response: %w", err)
 	}
 
-	forecast := &WeatherForecast{}
+	forecast := &WeatherForecast{
+		Source:      "Google Weather",
+		GeneratedAt: time.Now().UTC(),
+	}
 
 	// Parse daily items
 	for _, day := range dailyData.ForecastDays {
@@ -250,6 +256,7 @@ func FetchWeather(lat, lon float64) (*WeatherForecast, error) {
 	// Derive current conditions from first hourly item if available
 	if len(forecast.HourlyItems) > 0 {
 		first := forecast.HourlyItems[0]
+		forecast.ObservedAt = first.Time.UTC()
 		forecast.Current = &CurrentConditions{
 			TempC:       first.TempC,
 			FeelsLikeC:  first.TempC,

--- a/weather/weather_test.go
+++ b/weather/weather_test.go
@@ -109,7 +109,10 @@ func TestRenderWeatherPageGuestShowsAgentPathAndLoginScope(t *testing.T) {
 
 func TestFormatForecastTextAnchorsDatesToRealCalendarRows(t *testing.T) {
 	wf := &WeatherForecast{
-		Location: "London",
+		Location:    "London",
+		Source:      "Google Weather",
+		GeneratedAt: time.Date(2026, time.June, 30, 8, 59, 0, 0, time.UTC),
+		ObservedAt:  time.Date(2026, time.June, 30, 9, 0, 0, 0, time.UTC),
 		Current: &CurrentConditions{
 			TempC:             18,
 			FeelsLikeC:        17,
@@ -129,6 +132,8 @@ func TestFormatForecastTextAnchorsDatesToRealCalendarRows(t *testing.T) {
 	for _, want := range []string{
 		"Current request date: Tuesday, 30 June 2026 (2026-06-30, UTC).",
 		"Calendar rule: anchor relative words like today/tomorrow to the request date above",
+		"Freshness/source: source Google Weather; generated at 2026-06-30 08:59 UTC.",
+		"Current conditions observed at 2026-06-30 09:00 UTC.",
 		"Tuesday, 30 June 2026 (2026-06-30): 13–21°C, showers, rain 2mm",
 		"Wednesday, 1 July 2026 (2026-07-01): 12–20°C, bright spells",
 	} {
@@ -143,7 +148,8 @@ func TestFormatForecastTextAnchorsDatesToRealCalendarRows(t *testing.T) {
 
 func TestFormatForecastTextTreatsMissingCurrentObservationsAsUnavailable(t *testing.T) {
 	wf := &WeatherForecast{
-		Location: "New York",
+		Location:   "New York",
+		ObservedAt: time.Date(2026, time.July, 1, 12, 0, 0, 0, time.UTC),
 		Current: &CurrentConditions{
 			TempC:       24,
 			FeelsLikeC:  24,
@@ -159,5 +165,28 @@ func TestFormatForecastTextTreatsMissingCurrentObservationsAsUnavailable(t *test
 	}
 	if !strings.Contains(got, "some current observations unavailable") {
 		t.Fatalf("formatForecastText should disclose missing current observations in:\n%s", got)
+	}
+}
+
+func TestFormatForecastTextMarksCurrentUnavailableWithoutObservation(t *testing.T) {
+	wf := &WeatherForecast{
+		Location:    "Paris",
+		Source:      "Google Weather",
+		GeneratedAt: time.Date(2026, time.July, 1, 12, 1, 0, 0, time.UTC),
+		Current: &CurrentConditions{
+			TempC:       22,
+			Description: "clear",
+		},
+		DailyItems: []DailyItem{
+			{Date: time.Date(2026, time.July, 1, 0, 0, 0, 0, time.UTC), MinTempC: 16, MaxTempC: 25, Description: "sunny"},
+		},
+	}
+
+	got := formatForecastText(wf, time.Date(2026, time.July, 1, 12, 0, 0, 0, time.UTC))
+	if !strings.Contains(got, "Current conditions status: unavailable") {
+		t.Fatalf("formatForecastText should mark unsupported current conditions unavailable in:\n%s", got)
+	}
+	if strings.Contains(got, "Now: 22°C") {
+		t.Fatalf("formatForecastText should not present current-weather claim without observed-at timestamp in:\n%s", got)
 	}
 }


### PR DESCRIPTION
## Summary
- Add weather provider/source and generated-at metadata to weather forecasts used by the agent.
- Include observed-at disclosure for current conditions and mark current weather unavailable when no observation timestamp supports it.
- Add regression tests for weather freshness disclosure and unsupported current-condition claims.

Closes #910
Closes #912