### PR TITLE
Prefer article-level AI-news fallbacks

### DIFF
--- a/search/agent.go
+++ b/search/agent.go
@@ -66,6 +66,7 @@ func groundNewsWebResults(query string, results []BraveResult) []BraveResult {
 	if len(terms) == 0 {
 		return results
 	}
+	storyLike := make([]BraveResult, 0, len(results))
 	filtered := make([]BraveResult, 0, len(results))
 	for _, r := range results {
 		desc := strings.TrimSpace(r.Description)
@@ -85,12 +86,70 @@ func groundNewsWebResults(query string, results []BraveResult) []BraveResult {
 		}
 		if matchedTopic {
 			filtered = append(filtered, r)
+			if isArticleLevelNewsResult(r) {
+				storyLike = append(storyLike, r)
+			}
 		}
+	}
+	if len(storyLike) > 0 {
+		return storyLike
 	}
 	if len(filtered) == 0 {
 		return results
 	}
 	return filtered
+}
+
+func isArticleLevelNewsResult(r BraveResult) bool {
+	if strings.TrimSpace(r.URL) == "" {
+		return false
+	}
+	u, err := url.Parse(r.URL)
+	if err != nil {
+		return false
+	}
+	path := strings.Trim(strings.ToLower(u.EscapedPath()), "/")
+	if path == "" {
+		return false
+	}
+	segments := strings.Split(path, "/")
+	last := strings.TrimSuffix(segments[len(segments)-1], ".html")
+	last = strings.TrimSuffix(last, ".amp")
+	genericLast := map[string]struct{}{
+		"ai": {}, "artificial-intelligence": {}, "artificial_intelligence": {},
+		"news": {}, "tech": {}, "technology": {}, "updates": {},
+		"category": {}, "topics": {}, "topic": {}, "reviews": {},
+	}
+	if _, ok := genericLast[last]; ok && len(segments) <= 2 {
+		return false
+	}
+	if strings.Contains(strings.ToLower(r.Title), "|") {
+		left := strings.TrimSpace(strings.Split(strings.ToLower(r.Title), "|")[0])
+		if _, ok := genericLast[strings.ReplaceAll(left, " ", "-")]; ok {
+			return false
+		}
+	}
+	for _, segment := range segments {
+		if len(segment) >= 4 && containsDigit(segment) {
+			return true
+		}
+	}
+	storyWords := 0
+	for _, field := range strings.FieldsFunc(last, func(r rune) bool { return r == '-' || r == '_' || r == '+' }) {
+		if len(field) > 2 {
+			storyWords++
+		}
+	}
+	return storyWords >= 3 || len(segments) >= 3
+}
+
+func containsDigit(s string) bool {
+	for _, r := range s {
+		if unicode.IsDigit(r) {
+			return true
+		}
+	}
+	return false
 }
 
 func isNewsLikeWebQuery(query string) bool {

--- a/search/agent_test.go
+++ b/search/agent_test.go
@@ -61,3 +61,18 @@ func TestFormatWebSearchResultsGroundsNewsFallbackInSnippets(t *testing.T) {
 		}
 	}
 }
+
+func TestFormatWebSearchResultsPrefersArticleLevelNewsSources(t *testing.T) {
+	got := formatWebSearchResults("today's AI news", []BraveResult{
+		{Title: "The Information", Description: "Reporting on AI startup funding and model launches this week.", URL: "https://www.theinformation.com/"},
+		{Title: "AI News, Updates, Products and Reviews | Yahoo Tech", Description: "Meta is preparing new AI glasses as rivals race to ship wearable assistants.", URL: "https://www.yahoo.com/tech/ai/"},
+		{Title: "Meta prepares AI glasses for developers", Description: "Meta plans to show AI glasses to developers today, according to people familiar with the launch.", URL: "https://example.com/2026/07/04/meta-ai-glasses-developers"},
+	})
+
+	if strings.Contains(got, "The Information") || strings.Contains(got, "Yahoo Tech") {
+		t.Fatalf("expected generic/root AI-news sources to be dropped when article-level stories exist:\n%s", got)
+	}
+	if !strings.Contains(got, "Meta prepares AI glasses for developers") {
+		t.Fatalf("expected article-level AI-news source to remain:\n%s", got)
+	}
+}


### PR DESCRIPTION
## Summary
- Prefer article-level web search results for news-like fallback queries when story URLs are available.
- Keep generic root/category pages only when no article-level evidence is available.
- Add regression coverage for AI-news fallback source selection.

Closes #1114
Closes #1116

## Testing
- go build ./...
- go test ./... -short
- go vet ./...