### PR TITLE
Reduce market-mover agent planning latency

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1185,7 +1185,14 @@ func shortcutToolCalls(prompt string) []shortcutToolCall {
 		return tc
 	}
 
-	// Fuzzy matches for prompts with dynamic content
+	// Fuzzy matches for prompts with dynamic content. Simple market-mover
+	// prompts should reach the markets tool without an LLM planning turn so the
+	// first visible tool event is emitted as soon as possible. Explanation or
+	// cross-source requests still use the planner so they can add news/search.
+	if isMarketMoverPrompt(lower) && !wantsMarketMoverExplanation(lower) {
+		return []shortcutToolCall{{Tool: "markets", Args: map[string]any{}}}
+	}
+
 	if isLatestTechnologyNewsPrompt(lower) {
 		return []shortcutToolCall{{Tool: "news_search", Args: map[string]any{"query": newsTopicQuery(lower)}}}
 	}

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -326,12 +326,27 @@ func TestToolCallKeyDedupesEquivalentArgs(t *testing.T) {
 }
 
 func TestShortcutToolCallsMarketMoversAvoidsNewsPlanning(t *testing.T) {
-	got := shortcutToolCalls("What is moving in markets today?")
-	if len(got) != 1 {
-		t.Fatalf("expected one shortcut tool call, got %#v", got)
+	for _, prompt := range []string{
+		"What is moving in markets today?",
+		"What is moving in markets?",
+		"Which stocks are moving?",
+	} {
+		got := shortcutToolCalls(prompt)
+		if len(got) != 1 {
+			t.Fatalf("%q: expected one shortcut tool call, got %#v", prompt, got)
+		}
+		if got[0].Tool != "markets" {
+			t.Fatalf("%q: expected markets-only shortcut, got %#v", prompt, got)
+		}
 	}
-	if got[0].Tool != "markets" {
-		t.Fatalf("expected markets-only shortcut, got %#v", got)
+}
+
+func TestShortcutToolCallsMarketMoverExplanationUsesPlanner(t *testing.T) {
+	if got := shortcutToolCalls("Why is Bitcoin moving today?"); len(got) != 0 {
+		t.Fatalf("expected explanation prompt to use planner, got %#v", got)
+	}
+	if got := shortcutToolCalls("What is moving in markets, and what news explains it?"); len(got) != 0 {
+		t.Fatalf("expected cross-source explanation prompt to use planner, got %#v", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Route simple market-mover prompts directly to the markets tool without an LLM planning turn, including the live-review prompt "What is moving in markets?".
- Keep explanatory or cross-source market prompts on the planner so they can still add news/search context.
- Extend shortcut tests for simple mover prompts and planner-preserving explanation prompts.

## Testing
- go build ./...
- go test ./... -short
- go vet ./...

Closes #980
Closes #982