### PR TITLE
Keep AI-news fallback source URLs readable

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -1309,6 +1309,26 @@ Confidence: low — generic category pages only.
 	}
 }
 
+func TestCompleteToolAnswerKeepsLimitedEvidenceURLsReadable(t *testing.T) {
+	longSnippet := strings.Repeat("detailed AI category context with broad archive evidence ", 8)
+	rag := []string{
+		`### web_search
+Confidence: low — generic category pages only.
+1. AI news archive — ` + longSnippet + `(https://www.yahoo.com/tech/tag/artificial-intelligence/)`,
+	}
+
+	got := completeToolAnswer("I'll search the web.", rag)
+	if !strings.Contains(got, "limited source-backed evidence") {
+		t.Fatalf("expected limited-evidence disclosure, got %q", got)
+	}
+	if !strings.Contains(got, "https://www.yahoo.com/tech/tag/artificial-intelligence/") {
+		t.Fatalf("expected full usable URL in limited-evidence fallback, got %q", got)
+	}
+	if strings.Contains(got, "https://www.…") || strings.Contains(got, "https://www.yahoo.com/tech/tag/artificial-intelligence/…") {
+		t.Fatalf("expected URL not to be ellipsized, got %q", got)
+	}
+}
+
 func TestCompleteToolAnswerReplacesRawMixedSourcePayload(t *testing.T) {
 	rag := []string{
 		`### blog_list

--- a/agent/answer_guard.go
+++ b/agent/answer_guard.go
@@ -357,10 +357,7 @@ func meaningfulLines(body string, limit int) []string {
 		if line == "" {
 			continue
 		}
-		if len([]rune(line)) > 280 {
-			r := []rune(line)
-			line = string(r[:280]) + "…"
-		}
+		line = truncateFallbackLinePreservingURL(line, 280)
 		if isFallbackSecondaryContextLine(line) {
 			context = append(context, line)
 		} else {
@@ -495,6 +492,32 @@ func snippetStoryLead(snippet string) string {
 		}
 	}
 	return ""
+}
+
+func truncateFallbackLinePreservingURL(line string, limit int) string {
+	if limit <= 0 {
+		return ""
+	}
+	if len([]rune(line)) <= limit {
+		return line
+	}
+	url := fallbackLineURL(line)
+	if url == "" {
+		r := []rune(line)
+		return string(r[:limit]) + "…"
+	}
+
+	suffix := " (" + url + ")"
+	prefix := strings.TrimSpace(strings.TrimSuffix(line, suffix))
+	budget := limit - len([]rune(suffix)) - 1
+	if budget < 24 {
+		return url
+	}
+	prefixRunes := []rune(prefix)
+	if len(prefixRunes) > budget {
+		prefix = strings.TrimSpace(string(prefixRunes[:budget])) + "…"
+	}
+	return prefix + suffix
 }
 
 func fallbackLineURL(line string) string {


### PR DESCRIPTION
## Summary
- Preserve full parenthesized source URLs when truncating long fallback web-result lines.
- Add coverage for low-confidence AI-news web fallbacks so limited-evidence disclosures keep usable links.

Closes #1124
Closes #1127

## Testing
- go test ./agent -run 'TestCompleteToolAnswer(DisclosesLimitedWebEvidence|KeepsLimitedEvidenceURLsReadable)' -count=1\n- go build ./...\n- go test ./... -short\n- go vet ./...