### PR TITLE
Deduplicate agent market tool calls

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -185,11 +185,17 @@ func QueryWithOpts(accountID, prompt string, opts QueryOpts) (string, error) {
 	}
 	var results []toolResult
 	var unavailableTools []string
+	seenToolCalls := map[string]bool{}
 
 	for _, tc := range toolCalls {
 		if tc.Tool == "" {
 			continue
 		}
+		key := toolCallKey(tc.Tool, tc.Args)
+		if seenToolCalls[key] {
+			continue
+		}
+		seenToolCalls[key] = true
 		if skipMarketMoverCompanionTool(prompt, tc.Tool) {
 			continue
 		}
@@ -544,14 +550,24 @@ func streamNativeSSE(w http.ResponseWriter, accountID, prompt string, opts Query
 	emitted := false
 	var captured strings.Builder
 	var nativeTools []string
+	startedTools := map[string]bool{}
+	endedTools := map[string]bool{}
 
 	answer, handled, err := streamNative(accountID, prompt, opts, StreamHooks{
 		ToolStart: func(label string) {
+			if startedTools[label] {
+				return
+			}
+			startedTools[label] = true
 			emitted = true
 			nativeTools = append(nativeTools, label)
 			sse(w, map[string]any{"type": "tool_start", "name": label, "message": label})
 		},
 		ToolEnd: func(label string) {
+			if endedTools[label] {
+				return
+			}
+			endedTools[label] = true
 			sse(w, map[string]any{"type": "tool_done", "name": label, "message": label + " — done"})
 		},
 		Token: func(tok string) {
@@ -884,11 +900,17 @@ func handleQuery(w http.ResponseWriter, r *http.Request) {
 	}
 	var results []toolResult
 	var unavailableTools []string
+	seenToolCalls := map[string]bool{}
 
 	for _, tc := range toolCalls {
 		if tc.Tool == "" {
 			continue
 		}
+		key := toolCallKey(tc.Tool, tc.Args)
+		if seenToolCalls[key] {
+			continue
+		}
+		seenToolCalls[key] = true
 		if skipMarketMoverCompanionTool(req.Prompt, tc.Tool) {
 			continue
 		}
@@ -1113,6 +1135,17 @@ func shortcutToolCalls(prompt string) []shortcutToolCall {
 	}
 
 	return nil
+}
+
+func toolCallKey(tool string, args map[string]any) string {
+	if len(args) == 0 {
+		return strings.TrimSpace(tool)
+	}
+	b, err := json.Marshal(args)
+	if err != nil {
+		return strings.TrimSpace(tool)
+	}
+	return strings.TrimSpace(tool) + "\x00" + string(b)
 }
 
 // extractJSONArray extracts the first JSON array `[…]` from text produced by the AI.

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -314,6 +314,17 @@ func TestFormatToolResultMarketsRESTDataIncludesFreshnessDisclosure(t *testing.T
 	}
 }
 
+func TestToolCallKeyDedupesEquivalentArgs(t *testing.T) {
+	first := toolCallKey("markets", map[string]any{"category": "crypto", "limit": float64(10)})
+	second := toolCallKey("markets", map[string]any{"limit": float64(10), "category": "crypto"})
+	if first != second {
+		t.Fatalf("expected equivalent tool args to share a dedupe key: %q vs %q", first, second)
+	}
+	if first == toolCallKey("markets", map[string]any{"category": "futures", "limit": float64(10)}) {
+		t.Fatal("expected distinct market categories to keep distinct dedupe keys")
+	}
+}
+
 func TestShortcutToolCallsMarketMoversAvoidsNewsPlanning(t *testing.T) {
 	got := shortcutToolCalls("What is moving in markets today?")
 	if len(got) != 1 {

--- a/agent/native.go
+++ b/agent/native.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -88,6 +89,39 @@ func injectAccount(accountID string) gmai.ToolWrapper {
 	}
 }
 
+func dedupeNativeToolCalls() gmai.ToolWrapper {
+	var mu sync.Mutex
+	cache := map[string]gmai.ToolResult{}
+	return func(next gmai.ToolHandler) gmai.ToolHandler {
+		return func(ctx context.Context, call gmai.ToolCall) gmai.ToolResult {
+			key := nativeToolCallKey(call)
+			mu.Lock()
+			if res, ok := cache[key]; ok {
+				mu.Unlock()
+				return res
+			}
+			mu.Unlock()
+
+			res := next(ctx, call)
+			mu.Lock()
+			cache[key] = res
+			mu.Unlock()
+			return res
+		}
+	}
+}
+
+func nativeToolCallKey(call gmai.ToolCall) string {
+	if len(call.Input) == 0 {
+		return strings.TrimSpace(call.Name)
+	}
+	b, err := json.Marshal(call.Input)
+	if err != nil {
+		return strings.TrimSpace(call.Name)
+	}
+	return strings.TrimSpace(call.Name) + "\x00" + string(b)
+}
+
 // buildNativeAgent constructs the go-micro agent and the question (history +
 // prompt) shared by queryNative and streamNative. ok is false when no native
 // provider is configured, signalling the caller to fall back.
@@ -130,7 +164,7 @@ func buildNativeAgent(accountID, prompt string, opts QueryOpts, wrappers ...gmai
 	// Use a fresh named agent for each request. Some go-micro providers keep
 	// per-agent conversation state keyed by name, so reusing a stable "assistant"
 	// name can leak prior independent prompts into fresh guest requests.
-	toolWrappers := append([]gmai.ToolWrapper{injectAccount(accountID)}, wrappers...)
+	toolWrappers := append([]gmai.ToolWrapper{injectAccount(accountID), dedupeNativeToolCalls()}, wrappers...)
 	a = service.NewAgent(nativeAgentInstanceName(), sys, "atlascloud", key, nativeServices(opts.Public),
 		gmagent.Model(ai.ModelDeepSeekPro),
 		gmagent.MaxSteps(6),

--- a/agent/native_test.go
+++ b/agent/native_test.go
@@ -1,0 +1,18 @@
+package agent
+
+import (
+	"testing"
+
+	gmai "go-micro.dev/v6/ai"
+)
+
+func TestNativeToolCallKeyDedupesEquivalentInputs(t *testing.T) {
+	first := nativeToolCallKey(gmai.ToolCall{Name: "markets_Get", Input: map[string]any{"category": "crypto", "limit": float64(10)}})
+	second := nativeToolCallKey(gmai.ToolCall{Name: "markets_Get", Input: map[string]any{"limit": float64(10), "category": "crypto"}})
+	if first != second {
+		t.Fatalf("expected equivalent native tool inputs to share a dedupe key: %q vs %q", first, second)
+	}
+	if first == nativeToolCallKey(gmai.ToolCall{Name: "markets_Get", Input: map[string]any{"category": "commodities", "limit": float64(10)}}) {
+		t.Fatal("expected distinct native market inputs to keep distinct dedupe keys")
+	}
+}

--- a/agent/run.go
+++ b/agent/run.go
@@ -182,11 +182,17 @@ func RunHandler(w http.ResponseWriter, r *http.Request) {
 	// Step 2: Execute tools
 	var ragParts []string
 	var toolsUsed []ToolUsed
+	seenToolCalls := map[string]bool{}
 
 	for _, tc := range toolCalls {
 		if tc.Tool == "" {
 			continue
 		}
+		key := toolCallKey(tc.Tool, tc.Args)
+		if seenToolCalls[key] {
+			continue
+		}
+		seenToolCalls[key] = true
 		if isGuest && !isGuestAllowedTool(tc.Tool) {
 			continue
 		}


### PR DESCRIPTION
## Summary
- Deduplicate repeated planned tool calls before execution in the agent query paths.
- Cache duplicate native agent tool calls and suppress repeated native progress events for the same tool label.
- Add tests for stable dedupe keys across equivalent market tool arguments.

## Testing
- go build ./...
- go test ./... -short
- go vet ./...

Closes #944
Closes #946