### PR TITLE
Require MCP auth sessions

### DIFF
--- a/internal/api/mcp.go
+++ b/internal/api/mcp.go
@@ -144,17 +144,17 @@ type mcpContent struct {
 
 // Tool defines an MCP tool with its HTTP mapping
 type Tool struct {
-	Name        string      `json:"name"`
-	Description string      `json:"description"`
-	Title       string      `json:"title,omitempty"` // display title for the visual card
-	Icon        string      `json:"icon,omitempty"`
-	Method      string      `json:"method,omitempty"`
-	Path        string      `json:"path,omitempty"`
-	Params      []ToolParam `json:"params,omitempty"`
-	WalletOp    string      `json:"walletOp,omitempty"`                          // Wallet operation for credit gating (empty = included)
-	Handle      func(map[string]any) (string, error)            `json:"-"` // Optional direct handler (bypasses HTTP dispatch)
-	HandleAuth  func(map[string]any, string) (string, error)    `json:"-"` // Like Handle but receives the account ID
-	Card        func() string                                   `json:"-"` // Optional visual card body, rendered from live data
+	Name        string                                       `json:"name"`
+	Description string                                       `json:"description"`
+	Title       string                                       `json:"title,omitempty"` // display title for the visual card
+	Icon        string                                       `json:"icon,omitempty"`
+	Method      string                                       `json:"method,omitempty"`
+	Path        string                                       `json:"path,omitempty"`
+	Params      []ToolParam                                  `json:"params,omitempty"`
+	WalletOp    string                                       `json:"walletOp,omitempty"` // Wallet operation for credit gating (empty = included)
+	Handle      func(map[string]any) (string, error)         `json:"-"`                  // Optional direct handler (bypasses HTTP dispatch)
+	HandleAuth  func(map[string]any, string) (string, error) `json:"-"`                  // Like Handle but receives the account ID
+	Card        func() string                                `json:"-"`                  // Optional visual card body, rendered from live data
 }
 
 // QuotaCheck is called before executing a metered tool.
@@ -600,7 +600,6 @@ var tools = []Tool{
 	},
 }
 
-
 // ExecuteToolAs calls a tool on behalf of a user account (no HTTP request needed).
 // Creates a temporary session for auth. Used by background agents.
 func ExecuteToolAs(accountID, name string, args map[string]any) (string, bool, error) {
@@ -631,12 +630,14 @@ func ExecuteTool(r *http.Request, name string, args map[string]any) (string, boo
 	}
 
 	if tool.HandleAuth != nil {
-		// Extract account ID from the request session
-		accountID := ""
-		if _, acc := auth.TrySession(r); acc != nil {
-			accountID = acc.ID
+		// Auth-bound tools must never run without a server-validated account
+		// binding. Optional auth helpers intentionally return nil for guests,
+		// so use the required session path before invoking the handler.
+		_, acc, err := auth.RequireSession(r)
+		if err != nil {
+			return "Authentication required", true, err
 		}
-		text, err := tool.HandleAuth(args, accountID)
+		text, err := tool.HandleAuth(args, acc.ID)
 		return text, err != nil, err
 	}
 

--- a/internal/api/mcp_test.go
+++ b/internal/api/mcp_test.go
@@ -516,6 +516,58 @@ func TestMCPHandler_CustomHandlerError(t *testing.T) {
 	}
 }
 
+func TestMCPHandler_AuthHandlerRequiresSession(t *testing.T) {
+	origTools := make([]Tool, len(tools))
+	copy(origTools, tools)
+	called := false
+	RegisterToolWithAuth(Tool{
+		Name:        "test_auth_required",
+		Description: "Auth handler session guard test",
+	}, func(args map[string]any, accountID string) (string, error) {
+		called = true
+		return `{"accountID":"` + accountID + `"}`, nil
+	})
+	defer func() { tools = origTools }()
+
+	body := `{"jsonrpc":"2.0","id":15,"method":"tools/call","params":{"name":"test_auth_required","arguments":{}}}`
+	req := httptest.NewRequest("POST", "/mcp", strings.NewReader(body))
+	w := httptest.NewRecorder()
+
+	MCPHandler(w, req)
+
+	if called {
+		t.Fatal("auth-bound handler should not be invoked without a valid session")
+	}
+
+	var resp jsonrpcResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.Error != nil {
+		t.Fatalf("Expected tool error result, not JSON-RPC error: %s", resp.Error.Message)
+	}
+	result, ok := resp.Result.(map[string]any)
+	if !ok {
+		t.Fatal("Expected result object")
+	}
+	isError, _ := result["isError"].(bool)
+	if !isError {
+		t.Fatal("Expected isError=true for unauthenticated auth-bound tool")
+	}
+	content, ok := result["content"].([]any)
+	if !ok || len(content) == 0 {
+		t.Fatal("Expected content array")
+	}
+	first, ok := content[0].(map[string]any)
+	if !ok {
+		t.Fatal("Expected content item to be an object")
+	}
+	text, _ := first["text"].(string)
+	if !strings.Contains(strings.ToLower(text), "authentication required") {
+		t.Errorf("Expected authentication-required message, got: %s", text)
+	}
+}
+
 func TestMCPHandler_MeteredToolsHaveWalletOp(t *testing.T) {
 	// Verify that metered tools have WalletOp set
 	expected := map[string]string{


### PR DESCRIPTION
## Summary
- Require server-validated sessions before invoking MCP auth-bound handlers.
- Add regression coverage that unauthenticated MCP auth tools return an error result without invoking the handler.

## Testing
- go build ./...
- go test ./... -short
- go vet ./...

Closes #1079
Closes #1088