### PR TITLE
Polish fallback agent answer headings

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -855,8 +855,8 @@ func TestCompleteToolAnswerReplacesProgressOnlyWithResults(t *testing.T) {
 	if strings.Contains(strings.ToLower(got), "couldn't synthesize") {
 		t.Fatalf("expected synthesized fallback instead of generic incomplete-answer copy, got %q", got)
 	}
-	if !strings.Contains(got, "**markets**") || !strings.Contains(got, "BTC: $100,000") || !strings.Contains(got, "**news**") || !strings.Contains(got, "Bitcoin reaches new high") || strings.Contains(got, "Here's what I found") {
-		t.Fatalf("expected fallback to include organized tool results, got %q", got)
+	if strings.Contains(got, "**markets**") || strings.Contains(got, "**news**") || !strings.Contains(got, "BTC: $100,000") || !strings.Contains(got, "Bitcoin reaches new high") || strings.Contains(got, "Here's what I found") {
+		t.Fatalf("expected answer-first fallback to include results without implementation headings, got %q", got)
 	}
 }
 
@@ -1043,8 +1043,8 @@ func TestNativeToolRecorderFeedsProgressFallback(t *testing.T) {
 	if strings.Contains(strings.ToLower(got), "let me pull") {
 		t.Fatalf("expected weather tool payload to replace progress narration, got %q", got)
 	}
-	if !strings.Contains(got, "**weather**") || !strings.Contains(got, "14C") {
-		t.Fatalf("expected fallback to include weather result, got %q", got)
+	if strings.Contains(got, "**weather**") || !strings.Contains(got, "14C") {
+		t.Fatalf("expected fallback to include weather result without an implementation heading, got %q", got)
 	}
 }
 

--- a/agent/answer_guard.go
+++ b/agent/answer_guard.go
@@ -128,12 +128,11 @@ func formatWebSearchFallbackSection(body string) string {
 }
 
 func shouldShowFallbackHeading(title string) bool {
-	switch canonicalToolTitle(title) {
-	case "web_search":
-		return false
-	default:
-		return true
-	}
+	// The fallback answer is shown as the primary response when the model only
+	// produced progress narration or raw tool payloads. Keep it answer-first:
+	// implementation/service labels belong in the References card, not as the
+	// opening line of the user-facing answer.
+	return false
 }
 
 func readableToolNames(names []string) []string {


### PR DESCRIPTION
## Summary
- Keep synthesized fallback answers answer-first by suppressing primary implementation headings; detailed tool/source context remains in references.
- Update fallback tests to assert weather/market/news results remain present without internal headings.

Closes #1012
Closes #1018

## Testing
- go build ./...
- go test ./... -short
- go vet ./...