### PR TITLE
Restore weather agent live fallback

### DIFF
--- a/weather/google.go
+++ b/weather/google.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"strings"
 	"time"
 
 	"mu/internal/app"
@@ -15,6 +16,7 @@ const (
 	googleWeatherDailyURL  = "https://weather.googleapis.com/v1/forecast/days:lookup"
 	googleWeatherHourlyURL = "https://weather.googleapis.com/v1/forecast/hours:lookup"
 	googlePollenBaseURL    = "https://pollen.googleapis.com/v1/forecast:lookup"
+	nwsPointsBaseURL       = "https://api.weather.gov/points"
 )
 
 // googleAPIKey returns the Google API key from the environment.
@@ -24,6 +26,8 @@ func googleAPIKey() string {
 
 // httpClient is the shared HTTP client with timeout.
 var httpClient = &http.Client{Timeout: 15 * time.Second}
+
+var nwsBaseURL = nwsPointsBaseURL
 
 // WeatherForecast holds the parsed forecast data returned by the Google Weather API.
 type WeatherForecast struct {
@@ -128,6 +132,38 @@ type googleHourlyResponse struct {
 	ForecastHours []googleForecastHour `json:"forecastHours"`
 }
 
+type nwsPointsResponse struct {
+	Properties struct {
+		ForecastHourly   string `json:"forecastHourly"`
+		Forecast         string `json:"forecast"`
+		RelativeLocation *struct {
+			Properties struct {
+				City  string `json:"city"`
+				State string `json:"state"`
+			} `json:"properties"`
+		} `json:"relativeLocation"`
+	} `json:"properties"`
+}
+
+type nwsForecastResponse struct {
+	Properties struct {
+		GeneratedAt string      `json:"generatedAt"`
+		Periods     []nwsPeriod `json:"periods"`
+	} `json:"properties"`
+}
+
+type nwsPeriod struct {
+	Name             string  `json:"name"`
+	StartTime        string  `json:"startTime"`
+	EndTime          string  `json:"endTime"`
+	IsDaytime        bool    `json:"isDaytime"`
+	Temperature      float64 `json:"temperature"`
+	TemperatureUnit  string  `json:"temperatureUnit"`
+	WindSpeed        string  `json:"windSpeed"`
+	ShortForecast    string  `json:"shortForecast"`
+	DetailedForecast string  `json:"detailedForecast"`
+}
+
 type googleForecastHour struct {
 	Interval struct {
 		StartTime string `json:"startTime"`
@@ -170,7 +206,7 @@ type googlePollenTypeInfo struct {
 func FetchWeather(lat, lon float64) (*WeatherForecast, error) {
 	key := googleAPIKey()
 	if key == "" {
-		return nil, fmt.Errorf("GOOGLE_API_KEY not configured")
+		return fetchNWSWeather(lat, lon)
 	}
 
 	// Fetch daily forecast (10 days)
@@ -179,7 +215,7 @@ func FetchWeather(lat, lon float64) (*WeatherForecast, error) {
 
 	dailyResp, err := googleWeatherGet(dailyURL, "google_weather_daily")
 	if err != nil {
-		return nil, err
+		return fetchNWSWeatherFallback(lat, lon, err)
 	}
 
 	var dailyData googleWeatherResponse
@@ -193,7 +229,7 @@ func FetchWeather(lat, lon float64) (*WeatherForecast, error) {
 
 	hourlyResp, err := googleWeatherGet(hourlyURL, "google_weather_hourly")
 	if err != nil {
-		return nil, err
+		return fetchNWSWeatherFallback(lat, lon, err)
 	}
 
 	var hourlyData googleHourlyResponse
@@ -274,6 +310,139 @@ func FetchWeather(lat, lon float64) (*WeatherForecast, error) {
 	return forecast, nil
 }
 
+func fetchNWSWeatherFallback(lat, lon float64, originalErr error) (*WeatherForecast, error) {
+	wf, err := fetchNWSWeather(lat, lon)
+	if err == nil {
+		return wf, nil
+	}
+	return nil, originalErr
+}
+
+func fetchNWSWeather(lat, lon float64) (*WeatherForecast, error) {
+	pointsURL := fmt.Sprintf("%s/%0.4f,%0.4f", nwsBaseURL, lat, lon)
+	pointsResp, err := weatherGet(pointsURL, "nws_points")
+	if err != nil {
+		return nil, err
+	}
+
+	var points nwsPointsResponse
+	if err := json.Unmarshal(pointsResp, &points); err != nil {
+		return nil, fmt.Errorf("failed to parse NWS points response: %w", err)
+	}
+	if points.Properties.ForecastHourly == "" || points.Properties.Forecast == "" {
+		return nil, fmt.Errorf("NWS forecast links unavailable")
+	}
+
+	hourlyResp, err := weatherGet(points.Properties.ForecastHourly, "nws_hourly")
+	if err != nil {
+		return nil, err
+	}
+	dailyResp, err := weatherGet(points.Properties.Forecast, "nws_forecast")
+	if err != nil {
+		return nil, err
+	}
+
+	var hourlyData, dailyData nwsForecastResponse
+	if err := json.Unmarshal(hourlyResp, &hourlyData); err != nil {
+		return nil, fmt.Errorf("failed to parse NWS hourly response: %w", err)
+	}
+	if err := json.Unmarshal(dailyResp, &dailyData); err != nil {
+		return nil, fmt.Errorf("failed to parse NWS forecast response: %w", err)
+	}
+
+	generatedAt := time.Now().UTC()
+	if dailyData.Properties.GeneratedAt != "" {
+		if t, err := time.Parse(time.RFC3339, dailyData.Properties.GeneratedAt); err == nil {
+			generatedAt = t.UTC()
+		}
+	}
+	wf := &WeatherForecast{Source: "National Weather Service", GeneratedAt: generatedAt}
+	if loc := points.Properties.RelativeLocation; loc != nil {
+		city := strings.TrimSpace(loc.Properties.City)
+		state := strings.TrimSpace(loc.Properties.State)
+		switch {
+		case city != "" && state != "":
+			wf.Location = city + ", " + state
+		case city != "":
+			wf.Location = city
+		}
+	}
+
+	for _, p := range hourlyData.Properties.Periods {
+		t, err := time.Parse(time.RFC3339, p.StartTime)
+		if err != nil {
+			continue
+		}
+		item := HourlyItem{
+			Time:        t.UTC(),
+			TempC:       toCelsius(p.Temperature, p.TemperatureUnit),
+			Description: firstNonEmpty(p.ShortForecast, p.DetailedForecast),
+		}
+		wf.HourlyItems = append(wf.HourlyItems, item)
+		if wf.Current == nil {
+			wf.ObservedAt = item.Time
+			wf.Current = &CurrentConditions{
+				TempC:            item.TempC,
+				FeelsLikeC:       item.TempC,
+				Description:      item.Description,
+				WindKph:          parseNWSWindKph(p.WindSpeed),
+				WindKphAvailable: strings.TrimSpace(p.WindSpeed) != "",
+			}
+		}
+		if len(wf.HourlyItems) >= 24 {
+			break
+		}
+	}
+
+	for i := 0; i < len(dailyData.Properties.Periods) && len(wf.DailyItems) < 5; i++ {
+		day := dailyData.Properties.Periods[i]
+		if !day.IsDaytime {
+			continue
+		}
+		t, err := time.Parse(time.RFC3339, day.StartTime)
+		if err != nil {
+			continue
+		}
+		item := DailyItem{
+			Date:        t.UTC(),
+			MaxTempC:    toCelsius(day.Temperature, day.TemperatureUnit),
+			MinTempC:    toCelsius(day.Temperature, day.TemperatureUnit),
+			Description: firstNonEmpty(day.ShortForecast, day.DetailedForecast),
+		}
+		if i+1 < len(dailyData.Properties.Periods) {
+			night := dailyData.Properties.Periods[i+1]
+			if !night.IsDaytime {
+				item.MinTempC = toCelsius(night.Temperature, night.TemperatureUnit)
+			}
+		}
+		wf.DailyItems = append(wf.DailyItems, item)
+	}
+	if wf.Current == nil && len(wf.DailyItems) == 0 {
+		return nil, fmt.Errorf("NWS forecast response had no usable periods")
+	}
+	return wf, nil
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
+}
+
+func parseNWSWindKph(wind string) float64 {
+	fields := strings.Fields(wind)
+	for _, field := range fields {
+		var mph float64
+		if _, err := fmt.Sscanf(field, "%f", &mph); err == nil {
+			return mph * 1.60934
+		}
+	}
+	return 0
+}
+
 // FetchPollen retrieves pollen forecast from the Google Pollen API.
 // Returns an error when GOOGLE_API_KEY is not set.
 func FetchPollen(lat, lon float64) ([]PollenForecast, error) {
@@ -337,8 +506,19 @@ func FetchPollen(lat, lon float64) ([]PollenForecast, error) {
 
 // googleWeatherGet performs a GET request and returns the response body.
 func googleWeatherGet(apiURL, service string) ([]byte, error) {
+	return weatherGet(apiURL, service)
+}
+
+func weatherGet(apiURL, service string) ([]byte, error) {
 	start := time.Now()
-	resp, err := httpClient.Get(apiURL)
+	req, err := http.NewRequest(http.MethodGet, apiURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/geo+json, application/json")
+	req.Header.Set("User-Agent", "MuWeatherApp/1.0 (https://micro.mu)")
+
+	resp, err := httpClient.Do(req)
 	if err != nil {
 		app.RecordAPICall(service, "GET", apiURL, 0, time.Since(start), err, "", "")
 		return nil, fmt.Errorf("%s request failed: %w", service, err)
@@ -364,7 +544,7 @@ func googleWeatherGet(apiURL, service string) ([]byte, error) {
 
 // toCelsius converts a temperature to Celsius.
 func toCelsius(degrees float64, unit string) float64 {
-	if unit == "FAHRENHEIT" {
+	if unit == "FAHRENHEIT" || unit == "F" {
 		return (degrees - 32) * 5 / 9
 	}
 	return degrees

--- a/weather/weather_test.go
+++ b/weather/weather_test.go
@@ -1,6 +1,8 @@
 package weather
 
 import (
+	"fmt"
+	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
@@ -76,11 +78,79 @@ func TestForecastTextInvalidCoordinatesDoesNotFetch(t *testing.T) {
 
 func TestForecastTextProviderUnavailableIsClear(t *testing.T) {
 	t.Setenv("GOOGLE_API_KEY", "")
+	server := httptest.NewServer(http.NotFoundHandler())
+	t.Cleanup(server.Close)
+	restoreNWSBaseURL(t, server.URL)
 
 	got := ForecastText(51.5074, -0.1278)
 	if got != weatherUnavailableMessage {
 		t.Fatalf("ForecastText provider unavailable = %q, want %q", got, weatherUnavailableMessage)
 	}
+}
+
+func TestForecastTextUsesNWSFallbackWithoutGoogleKey(t *testing.T) {
+	t.Setenv("GOOGLE_API_KEY", "")
+
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+	restoreNWSBaseURL(t, server.URL+"/points")
+
+	mux.HandleFunc("/points/40.7128,-74.0060", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, `{
+			"properties": {
+				"forecastHourly": %q,
+				"forecast": %q,
+				"relativeLocation": {"properties": {"city": "New York", "state": "NY"}}
+			}
+		}`, server.URL+"/hourly", server.URL+"/daily")
+	})
+	mux.HandleFunc("/hourly", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{
+			"properties": {
+				"generatedAt": "2026-07-02T12:00:00Z",
+				"periods": [{
+					"startTime": "2026-07-02T12:00:00Z",
+					"temperature": 77,
+					"temperatureUnit": "F",
+					"windSpeed": "10 mph",
+					"shortForecast": "Partly Sunny"
+				}]
+			}
+		}`))
+	})
+	mux.HandleFunc("/daily", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{
+			"properties": {
+				"generatedAt": "2026-07-02T12:00:00Z",
+				"periods": [
+					{"name": "Today", "startTime": "2026-07-02T06:00:00Z", "isDaytime": true, "temperature": 82, "temperatureUnit": "F", "shortForecast": "Mostly Sunny"},
+					{"name": "Tonight", "startTime": "2026-07-02T18:00:00Z", "isDaytime": false, "temperature": 68, "temperatureUnit": "F", "shortForecast": "Clear"}
+				]
+			}
+		}`))
+	})
+
+	got := ForecastText(40.7128, -74.0060)
+	for _, want := range []string{
+		"Weather for New York, NY.",
+		"Freshness/source: source National Weather Service",
+		"Current conditions observed at 2026-07-02 12:00 UTC.",
+		"Now: 25°C, feels 25°C, Partly Sunny",
+		"wind 16 km/h",
+		"Thursday, 2 July 2026 (2026-07-02): 20–28°C, Mostly Sunny",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("ForecastText NWS fallback missing %q in:\n%s", want, got)
+		}
+	}
+}
+
+func restoreNWSBaseURL(t *testing.T, value string) {
+	t.Helper()
+	old := nwsBaseURL
+	nwsBaseURL = value
+	t.Cleanup(func() { nwsBaseURL = old })
 }
 
 func TestCardHTMLShowsWeatherUnavailableOnFetchFailure(t *testing.T) {


### PR DESCRIPTION
Restores live weather-backed agent answers by adding a National Weather Service fallback when Google Weather is not configured or cannot serve the request, while preserving explicit unavailable fallbacks. Adds tests for the NWS-backed path and unavailable-provider path.

Closes #992
Closes #994