### PR TITLE
Filter generic AI news fallback directories

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -987,6 +987,33 @@ Sources:
 	}
 }
 
+func TestCompleteToolAnswerFiltersGenericAINewsDirectoryFallbacks(t *testing.T) {
+	rag := []string{
+		"### news_search\n" + unavailableToolMessage("news_search"),
+		`### web_search
+Current request date: Saturday, 4 July 2026 (2026-07-04, UTC).
+Search results for "AI news":
+Grounding rule: only use source-backed snippets.
+Sources:
+1. Artificial Intelligence News — Latest AI news and directory links. (https://artificialintelligence-news.com/)
+2. AI News - Artificial Intelligence — Breaking news, analysis and category coverage. (https://www.yahoo.com/news/tag/artificial-intelligence/)
+3. Artificial Intelligence | TechCrunch — AI startup and product coverage. (https://techcrunch.com/category/artificial-intelligence/)
+4. Model lab ships safer assistant — The company announced a new model release today. (https://example.com/model-release)
+5. Chip supplier expands AI capacity — Demand for inference hardware is rising this week. (https://example.com/chip-capacity)`,
+	}
+
+	got := completeToolAnswer("Here are the search results I found.", rag)
+	firstLine, _, _ := strings.Cut(got, "\n")
+	if !strings.Contains(firstLine, "Model lab ships safer assistant; Chip supplier expands AI capacity") {
+		t.Fatalf("expected story-like AI news lead after directory filtering, got %q", got)
+	}
+	for _, generic := range []string{"artificialintelligence-news.com", "yahoo.com/news/tag/artificial-intelligence", "techcrunch.com/category/artificial-intelligence", "Artificial Intelligence | TechCrunch"} {
+		if strings.Contains(got, generic) {
+			t.Fatalf("expected generic AI directory result %q to be filtered, got %q", generic, got)
+		}
+	}
+}
+
 func TestCompleteToolAnswerRepairsOperationalWeatherLead(t *testing.T) {
 	rag := []string{`### weather_forecast
 Current request date: Friday, 3 July 2026 (2026-07-03, UTC).

--- a/agent/answer_guard.go
+++ b/agent/answer_guard.go
@@ -158,8 +158,9 @@ func formatFallbackSection(title, body string) string {
 }
 
 func formatWebSearchFallbackSection(body string) string {
-	lines := meaningfulLines(body, 4)
+	lines := meaningfulLines(body, 6)
 	lines = prioritizeSnippetBackedWebLines(lines)
+	lines = filterGenericWebResultLines(lines, 4)
 	if len(lines) == 0 {
 		return ""
 	}
@@ -454,6 +455,25 @@ func prioritizeSnippetBackedWebLines(lines []string) []string {
 	return lines
 }
 
+func filterGenericWebResultLines(lines []string, limit int) []string {
+	if len(lines) == 0 {
+		return lines
+	}
+	kept := make([]string, 0, len(lines))
+	for _, line := range lines {
+		if !isGenericWebResultLine(line) {
+			kept = append(kept, line)
+		}
+	}
+	if len(kept) == 0 {
+		kept = lines
+	}
+	if len(kept) > limit {
+		kept = kept[:limit]
+	}
+	return kept
+}
+
 func webResultFallbackPriority(line string) int {
 	if isGenericWebResultLine(line) {
 		return 3
@@ -504,6 +524,17 @@ func isGenericWebResultLine(line string) bool {
 	title, snippet, hasSnippet := strings.Cut(cleaned, " — ")
 	if !hasSnippet {
 		title, snippet, hasSnippet = strings.Cut(cleaned, " - ")
+	}
+	genericURLTerms := []string{
+		"artificialintelligence-news.com",
+		"yahoo.com/news/tag/artificial-intelligence",
+		"yahoo.com/tech/tag/artificial-intelligence",
+		"techcrunch.com/category/artificial-intelligence",
+	}
+	for _, term := range genericURLTerms {
+		if strings.Contains(cleaned, term) {
+			return true
+		}
 	}
 	genericTitleTerms := []string{
 		"category",


### PR DESCRIPTION
## Summary
- Filter generic AI-news directory/category pages out of web fallback answers when story-like results are available.
- Keep enough fallback candidates before filtering so later story results can replace generic directory leads.
- Add regression coverage for artificialintelligence-news.com, Yahoo AI tag pages, and TechCrunch AI category pages.

Closes #1104
Closes #1106

## Testing
- go build ./...
- go test ./... -short
- go vet ./...