### PR TITLE
Prevent blog currency amounts from rendering as math

### DIFF
--- a/blog/render_test.go
+++ b/blog/render_test.go
@@ -1,0 +1,20 @@
+package blog
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestLinkifyProtectsCurrencyDollarsFromMathRendering(t *testing.T) {
+	got := Linkify("Daily Digest: AI startup raised $1 billion while BTC traded at $94,000.")
+	for _, bad := range []string{"$1", "$94"} {
+		if strings.Contains(got, bad) {
+			t.Fatalf("Linkify left currency sequence %q exposed to math rendering: %q", bad, got)
+		}
+	}
+	for _, want := range []string{"$\u20601 billion", "$\u206094,000"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("Linkify() missing protected currency %q in %q", want, got)
+		}
+	}
+}

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -1262,11 +1262,15 @@ func Session(w http.ResponseWriter, r *http.Request) {
 
 // Render a markdown document as html
 func Render(md []byte) []byte {
-	// Strip LaTeX dollar sign escapes before parsing markdown
-	md = []byte(StripLatexDollars(string(md)))
+	// Strip LaTeX dollar sign escapes and protect plain currency before
+	// parsing markdown so downstream MathJax scanners do not treat blog cards
+	// or other rendered content as inline math.
+	md = []byte(protectCurrencyDollars(StripLatexDollars(string(md))))
 
-	// create markdown parser with extensions
-	extensions := parser.CommonExtensions | parser.AutoHeadingIDs | parser.NoEmptyLineBeforeBlock
+	// create markdown parser with extensions. MathJax is intentionally disabled:
+	// Mu renders everyday prose more often than formulas, and paired currency
+	// amounts such as "$1 billion ... $94,000" must remain readable text.
+	extensions := (parser.CommonExtensions &^ parser.MathJax) | parser.AutoHeadingIDs | parser.NoEmptyLineBeforeBlock
 	p := parser.NewWithExtensions(extensions)
 	doc := p.Parse(md)
 


### PR DESCRIPTION
## Summary
- disable MathJax parsing in shared markdown rendering so paired dollar amounts stay readable text
- protect plain currency dollars before rendering markdown
- add a blog Linkify regression test for Daily Digest-style dollar amounts

Closes #939
Closes #941