### PR TITLE
Tighten asset mover prompt filtering

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1129,8 +1129,22 @@ func skipMarketMoverCompanionTool(prompt, tool string) bool {
 
 func isMarketMoverPrompt(prompt string) bool {
 	lower := strings.ToLower(prompt)
-	return strings.Contains(lower, "market") &&
-		(strings.Contains(lower, "moving") || strings.Contains(lower, "mover") || strings.Contains(lower, "move"))
+	hasMoveIntent := strings.Contains(lower, "moving") ||
+		strings.Contains(lower, "mover") ||
+		strings.Contains(lower, "move") ||
+		strings.Contains(lower, "rally") ||
+		strings.Contains(lower, "selloff") ||
+		strings.Contains(lower, "up today") ||
+		strings.Contains(lower, "down today")
+	if !hasMoveIntent {
+		return false
+	}
+	for _, term := range []string{"market", "markets", "stock", "stocks", "equity", "equities", "crypto", "bitcoin", "btc", "eth", "ethereum", "index", "indices", "futures"} {
+		if strings.Contains(lower, term) {
+			return true
+		}
+	}
+	return false
 }
 
 func wantsMarketMoverExplanation(prompt string) bool {

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -336,6 +336,18 @@ func TestSkipMarketMoverCompanionToolFiltersUnrequestedNews(t *testing.T) {
 	}
 }
 
+func TestSkipMarketMoverCompanionToolFiltersAssetMoverPrompts(t *testing.T) {
+	for _, prompt := range []string{
+		"What crypto is moving today?",
+		"Which stocks are up today?",
+		"Any Bitcoin rally today?",
+	} {
+		if !skipMarketMoverCompanionTool(prompt, "news_headlines") {
+			t.Fatalf("expected unrequested news to be skipped for %q", prompt)
+		}
+	}
+}
+
 func TestSkipMarketMoverCompanionToolAllowsExplanatoryNews(t *testing.T) {
 	prompt := "What is moving in markets today, and what news explains the moves?"
 	if skipMarketMoverCompanionTool(prompt, "news_headlines") {


### PR DESCRIPTION
## Summary
- Broaden market-mover prompt detection to asset-specific mover phrasing such as crypto, stocks, and Bitcoin rally prompts.
- Add regression coverage to keep unrequested news out of asset mover answers.

Closes #931