### PR TITLE
Polish answer-first fallback ordering

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -1111,6 +1111,23 @@ Freshness/source: Google Weather; generated at 2026-07-03 12:00 UTC.`}
 	}
 }
 
+func TestCompleteToolAnswerTreatsObservationReadingAsCurrentCondition(t *testing.T) {
+	rag := []string{`### weather_forecast
+Weather for New York today.
+Observation: 30°C, sunny.
+Provider timestamp: 2026-07-03 12:00 UTC.
+Today: high 33°C, low 24°C.
+Freshness/source: Google Weather; generated at 2026-07-03 12:00 UTC.`}
+	got := completeToolAnswer("- Observation: 30°C, sunny.\n- Provider timestamp: 2026-07-03 12:00 UTC.", rag)
+	firstLine, _, _ := strings.Cut(got, "\n")
+	if !strings.Contains(firstLine, "Right now: 30°C, sunny; today: high 33°C, low 24°C.") {
+		t.Fatalf("expected observation reading to become the current-condition answer lead, got %q", got)
+	}
+	if strings.Contains(firstLine, "Provider timestamp:") {
+		t.Fatalf("expected provider timestamp below the answer lead, got %q", got)
+	}
+}
+
 func TestCompleteToolAnswerRepairsGenericSearchResultIntro(t *testing.T) {
 	rag := []string{`### news_search
 ` + unavailableToolMessage("news_search"), `### web_search
@@ -1125,6 +1142,28 @@ Sources:
 	}
 	if strings.Contains(got, "- 1.") || !strings.Contains(got, "Unavailable right now: news.") {
 		t.Fatalf("expected de-numbered source bullets and unavailable disclosure, got %q", got)
+	}
+}
+
+func TestCompleteToolAnswerPrefersSnippetBackedNewsOverGenericWebPages(t *testing.T) {
+	rag := []string{`### news_search
+` + unavailableToolMessage("news_search"), `### web_search
+Search results for "AI news":
+Sources:
+1. Artificial Intelligence News — Latest news and headlines about artificial intelligence. (https://example.com/ai-category)
+2. AI archive — Archive of articles about AI. (https://example.com/ai-archive)
+3. AI lab releases new model — Company announced a new assistant release today. (https://example.com/ai-model)
+4. Chip supplier expands AI capacity — Demand for AI chips is rising this week. (https://example.com/ai-chips)`}
+	got := completeToolAnswer("Here are the search results I found.", rag)
+	firstLine, _, _ := strings.Cut(got, "\n")
+	if !strings.Contains(firstLine, "Top results: AI lab releases new model; Chip supplier expands AI capacity.") {
+		t.Fatalf("expected snippet-backed current news to lead over generic web pages, got %q", got)
+	}
+	if strings.Contains(firstLine, "Artificial Intelligence News") || strings.Contains(firstLine, "AI archive") {
+		t.Fatalf("expected generic category pages moved below source-backed stories, got %q", got)
+	}
+	if !strings.Contains(got, "Unavailable right now: news.") {
+		t.Fatalf("expected unavailable news disclosure to remain, got %q", got)
 	}
 }
 

--- a/agent/answer_guard.go
+++ b/agent/answer_guard.go
@@ -153,6 +153,7 @@ func formatFallbackSection(title, body string) string {
 
 func formatWebSearchFallbackSection(body string) string {
 	lines := meaningfulLines(body, 4)
+	lines = prioritizeSnippetBackedWebLines(lines)
 	if len(lines) == 0 {
 		return ""
 	}
@@ -180,7 +181,7 @@ func weatherAnswerLead(lines []string) string {
 	for _, line := range lines {
 		label, value := splitFallbackLabel(line)
 		switch strings.ToLower(label) {
-		case "now", "current", "current conditions", "conditions", "temperature":
+		case "now", "current", "current conditions", "conditions", "temperature", "observation":
 			if now == "" {
 				now = value
 			}
@@ -350,7 +351,7 @@ func prioritizeCurrentWeatherLines(lines []string) []string {
 	for i, line := range lines {
 		label, _ := splitFallbackLabel(line)
 		switch strings.ToLower(label) {
-		case "now", "current", "current conditions", "conditions", "temperature":
+		case "now", "current", "current conditions", "conditions", "temperature", "observation":
 			out = append(out, line)
 			used[i] = true
 		}
@@ -393,6 +394,65 @@ func isGenericSearchFallbackIntro(line string) bool {
 		strings.HasPrefix(lower, "here are some search results") ||
 		strings.HasPrefix(lower, "i found these search results") ||
 		strings.HasPrefix(lower, "these search results")
+}
+
+func prioritizeSnippetBackedWebLines(lines []string) []string {
+	if len(lines) < 2 {
+		return lines
+	}
+	var snippetBacked []string
+	var generic []string
+	for _, line := range lines {
+		if isGenericWebResultLine(line) {
+			generic = append(generic, line)
+			continue
+		}
+		snippetBacked = append(snippetBacked, line)
+	}
+	if len(snippetBacked) >= 2 {
+		return append(snippetBacked, generic...)
+	}
+	return lines
+}
+
+func isGenericWebResultLine(line string) bool {
+	cleaned := strings.ToLower(cleanFallbackLine(line))
+	title, snippet, hasSnippet := strings.Cut(cleaned, " — ")
+	if !hasSnippet {
+		title, snippet, hasSnippet = strings.Cut(cleaned, " - ")
+	}
+	genericTitleTerms := []string{
+		"category",
+		"archive",
+		"tag",
+		"search results",
+		"latest news and headlines",
+		"news &",
+		"artificial intelligence |",
+		"artificial intelligence news",
+	}
+	for _, term := range genericTitleTerms {
+		if strings.Contains(title, term) {
+			return true
+		}
+	}
+	if !hasSnippet {
+		return false
+	}
+	genericSnippetTerms := []string{
+		"articles about",
+		"archive of",
+		"category page",
+		"latest news and headlines",
+		"breaking news, analysis",
+		"coverage of",
+	}
+	for _, term := range genericSnippetTerms {
+		if strings.Contains(snippet, term) {
+			return true
+		}
+	}
+	return false
 }
 
 func isFallbackSectionLabel(line string) bool {


### PR DESCRIPTION
Tightens fallback synthesis so weather observation readings become current-condition answer leads and web fallback answers prefer snippet-backed news over generic category/search pages.

Closes #1053
Closes #1055