### PR TITLE
Speed up guest weather answers

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -833,8 +833,8 @@ func handleQuery(w http.ResponseWriter, r *http.Request) {
 	// pipeline below can start the relevant tool immediately, which improves
 	// first visible progress for the first-run core loop without changing any
 	// public endpoint or tool contract.
-	preferShortcutPlanner := isGuest && len(shortcutToolCalls(req.Prompt)) > 0
-	if nativeStreamEnabled() && !preferShortcutPlanner {
+	preferPlanner := isGuest && (len(shortcutToolCalls(req.Prompt)) > 0 || isSimpleWeatherPrompt(req.Prompt))
+	if nativeStreamEnabled() && !preferPlanner {
 		nopts := QueryOpts{Public: isGuest}
 		for _, f := range conversationHistory {
 			if strings.TrimSpace(f.Prompt) == "" {
@@ -996,13 +996,16 @@ func handleQuery(w http.ResponseWriter, r *http.Request) {
 	}
 
 	hasMarketsTool := false
+	hasWeatherTool := false
 	for _, tc := range toolCalls {
-		if tc.Tool == "markets" {
+		switch tc.Tool {
+		case "markets":
 			hasMarketsTool = true
-			break
+		case "weather_forecast":
+			hasWeatherTool = true
 		}
 	}
-	if useFastToolFallback(req.Prompt, isGuest, hasMarketsTool, ragParts) {
+	if useFastToolFallback(req.Prompt, isGuest, hasMarketsTool, hasWeatherTool, ragParts) {
 		answer := app.NormalizeAnswerMarkdown(app.StripLatexDollars(synthesizeToolFallback(ragParts)))
 		rendered := app.RenderString(answer)
 		html := `<div class="card" id="agent-response">` + rendered + `</div>`
@@ -1240,12 +1243,26 @@ func isLatestTechnologyNewsPrompt(lower string) bool {
 	return false
 }
 
-func useFastToolFallback(prompt string, isGuest bool, hasMarketsTool bool, ragParts []string) bool {
-	if !isGuest || !hasMarketsTool || len(ragParts) == 0 || !isMarketMoverPrompt(prompt) {
+func useFastToolFallback(prompt string, isGuest bool, hasMarketsTool bool, hasWeatherTool bool, ragParts []string) bool {
+	if !isGuest || len(ragParts) == 0 {
 		return false
 	}
-	if wantsMarketMoverExplanation(prompt) {
+	if hasMarketsTool && isMarketMoverPrompt(prompt) && !wantsMarketMoverExplanation(prompt) {
+		return true
+	}
+	return hasWeatherTool && isSimpleWeatherPrompt(prompt)
+}
+
+func isSimpleWeatherPrompt(prompt string) bool {
+	lower := strings.ToLower(strings.TrimSpace(prompt))
+	if lower == "" || !strings.Contains(lower, "weather") {
 		return false
+	}
+	complexTerms := []string{"compare", "versus", " vs ", "and news", "market", "markets", "why", "explain", "impact", "affect"}
+	for _, term := range complexTerms {
+		if strings.Contains(lower, term) {
+			return false
+		}
 	}
 	return true
 }

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -337,20 +337,36 @@ func TestShortcutToolCallsMarketMoversAvoidsNewsPlanning(t *testing.T) {
 
 func TestUseFastToolFallbackOnlyForGuestMarketMovers(t *testing.T) {
 	rag := []string{"### markets\nLive crypto prices:\nBTC: $97000.00 (+1.23% 24h)"}
-	if !useFastToolFallback("What is moving in markets today?", true, true, rag) {
+	if !useFastToolFallback("What is moving in markets today?", true, true, false, rag) {
 		t.Fatal("expected guest market-mover prompts with market data to use the fast fallback")
 	}
-	if useFastToolFallback("What is moving in markets today?", false, true, rag) {
+	if useFastToolFallback("What is moving in markets today?", false, true, false, rag) {
 		t.Fatal("authenticated users should keep full synthesis")
 	}
-	if useFastToolFallback("Why is Bitcoin moving today?", true, true, rag) {
+	if useFastToolFallback("Why is Bitcoin moving today?", true, true, false, rag) {
 		t.Fatal("explanation prompts should keep full synthesis")
 	}
-	if useFastToolFallback("What is moving in markets today?", true, false, rag) {
+	if useFastToolFallback("What is moving in markets today?", true, false, false, rag) {
 		t.Fatal("fallback requires a market tool result")
 	}
-	if useFastToolFallback("What is moving in markets today?", true, true, nil) {
+	if useFastToolFallback("What is moving in markets today?", true, true, false, nil) {
 		t.Fatal("fallback requires result context")
+	}
+}
+
+func TestUseFastToolFallbackForGuestSimpleWeather(t *testing.T) {
+	rag := []string{"### weather_forecast\nWeather for New York.\nNow: 21°C, partly cloudy.\nFreshness/source: source Google Weather; generated at 2026-07-02 12:00 UTC."}
+	if !useFastToolFallback("Weather in New York today", true, false, true, rag) {
+		t.Fatal("expected simple guest weather prompts with weather data to use the fast fallback")
+	}
+	if useFastToolFallback("Compare weather in New York and London", true, false, true, rag) {
+		t.Fatal("comparative weather prompts should keep full synthesis")
+	}
+	if useFastToolFallback("Weather in New York today", false, false, true, rag) {
+		t.Fatal("authenticated users should keep full synthesis")
+	}
+	if useFastToolFallback("Weather in New York today", true, false, false, rag) {
+		t.Fatal("fallback requires a weather tool result")
 	}
 }
 


### PR DESCRIPTION
## Summary
- Route simple guest weather prompts through the planner path so the weather tool starts directly instead of waiting on native streaming synthesis.
- Reuse the fast tool-result fallback for simple weather answers after weather data is available, while keeping comparative/explanatory prompts on full synthesis.
- Add tests covering the weather fast fallback guardrails.

Closes #974
Closes #977

## Testing
- go build ./...
- go test ./... -short
- go vet ./...