### PR TITLE
Polish agent answer fallbacks

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1069,7 +1069,7 @@ func handleQuery(w http.ResponseWriter, r *http.Request) {
 	} else {
 		synthSystem = "You are a helpful assistant. Today's date is " + today + ". " +
 			"The tool results below come from live data feeds. For prompts about today, latest, current, or now, anchor the answer to the current date above; do not label today as a different date unless a provider timestamp explicitly proves staleness, and disclose that staleness. Use article publication dates when reasoning about recency. For weather, use the dated forecast rows exactly and never invent calendar dates or weekdays; if the date is ambiguous or absent, say so.\n\n" +
-			"Answer the user's question using the tool results provided below.\n\n" +
+			"Answer the user's question directly, as user-facing prose. Start with the answer, not with process narration such as \"Here's what I found\" or \"Based on the tool results\". Do not use internal tool names or implementation headings like weather_forecast, markets, or Web sources in the primary answer; translate them to natural labels only when needed. Preserve useful freshness, source, provider-unavailable, and link details.\n\n" +
 			"For web_search results, preserve the user's query intent exactly, cite the listed source URLs, and if confidence is low say the results do not clearly support the requested answer and ask for a refinement.\n\n" +
 			"For news results, include the article URL next to each headline whenever the tool result provides one; if a headline has no URL, do not invent one.\n\n" +
 			"IMPORTANT: For any prices, market values, weather conditions, or other real-time data, you MUST use " +

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -855,7 +855,7 @@ func TestCompleteToolAnswerReplacesProgressOnlyWithResults(t *testing.T) {
 	if strings.Contains(strings.ToLower(got), "couldn't synthesize") {
 		t.Fatalf("expected synthesized fallback instead of generic incomplete-answer copy, got %q", got)
 	}
-	if !strings.Contains(got, "**markets**") || !strings.Contains(got, "BTC: $100,000") || !strings.Contains(got, "**news**") || !strings.Contains(got, "Bitcoin reaches new high") {
+	if !strings.Contains(got, "**markets**") || !strings.Contains(got, "BTC: $100,000") || !strings.Contains(got, "**news**") || !strings.Contains(got, "Bitcoin reaches new high") || strings.Contains(got, "Here's what I found") {
 		t.Fatalf("expected fallback to include organized tool results, got %q", got)
 	}
 }
@@ -881,7 +881,7 @@ func TestCompleteToolAnswerNamesUnavailableSlices(t *testing.T) {
 	if !strings.Contains(got, "Useful headline") {
 		t.Fatalf("expected available slice in fallback, got %q", got)
 	}
-	if !strings.Contains(got, "Unavailable: weather.") {
+	if !strings.Contains(got, "Unavailable right now: weather.") {
 		t.Fatalf("expected unavailable slice to be named clearly, got %q", got)
 	}
 }
@@ -931,7 +931,7 @@ Sources:
 	if !strings.Contains(got, "AI lab releases new model") || !strings.Contains(got, "https://example.com/ai-model") {
 		t.Fatalf("expected available web sources in fallback, got %q", got)
 	}
-	if !strings.Contains(got, "Unavailable: news.") {
+	if !strings.Contains(got, "Unavailable right now: news.") {
 		t.Fatalf("expected unavailable news disclosure, got %q", got)
 	}
 }
@@ -956,10 +956,10 @@ Sources:
 			t.Fatalf("expected polished fallback to hide %q, got %q", internal, got)
 		}
 	}
-	if !strings.Contains(got, "**Web sources**") || !strings.Contains(got, "AI lab releases new model") || !strings.Contains(got, "https://example.com/ai-model") {
+	if strings.Contains(got, "**Web sources**") || !strings.Contains(got, "AI lab releases new model") || !strings.Contains(got, "https://example.com/ai-model") {
 		t.Fatalf("expected concise source-backed web summary, got %q", got)
 	}
-	if !strings.Contains(got, "Unavailable: news_search.") {
+	if !strings.Contains(got, "Unavailable right now: news.") {
 		t.Fatalf("expected human-readable unavailable news disclosure, got %q", got)
 	}
 }
@@ -1000,7 +1000,7 @@ Sources:
 	if !strings.Contains(got, "Mu daily note") || !strings.Contains(got, "https://example.com/agents") {
 		t.Fatalf("expected available mixed-source context in fallback, got %q", got)
 	}
-	if !strings.Contains(got, "Unavailable: social.") {
+	if !strings.Contains(got, "Unavailable right now: social.") {
 		t.Fatalf("expected unavailable source disclosure, got %q", got)
 	}
 }

--- a/agent/answer_guard.go
+++ b/agent/answer_guard.go
@@ -51,7 +51,6 @@ func synthesizeToolFallback(ragParts []string) string {
 
 	var b strings.Builder
 	if len(sections) > 0 {
-		b.WriteString("Here's what I found from the live results:\n\n")
 		b.WriteString(strings.Join(sections, "\n\n"))
 	} else {
 		b.WriteString("I checked the live sources, but the requested data is unavailable right now.")
@@ -60,8 +59,8 @@ func synthesizeToolFallback(ragParts []string) string {
 		if b.Len() > 0 {
 			b.WriteString("\n\n")
 		}
-		b.WriteString("Unavailable: ")
-		b.WriteString(strings.Join(unavailable, ", "))
+		b.WriteString("Unavailable right now: ")
+		b.WriteString(strings.Join(readableToolNames(unavailable), ", "))
 		b.WriteString(".")
 	}
 	return b.String()
@@ -96,9 +95,11 @@ func formatFallbackSection(title, body string) string {
 		return ""
 	}
 	var b strings.Builder
-	b.WriteString("**")
-	b.WriteString(title)
-	b.WriteString("**\n")
+	if shouldShowFallbackHeading(title) {
+		b.WriteString("**")
+		b.WriteString(readableToolName(title))
+		b.WriteString("**\n")
+	}
 	for _, line := range lines {
 		b.WriteString("- ")
 		b.WriteString(line)
@@ -115,7 +116,6 @@ func formatWebSearchFallbackSection(body string) string {
 
 	limited := hasLowConfidenceWebEvidence(body)
 	var b strings.Builder
-	b.WriteString("**Web sources**\n")
 	if limited {
 		b.WriteString("- The available web results do not clearly prove a complete answer; here is the limited source-backed evidence I found.\n")
 	}
@@ -125,6 +125,48 @@ func formatWebSearchFallbackSection(body string) string {
 		b.WriteString("\n")
 	}
 	return strings.TrimSpace(b.String())
+}
+
+func shouldShowFallbackHeading(title string) bool {
+	switch canonicalToolTitle(title) {
+	case "web_search":
+		return false
+	default:
+		return true
+	}
+}
+
+func readableToolNames(names []string) []string {
+	out := make([]string, 0, len(names))
+	for _, name := range names {
+		out = append(out, readableToolName(name))
+	}
+	return out
+}
+
+func readableToolName(name string) string {
+	switch canonicalToolTitle(name) {
+	case "weather":
+		return "weather"
+	case "news":
+		return "news"
+	case "web_search":
+		return "web search"
+	case "markets":
+		return "markets"
+	case "video":
+		return "video"
+	case "blog":
+		return "blog"
+	case "social":
+		return "social"
+	case "places_search", "places_nearby":
+		return "places"
+	case "recall":
+		return "memory"
+	default:
+		return strings.ReplaceAll(strings.TrimSpace(name), "_", " ")
+	}
 }
 
 func hasLowConfidenceWebEvidence(body string) bool {


### PR DESCRIPTION
Polishes agent answer synthesis and fallback formatting so direct user-facing summaries avoid implementation scaffolding while preserving source/freshness and unavailable-provider details.\n\nCloses #1012\nCloses #1014