### PR TITLE
Polish fallback answer leads

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -990,9 +990,9 @@ Search results for "AI news":
 Sources:
 1. AI lab releases new model — Company announced a new assistant release. (https://example.com/ai-model)
 2. Chip supplier expands AI capacity — Demand for AI chips is rising. (https://example.com/ai-chips)`}
-	got := completeToolAnswer("Search results for AI news:\n1. AI lab releases new model", rag)
+	got := completeToolAnswer("Search results for Top results:\n1. AI lab releases new model", rag)
 	firstLine, _, _ := strings.Cut(got, "\n")
-	if !strings.Contains(firstLine, "source-backed results") || strings.Contains(firstLine, "Search results") {
+	if !strings.Contains(firstLine, "Top results:") || strings.Contains(firstLine, "Search results") {
 		t.Fatalf("expected search-result lead to be repaired into concise synthesis, got %q", got)
 	}
 	if !strings.Contains(got, "Unavailable right now: news.") {
@@ -1017,6 +1017,24 @@ Freshness/source: Google Weather; generated at 2026-07-03 12:00 UTC.`}
 	}
 	if strings.Contains(firstLine, "Current request date:") || strings.Contains(firstLine, "Freshness/source:") {
 		t.Fatalf("expected operational context below current condition, got %q", got)
+	}
+}
+
+func TestCompleteToolAnswerLeadsWeatherWithTemperatureLabel(t *testing.T) {
+	rag := []string{`### weather_forecast
+Weather for New York today.
+Observation: Google Weather current conditions are available.
+Temperature: 30°C, sunny.
+Today: high 33°C, low 24°C.
+Provider: Google Weather.
+Provider timestamp: 2026-07-03 12:00 UTC.`}
+	got := completeToolAnswer("- Provider: Google Weather.\n- Provider timestamp: 2026-07-03 12:00 UTC.", rag)
+	firstLine, _, _ := strings.Cut(got, "\n")
+	if !strings.Contains(firstLine, "Right now: 30°C, sunny; today: high 33°C, low 24°C.") {
+		t.Fatalf("expected temperature-labelled weather to lead with current conditions, got %q", got)
+	}
+	if strings.Contains(firstLine, "Provider:") || strings.Contains(firstLine, "Provider timestamp:") || strings.Contains(firstLine, "Observation:") {
+		t.Fatalf("expected provider metadata below the answer, got %q", got)
 	}
 }
 
@@ -1067,7 +1085,7 @@ Sources:
 		t.Fatalf("expected web fallback to read like synthesized bullets, not numbered search results, got %q", got)
 	}
 	firstLine, _, _ := strings.Cut(got, "\n")
-	if !strings.Contains(firstLine, "source-backed results") || strings.Contains(firstLine, "Search results") {
+	if !strings.Contains(firstLine, "Top results:") || strings.Contains(firstLine, "Search results") {
 		t.Fatalf("expected web fallback to open with concise synthesis, got %q", got)
 	}
 	if !strings.Contains(got, "- AI lab releases new model") || !strings.Contains(got, "Unavailable right now: news.") {
@@ -1102,7 +1120,7 @@ Sources:
 2. Chip supplier expands AI capacity — Demand for AI chips is rising. (https://example.com/ai-chips)`}
 	got := completeToolAnswer("Here are the search results I found:\n1. AI lab releases new model\n2. Chip supplier expands AI capacity", rag)
 	firstLine, _, _ := strings.Cut(got, "\n")
-	if !strings.Contains(firstLine, "source-backed results") || strings.Contains(firstLine, "Here are") {
+	if !strings.Contains(firstLine, "Top results:") || strings.Contains(firstLine, "Here are") {
 		t.Fatalf("expected generic search-result intro to be repaired into concise synthesis, got %q", got)
 	}
 	if strings.Contains(got, "- 1.") || !strings.Contains(got, "Unavailable right now: news.") {

--- a/agent/answer_guard.go
+++ b/agent/answer_guard.go
@@ -85,6 +85,7 @@ func hasOperationalFallbackLead(answer string) bool {
 		operationalPrefixes := []string{
 			"observation:",
 			"provider timestamp:",
+			"provider:",
 			"current request date:",
 			"current date context:",
 		}
@@ -179,7 +180,7 @@ func weatherAnswerLead(lines []string) string {
 	for _, line := range lines {
 		label, value := splitFallbackLabel(line)
 		switch strings.ToLower(label) {
-		case "now", "current", "current conditions", "conditions":
+		case "now", "current", "current conditions", "conditions", "temperature":
 			if now == "" {
 				now = value
 			}
@@ -219,7 +220,7 @@ func webSearchAnswerLead(lines []string) string {
 	if first == "" || second == "" {
 		return ""
 	}
-	return "The source-backed results I found center on " + first + " and " + second + "."
+	return "Top results: " + first + "; " + second + "."
 }
 
 func webSearchStoryTitle(line string) string {
@@ -349,7 +350,7 @@ func prioritizeCurrentWeatherLines(lines []string) []string {
 	for i, line := range lines {
 		label, _ := splitFallbackLabel(line)
 		switch strings.ToLower(label) {
-		case "now", "current", "current conditions", "conditions":
+		case "now", "current", "current conditions", "conditions", "temperature":
 			out = append(out, line)
 			used[i] = true
 		}
@@ -418,6 +419,10 @@ func isFallbackMetadataLine(line string) bool {
 		"current date context:",
 		"current request date:",
 		"grounding rule:",
+		"provider timestamp:",
+	}
+	if strings.HasPrefix(lower, "observation:") && !strings.Contains(lower, "°") {
+		return true
 	}
 	for _, prefix := range prefixes {
 		if strings.HasPrefix(lower, prefix) {


### PR DESCRIPTION
## Summary
- Keep weather fallback answers focused on current conditions before provider metadata.
- Make unavailable-news web fallback leads read as concise synthesized results instead of search-result pages.
- Add regression coverage for temperature-labelled weather context and updated web fallback leads.

Closes #1048
Closes #1050

## Testing
- go build ./...
- go test ./... -short
- go vet ./...