### PR TITLE
Keep fallback answers result-first

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -964,6 +964,43 @@ Sources:
 	}
 }
 
+func TestCompleteToolAnswerLeadsWeatherWithCurrentCondition(t *testing.T) {
+	rag := []string{`### weather_forecast
+Current request date: Friday, 3 July 2026 (2026-07-03, UTC).
+Weather for New York today.
+Now: 32°C, clear.
+Forecast: Fri 2026-07-03: high 33°C, low 24°C.
+Freshness/source: Google Weather; generated at 2026-07-03 12:00 UTC.`}
+	got := completeToolAnswer("I'll check the weather now.", rag)
+	firstLine, _, _ := strings.Cut(got, "\n")
+	if !strings.Contains(firstLine, "Now: 32°C, clear") {
+		t.Fatalf("expected weather fallback to lead with current conditions, got %q", got)
+	}
+	if !strings.Contains(got, "Weather for New York today") || !strings.Contains(got, "Freshness/source: Google Weather") {
+		t.Fatalf("expected location and freshness context to remain below the answer, got %q", got)
+	}
+	if strings.Contains(firstLine, "Current request date:") || strings.Contains(firstLine, "Freshness/source:") {
+		t.Fatalf("expected operational context below current condition, got %q", got)
+	}
+}
+
+func TestCompleteToolAnswerSkipsMarketSectionLabels(t *testing.T) {
+	rag := []string{`### markets
+Current request date: Friday, 3 July 2026 (2026-07-03, UTC).
+Live crypto prices:
+BTC: $97000.00 (+1.23% 24h)
+ETH: $3500.00 (-0.42% 24h)
+Last refresh: 2026-07-03 12:00 UTC.`}
+	got := completeToolAnswer("Let me pull the latest market data.", rag)
+	firstLine, _, _ := strings.Cut(got, "\n")
+	if !strings.Contains(firstLine, "BTC: $97000.00") {
+		t.Fatalf("expected market fallback to lead with prices, got %q", got)
+	}
+	if strings.Contains(got, "Live crypto prices:") || strings.Contains(firstLine, "Current request date:") {
+		t.Fatalf("expected market section labels and request context not to lead, got %q", got)
+	}
+}
+
 func TestCompleteToolAnswerMovesMarketsFreshnessAfterPrices(t *testing.T) {
 	rag := []string{`### markets
 Last refresh: 2026-07-03 12:00 UTC.

--- a/agent/answer_guard.go
+++ b/agent/answer_guard.go
@@ -89,11 +89,15 @@ func splitRAGPart(part string) (string, string) {
 }
 
 func formatFallbackSection(title, body string) string {
-	if canonicalToolTitle(title) == "web_search" {
+	canonical := canonicalToolTitle(title)
+	if canonical == "web_search" {
 		return formatWebSearchFallbackSection(body)
 	}
 
 	lines := meaningfulLines(body, 6)
+	if canonical == "weather" {
+		lines = prioritizeCurrentWeatherLines(lines)
+	}
 	if len(lines) == 0 {
 		return ""
 	}
@@ -190,7 +194,7 @@ func meaningfulLines(body string, limit int) []string {
 			continue
 		}
 		line = strings.TrimLeft(line, "-• ")
-		if line == "" || isFallbackMetadataLine(line) || isUnavailableLine(line) || isSearchResultHeading(line) {
+		if line == "" || isFallbackMetadataLine(line) || isUnavailableLine(line) || isSearchResultHeading(line) || isFallbackSectionLabel(line) {
 			continue
 		}
 		line = cleanFallbackLine(line)
@@ -221,6 +225,26 @@ func cleanFallbackLine(line string) string {
 	return strings.TrimSpace(fallbackOrdinalPrefix.ReplaceAllString(line, ""))
 }
 
+func prioritizeCurrentWeatherLines(lines []string) []string {
+	if len(lines) < 2 {
+		return lines
+	}
+	out := make([]string, 0, len(lines))
+	used := make([]bool, len(lines))
+	for i, line := range lines {
+		if strings.HasPrefix(strings.ToLower(strings.TrimSpace(line)), "now:") {
+			out = append(out, line)
+			used[i] = true
+		}
+	}
+	for i, line := range lines {
+		if !used[i] {
+			out = append(out, line)
+		}
+	}
+	return out
+}
+
 func isFallbackSecondaryContextLine(line string) bool {
 	lower := strings.ToLower(strings.TrimSpace(line))
 	prefixes := []string{
@@ -245,6 +269,21 @@ func isSearchResultHeading(line string) bool {
 	return strings.HasPrefix(lower, "search results for ") || lower == "search results:" || strings.HasPrefix(lower, "web results for ")
 }
 
+func isFallbackSectionLabel(line string) bool {
+	lower := strings.ToLower(strings.TrimSpace(line))
+	labels := []string{
+		"live crypto prices:",
+		"latest news:",
+		"news results:",
+	}
+	for _, label := range labels {
+		if lower == label {
+			return true
+		}
+	}
+	return false
+}
+
 func isFallbackMetadataLine(line string) bool {
 	lower := strings.ToLower(strings.TrimSpace(line))
 	prefixes := []string{
@@ -252,6 +291,7 @@ func isFallbackMetadataLine(line string) bool {
 		"confidence:",
 		"sources:",
 		"current date context:",
+		"current request date:",
 		"grounding rule:",
 	}
 	for _, prefix := range prefixes {


### PR DESCRIPTION
## Summary
- Keep fallback answers focused on live results before operational context.
- Put current weather conditions first when weather fallback synthesis is used.
- Drop generic market/news section labels so prices and sourced snippets lead.

Closes #1026
Closes #1028

## Testing
- go build ./...
- go test ./... -short
- go vet ./...