### PR TITLE
Polish fallback answer leads

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -1357,3 +1357,39 @@ Sources:
 		t.Fatalf("expected no generic top-results/category-page lead, got %q", got)
 	}
 }
+
+func TestCompleteToolAnswerRepairsObservedAtWeatherLead(t *testing.T) {
+	rag := []string{`### weather_forecast
+Current request date: Friday, 3 July 2026 (2026-07-03, UTC).
+Weather for New York today.
+Current conditions: 30°C, sunny.
+Today: high 33°C, low 24°C.
+Observed at 2026-07-03 12:00 UTC via Google Weather.
+Freshness/source: Google Weather; generated at 2026-07-03 12:00 UTC.`}
+	got := completeToolAnswer("Observed at 2026-07-03 12:00 UTC via Google Weather. Forecast metadata follows.", rag)
+	firstLine, _, _ := strings.Cut(got, "\n")
+	if !strings.Contains(firstLine, "Right now: 30°C, sunny; today: high 33°C, low 24°C.") {
+		t.Fatalf("expected observed-at weather lead to be repaired into current conditions, got %q", got)
+	}
+	if strings.Contains(firstLine, "Observed at") || strings.Contains(firstLine, "Google Weather") {
+		t.Fatalf("expected observation metadata below the answer lead, got %q", got)
+	}
+}
+
+func TestCompleteToolAnswerRepairsTopResultsLead(t *testing.T) {
+	rag := []string{`### news_search
+` + unavailableToolMessage("news_search"), `### web_search
+Search results for "AI news":
+Sources:
+1. Artificial Intelligence News — Latest news and headlines about artificial intelligence. (https://example.com/ai-category)
+2. AI lab releases new model — Company announced a new assistant release today. (https://example.com/ai-model)
+3. Chip supplier expands AI capacity — Demand for AI chips is rising this week. (https://example.com/ai-chips)`}
+	got := completeToolAnswer("Top results:\n1. Artificial Intelligence News\n2. AI lab releases new model", rag)
+	firstLine, _, _ := strings.Cut(got, "\n")
+	if !strings.Contains(firstLine, "Latest source-backed items: AI lab releases new model; Chip supplier expands AI capacity.") {
+		t.Fatalf("expected top-results lead to be repaired into source-backed stories, got %q", got)
+	}
+	if strings.Contains(firstLine, "Top results") || strings.Contains(firstLine, "Artificial Intelligence News") {
+		t.Fatalf("expected generic top-results/category-page lead to move below the direct answer, got %q", got)
+	}
+}

--- a/agent/answer_guard.go
+++ b/agent/answer_guard.go
@@ -84,6 +84,8 @@ func hasOperationalFallbackLead(answer string) bool {
 		}
 		operationalPrefixes := []string{
 			"observation:",
+			"observed at ",
+			"observation time:",
 			"current conditions observed",
 			"provider timestamp:",
 			"provider:",
@@ -391,7 +393,7 @@ func isFallbackSecondaryContextLine(line string) bool {
 
 func isSearchResultHeading(line string) bool {
 	lower := strings.ToLower(strings.TrimSpace(line))
-	return strings.HasPrefix(lower, "search results for ") || lower == "search results:" || strings.HasPrefix(lower, "web results for ")
+	return strings.HasPrefix(lower, "search results for ") || lower == "search results:" || strings.HasPrefix(lower, "web results for ") || strings.HasPrefix(lower, "top results")
 }
 
 func isGenericSearchFallbackIntro(line string) bool {
@@ -489,6 +491,9 @@ func isFallbackMetadataLine(line string) bool {
 		"provider timestamp:",
 	}
 	if strings.HasPrefix(lower, "observation:") && !strings.Contains(lower, "°") {
+		return true
+	}
+	if strings.HasPrefix(lower, "observed at ") || strings.HasPrefix(lower, "observation time:") || strings.HasPrefix(lower, "current conditions observed") {
 		return true
 	}
 	if strings.HasPrefix(lower, "provider:") || strings.HasPrefix(lower, "provider timestamp:") {


### PR DESCRIPTION
Tightens fallback answer repair for the deployed metadata-first cases called out in the queue.

- Treat observed-at/weather observation metadata as operational context so weather fallbacks start with current conditions and today's range.
- Treat `Top results` search leads as repairable so unavailable-news web fallbacks start with source-backed story snippets instead of generic result pages.
- Adds regression coverage for both deployed-style leads.

Closes #1068
Closes #1071