### PR TITLE
Make weather fallback answers answer-first

### DIFF
--- a/weather/agent.go
+++ b/weather/agent.go
@@ -29,24 +29,8 @@ func formatForecastText(wf *WeatherForecast, now time.Time) string {
 
 	now = now.UTC()
 	var sb strings.Builder
-	fmt.Fprintf(&sb, "Current request date: %s.\n", now.Format("Monday, 2 January 2006 (2006-01-02, UTC)"))
-	sb.WriteString("Calendar rule: anchor relative words like today/tomorrow to the request date above, use only the dated forecast rows below, and do not invent dates. If a requested day is not listed, say it is unavailable.\n")
 	if wf.Location != "" {
 		fmt.Fprintf(&sb, "Weather for %s.\n", wf.Location)
-	}
-	source := strings.TrimSpace(wf.Source)
-	if source == "" {
-		source = "weather provider"
-	}
-	generatedAt := wf.GeneratedAt.UTC()
-	if generatedAt.IsZero() {
-		generatedAt = now
-	}
-	fmt.Fprintf(&sb, "Freshness/source: source %s; generated at %s.\n", source, generatedAt.Format("2006-01-02 15:04 UTC"))
-	if wf.ObservedAt.IsZero() {
-		sb.WriteString("Current conditions status: unavailable — provider did not return a current/hourly observation timestamp, so do not present a current-weather claim.\n")
-	} else {
-		fmt.Fprintf(&sb, "Current conditions observed at %s.\n", wf.ObservedAt.UTC().Format("2006-01-02 15:04 UTC"))
 	}
 	if c := wf.Current; c != nil && !wf.ObservedAt.IsZero() {
 		details := []string{fmt.Sprintf("%.0f°C", c.TempC)}
@@ -66,6 +50,30 @@ func formatForecastText(wf *WeatherForecast, now time.Time) string {
 			details = append(details, "some current observations unavailable")
 		}
 		fmt.Fprintf(&sb, "Now: %s.\n", strings.Join(details, ", "))
+	}
+	if len(wf.DailyItems) > 0 {
+		d := wf.DailyItems[0]
+		rain := ""
+		if d.WillRain || d.RainMM > 0 {
+			rain = fmt.Sprintf(", rain %.0fmm", d.RainMM)
+		}
+		fmt.Fprintf(&sb, "Today: %s: %.0f–%.0f°C, %s%s.\n", d.Date.Format("Monday, 2 January 2006 (2006-01-02)"), d.MinTempC, d.MaxTempC, d.Description, rain)
+	}
+	source := strings.TrimSpace(wf.Source)
+	if source == "" {
+		source = "weather provider"
+	}
+	generatedAt := wf.GeneratedAt.UTC()
+	if generatedAt.IsZero() {
+		generatedAt = now
+	}
+	fmt.Fprintf(&sb, "Current request date: %s.\n", now.Format("Monday, 2 January 2006 (2006-01-02, UTC)"))
+	sb.WriteString("Calendar rule: anchor relative words like today/tomorrow to the request date above, use only the dated forecast rows below, and do not invent dates. If a requested day is not listed, say it is unavailable.\n")
+	fmt.Fprintf(&sb, "Freshness/source: source %s; generated at %s.\n", source, generatedAt.Format("2006-01-02 15:04 UTC"))
+	if wf.ObservedAt.IsZero() {
+		sb.WriteString("Current conditions status: unavailable — provider did not return a current/hourly observation timestamp, so do not present a current-weather claim.\n")
+	} else {
+		fmt.Fprintf(&sb, "Current conditions observed at %s.\n", wf.ObservedAt.UTC().Format("2006-01-02 15:04 UTC"))
 	}
 	if len(wf.DailyItems) > 0 {
 		sb.WriteString("Dated daily forecast (provider timestamps):\n")

--- a/weather/weather_test.go
+++ b/weather/weather_test.go
@@ -199,6 +199,16 @@ func TestFormatForecastTextAnchorsDatesToRealCalendarRows(t *testing.T) {
 	}
 
 	got := formatForecastText(wf, time.Date(2026, time.June, 30, 9, 0, 0, 0, time.UTC))
+	firstLine, rest, _ := strings.Cut(got, "\n")
+	if firstLine != "Weather for London." {
+		t.Fatalf("formatForecastText should start with the requested place, got first line %q in:\n%s", firstLine, got)
+	}
+	if !strings.HasPrefix(rest, "Now: 18°C") {
+		t.Fatalf("formatForecastText should put current conditions before metadata, got:\n%s", got)
+	}
+	if strings.Index(got, "Dated daily forecast (provider timestamps):") < strings.Index(got, "Freshness/source:") {
+		t.Fatalf("formatForecastText should keep provider forecast context below answer-first lines, got:\n%s", got)
+	}
 	for _, want := range []string{
 		"Current request date: Tuesday, 30 June 2026 (2026-06-30, UTC).",
 		"Calendar rule: anchor relative words like today/tomorrow to the request date above",


### PR DESCRIPTION
## Summary
- Move weather tool fallback output so the requested location, current conditions, and today's forecast appear before provider/request metadata.
- Keep freshness/source details, dated forecast rows, and unavailable-current-condition guidance below the answer-first lead.
- Add regression coverage for answer-first weather forecast text ordering.

Closes #1074
Closes #1076

## Testing
- go build ./...
- go test ./... -short
- go vet ./...