### PR TITLE
Anchor weather today forecast to request date

### DIFF
--- a/weather/agent.go
+++ b/weather/agent.go
@@ -51,13 +51,14 @@ func formatForecastText(wf *WeatherForecast, now time.Time) string {
 		}
 		fmt.Fprintf(&sb, "Now: %s.\n", strings.Join(details, ", "))
 	}
-	if len(wf.DailyItems) > 0 {
-		d := wf.DailyItems[0]
+	if d, ok := dailyItemForDate(wf.DailyItems, now); ok {
 		rain := ""
 		if d.WillRain || d.RainMM > 0 {
 			rain = fmt.Sprintf(", rain %.0fmm", d.RainMM)
 		}
 		fmt.Fprintf(&sb, "Today: %s: %.0f–%.0f°C, %s%s.\n", d.Date.Format("Monday, 2 January 2006 (2006-01-02)"), d.MinTempC, d.MaxTempC, d.Description, rain)
+	} else if len(wf.DailyItems) > 0 {
+		fmt.Fprintf(&sb, "Today: forecast unavailable for the request date %s.\n", now.Format("Monday, 2 January 2006 (2006-01-02)"))
 	}
 	source := strings.TrimSpace(wf.Source)
 	if source == "" {
@@ -93,6 +94,16 @@ func formatForecastText(wf *WeatherForecast, now time.Time) string {
 		return weatherUnavailableMessage
 	}
 	return sb.String()
+}
+
+func dailyItemForDate(items []DailyItem, date time.Time) (DailyItem, bool) {
+	want := date.UTC().Format("2006-01-02")
+	for _, item := range items {
+		if item.Date.UTC().Format("2006-01-02") == want {
+			return item, true
+		}
+	}
+	return DailyItem{}, false
 }
 
 func validCoordinates(lat, lon float64) bool {

--- a/weather/weather_test.go
+++ b/weather/weather_test.go
@@ -226,6 +226,53 @@ func TestFormatForecastTextAnchorsDatesToRealCalendarRows(t *testing.T) {
 	}
 }
 
+func TestFormatForecastTextUsesRequestDateForTodayLine(t *testing.T) {
+	wf := &WeatherForecast{
+		Location:    "New York",
+		Source:      "Google Weather",
+		GeneratedAt: time.Date(2026, time.July, 4, 10, 0, 0, 0, time.UTC),
+		ObservedAt:  time.Date(2026, time.July, 4, 10, 0, 0, 0, time.UTC),
+		Current: &CurrentConditions{
+			TempC:             27,
+			Description:       "partly cloudy",
+			HumidityAvailable: true,
+			WindKphAvailable:  true,
+		},
+		DailyItems: []DailyItem{
+			{Date: time.Date(2026, time.July, 3, 0, 0, 0, 0, time.UTC), MinTempC: 21, MaxTempC: 29, Description: "older provider row"},
+			{Date: time.Date(2026, time.July, 4, 0, 0, 0, 0, time.UTC), MinTempC: 22, MaxTempC: 31, Description: "request-date sunshine"},
+			{Date: time.Date(2026, time.July, 5, 0, 0, 0, 0, time.UTC), MinTempC: 23, MaxTempC: 30, Description: "tomorrow showers"},
+		},
+	}
+
+	got := formatForecastText(wf, time.Date(2026, time.July, 4, 12, 0, 0, 0, time.UTC))
+	if !strings.Contains(got, "Today: Saturday, 4 July 2026 (2026-07-04): 22–31°C, request-date sunshine.") {
+		t.Fatalf("formatForecastText should anchor Today to the request date, got:\n%s", got)
+	}
+	if strings.Contains(got, "Today: Friday, 3 July 2026") || strings.Contains(got, "Today: older provider row") {
+		t.Fatalf("formatForecastText should not label the first provider row as today when it predates the request, got:\n%s", got)
+	}
+}
+
+func TestFormatForecastTextDisclosesMissingRequestDateForecast(t *testing.T) {
+	wf := &WeatherForecast{
+		Location:    "New York",
+		Source:      "Google Weather",
+		GeneratedAt: time.Date(2026, time.July, 4, 10, 0, 0, 0, time.UTC),
+		DailyItems: []DailyItem{
+			{Date: time.Date(2026, time.July, 3, 0, 0, 0, 0, time.UTC), MinTempC: 21, MaxTempC: 29, Description: "stale row"},
+		},
+	}
+
+	got := formatForecastText(wf, time.Date(2026, time.July, 4, 12, 0, 0, 0, time.UTC))
+	if !strings.Contains(got, "Today: forecast unavailable for the request date Saturday, 4 July 2026 (2026-07-04).") {
+		t.Fatalf("formatForecastText should disclose missing request-date forecast, got:\n%s", got)
+	}
+	if strings.Contains(got, "Today: Friday, 3 July 2026") {
+		t.Fatalf("formatForecastText should not relabel a stale provider row as today, got:\n%s", got)
+	}
+}
+
 func TestFormatForecastTextTreatsMissingCurrentObservationsAsUnavailable(t *testing.T) {
 	wf := &WeatherForecast{
 		Location:   "New York",


### PR DESCRIPTION
## Summary
- Anchor the weather fallback Today line to the request date rather than the first provider row.
- Disclose when provider forecast rows do not include the request date.
- Add regression coverage for stale provider rows around 2026-07-04.

Closes #1081
Closes #1083

## Testing
- go build ./...
- go test ./... -short
- go vet ./...