### PR TITLE
Prefer article sources in AI news fallback

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -1506,6 +1506,29 @@ Sources:
 	}
 }
 
+func TestCompleteToolAnswerPrefersArticlesOverYahooAndReutersAINewsCategoryPages(t *testing.T) {
+	rag := []string{`### news_search
+` + unavailableToolMessage("news_search"), `### web_search
+Current request date: Sunday, 5 July 2026 (2026-07-05, UTC).
+Search results for "AI news":
+Sources:
+1. AI News, Updates, Products and Reviews | Yahoo Tech — The latest AI product coverage and reviews. (https://tech.yahoo.com/ai/)
+2. Artificial Intelligence | Reuters — The latest artificial intelligence news and analysis. (https://www.reuters.com/technology/artificial-intelligence/)
+3. Robotics startup launches home assistant — The company launched a household AI robot today after a new funding round. (https://example.com/2026/07/05/robotics-startup-home-assistant)
+4. Lab releases compact AI model — July 5, 2026: researchers released a smaller model for on-device assistants. (https://example.com/2026/07/05/compact-ai-model)`}
+
+	got := completeToolAnswer("Top results:\n1. AI News, Updates, Products and Reviews | Yahoo Tech\n2. Artificial Intelligence | Reuters", rag)
+	firstLine, _, _ := strings.Cut(got, "\n")
+	if !strings.Contains(firstLine, "Latest source-backed items for Sunday, 5 July 2026 (2026-07-05): Robotics startup launches home assistant; Lab releases compact AI model.") {
+		t.Fatalf("expected article-level AI news sources in the lead, got %q", got)
+	}
+	for _, generic := range []string{"Yahoo Tech", "Reuters", "tech.yahoo.com/ai", "reuters.com/technology/artificial-intelligence"} {
+		if strings.Contains(got, generic) {
+			t.Fatalf("expected generic AI category page %q to be filtered, got %q", generic, got)
+		}
+	}
+}
+
 func TestCompleteToolAnswerRepairsObservedAtWeatherLead(t *testing.T) {
 	rag := []string{`### weather_forecast
 Current request date: Friday, 3 July 2026 (2026-07-03, UTC).

--- a/agent/answer_guard.go
+++ b/agent/answer_guard.go
@@ -646,7 +646,10 @@ func isGenericWebResultLine(line string) bool {
 		"bloomberg.com/ai",
 		"bloomberg.com/technology/ai",
 		"theguardian.com/technology/artificialintelligenceai",
+		"reuters.com/technology/artificial-intelligence",
+		"tech.yahoo.com/ai",
 		"yahoo.com/news/tag/artificial-intelligence",
+		"yahoo.com/tech/ai",
 		"yahoo.com/tech/tag/artificial-intelligence",
 		"techcrunch.com/category/artificial-intelligence",
 	}

--- a/search/agent.go
+++ b/search/agent.go
@@ -159,6 +159,7 @@ func isGenericNewsResult(r BraveResult) bool {
 		"artificial intelligence news",
 		"ai news",
 		"ai (artificial intelligence)",
+		"artificial intelligence |",
 		"technology news",
 		"tech news",
 		"updates, products and reviews",
@@ -179,6 +180,9 @@ func isGenericNewsResult(r BraveResult) bool {
 	if path == "" {
 		return true
 	}
+	if isGenericNewsURLPath(u.Host, path) {
+		return true
+	}
 	segments := strings.Split(path, "/")
 	last := segments[len(segments)-1]
 	genericPath := map[string]struct{}{
@@ -188,6 +192,21 @@ func isGenericNewsResult(r BraveResult) bool {
 	}
 	_, ok := genericPath[last]
 	return ok && len(segments) <= 2
+}
+
+func isGenericNewsURLPath(host, path string) bool {
+	host = strings.ToLower(host)
+	path = strings.Trim(path, "/")
+	genericPaths := []string{
+		"technology/artificial-intelligence",
+		"tech/ai",
+	}
+	for _, generic := range genericPaths {
+		if path == generic {
+			return true
+		}
+	}
+	return strings.Contains(host, "reuters.com") && path == "technology/artificial-intelligence"
 }
 
 func limitedEvidenceNewsTitle(r BraveResult) string {

--- a/search/agent_test.go
+++ b/search/agent_test.go
@@ -79,6 +79,21 @@ func TestFormatWebSearchResultsPrefersArticleLevelNewsSources(t *testing.T) {
 	}
 }
 
+func TestFormatWebSearchResultsDropsLiveAINewsCategoryPagesWhenArticlesExist(t *testing.T) {
+	got := formatWebSearchResults("today's AI news", []BraveResult{
+		{Title: "AI News, Updates, Products and Reviews | Yahoo Tech", Description: "The latest AI product coverage and reviews.", URL: "https://tech.yahoo.com/ai/"},
+		{Title: "Artificial Intelligence | Reuters", Description: "The latest artificial intelligence news and analysis.", URL: "https://www.reuters.com/technology/artificial-intelligence/"},
+		{Title: "Robotics startup launches home assistant", Description: "The company launched an AI household robot today after raising a new funding round.", URL: "https://example.com/2026/07/05/robotics-startup-home-assistant"},
+	})
+
+	if strings.Contains(got, "Yahoo Tech") || strings.Contains(got, "Reuters") || strings.Contains(got, "tech.yahoo.com/ai") || strings.Contains(got, "reuters.com/technology/artificial-intelligence") {
+		t.Fatalf("expected live AI-news category pages to be dropped when article-level stories exist:\n%s", got)
+	}
+	if !strings.Contains(got, "Robotics startup launches home assistant") {
+		t.Fatalf("expected article-level AI-news source to remain:\n%s", got)
+	}
+}
+
 func TestFormatWebSearchResultsLabelsGenericNewsSourcesAsLimitedEvidence(t *testing.T) {
 	got := formatWebSearchResults("today's AI news", []BraveResult{
 		{Title: "The Information", Description: "Reporting on AI startup funding and model launches this week.", URL: "https://www.theinformation.com/"},


### PR DESCRIPTION
Tightens AI-news unavailable web fallbacks so known Yahoo/Reuters category pages cannot lead when concrete article-level sources are available.

Closes #1137
Closes #1139