### PR TITLE
Ground news web fallbacks in snippets

### DIFF
--- a/search/agent.go
+++ b/search/agent.go
@@ -29,6 +29,7 @@ func WebSearchText(query string, limit int) string {
 }
 
 func formatWebSearchResults(query string, results []BraveResult) string {
+	results = groundNewsWebResults(query, results)
 	confidence := webSearchConfidence(query, results)
 
 	var sb strings.Builder
@@ -38,6 +39,9 @@ func formatWebSearchResults(query string, results []BraveResult) string {
 		fmt.Fprintf(&sb, "Confidence: low — the returned snippets only partially match the query intent. Say that the search results do not clearly support an answer and ask the user to refine the query before making unsupported claims.\n")
 	} else {
 		fmt.Fprintf(&sb, "Confidence: %s — synthesize only what the listed sources support.\n", confidence)
+	}
+	if isNewsLikeWebQuery(query) {
+		fmt.Fprintf(&sb, "Grounding rule: treat each source as evidence only for facts named in its title or snippet; do not turn generic topic/category pages or weak snippets into specific news headlines. If the snippets are thin, say the evidence is limited.\n")
 	}
 	fmt.Fprintf(&sb, "Sources:\n")
 	for i, r := range results {
@@ -52,6 +56,46 @@ func formatWebSearchResults(query string, results []BraveResult) string {
 		fmt.Fprintf(&sb, "%d. %s — %s (%s)\n", i+1, title, desc, r.URL)
 	}
 	return sb.String()
+}
+
+func groundNewsWebResults(query string, results []BraveResult) []BraveResult {
+	if !isNewsLikeWebQuery(query) {
+		return results
+	}
+	terms := meaningfulQueryTerms(query)
+	if len(terms) == 0 {
+		return results
+	}
+	filtered := make([]BraveResult, 0, len(results))
+	for _, r := range results {
+		desc := strings.TrimSpace(r.Description)
+		if desc == "" {
+			continue
+		}
+		haystack := strings.ToLower(r.Title + " " + desc + " " + r.URL)
+		matchedTopic := false
+		for term := range terms {
+			if term == "news" || term == "latest" || term == "today" || term == "current" {
+				continue
+			}
+			if strings.Contains(haystack, term) {
+				matchedTopic = true
+				break
+			}
+		}
+		if matchedTopic {
+			filtered = append(filtered, r)
+		}
+	}
+	if len(filtered) == 0 {
+		return results
+	}
+	return filtered
+}
+
+func isNewsLikeWebQuery(query string) bool {
+	lower := strings.ToLower(query)
+	return strings.Contains(lower, "news") || strings.Contains(lower, "latest") || strings.Contains(lower, "today") || strings.Contains(lower, "current")
 }
 
 func webSearchConfidence(query string, results []BraveResult) string {

--- a/search/agent_test.go
+++ b/search/agent_test.go
@@ -40,3 +40,24 @@ func TestFormatWebSearchResultsFlagsLowConfidenceMismatch(t *testing.T) {
 		}
 	}
 }
+
+func TestFormatWebSearchResultsGroundsNewsFallbackInSnippets(t *testing.T) {
+	got := formatWebSearchResults("latest AI news", []BraveResult{
+		{Title: "Artificial Intelligence News", Description: "", URL: "https://example.com/ai"},
+		{Title: "AI chip supplier expands capacity", Description: "A chip supplier said demand from AI data centers is rising this quarter.", URL: "https://example.com/ai-chips"},
+		{Title: "Sports scores", Description: "Local football results from last night.", URL: "https://example.com/sports"},
+	})
+
+	if strings.Contains(got, "Artificial Intelligence News") || strings.Contains(got, "Sports scores") {
+		t.Fatalf("expected weak or unrelated news fallback sources to be filtered:\n%s", got)
+	}
+	for _, want := range []string{
+		"AI chip supplier expands capacity",
+		"Grounding rule:",
+		"do not turn generic topic/category pages or weak snippets into specific news headlines",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("expected %q in grounded web search results:\n%s", want, got)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Filter latest-news web fallback sources to snippet-backed, topic-matching results before synthesis.
- Add an explicit grounding instruction so generic category pages or weak snippets are not promoted into specific headlines.
- Add test coverage for snippet-grounded AI-news fallback results.

Closes #969
Closes #971

## Testing
- go build ./...
- go test ./... -short
- go vet ./...