### PR TITLE
Reduce guest agent planning latency

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -821,7 +821,13 @@ func handleQuery(w http.ResponseWriter, r *http.Request) {
 	// emitting tool start/end events. Falls through to the hand-rolled
 	// pipeline below if disabled, no provider is configured, or it fails
 	// before producing any output.
-	if nativeStreamEnabled() {
+	// Guest starter/live-data prompts with deterministic tool shortcuts should
+	// skip the native agent's initial model planning turn. The hand-rolled
+	// pipeline below can start the relevant tool immediately, which improves
+	// first visible progress for the first-run core loop without changing any
+	// public endpoint or tool contract.
+	preferShortcutPlanner := isGuest && len(shortcutToolCalls(req.Prompt)) > 0
+	if nativeStreamEnabled() && !preferShortcutPlanner {
 		nopts := QueryOpts{Public: isGuest}
 		for _, f := range conversationHistory {
 			if strings.TrimSpace(f.Prompt) == "" {
@@ -1128,6 +1134,10 @@ func shortcutToolCalls(prompt string) []shortcutToolCall {
 	}
 
 	// Fuzzy matches for prompts with dynamic content
+	if isLatestTechnologyNewsPrompt(lower) {
+		return []shortcutToolCall{{Tool: "news_search", Args: map[string]any{"query": "technology news"}}}
+	}
+
 	if strings.Contains(lower, "unread email") || strings.Contains(lower, "unread mail") ||
 		(strings.Contains(lower, "read") && strings.Contains(lower, "mail")) ||
 		(strings.Contains(lower, "read") && strings.Contains(lower, "email")) {
@@ -1135,6 +1145,22 @@ func shortcutToolCalls(prompt string) []shortcutToolCall {
 	}
 
 	return nil
+}
+
+func isLatestTechnologyNewsPrompt(lower string) bool {
+	hasRecency := strings.Contains(lower, "latest") ||
+		strings.Contains(lower, "today") ||
+		strings.Contains(lower, "current") ||
+		strings.Contains(lower, "happening")
+	if !hasRecency || !strings.Contains(lower, "news") {
+		return false
+	}
+	for _, topic := range []string{"tech", "technology", "ai", "artificial intelligence"} {
+		if strings.Contains(lower, topic) {
+			return true
+		}
+	}
+	return false
 }
 
 func toolCallKey(tool string, args map[string]any) string {

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -335,6 +335,25 @@ func TestShortcutToolCallsMarketMoversAvoidsNewsPlanning(t *testing.T) {
 	}
 }
 
+func TestShortcutToolCallsLatestTechnologyNews(t *testing.T) {
+	for _, prompt := range []string{
+		"latest technology news",
+		"What is the latest AI news today?",
+		"current artificial intelligence news",
+	} {
+		got := shortcutToolCalls(prompt)
+		if len(got) != 1 {
+			t.Fatalf("expected one shortcut tool call for %q, got %#v", prompt, got)
+		}
+		if got[0].Tool != "news_search" {
+			t.Fatalf("expected news_search shortcut for %q, got %#v", prompt, got)
+		}
+		if got[0].Args["query"] != "technology news" {
+			t.Fatalf("expected technology news query for %q, got %#v", prompt, got[0].Args)
+		}
+	}
+}
+
 func TestSkipMarketMoverCompanionToolFiltersUnrequestedNews(t *testing.T) {
 	prompt := "What is moving in markets today?"
 	for _, tool := range []string{"news", "news_headlines", "news_search", "web_search", "recall"} {

--- a/internal/data/owner_test.go
+++ b/internal/data/owner_test.go
@@ -2,7 +2,6 @@ package data
 
 import (
 	"os"
-	"sync"
 	"testing"
 )
 
@@ -51,9 +50,7 @@ func TestOwnerScopingInMemory(t *testing.T) {
 
 // TestOwnerScopingSQLite verifies the same guarantees on the SQLite backend.
 func TestOwnerScopingSQLite(t *testing.T) {
-	os.Setenv("HOME", t.TempDir())
-	dbOnce = sync.Once{}
-	db = nil
+	resetSQLiteTestDB(t)
 
 	if err := IndexSQLite("pub1", "news", "Public bitcoin rally", "public news about bitcoin", "", nil); err != nil {
 		t.Fatalf("index pub: %v", err)

--- a/internal/data/sqlite_test.go
+++ b/internal/data/sqlite_test.go
@@ -7,14 +7,26 @@ import (
 	"testing"
 )
 
-func TestSQLiteMigration(t *testing.T) {
-	// Use a temp directory for test
-	tempDir := t.TempDir()
-	os.Setenv("HOME", tempDir)
+var sqliteTestMu sync.Mutex
 
-	// Reset singleton
+func resetSQLiteTestDB(t *testing.T) string {
+	t.Helper()
+	sqliteTestMu.Lock()
+	t.Cleanup(sqliteTestMu.Unlock)
+	tempDir := t.TempDir()
+	t.Setenv("HOME", tempDir)
+	if db != nil {
+		_ = db.Close()
+	}
 	dbOnce = sync.Once{}
 	db = nil
+	dbPath = ""
+	return tempDir
+}
+
+func TestSQLiteMigration(t *testing.T) {
+	// Use an isolated temp directory for this test.
+	tempDir := resetSQLiteTestDB(t)
 
 	// Create test index.json
 	testIndex := `{
@@ -81,11 +93,7 @@ func TestSQLiteMigration(t *testing.T) {
 }
 
 func TestSQLiteSearch(t *testing.T) {
-	tempDir := t.TempDir()
-	os.Setenv("HOME", tempDir)
-
-	dbOnce = sync.Once{}
-	db = nil
+	resetSQLiteTestDB(t)
 
 	// Initialize and add some entries
 	err := IndexSQLite("search1", "news", "AI Revolution in Tech", "Artificial intelligence is transforming the technology industry.", "", nil)
@@ -132,11 +140,7 @@ func TestSQLiteSearch(t *testing.T) {
 }
 
 func TestSQLiteSearchFindsPartialContentMatches(t *testing.T) {
-	tempDir := t.TempDir()
-	os.Setenv("HOME", tempDir)
-
-	dbOnce = sync.Once{}
-	db = nil
+	resetSQLiteTestDB(t)
 
 	err := IndexSQLite("partial1", "news", "Space Telescope", "Astronomers photographed galaxies in ultraviolet light.", "", nil)
 	if err != nil {
@@ -160,11 +164,7 @@ func TestSQLiteSearchFindsPartialContentMatches(t *testing.T) {
 }
 
 func TestSQLiteIndexUpdate(t *testing.T) {
-	tempDir := t.TempDir()
-	os.Setenv("HOME", tempDir)
-
-	dbOnce = sync.Once{}
-	db = nil
+	resetSQLiteTestDB(t)
 
 	// Add entry
 	err := IndexSQLite("update1", "news", "Original Title", "Original content.", "", map[string]interface{}{"version": 1})
@@ -198,11 +198,7 @@ func TestSQLiteIndexUpdate(t *testing.T) {
 }
 
 func TestFTS5Search(t *testing.T) {
-	tempDir := t.TempDir()
-	os.Setenv("HOME", tempDir)
-
-	dbOnce = sync.Once{}
-	db = nil
+	resetSQLiteTestDB(t)
 
 	// Add entries
 	IndexSQLite("fts1", "news", "Bitcoin Hits All-Time High", "Bitcoin reached a new record price amid growing institutional adoption.", "", nil)


### PR DESCRIPTION
## Summary
- route guest prompts with deterministic shortcuts through the faster planner path so first visible tool progress does not wait on native model planning
- add a technology-news shortcut for common latest/current AI and tech news prompts
- isolate SQLite tests so the verification suite is stable

Closes #949
Closes #952