### PR TITLE
Keep usable weather forecasts available

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -900,6 +900,19 @@ func TestCompleteToolAnswerPrefersSuccessfulWeatherOverUnavailableMarker(t *test
 	}
 }
 
+func TestCompleteToolAnswerKeepsUsableWeatherWithInlineUnavailableMarker(t *testing.T) {
+	rag := []string{
+		"### weather_forecast\nWeather for New York today.\nNow: 21°C, partly cloudy.\nForecast: Thu 2026-07-02: high 24°C, low 18°C.\nFreshness/source: Google Weather; generated at 2026-07-02 12:00 UTC.\nUnavailable: weather_forecast.",
+	}
+	got := completeToolAnswer("I'll check the weather now.", rag)
+	if !strings.Contains(got, "Weather for New York today") || !strings.Contains(got, "Freshness/source: Google Weather") {
+		t.Fatalf("expected usable weather and freshness details in fallback, got %q", got)
+	}
+	if strings.Contains(got, "Unavailable: weather_forecast") || strings.Contains(got, "Unavailable: weather") {
+		t.Fatalf("did not expect inline unavailable marker when weather data is usable, got %q", got)
+	}
+}
+
 func TestCompleteToolAnswerUsesAvailableWebWhenNewsUnavailable(t *testing.T) {
 	rag := []string{
 		"### news\n" + unavailableToolMessage("news"),

--- a/agent/answer_guard.go
+++ b/agent/answer_guard.go
@@ -111,7 +111,7 @@ func meaningfulLines(body string, limit int) []string {
 			continue
 		}
 		line = strings.TrimLeft(line, "-• ")
-		if line == "" || isFallbackMetadataLine(line) {
+		if line == "" || isFallbackMetadataLine(line) || isUnavailableLine(line) {
 			continue
 		}
 		if len([]rune(line)) > 280 {
@@ -142,7 +142,23 @@ func isFallbackMetadataLine(line string) bool {
 }
 
 func isUnavailableToolResult(body string) bool {
-	lower := strings.ToLower(strings.TrimSpace(body))
+	hasUnavailable := false
+	for _, raw := range strings.Split(body, "\n") {
+		line := strings.TrimSpace(strings.TrimLeft(raw, "-• "))
+		if line == "" || isFallbackMetadataLine(line) {
+			continue
+		}
+		if isUnavailableLine(line) {
+			hasUnavailable = true
+			continue
+		}
+		return false
+	}
+	return hasUnavailable
+}
+
+func isUnavailableLine(line string) bool {
+	lower := strings.ToLower(strings.TrimSpace(line))
 	unavailablePhrases := []string{
 		"unavailable",
 		"no news available",


### PR DESCRIPTION
## Summary
- Keep mixed weather fallback payloads available when they contain usable forecast lines plus an inline unavailable marker.
- Filter unavailable-marker lines out of synthesized fallback bullets so source/freshness and forecast details remain visible.
- Add regression coverage for usable New York weather payloads with inline unavailable text.

Closes #1003
Closes #1005

## Testing
- go test ./agent -run 'TestCompleteToolAnswer' -count=1\n- go build ./...\n- go test ./... -short\n- go vet ./...