### PR TITLE
Keep fallback answers result-first

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -973,8 +973,8 @@ Forecast: Fri 2026-07-03: high 33°C, low 24°C.
 Freshness/source: Google Weather; generated at 2026-07-03 12:00 UTC.`}
 	got := completeToolAnswer("I'll check the weather now.", rag)
 	firstLine, _, _ := strings.Cut(got, "\n")
-	if !strings.Contains(firstLine, "Now: 32°C, clear") {
-		t.Fatalf("expected weather fallback to lead with current conditions, got %q", got)
+	if !strings.Contains(firstLine, "Right now: 32°C, clear; today: Fri 2026-07-03: high 33°C, low 24°C.") {
+		t.Fatalf("expected weather fallback to lead with the current condition and today's forecast, got %q", got)
 	}
 	if !strings.Contains(got, "Weather for New York today") || !strings.Contains(got, "Freshness/source: Google Weather") {
 		t.Fatalf("expected location and freshness context to remain below the answer, got %q", got)
@@ -1029,6 +1029,10 @@ Sources:
 	got := completeToolAnswer("Let me search the web for more AI stories.", rag)
 	if strings.Contains(got, "- 1. AI lab") || strings.Contains(got, "- 2. Chip") {
 		t.Fatalf("expected web fallback to read like synthesized bullets, not numbered search results, got %q", got)
+	}
+	firstLine, _, _ := strings.Cut(got, "\n")
+	if !strings.Contains(firstLine, "source-backed results") || strings.Contains(firstLine, "Search results") {
+		t.Fatalf("expected web fallback to open with concise synthesis, got %q", got)
 	}
 	if !strings.Contains(got, "- AI lab releases new model") || !strings.Contains(got, "Unavailable right now: news.") {
 		t.Fatalf("expected concise source-backed bullets and unavailable disclosure, got %q", got)

--- a/agent/answer_guard.go
+++ b/agent/answer_guard.go
@@ -97,6 +97,9 @@ func formatFallbackSection(title, body string) string {
 	lines := meaningfulLines(body, 6)
 	if canonical == "weather" {
 		lines = prioritizeCurrentWeatherLines(lines)
+		if summary := weatherAnswerLead(lines); summary != "" {
+			lines = prependDistinctLine(summary, lines)
+		}
 	}
 	if len(lines) == 0 {
 		return ""
@@ -122,6 +125,11 @@ func formatWebSearchFallbackSection(body string) string {
 	}
 
 	limited := hasLowConfidenceWebEvidence(body)
+	if !limited {
+		if summary := webSearchAnswerLead(lines); summary != "" {
+			lines = prependDistinctLine(summary, lines)
+		}
+	}
 	var b strings.Builder
 	if limited {
 		b.WriteString("- The available web results do not clearly prove a complete answer; here is the limited source-backed evidence I found.\n")
@@ -132,6 +140,69 @@ func formatWebSearchFallbackSection(body string) string {
 		b.WriteString("\n")
 	}
 	return strings.TrimSpace(b.String())
+}
+
+func weatherAnswerLead(lines []string) string {
+	var now, forecast string
+	for _, line := range lines {
+		lower := strings.ToLower(strings.TrimSpace(line))
+		switch {
+		case now == "" && strings.HasPrefix(lower, "now:"):
+			now = strings.TrimSpace(strings.TrimPrefix(line, "Now:"))
+		case forecast == "" && strings.HasPrefix(lower, "forecast:"):
+			forecast = strings.TrimSpace(strings.TrimPrefix(line, "Forecast:"))
+		}
+	}
+	if now == "" {
+		return ""
+	}
+	if forecast != "" {
+		return "Right now: " + trimTrailingSentencePunctuation(now) + "; today: " + trimTrailingSentencePunctuation(forecast) + "."
+	}
+	return "Right now: " + trimTrailingSentencePunctuation(now) + "."
+}
+
+func trimTrailingSentencePunctuation(s string) string {
+	return strings.TrimRight(strings.TrimSpace(s), ".")
+}
+
+func webSearchAnswerLead(lines []string) string {
+	if len(lines) < 2 {
+		return ""
+	}
+	first := webSearchStoryTitle(lines[0])
+	second := webSearchStoryTitle(lines[1])
+	if first == "" || second == "" {
+		return ""
+	}
+	return "The source-backed results I found center on " + first + " and " + second + "."
+}
+
+func webSearchStoryTitle(line string) string {
+	line = cleanFallbackLine(line)
+	if title, _, ok := strings.Cut(line, " — "); ok {
+		return strings.TrimSpace(title)
+	}
+	if title, _, ok := strings.Cut(line, " - "); ok {
+		return strings.TrimSpace(title)
+	}
+	return ""
+}
+
+func prependDistinctLine(line string, lines []string) []string {
+	line = strings.TrimSpace(line)
+	if line == "" {
+		return lines
+	}
+	for _, existing := range lines {
+		if strings.EqualFold(strings.TrimSpace(existing), line) {
+			return lines
+		}
+	}
+	out := make([]string, 0, len(lines)+1)
+	out = append(out, line)
+	out = append(out, lines...)
+	return out
 }
 
 func shouldShowFallbackHeading(title string) bool {


### PR DESCRIPTION
## Summary
- Lead weather fallbacks with current conditions and today's forecast before provider/request metadata.
- Lead web-search fallbacks with a concise source-backed synthesis before individual results.
- Strengthen fallback-formatting tests for the issue acceptance criteria.

Closes #1031
Closes #1033

## Testing
- go build ./...
- go test ./... -short
- go vet ./...