### PR TITLE
Keep fallback answers answer-first

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -964,6 +964,40 @@ Sources:
 	}
 }
 
+func TestCompleteToolAnswerMovesMarketsFreshnessAfterPrices(t *testing.T) {
+	rag := []string{`### markets
+Last refresh: 2026-07-03 12:00 UTC.
+Disclosure: market data may be stale.
+Live crypto prices:
+BTC: $97000.00 (+1.23% 24h)
+ETH: $3500.00 (-0.42% 24h)`}
+	got := completeToolAnswer("Let me pull the latest market data.", rag)
+	btc := strings.Index(got, "BTC: $97000.00")
+	freshness := strings.Index(got, "Last refresh:")
+	if btc < 0 || freshness < 0 || freshness < btc {
+		t.Fatalf("expected market fallback to lead with prices and keep freshness later, got %q", got)
+	}
+	if strings.HasPrefix(got, "- Last refresh:") {
+		t.Fatalf("expected first bullet to answer the market prompt, got %q", got)
+	}
+}
+
+func TestCompleteToolAnswerRemovesWebResultNumbering(t *testing.T) {
+	rag := []string{`### news_search
+` + unavailableToolMessage("news_search"), `### web_search
+Search results for "AI news":
+Sources:
+1. AI lab releases new model — Company announced a new assistant release. (https://example.com/ai-model)
+2. Chip supplier expands AI capacity — Demand for AI chips is rising. (https://example.com/ai-chips)`}
+	got := completeToolAnswer("Let me search the web for more AI stories.", rag)
+	if strings.Contains(got, "- 1. AI lab") || strings.Contains(got, "- 2. Chip") {
+		t.Fatalf("expected web fallback to read like synthesized bullets, not numbered search results, got %q", got)
+	}
+	if !strings.Contains(got, "- AI lab releases new model") || !strings.Contains(got, "Unavailable right now: news.") {
+		t.Fatalf("expected concise source-backed bullets and unavailable disclosure, got %q", got)
+	}
+}
+
 func TestCompleteToolAnswerDisclosesLimitedWebEvidence(t *testing.T) {
 	rag := []string{
 		`### web_search

--- a/agent/answer_guard.go
+++ b/agent/answer_guard.go
@@ -1,6 +1,9 @@
 package agent
 
-import "strings"
+import (
+	"regexp"
+	"strings"
+)
 
 func unavailableToolMessage(tool string) string {
 	name := strings.TrimSpace(tool)
@@ -179,7 +182,8 @@ func hasLowConfidenceWebEvidence(body string) bool {
 }
 
 func meaningfulLines(body string, limit int) []string {
-	var lines []string
+	var primary []string
+	var context []string
 	for _, raw := range strings.Split(body, "\n") {
 		line := strings.TrimSpace(raw)
 		if line == "" {
@@ -189,16 +193,51 @@ func meaningfulLines(body string, limit int) []string {
 		if line == "" || isFallbackMetadataLine(line) || isUnavailableLine(line) || isSearchResultHeading(line) {
 			continue
 		}
+		line = cleanFallbackLine(line)
+		if line == "" {
+			continue
+		}
 		if len([]rune(line)) > 280 {
 			r := []rune(line)
 			line = string(r[:280]) + "…"
 		}
-		lines = append(lines, line)
-		if len(lines) >= limit {
-			break
+		if isFallbackSecondaryContextLine(line) {
+			context = append(context, line)
+		} else {
+			primary = append(primary, line)
 		}
 	}
+
+	lines := append(primary, context...)
+	if len(lines) > limit {
+		lines = lines[:limit]
+	}
 	return lines
+}
+
+var fallbackOrdinalPrefix = regexp.MustCompile(`^\d+[.)]\s+`)
+
+func cleanFallbackLine(line string) string {
+	return strings.TrimSpace(fallbackOrdinalPrefix.ReplaceAllString(line, ""))
+}
+
+func isFallbackSecondaryContextLine(line string) bool {
+	lower := strings.ToLower(strings.TrimSpace(line))
+	prefixes := []string{
+		"freshness/source:",
+		"last refresh:",
+		"generated at ",
+		"source:",
+		"sources:",
+		"disclosure:",
+		"request date:",
+	}
+	for _, prefix := range prefixes {
+		if strings.HasPrefix(lower, prefix) {
+			return true
+		}
+	}
+	return false
 }
 
 func isSearchResultHeading(line string) bool {


### PR DESCRIPTION
Refines tool-backed fallback answers so market, weather, and web-news fallbacks lead with the direct answer while preserving freshness/source and unavailable-provider context as secondary details.

Closes #1021
Closes #1023