### PR TITLE
Keep fallback answers answer-first

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -1038,6 +1038,24 @@ Provider timestamp: 2026-07-03 12:00 UTC.`}
 	}
 }
 
+func TestCompleteToolAnswerRepairsProviderPrefaceWeatherLead(t *testing.T) {
+	rag := []string{`### weather_forecast
+Weather for New York today.
+Provider: Google Weather.
+Provider timestamp: 2026-07-03 12:00 UTC.
+Feels like: 31°C, sunny.
+High: 33°C, low 24°C.
+Freshness/source: Google Weather; generated at 2026-07-03 12:00 UTC.`}
+	got := completeToolAnswer("As of provider timestamp 2026-07-03 12:00 UTC, Google Weather has data for New York.", rag)
+	firstLine, _, _ := strings.Cut(got, "\n")
+	if !strings.Contains(firstLine, "Right now: 31°C, sunny; today: 33°C, low 24°C.") {
+		t.Fatalf("expected provider-prefaced weather answer to be repaired into current conditions, got %q", got)
+	}
+	if strings.Contains(firstLine, "Provider") || strings.Contains(firstLine, "timestamp") {
+		t.Fatalf("expected provider metadata below the answer lead, got %q", got)
+	}
+}
+
 func TestCompleteToolAnswerSkipsMarketSectionLabels(t *testing.T) {
 	rag := []string{`### markets
 Current request date: Friday, 3 July 2026 (2026-07-03, UTC).
@@ -1164,6 +1182,25 @@ Sources:
 	}
 	if !strings.Contains(got, "Unavailable right now: news.") {
 		t.Fatalf("expected unavailable news disclosure to remain, got %q", got)
+	}
+}
+
+func TestCompleteToolAnswerPrefersCurrentStoriesOverOfficialNewsPages(t *testing.T) {
+	rag := []string{`### news_search
+` + unavailableToolMessage("news_search"), `### web_search
+Search results for "AI news":
+Sources:
+1. OpenAI News — Company news and announcements. (https://openai.com/news/)
+2. Artificial Intelligence News — Latest news and headlines about artificial intelligence. (https://example.com/ai-category)
+3. AI safety bill advances — Lawmakers moved the proposal after new model-risk hearings. (https://example.com/ai-bill)
+4. Startup launches healthcare AI tool — The company says hospitals are piloting the assistant this week. (https://example.com/ai-health)`}
+	got := completeToolAnswer("Here are some search results for AI news.", rag)
+	firstLine, _, _ := strings.Cut(got, "\n")
+	if !strings.Contains(firstLine, "Latest source-backed items: AI safety bill advances; Startup launches healthcare AI tool.") {
+		t.Fatalf("expected current story snippets to lead over generic news pages, got %q", got)
+	}
+	if strings.Contains(firstLine, "OpenAI News") || strings.Contains(firstLine, "Artificial Intelligence News") {
+		t.Fatalf("expected generic pages below the answer lead, got %q", got)
 	}
 }
 

--- a/agent/answer_guard.go
+++ b/agent/answer_guard.go
@@ -87,6 +87,9 @@ func hasOperationalFallbackLead(answer string) bool {
 			"current conditions observed",
 			"provider timestamp:",
 			"provider:",
+			"as of provider",
+			"as of the provider",
+			"according to provider",
 			"current request date:",
 			"current date context:",
 		}
@@ -182,11 +185,11 @@ func weatherAnswerLead(lines []string) string {
 	for _, line := range lines {
 		label, value := splitFallbackLabel(line)
 		switch strings.ToLower(label) {
-		case "now", "current", "current conditions", "conditions", "temperature", "observation":
+		case "now", "current", "current conditions", "conditions", "temperature", "observation", "feels like":
 			if now == "" {
 				now = value
 			}
-		case "forecast", "today", "today's forecast":
+		case "forecast", "today", "today's forecast", "high", "daily forecast":
 			if forecast == "" {
 				forecast = value
 			}
@@ -352,7 +355,7 @@ func prioritizeCurrentWeatherLines(lines []string) []string {
 	for i, line := range lines {
 		label, _ := splitFallbackLabel(line)
 		switch strings.ToLower(label) {
-		case "now", "current", "current conditions", "conditions", "temperature", "observation":
+		case "now", "current", "current conditions", "conditions", "temperature", "observation", "feels like":
 			out = append(out, line)
 			used[i] = true
 		}
@@ -375,6 +378,8 @@ func isFallbackSecondaryContextLine(line string) bool {
 		"sources:",
 		"disclosure:",
 		"request date:",
+		"provider:",
+		"provider timestamp:",
 	}
 	for _, prefix := range prefixes {
 		if strings.HasPrefix(lower, prefix) {
@@ -447,6 +452,7 @@ func isGenericWebResultLine(line string) bool {
 		"latest news and headlines",
 		"breaking news, analysis",
 		"coverage of",
+		"company news and announcements",
 	}
 	for _, term := range genericSnippetTerms {
 		if strings.Contains(snippet, term) {
@@ -483,6 +489,9 @@ func isFallbackMetadataLine(line string) bool {
 		"provider timestamp:",
 	}
 	if strings.HasPrefix(lower, "observation:") && !strings.Contains(lower, "°") {
+		return true
+	}
+	if strings.HasPrefix(lower, "provider:") || strings.HasPrefix(lower, "provider timestamp:") {
 		return true
 	}
 	for _, prefix := range prefixes {


### PR DESCRIPTION
Refines fallback synthesis so weather answers recover provider-prefaced responses into current-condition leads, and AI-news web fallbacks prefer current story snippets over generic news/category pages while keeping provider/source context below the answer.

Closes #1063
Closes #1065