### PR TITLE
Label generic AI news fallbacks as limited evidence

### DIFF
--- a/search/agent.go
+++ b/search/agent.go
@@ -50,6 +50,9 @@ func formatWebSearchResults(query string, results []BraveResult) string {
 			desc = desc[:220] + "…"
 		}
 		title := strings.TrimSpace(r.Title)
+		if isNewsLikeWebQuery(query) && !isArticleLevelNewsResult(r) && isGenericNewsResult(r) {
+			title = limitedEvidenceNewsTitle(r)
+		}
 		if title == "" {
 			title = sourceHost(r.URL)
 		}
@@ -141,6 +144,53 @@ func isArticleLevelNewsResult(r BraveResult) bool {
 		}
 	}
 	return storyWords >= 3 || len(segments) >= 3
+}
+
+func isGenericNewsResult(r BraveResult) bool {
+	title := strings.TrimSpace(strings.ToLower(r.Title))
+	if title == "" {
+		return true
+	}
+	genericPhrases := []string{
+		"artificial intelligence news",
+		"ai news",
+		"ai (artificial intelligence)",
+		"technology news",
+		"tech news",
+		"updates, products and reviews",
+	}
+	for _, phrase := range genericPhrases {
+		if strings.Contains(title, phrase) {
+			return true
+		}
+	}
+	if !strings.Contains(title, " ") && !strings.Contains(title, "-") && !strings.Contains(title, ":") {
+		return true
+	}
+	u, err := url.Parse(r.URL)
+	if err != nil {
+		return false
+	}
+	path := strings.Trim(strings.ToLower(u.EscapedPath()), "/")
+	if path == "" {
+		return true
+	}
+	segments := strings.Split(path, "/")
+	last := segments[len(segments)-1]
+	genericPath := map[string]struct{}{
+		"ai": {}, "artificial-intelligence": {}, "artificial_intelligence": {},
+		"news": {}, "tech": {}, "technology": {}, "topics": {}, "topic": {},
+	}
+	_, ok := genericPath[last]
+	return ok && len(segments) <= 2
+}
+
+func limitedEvidenceNewsTitle(r BraveResult) string {
+	host := sourceHost(r.URL)
+	if host == "" {
+		host = "this source"
+	}
+	return "Limited evidence from " + host
 }
 
 func containsDigit(s string) bool {

--- a/search/agent_test.go
+++ b/search/agent_test.go
@@ -76,3 +76,30 @@ func TestFormatWebSearchResultsPrefersArticleLevelNewsSources(t *testing.T) {
 		t.Fatalf("expected article-level AI-news source to remain:\n%s", got)
 	}
 }
+
+func TestFormatWebSearchResultsLabelsGenericNewsSourcesAsLimitedEvidence(t *testing.T) {
+	got := formatWebSearchResults("today's AI news", []BraveResult{
+		{Title: "The Information", Description: "Reporting on AI startup funding and model launches this week.", URL: "https://www.theinformation.com/"},
+		{Title: "AI News, Updates, Products and Reviews | Yahoo Tech", Description: "Meta is preparing new AI glasses as rivals race to ship wearable assistants.", URL: "https://www.yahoo.com/tech/ai/"},
+		{Title: "AI (artificial intelligence) | The Guardian", Description: "Coverage of AI policy and product launches from around the world.", URL: "https://www.theguardian.com/technology/artificialintelligenceai"},
+	})
+
+	for _, unwanted := range []string{
+		"1. The Information —",
+		"AI News, Updates, Products and Reviews | Yahoo Tech",
+		"AI (artificial intelligence) | The Guardian",
+	} {
+		if strings.Contains(got, unwanted) {
+			t.Fatalf("expected generic source labels to be replaced with limited-evidence labels, still found %q:\n%s", unwanted, got)
+		}
+	}
+	for _, want := range []string{
+		"Limited evidence from www.theinformation.com",
+		"Limited evidence from www.yahoo.com",
+		"If the snippets are thin, say the evidence is limited.",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("expected %q in limited-evidence web search results:\n%s", want, got)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Replaces generic/root AI-news fallback source labels with limited-evidence labels when no article-level URL is available.
- Keeps article-level AI-news fallback sources preferred when present.
- Adds regression coverage for The Information/Yahoo Tech/Guardian generic-source labels.

Closes #1119
Closes #1121