### PR TITLE
Protect market prices from MathJax rendering

### DIFF
--- a/internal/app/answer_format.go
+++ b/internal/app/answer_format.go
@@ -50,6 +50,7 @@ func NormalizeAnswerMarkdown(answer string) string {
 }
 
 func normalizeMarkdownLine(line string) string {
+	line = protectCurrencyDollars(line)
 	line = repairMalformedLeadingBold(line)
 	if heading, rest, ok := strings.Cut(line, " "); ok && isMarkdownHeading(heading) {
 		return heading + " " + strings.TrimSpace(rest)
@@ -85,7 +86,14 @@ func normalizeMarkdownLine(line string) string {
 	return line
 }
 
-var malformedLeadingBoldRe = regexp.MustCompile(`^\*([^*\n]+?:)\*\*(\s|$)`)
+var (
+	malformedLeadingBoldRe = regexp.MustCompile(`^\*([^*\n]+?:)\*\*(\s|$)`)
+	currencyDollarRe       = regexp.MustCompile(`\$(\d)`)
+)
+
+func protectCurrencyDollars(line string) string {
+	return currencyDollarRe.ReplaceAllString(line, "$\u2060$1")
+}
 
 func repairMalformedLeadingBold(line string) string {
 	return malformedLeadingBoldRe.ReplaceAllString(line, `**$1**$2`)

--- a/internal/app/answer_format_test.go
+++ b/internal/app/answer_format_test.go
@@ -66,3 +66,16 @@ func TestNormalizeAnswerMarkdownConvertsBulletGlyphs(t *testing.T) {
 		t.Fatalf("NormalizeAnswerMarkdown() = %q, want %q", got, want)
 	}
 }
+
+func TestNormalizeAnswerMarkdownProtectsCurrencyDollars(t *testing.T) {
+	input := "- BTC: $94,000\n- ETH: $4,703\n- PAXG: $3,942"
+	got := NormalizeAnswerMarkdown(input)
+	if strings.Contains(got, "$94") || strings.Contains(got, "$4") || strings.Contains(got, "$3") {
+		t.Fatalf("currency dollars were not protected from math rendering: %q", got)
+	}
+	for _, want := range []string{"$\u206094,000", "$\u20604,703", "$\u20603,942"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("NormalizeAnswerMarkdown() missing %q in %q", want, got)
+		}
+	}
+}

--- a/internal/app/chat.go
+++ b/internal/app/chat.go
@@ -123,6 +123,7 @@ if(!SESSION){
 }
 
 function esc(s){return String(s||'').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');}
+function protectCurrencyDollars(s){return String(s||'').replace(/\$(?=\d)/g,'$\u2060');}
 
 var SUGGEST=['Give me a morning brief','What is moving in markets?','Weather in San Francisco','Find today\'s AI news'];
 function showSuggestions(){
@@ -209,7 +210,7 @@ function ask(q){
                 a.innerHTML='<div style="white-space:pre-wrap"><span id="mu-stream-out"></span><span class="mu-cursor"></span></div>';
               }
               var el=document.getElementById('mu-stream-out');
-              if(el)el.textContent=streamText;
+              if(el)el.textContent=protectCurrencyDollars(streamText);
               a.scrollIntoView({behavior:'smooth',block:'end'});
             }else if(ev.type==='response'){
               stopWork();


### PR DESCRIPTION
## Summary
- Protect assistant-rendered currency prices so MathJax does not treat repeated dollar prices as inline math.
- Apply the same protection to in-progress streamed agent text before final HTML arrives.
- Add regression coverage for market-style BTC/ETH/PAXG dollar price lines.

Closes #934
Closes #936

## Verification
- go build ./...
- go test ./... -short
- go vet ./...