### PR TITLE
Prioritize dated AI news fallback stories

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -1219,11 +1219,31 @@ Sources:
 4. Startup launches healthcare AI tool — The company says hospitals are piloting the assistant this week. (https://example.com/ai-health)`}
 	got := completeToolAnswer("Here are some search results for AI news.", rag)
 	firstLine, _, _ := strings.Cut(got, "\n")
-	if !strings.Contains(firstLine, "Latest source-backed items: AI safety bill advances; Startup launches healthcare AI tool.") {
+	if !strings.Contains(firstLine, "Latest source-backed items: Startup launches healthcare AI tool; AI safety bill advances.") {
 		t.Fatalf("expected current story snippets to lead over generic news pages, got %q", got)
 	}
 	if strings.Contains(firstLine, "OpenAI News") || strings.Contains(firstLine, "Artificial Intelligence News") {
 		t.Fatalf("expected generic pages below the answer lead, got %q", got)
+	}
+}
+
+func TestCompleteToolAnswerPrefersDatedNewsStories(t *testing.T) {
+	rag := []string{`### news_search
+` + unavailableToolMessage("news_search"), `### web_search
+Current request date: Saturday, 4 July 2026 (2026-07-04, UTC)
+Search results for "AI news":
+Sources:
+1. AI newsletter roundup — A broad collection of AI links and analysis. (https://example.com/ai-roundup)
+2. Artificial Intelligence News — Latest news and headlines about artificial intelligence. (https://example.com/ai-directory)
+3. AI lab releases new reasoning model — July 4, 2026: the company announced a model update for enterprise assistants. (https://example.com/ai-model)
+4. Chipmaker signs AI supply deal — 2026-07-04: the supplier expanded capacity for accelerator customers. (https://example.com/ai-chips)`}
+	got := completeToolAnswer("Here are the search results I found.", rag)
+	firstLine, _, _ := strings.Cut(got, "\n")
+	if !strings.Contains(firstLine, "Latest source-backed items for Saturday, 4 July 2026 (2026-07-04): AI lab releases new reasoning model; Chipmaker signs AI supply deal.") {
+		t.Fatalf("expected dated story sources to lead generic or undated AI pages, got %q", got)
+	}
+	if strings.Contains(firstLine, "AI newsletter roundup") || strings.Contains(firstLine, "Artificial Intelligence News") {
+		t.Fatalf("expected dated stories above generic and undated pages, got %q", got)
 	}
 }
 

--- a/agent/answer_guard.go
+++ b/agent/answer_guard.go
@@ -439,20 +439,65 @@ func prioritizeSnippetBackedWebLines(lines []string) []string {
 	if len(lines) < 2 {
 		return lines
 	}
-	var snippetBacked []string
-	var generic []string
+	buckets := make([][]string, 4)
 	for _, line := range lines {
-		if isGenericWebResultLine(line) {
-			generic = append(generic, line)
-			continue
-		}
-		snippetBacked = append(snippetBacked, line)
+		priority := webResultFallbackPriority(line)
+		buckets[priority] = append(buckets[priority], line)
 	}
-	if len(snippetBacked) >= 2 {
-		return append(snippetBacked, generic...)
+	if len(buckets[0])+len(buckets[1]) >= 2 {
+		out := make([]string, 0, len(lines))
+		for _, bucket := range buckets {
+			out = append(out, bucket...)
+		}
+		return out
 	}
 	return lines
 }
+
+func webResultFallbackPriority(line string) int {
+	if isGenericWebResultLine(line) {
+		return 3
+	}
+	if isDatedWebStoryLine(line) {
+		return 0
+	}
+	if hasWebResultSnippet(line) {
+		return 1
+	}
+	return 2
+}
+
+func hasWebResultSnippet(line string) bool {
+	cleaned := cleanFallbackLine(line)
+	if _, _, ok := strings.Cut(cleaned, " — "); ok {
+		return true
+	}
+	_, _, ok := strings.Cut(cleaned, " - ")
+	return ok
+}
+
+func isDatedWebStoryLine(line string) bool {
+	lower := strings.ToLower(cleanFallbackLine(line))
+	dateMarkers := []string{
+		"today",
+		"yesterday",
+		"this morning",
+		"this afternoon",
+		"this evening",
+		"this week",
+	}
+	for _, marker := range dateMarkers {
+		if strings.Contains(lower, marker) {
+			return true
+		}
+	}
+	return webStoryNumericDatePattern.MatchString(lower) || webStoryMonthDatePattern.MatchString(lower)
+}
+
+var (
+	webStoryNumericDatePattern = regexp.MustCompile(`\b(?:20\d{2}[-/]\d{1,2}[-/]\d{1,2}|\d{1,2}[-/]\d{1,2}[-/]20\d{2})\b`)
+	webStoryMonthDatePattern   = regexp.MustCompile(`\b(?:jan(?:uary)?|feb(?:ruary)?|mar(?:ch)?|apr(?:il)?|may|jun(?:e)?|jul(?:y)?|aug(?:ust)?|sep(?:t(?:ember)?)?|oct(?:ober)?|nov(?:ember)?|dec(?:ember)?)\.?\s+\d{1,2}(?:,\s*20\d{2})?\b`)
+)
 
 func isGenericWebResultLine(line string) bool {
 	cleaned := strings.ToLower(cleanFallbackLine(line))


### PR DESCRIPTION
Summary:
- Prioritize dated, snippet-backed web search stories ahead of generic AI directory/news pages in fallback synthesis.
- Add regression coverage for dated AI-news fallback ranking.

Closes #1099
Closes #1101