### PR TITLE
Prefer article AI news fallback sources

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -1484,6 +1484,28 @@ Sources:
 	}
 }
 
+func TestCompleteToolAnswerPrefersArticlesOverLiveAINewsCategoryPages(t *testing.T) {
+	rag := []string{`### news_search
+` + unavailableToolMessage("news_search"), `### web_search
+Current request date: Sunday, 5 July 2026 (2026-07-05, UTC).
+Search results for "AI news":
+Sources:
+1. AI (artificial intelligence) | The Guardian — Coverage of AI policy and product launches from around the world. (https://www.theguardian.com/technology/artificialintelligenceai)
+2. Artificial Intelligence News | Bloomberg — Latest artificial intelligence stories, analysis and market coverage. (https://www.bloomberg.com/technology/ai)
+3. Robotics startup launches home assistant — The company launched a household AI robot today after a new funding round. (https://example.com/2026/07/05/robotics-startup-home-assistant)
+4. Lab releases compact AI model — July 5, 2026: researchers released a smaller model for on-device assistants. (https://example.com/2026/07/05/compact-ai-model)`}
+	got := completeToolAnswer("Top results:\n1. AI (artificial intelligence) | The Guardian\n2. Artificial Intelligence News | Bloomberg", rag)
+	firstLine, _, _ := strings.Cut(got, "\n")
+	if !strings.Contains(firstLine, "Latest source-backed items for Sunday, 5 July 2026 (2026-07-05): Robotics startup launches home assistant; Lab releases compact AI model.") {
+		t.Fatalf("expected article-level AI news sources in the lead, got %q", got)
+	}
+	for _, generic := range []string{"The Guardian", "Bloomberg", "theguardian.com/technology/artificialintelligenceai", "bloomberg.com/technology/ai"} {
+		if strings.Contains(got, generic) {
+			t.Fatalf("expected generic AI category page %q to be filtered, got %q", generic, got)
+		}
+	}
+}
+
 func TestCompleteToolAnswerRepairsObservedAtWeatherLead(t *testing.T) {
 	rag := []string{`### weather_forecast
 Current request date: Friday, 3 July 2026 (2026-07-03, UTC).

--- a/agent/answer_guard.go
+++ b/agent/answer_guard.go
@@ -643,6 +643,9 @@ func isGenericWebResultLine(line string) bool {
 	}
 	genericURLTerms := []string{
 		"artificialintelligence-news.com",
+		"bloomberg.com/ai",
+		"bloomberg.com/technology/ai",
+		"theguardian.com/technology/artificialintelligenceai",
 		"yahoo.com/news/tag/artificial-intelligence",
 		"yahoo.com/tech/tag/artificial-intelligence",
 		"techcrunch.com/category/artificial-intelligence",

--- a/search/agent.go
+++ b/search/agent.go
@@ -120,10 +120,14 @@ func isArticleLevelNewsResult(r BraveResult) bool {
 	last = strings.TrimSuffix(last, ".amp")
 	genericLast := map[string]struct{}{
 		"ai": {}, "artificial-intelligence": {}, "artificial_intelligence": {},
-		"news": {}, "tech": {}, "technology": {}, "updates": {},
+		"artificialintelligenceai": {},
+		"news":                     {}, "tech": {}, "technology": {}, "updates": {},
 		"category": {}, "topics": {}, "topic": {}, "reviews": {},
 	}
 	if _, ok := genericLast[last]; ok && len(segments) <= 2 {
+		return false
+	}
+	if isGenericNewsResult(r) {
 		return false
 	}
 	if strings.Contains(strings.ToLower(r.Title), "|") {
@@ -179,7 +183,8 @@ func isGenericNewsResult(r BraveResult) bool {
 	last := segments[len(segments)-1]
 	genericPath := map[string]struct{}{
 		"ai": {}, "artificial-intelligence": {}, "artificial_intelligence": {},
-		"news": {}, "tech": {}, "technology": {}, "topics": {}, "topic": {},
+		"artificialintelligenceai": {},
+		"news":                     {}, "tech": {}, "technology": {}, "topics": {}, "topic": {},
 	}
 	_, ok := genericPath[last]
 	return ok && len(segments) <= 2

--- a/search/agent_test.go
+++ b/search/agent_test.go
@@ -66,10 +66,12 @@ func TestFormatWebSearchResultsPrefersArticleLevelNewsSources(t *testing.T) {
 	got := formatWebSearchResults("today's AI news", []BraveResult{
 		{Title: "The Information", Description: "Reporting on AI startup funding and model launches this week.", URL: "https://www.theinformation.com/"},
 		{Title: "AI News, Updates, Products and Reviews | Yahoo Tech", Description: "Meta is preparing new AI glasses as rivals race to ship wearable assistants.", URL: "https://www.yahoo.com/tech/ai/"},
+		{Title: "AI (artificial intelligence) | The Guardian", Description: "Coverage of AI policy and product launches from around the world.", URL: "https://www.theguardian.com/technology/artificialintelligenceai"},
+		{Title: "Artificial Intelligence News | Bloomberg", Description: "Latest artificial intelligence stories, analysis and market coverage.", URL: "https://www.bloomberg.com/technology/ai"},
 		{Title: "Meta prepares AI glasses for developers", Description: "Meta plans to show AI glasses to developers today, according to people familiar with the launch.", URL: "https://example.com/2026/07/04/meta-ai-glasses-developers"},
 	})
 
-	if strings.Contains(got, "The Information") || strings.Contains(got, "Yahoo Tech") {
+	if strings.Contains(got, "The Information") || strings.Contains(got, "Yahoo Tech") || strings.Contains(got, "The Guardian") || strings.Contains(got, "Bloomberg") {
 		t.Fatalf("expected generic/root AI-news sources to be dropped when article-level stories exist:\n%s", got)
 	}
 	if !strings.Contains(got, "Meta prepares AI glasses for developers") {


### PR DESCRIPTION
## Summary
- Treat AI category/root pages from sources such as Guardian and Bloomberg as generic fallback evidence instead of article-level stories.
- Keep AI-news unavailable fallbacks focused on concrete article URLs when those are available, while retaining limited-evidence framing for category pages.
- Add regression coverage for source formatting and fallback answer synthesis.

Closes #1130
Closes #1132

## Testing
- go build ./...
- go test ./... -short
- go vet ./...