### PR TITLE
Polish news web fallback answers

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -936,6 +936,50 @@ Sources:
 	}
 }
 
+func TestCompleteToolAnswerPolishesNewsWebFallback(t *testing.T) {
+	rag := []string{
+		"### news_search\n" + unavailableToolMessage("news_search"),
+		`### web_search
+Current date context: request date is 2026-07-02 UTC.
+Search results for "AI news":
+Grounding rule: only use source-backed snippets.
+Query intent: answer the user's original query "AI news"; do not replace it with a broader or different meaning.
+Confidence: high — synthesize only what the listed sources support.
+Sources:
+1. AI lab releases new model — Company announced a new assistant release. (https://example.com/ai-model)
+2. Chip supplier expands AI capacity — Demand for AI chips is rising. (https://example.com/ai-chips)`,
+	}
+
+	got := completeToolAnswer("Let me search the web for more AI stories to round this out.", rag)
+	for _, internal := range []string{"Grounding rule:", "Query intent:", "Search results for", "Confidence:", "Sources:"} {
+		if strings.Contains(got, internal) {
+			t.Fatalf("expected polished fallback to hide %q, got %q", internal, got)
+		}
+	}
+	if !strings.Contains(got, "**Web sources**") || !strings.Contains(got, "AI lab releases new model") || !strings.Contains(got, "https://example.com/ai-model") {
+		t.Fatalf("expected concise source-backed web summary, got %q", got)
+	}
+	if !strings.Contains(got, "Unavailable: news_search.") {
+		t.Fatalf("expected human-readable unavailable news disclosure, got %q", got)
+	}
+}
+
+func TestCompleteToolAnswerDisclosesLimitedWebEvidence(t *testing.T) {
+	rag := []string{
+		`### web_search
+Confidence: low — generic category pages only.
+1. AI category page — A broad archive of AI articles. (https://example.com/ai)`,
+	}
+
+	got := completeToolAnswer("I'll search the web.", rag)
+	if !strings.Contains(got, "limited source-backed evidence") {
+		t.Fatalf("expected limited-evidence disclosure, got %q", got)
+	}
+	if !strings.Contains(got, "AI category page") {
+		t.Fatalf("expected available web result to remain visible, got %q", got)
+	}
+}
+
 func TestCompleteToolAnswerReplacesRawMixedSourcePayload(t *testing.T) {
 	rag := []string{
 		`### blog_list

--- a/agent/answer_guard.go
+++ b/agent/answer_guard.go
@@ -87,6 +87,10 @@ func splitRAGPart(part string) (string, string) {
 }
 
 func formatFallbackSection(title, body string) string {
+	if canonicalToolTitle(title) == "web_search" {
+		return formatWebSearchFallbackSection(body)
+	}
+
 	lines := meaningfulLines(body, 6)
 	if len(lines) == 0 {
 		return ""
@@ -103,6 +107,36 @@ func formatFallbackSection(title, body string) string {
 	return strings.TrimSpace(b.String())
 }
 
+func formatWebSearchFallbackSection(body string) string {
+	lines := meaningfulLines(body, 4)
+	if len(lines) == 0 {
+		return ""
+	}
+
+	limited := hasLowConfidenceWebEvidence(body)
+	var b strings.Builder
+	b.WriteString("**Web sources**\n")
+	if limited {
+		b.WriteString("- The available web results do not clearly prove a complete answer; here is the limited source-backed evidence I found.\n")
+	}
+	for _, line := range lines {
+		b.WriteString("- ")
+		b.WriteString(line)
+		b.WriteString("\n")
+	}
+	return strings.TrimSpace(b.String())
+}
+
+func hasLowConfidenceWebEvidence(body string) bool {
+	for _, raw := range strings.Split(body, "\n") {
+		lower := strings.ToLower(strings.TrimSpace(raw))
+		if strings.HasPrefix(lower, "confidence:") && (strings.Contains(lower, "low") || strings.Contains(lower, "limited")) {
+			return true
+		}
+	}
+	return false
+}
+
 func meaningfulLines(body string, limit int) []string {
 	var lines []string
 	for _, raw := range strings.Split(body, "\n") {
@@ -111,7 +145,7 @@ func meaningfulLines(body string, limit int) []string {
 			continue
 		}
 		line = strings.TrimLeft(line, "-• ")
-		if line == "" || isFallbackMetadataLine(line) || isUnavailableLine(line) {
+		if line == "" || isFallbackMetadataLine(line) || isUnavailableLine(line) || isSearchResultHeading(line) {
 			continue
 		}
 		if len([]rune(line)) > 280 {
@@ -126,12 +160,19 @@ func meaningfulLines(body string, limit int) []string {
 	return lines
 }
 
+func isSearchResultHeading(line string) bool {
+	lower := strings.ToLower(strings.TrimSpace(line))
+	return strings.HasPrefix(lower, "search results for ") || lower == "search results:" || strings.HasPrefix(lower, "web results for ")
+}
+
 func isFallbackMetadataLine(line string) bool {
 	lower := strings.ToLower(strings.TrimSpace(line))
 	prefixes := []string{
 		"query intent:",
 		"confidence:",
 		"sources:",
+		"current date context:",
+		"grounding rule:",
 	}
 	for _, prefix := range prefixes {
 		if strings.HasPrefix(lower, prefix) {
@@ -285,6 +326,8 @@ func canonicalToolTitle(title string) string {
 		return "weather"
 	case "news_search", "news_headlines", "news_read":
 		return "news"
+	case "web_search":
+		return "web_search"
 	default:
 		return strings.TrimSpace(title)
 	}


### PR DESCRIPTION
## Summary
- Hide internal web-search scaffolding from news fallback answers.
- Present web fallback sources as concise, source-backed bullets.
- Disclose limited web evidence when fallback confidence is low.

Closes #998
Closes #1009

## Verification
- go build ./...
- go test ./... -short
- go vet ./...