### PR TITLE
Keep fallback answers result-first

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -1075,6 +1075,41 @@ Sources:
 	}
 }
 
+func TestCompleteToolAnswerLeadsWeatherWithCurrentConditionsLabel(t *testing.T) {
+	rag := []string{`### weather_forecast
+Current request date: Friday, 3 July 2026 (2026-07-03, UTC).
+Weather for New York today.
+Current conditions: 30°C, sunny.
+Today: high 33°C, low 24°C.
+Provider timestamp: 2026-07-03 12:00 UTC.
+Freshness/source: Google Weather; generated at 2026-07-03 12:00 UTC.`}
+	got := completeToolAnswer("- Observation: Google Weather current conditions are available.\n- Provider timestamp: 2026-07-03 12:00 UTC.", rag)
+	firstLine, _, _ := strings.Cut(got, "\n")
+	if !strings.Contains(firstLine, "Right now: 30°C, sunny; today: high 33°C, low 24°C.") {
+		t.Fatalf("expected weather fallback to use current-conditions/today labels as the answer lead, got %q", got)
+	}
+	if strings.Contains(firstLine, "Observation:") || strings.Contains(firstLine, "Provider timestamp:") {
+		t.Fatalf("expected operational context below current conditions, got %q", got)
+	}
+}
+
+func TestCompleteToolAnswerRepairsGenericSearchResultIntro(t *testing.T) {
+	rag := []string{`### news_search
+` + unavailableToolMessage("news_search"), `### web_search
+Search results for "AI news":
+Sources:
+1. AI lab releases new model — Company announced a new assistant release. (https://example.com/ai-model)
+2. Chip supplier expands AI capacity — Demand for AI chips is rising. (https://example.com/ai-chips)`}
+	got := completeToolAnswer("Here are the search results I found:\n1. AI lab releases new model\n2. Chip supplier expands AI capacity", rag)
+	firstLine, _, _ := strings.Cut(got, "\n")
+	if !strings.Contains(firstLine, "source-backed results") || strings.Contains(firstLine, "Here are") {
+		t.Fatalf("expected generic search-result intro to be repaired into concise synthesis, got %q", got)
+	}
+	if strings.Contains(got, "- 1.") || !strings.Contains(got, "Unavailable right now: news.") {
+		t.Fatalf("expected de-numbered source bullets and unavailable disclosure, got %q", got)
+	}
+}
+
 func TestCompleteToolAnswerDisclosesLimitedWebEvidence(t *testing.T) {
 	rag := []string{
 		`### web_search

--- a/agent/answer_guard.go
+++ b/agent/answer_guard.go
@@ -93,6 +93,9 @@ func hasOperationalFallbackLead(answer string) bool {
 				return true
 			}
 		}
+		if isGenericSearchFallbackIntro(line) {
+			return true
+		}
 		return false
 	}
 	return false
@@ -174,12 +177,16 @@ func formatWebSearchFallbackSection(body string) string {
 func weatherAnswerLead(lines []string) string {
 	var now, forecast string
 	for _, line := range lines {
-		lower := strings.ToLower(strings.TrimSpace(line))
-		switch {
-		case now == "" && strings.HasPrefix(lower, "now:"):
-			now = strings.TrimSpace(strings.TrimPrefix(line, "Now:"))
-		case forecast == "" && strings.HasPrefix(lower, "forecast:"):
-			forecast = strings.TrimSpace(strings.TrimPrefix(line, "Forecast:"))
+		label, value := splitFallbackLabel(line)
+		switch strings.ToLower(label) {
+		case "now", "current", "current conditions", "conditions":
+			if now == "" {
+				now = value
+			}
+		case "forecast", "today", "today's forecast":
+			if forecast == "" {
+				forecast = value
+			}
 		}
 	}
 	if now == "" {
@@ -189,6 +196,14 @@ func weatherAnswerLead(lines []string) string {
 		return "Right now: " + trimTrailingSentencePunctuation(now) + "; today: " + trimTrailingSentencePunctuation(forecast) + "."
 	}
 	return "Right now: " + trimTrailingSentencePunctuation(now) + "."
+}
+
+func splitFallbackLabel(line string) (string, string) {
+	label, value, ok := strings.Cut(strings.TrimSpace(line), ":")
+	if !ok {
+		return "", ""
+	}
+	return strings.TrimSpace(label), strings.TrimSpace(value)
 }
 
 func trimTrailingSentencePunctuation(s string) string {
@@ -332,7 +347,9 @@ func prioritizeCurrentWeatherLines(lines []string) []string {
 	out := make([]string, 0, len(lines))
 	used := make([]bool, len(lines))
 	for i, line := range lines {
-		if strings.HasPrefix(strings.ToLower(strings.TrimSpace(line)), "now:") {
+		label, _ := splitFallbackLabel(line)
+		switch strings.ToLower(label) {
+		case "now", "current", "current conditions", "conditions":
 			out = append(out, line)
 			used[i] = true
 		}
@@ -367,6 +384,14 @@ func isFallbackSecondaryContextLine(line string) bool {
 func isSearchResultHeading(line string) bool {
 	lower := strings.ToLower(strings.TrimSpace(line))
 	return strings.HasPrefix(lower, "search results for ") || lower == "search results:" || strings.HasPrefix(lower, "web results for ")
+}
+
+func isGenericSearchFallbackIntro(line string) bool {
+	lower := strings.ToLower(strings.TrimSpace(line))
+	return strings.HasPrefix(lower, "here are the search results") ||
+		strings.HasPrefix(lower, "here are some search results") ||
+		strings.HasPrefix(lower, "i found these search results") ||
+		strings.HasPrefix(lower, "these search results")
 }
 
 func isFallbackSectionLabel(line string) bool {


### PR DESCRIPTION
## Summary
- Keep fallback repair active for generic search-result intros so AI-news web fallbacks open with synthesis instead of search-result phrasing.
- Treat weather `Current conditions:` / `Today:` labels as primary answer data so weather fallbacks lead with conditions and forecast before operational metadata.
- Add regression coverage for both deployed fallback shapes.

Closes #1043
Closes #1045

## Testing
- go build ./...
- go test ./... -short
- go vet ./...