### PR TITLE
Date-stamp AI news web fallbacks

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -964,6 +964,29 @@ Sources:
 	}
 }
 
+func TestCompleteToolAnswerDatesTodayNewsWebFallback(t *testing.T) {
+	rag := []string{
+		"### news_search\n" + unavailableToolMessage("news_search"),
+		`### web_search
+Current request date: Saturday, 4 July 2026 (2026-07-04, UTC).
+Search results for "AI news":
+Grounding rule: only use source-backed snippets.
+Sources:
+1. Artificial Intelligence News — Latest news and headlines about artificial intelligence. (https://example.com/ai-directory)
+2. AI lab releases new model — Company announced a new assistant release today. (https://example.com/ai-model)
+3. Chip supplier expands AI capacity — Demand for AI chips is rising this week. (https://example.com/ai-chips)`,
+	}
+
+	got := completeToolAnswer("Here are the search results I found.", rag)
+	firstLine, _, _ := strings.Cut(got, "\n")
+	if !strings.Contains(firstLine, "Latest source-backed items for Saturday, 4 July 2026 (2026-07-04): AI lab releases new model; Chip supplier expands AI capacity.") {
+		t.Fatalf("expected date-specific source-backed news lead, got %q", got)
+	}
+	if strings.Contains(firstLine, "Artificial Intelligence News") || strings.Contains(got, "Current request date:") {
+		t.Fatalf("expected generic directory and raw request-date metadata hidden from the lead, got %q", got)
+	}
+}
+
 func TestCompleteToolAnswerRepairsOperationalWeatherLead(t *testing.T) {
 	rag := []string{`### weather_forecast
 Current request date: Friday, 3 July 2026 (2026-07-03, UTC).

--- a/agent/answer_guard.go
+++ b/agent/answer_guard.go
@@ -165,8 +165,9 @@ func formatWebSearchFallbackSection(body string) string {
 	}
 
 	limited := hasLowConfidenceWebEvidence(body)
+	requestDate := fallbackRequestDate(body)
 	if !limited {
-		if summary := webSearchAnswerLead(lines); summary != "" {
+		if summary := webSearchAnswerLead(lines, requestDate); summary != "" {
 			lines = prependDistinctLine(summary, lines)
 		}
 	}
@@ -218,7 +219,7 @@ func trimTrailingSentencePunctuation(s string) string {
 	return strings.TrimRight(strings.TrimSpace(s), ".")
 }
 
-func webSearchAnswerLead(lines []string) string {
+func webSearchAnswerLead(lines []string, requestDate string) string {
 	if len(lines) < 2 {
 		return ""
 	}
@@ -227,7 +228,37 @@ func webSearchAnswerLead(lines []string) string {
 	if first == "" || second == "" {
 		return ""
 	}
-	return "Latest source-backed items: " + first + "; " + second + "."
+	prefix := "Latest source-backed items"
+	if requestDate != "" {
+		prefix += " for " + requestDate
+	}
+	return prefix + ": " + first + "; " + second + "."
+}
+
+func fallbackRequestDate(body string) string {
+	for _, raw := range strings.Split(body, "\n") {
+		line := strings.TrimSpace(raw)
+		lower := strings.ToLower(line)
+		switch {
+		case strings.HasPrefix(lower, "current request date:"):
+			return cleanRequestDateLabel(strings.TrimSpace(line[len("Current request date:"):]))
+		case strings.HasPrefix(lower, "current date context: request date is "):
+			return cleanRequestDateLabel(strings.TrimSpace(line[len("Current date context: request date is "):]))
+		}
+	}
+	return ""
+}
+
+func cleanRequestDateLabel(value string) string {
+	value = strings.TrimSpace(strings.TrimSuffix(value, "."))
+	for _, suffix := range []string{", UTC)", " UTC)"} {
+		if strings.HasSuffix(value, suffix) {
+			return strings.TrimSpace(strings.TrimSuffix(value, suffix) + ")")
+		}
+	}
+	value = strings.TrimSuffix(value, ", UTC")
+	value = strings.TrimSuffix(value, " UTC")
+	return strings.TrimSpace(value)
 }
 
 func webSearchStoryTitle(line string) string {


### PR DESCRIPTION
## Summary
- Date-stamp synthesized web-search fallback leads for latest/today AI-news answers when the live news provider is unavailable.
- Preserve source-backed story prioritization over generic AI directory pages while hiding raw request-date metadata from the answer body.
- Add regression coverage for the 2026-07-04 AI-news fallback case.

## Testing
- go build ./...
- go test ./... -short
- go vet ./...

Closes #1091
Closes #1093
