### PR TITLE
Avoid false weather unavailable fallback

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -886,6 +886,20 @@ func TestCompleteToolAnswerNamesUnavailableSlices(t *testing.T) {
 	}
 }
 
+func TestCompleteToolAnswerPrefersSuccessfulWeatherOverUnavailableMarker(t *testing.T) {
+	rag := []string{
+		"### weather_forecast\nWeather for New York.\nNow: 21°C, partly cloudy.\nFreshness/source: Google Weather; generated at 2026-07-02 12:00 UTC.",
+		"### weather_forecast\n" + unavailableToolMessage("weather_forecast"),
+	}
+	got := completeToolAnswer("I'll check the weather now.", rag)
+	if !strings.Contains(got, "Now: 21°C, partly cloudy") {
+		t.Fatalf("expected successful weather result in fallback, got %q", got)
+	}
+	if strings.Contains(got, "Unavailable: weather_forecast") || strings.Contains(got, "Unavailable: weather") {
+		t.Fatalf("did not expect unavailable weather disclosure when weather data is usable, got %q", got)
+	}
+}
+
 func TestCompleteToolAnswerUsesAvailableWebWhenNewsUnavailable(t *testing.T) {
 	rag := []string{
 		"### news\n" + unavailableToolMessage("news"),

--- a/agent/answer_guard.go
+++ b/agent/answer_guard.go
@@ -27,18 +27,26 @@ func completeToolAnswer(answer string, ragParts []string) string {
 func synthesizeToolFallback(ragParts []string) string {
 	var sections []string
 	var unavailable []string
+	available := map[string]bool{}
 	for _, part := range ragParts {
 		title, body := splitRAGPart(part)
-		if body == "" {
-			continue
-		}
-		if isUnavailableToolResult(body) {
-			unavailable = append(unavailable, title)
+		if body == "" || isUnavailableToolResult(body) {
 			continue
 		}
 		if section := formatFallbackSection(title, body); section != "" {
 			sections = append(sections, section)
+			available[canonicalToolTitle(title)] = true
 		}
+	}
+	for _, part := range ragParts {
+		title, body := splitRAGPart(part)
+		if body == "" || !isUnavailableToolResult(body) {
+			continue
+		}
+		if available[canonicalToolTitle(title)] {
+			continue
+		}
+		unavailable = append(unavailable, title)
 	}
 
 	var b strings.Builder
@@ -253,4 +261,15 @@ func isRawToolPayloadAnswer(answer string) bool {
 		}
 	}
 	return matches >= 2
+}
+
+func canonicalToolTitle(title string) string {
+	switch strings.TrimSpace(title) {
+	case "weather_forecast":
+		return "weather"
+	case "news_search", "news_headlines", "news_read":
+		return "news"
+	default:
+		return strings.TrimSpace(title)
+	}
 }


### PR DESCRIPTION
## Summary
- Prefer successful weather tool context over stale unavailable markers when synthesizing fallback answers.
- Add regression coverage for weather results that arrive alongside an unavailable marker.

Closes #997
Closes #1000

## Testing
- go build ./...
- go test ./... -short
- go vet ./...