### PR TITLE
Guard agent answers against raw tool payloads

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -741,6 +741,31 @@ Sources:
 	}
 }
 
+func TestCompleteToolAnswerReplacesRawMixedSourcePayload(t *testing.T) {
+	rag := []string{
+		`### blog_list
+Recent blog posts:
+1. Mu daily note — Agent reliability improved. (/blog/mu-note)`,
+		"### social\n" + unavailableToolMessage("social"),
+		`### web_search
+Web results for "mu agent reliability":
+Sources:
+1. Reliability patterns for agents — Fallbacks should produce readable summaries. (https://example.com/agents)`,
+	}
+	raw := `{"results":[{"title":"Reliability patterns for agents","url":"https://example.com/agents"}],"error":"social unavailable","status":"partial"}`
+
+	got := completeToolAnswer(raw, rag)
+	if strings.Contains(got, `{"results"`) || strings.Contains(got, `"status":"partial"`) {
+		t.Fatalf("expected raw payload to be replaced, got %q", got)
+	}
+	if !strings.Contains(got, "Mu daily note") || !strings.Contains(got, "https://example.com/agents") {
+		t.Fatalf("expected available mixed-source context in fallback, got %q", got)
+	}
+	if !strings.Contains(got, "Unavailable: social.") {
+		t.Fatalf("expected unavailable source disclosure, got %q", got)
+	}
+}
+
 func TestFormatToolResultNewsHeadlinesStaysReadable(t *testing.T) {
 	result := "Latest headlines — 1 across 1 topics.\n\n[tech] AI lab releases a new model — Useful summary (source: Example, url: https://example.com/ai)"
 	got := formatToolResult("news_headlines", result, nil)

--- a/agent/answer_guard.go
+++ b/agent/answer_guard.go
@@ -17,7 +17,7 @@ func unavailableToolMessage(tool string) string {
 // so the user still gets useful output and unavailable slices are explicit.
 func completeToolAnswer(answer string, ragParts []string) string {
 	trimmed := strings.TrimSpace(answer)
-	if len(ragParts) == 0 || !isProgressOnlyAnswer(trimmed) {
+	if len(ragParts) == 0 || (!isProgressOnlyAnswer(trimmed) && !isRawToolPayloadAnswer(trimmed)) {
 		return answer
 	}
 
@@ -203,4 +203,54 @@ func isProgressOnlyAnswer(answer string) bool {
 		}
 	}
 	return false
+}
+
+func isRawToolPayloadAnswer(answer string) bool {
+	if answer == "" {
+		return false
+	}
+
+	trimmed := strings.TrimSpace(answer)
+	if len([]rune(trimmed)) > 4000 {
+		return false
+	}
+
+	lower := strings.ToLower(trimmed)
+	if (strings.HasPrefix(trimmed, "{") && strings.HasSuffix(trimmed, "}")) ||
+		(strings.HasPrefix(trimmed, "[") && strings.HasSuffix(trimmed, "]")) {
+		jsonMarkers := []string{
+			`"results"`,
+			`"feed"`,
+			`"items"`,
+			`"title"`,
+			`"url"`,
+			`"error"`,
+			`"text"`,
+			`"summary"`,
+			`"source"`,
+			`"status"`,
+		}
+		for _, marker := range jsonMarkers {
+			if strings.Contains(lower, marker) {
+				return true
+			}
+		}
+	}
+
+	payloadMarkers := []string{
+		`{"results":`,
+		`{"feed":`,
+		`[{"title":`,
+		`"error":`,
+		`"url":`,
+		`"source":`,
+		`"status":`,
+	}
+	matches := 0
+	for _, marker := range payloadMarkers {
+		if strings.Contains(lower, marker) {
+			matches++
+		}
+	}
+	return matches >= 2
 }


### PR DESCRIPTION
## Summary
- Detect raw JSON-like tool payload answers and replace them with the existing readable tool-result fallback.
- Preserve mixed-source context and human-readable unavailable-source disclosure when one provider fails.
- Add regression coverage for mixed blog/social/web context returning a raw partial payload.

Closes #915
Closes #917

## Testing
- go build ./...
- go test ./... -short
- go vet ./...