### PR TITLE
Fallback to web search for unavailable AI news

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -187,7 +187,8 @@ func QueryWithOpts(accountID, prompt string, opts QueryOpts) (string, error) {
 	var unavailableTools []string
 	seenToolCalls := map[string]bool{}
 
-	for _, tc := range toolCalls {
+	for i := 0; i < len(toolCalls); i++ {
+		tc := toolCalls[i]
 		if tc.Tool == "" {
 			continue
 		}
@@ -205,6 +206,12 @@ func QueryWithOpts(accountID, prompt string, opts QueryOpts) (string, error) {
 		text, isErr, execErr := api.ExecuteToolAs(accountID, tc.Tool, tc.Args)
 		if execErr != nil || isErr {
 			unavailableTools = append(unavailableTools, tc.Tool)
+			if fallback, ok := fallbackNewsSearchToolCall(prompt, tc.Tool, tc.Args); ok {
+				key := toolCallKey(fallback.Tool, fallback.Args)
+				if !seenToolCalls[key] && (!opts.Public || isGuestAllowedTool(fallback.Tool)) {
+					toolCalls = append(toolCalls, toolCall{Tool: fallback.Tool, Args: fallback.Args})
+				}
+			}
 			continue
 		}
 		if len(text) > 8000 {
@@ -908,7 +915,8 @@ func handleQuery(w http.ResponseWriter, r *http.Request) {
 	var unavailableTools []string
 	seenToolCalls := map[string]bool{}
 
-	for _, tc := range toolCalls {
+	for i := 0; i < len(toolCalls); i++ {
+		tc := toolCalls[i]
 		if tc.Tool == "" {
 			continue
 		}
@@ -935,6 +943,12 @@ func handleQuery(w http.ResponseWriter, r *http.Request) {
 				"name":    tc.Tool,
 				"message": tc.Tool + " — unavailable",
 			})
+			if fallback, ok := fallbackNewsSearchToolCall(req.Prompt, tc.Tool, tc.Args); ok {
+				key := toolCallKey(fallback.Tool, fallback.Args)
+				if !seenToolCalls[key] && (!isGuest || isGuestAllowedTool(fallback.Tool)) {
+					toolCalls = append(toolCalls, toolCall{Tool: fallback.Tool, Args: fallback.Args})
+				}
+			}
 			continue
 		}
 
@@ -1180,6 +1194,17 @@ func shortcutToolCalls(prompt string) []shortcutToolCall {
 	}
 
 	return nil
+}
+
+func fallbackNewsSearchToolCall(prompt, tool string, args map[string]any) (shortcutToolCall, bool) {
+	if tool != "news_search" || !isLatestTechnologyNewsPrompt(strings.ToLower(prompt)) {
+		return shortcutToolCall{}, false
+	}
+	query := "latest AI news"
+	if raw, ok := args["query"].(string); ok && strings.TrimSpace(raw) != "" {
+		query = strings.TrimSpace(raw)
+	}
+	return shortcutToolCall{Tool: "web_search", Args: map[string]any{"q": query}}, true
 }
 
 func isLatestTechnologyNewsPrompt(lower string) bool {

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -373,6 +373,28 @@ func TestShortcutToolCallsLatestTechnologyNews(t *testing.T) {
 	}
 }
 
+func TestFallbackNewsSearchToolCallUsesWebSearchForLatestAINews(t *testing.T) {
+	got, ok := fallbackNewsSearchToolCall("Find today's AI news", "news_search", map[string]any{"query": "technology news"})
+	if !ok {
+		t.Fatal("expected latest AI news prompts to fall back when news_search is unavailable")
+	}
+	if got.Tool != "web_search" {
+		t.Fatalf("expected web_search fallback, got %#v", got)
+	}
+	if got.Args["q"] != "technology news" {
+		t.Fatalf("expected fallback to preserve news query, got %#v", got.Args)
+	}
+}
+
+func TestFallbackNewsSearchToolCallIgnoresNonNewsSearchFailures(t *testing.T) {
+	if got, ok := fallbackNewsSearchToolCall("Find today's AI news", "weather_forecast", nil); ok {
+		t.Fatalf("expected non-news tool failures to be ignored, got %#v", got)
+	}
+	if got, ok := fallbackNewsSearchToolCall("old saved AI article", "news_search", map[string]any{"query": "AI"}); ok {
+		t.Fatalf("expected non-current news prompts to be ignored, got %#v", got)
+	}
+}
+
 func TestSkipMarketMoverCompanionToolFiltersUnrequestedNews(t *testing.T) {
 	prompt := "What is moving in markets today?"
 	for _, tool := range []string{"news", "news_headlines", "news_search", "web_search", "recall"} {


### PR DESCRIPTION
## Summary
- Add a latest AI/technology news fallback that queues web_search when news_search is unavailable, preserving the original news query and keeping unavailable-news disclosure concise.
- Apply the fallback in both programmatic agent queries and the SSE /agent path.
- Add tests for fallback eligibility and non-news/non-current guardrails.

Closes #959
Closes #961

## Testing
- go test ./agent -short
- go build ./...
- go test ./... -short
- go vet ./...