### PR TITLE
Keep news fallbacks topic-specific

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1184,7 +1184,7 @@ func shortcutToolCalls(prompt string) []shortcutToolCall {
 
 	// Fuzzy matches for prompts with dynamic content
 	if isLatestTechnologyNewsPrompt(lower) {
-		return []shortcutToolCall{{Tool: "news_search", Args: map[string]any{"query": "technology news"}}}
+		return []shortcutToolCall{{Tool: "news_search", Args: map[string]any{"query": newsTopicQuery(lower)}}}
 	}
 
 	if strings.Contains(lower, "unread email") || strings.Contains(lower, "unread mail") ||
@@ -1200,11 +1200,28 @@ func fallbackNewsSearchToolCall(prompt, tool string, args map[string]any) (short
 	if tool != "news_search" || !isLatestTechnologyNewsPrompt(strings.ToLower(prompt)) {
 		return shortcutToolCall{}, false
 	}
-	query := "latest AI news"
+	query := newsTopicQuery(strings.ToLower(prompt))
 	if raw, ok := args["query"].(string); ok && strings.TrimSpace(raw) != "" {
 		query = strings.TrimSpace(raw)
 	}
+	if promptQuery := newsTopicQuery(strings.ToLower(prompt)); promptQuery != "technology news" && query == "technology news" {
+		query = promptQuery
+	}
 	return shortcutToolCall{Tool: "web_search", Args: map[string]any{"q": query}}, true
+}
+
+func newsTopicQuery(lower string) string {
+	if strings.Contains(lower, "artificial intelligence") {
+		return "artificial intelligence news"
+	}
+	for _, token := range strings.FieldsFunc(lower, func(r rune) bool {
+		return (r < 'a' || r > 'z') && (r < '0' || r > '9')
+	}) {
+		if token == "ai" {
+			return "AI news"
+		}
+	}
+	return "technology news"
 }
 
 func isLatestTechnologyNewsPrompt(lower string) bool {

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -355,20 +355,23 @@ func TestUseFastToolFallbackOnlyForGuestMarketMovers(t *testing.T) {
 }
 
 func TestShortcutToolCallsLatestTechnologyNews(t *testing.T) {
-	for _, prompt := range []string{
-		"latest technology news",
-		"What is the latest AI news today?",
-		"current artificial intelligence news",
+	for _, tt := range []struct {
+		prompt string
+		query  string
+	}{
+		{prompt: "latest technology news", query: "technology news"},
+		{prompt: "What is the latest AI news today?", query: "AI news"},
+		{prompt: "current artificial intelligence news", query: "artificial intelligence news"},
 	} {
-		got := shortcutToolCalls(prompt)
+		got := shortcutToolCalls(tt.prompt)
 		if len(got) != 1 {
-			t.Fatalf("expected one shortcut tool call for %q, got %#v", prompt, got)
+			t.Fatalf("expected one shortcut tool call for %q, got %#v", tt.prompt, got)
 		}
 		if got[0].Tool != "news_search" {
-			t.Fatalf("expected news_search shortcut for %q, got %#v", prompt, got)
+			t.Fatalf("expected news_search shortcut for %q, got %#v", tt.prompt, got)
 		}
-		if got[0].Args["query"] != "technology news" {
-			t.Fatalf("expected technology news query for %q, got %#v", prompt, got[0].Args)
+		if got[0].Args["query"] != tt.query {
+			t.Fatalf("expected %q query for %q, got %#v", tt.query, tt.prompt, got[0].Args)
 		}
 	}
 }
@@ -381,8 +384,8 @@ func TestFallbackNewsSearchToolCallUsesWebSearchForLatestAINews(t *testing.T) {
 	if got.Tool != "web_search" {
 		t.Fatalf("expected web_search fallback, got %#v", got)
 	}
-	if got.Args["q"] != "technology news" {
-		t.Fatalf("expected fallback to preserve news query, got %#v", got.Args)
+	if got.Args["q"] != "AI news" {
+		t.Fatalf("expected fallback to preserve prompt topic, got %#v", got.Args)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Preserve specific AI/artificial-intelligence topics when shortcutting latest-news prompts.
- Prefer the user's prompt topic over a broad technology query when news_search is unavailable and web_search is used as fallback.
- Add regression coverage for topic-specific shortcut and fallback queries.

Closes #964
Closes #966

## Testing
- go build ./...
- go test ./... -short
- go vet ./...