### PR TITLE
Polish AI news directory fallbacks

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -1329,6 +1329,42 @@ Confidence: low — generic category pages only.
 	}
 }
 
+func TestCompleteToolAnswerTreatsDirectoryOnlyAINewsAsLimitedEvidence(t *testing.T) {
+	rag := []string{`### news_search
+` + unavailableToolMessage("news_search"), `### web_search
+Current request date: Sunday, 5 July 2026 (2026-07-05, UTC).
+Search results for "AI news":
+Sources:
+1. AI | MIT News — News and campus articles tagged artificial intelligence. (https://news.mit.edu/topic/artificial-intelligence2)
+2. AI Magazine — Artificial intelligence industry coverage and topic pages. (https://aimagazine.com/)
+3. AI News, Updates, Products and Reviews | Yahoo Tech — The latest AI product coverage and reviews. (https://tech.yahoo.com/ai/)`}
+
+	got := completeToolAnswer("Top results:\n1. AI | MIT News\n2. AI Magazine", rag)
+	firstLine, _, _ := strings.Cut(got, "\n")
+	if !strings.Contains(firstLine, "limited source-backed evidence") {
+		t.Fatalf("expected directory-only AI news fallback to use limited-evidence framing, got %q", got)
+	}
+	if strings.Contains(firstLine, "Latest source-backed items") {
+		t.Fatalf("expected no latest-news lead from directory-only evidence, got %q", got)
+	}
+}
+
+func TestCompleteToolAnswerStripsInlineHTMLFromFallbackBullets(t *testing.T) {
+	rag := []string{`### web_search
+Search results for "AI news":
+Sources:
+1. <strong>AI roundup</strong> — <strong><strong>OpenAI released a model update today</strong></strong> for enterprise assistants. (https://example.com/ai-roundup)
+2. Chip supplier expands AI capacity — Demand for AI chips is rising this week. (https://example.com/ai-chips)`}
+
+	got := completeToolAnswer("Here are the search results I found.", rag)
+	if strings.Contains(got, "<strong>") || strings.Contains(got, "</strong>") {
+		t.Fatalf("expected fallback bullets to strip inline strong markup, got %q", got)
+	}
+	if !strings.Contains(got, "OpenAI released a model update today") {
+		t.Fatalf("expected cleaned snippet-backed story to remain, got %q", got)
+	}
+}
+
 func TestCompleteToolAnswerReplacesRawMixedSourcePayload(t *testing.T) {
 	rag := []string{
 		`### blog_list

--- a/agent/answer_guard.go
+++ b/agent/answer_guard.go
@@ -161,12 +161,13 @@ func formatWebSearchFallbackSection(body string) string {
 	lines := meaningfulLines(body, 6)
 	lines = promoteSnippetBackedGenericWebStories(lines)
 	lines = prioritizeSnippetBackedWebLines(lines)
+	genericOnly := hasOnlyGenericWebEvidence(lines)
 	lines = filterGenericWebResultLines(lines, 4)
 	if len(lines) == 0 {
 		return ""
 	}
 
-	limited := hasLowConfidenceWebEvidence(body)
+	limited := hasLowConfidenceWebEvidence(body) || genericOnly
 	requestDate := fallbackRequestDate(body)
 	if !limited {
 		if summary := webSearchAnswerLead(lines, requestDate); summary != "" {
@@ -375,8 +376,12 @@ func meaningfulLines(body string, limit int) []string {
 var fallbackOrdinalPrefix = regexp.MustCompile(`^\d+[.)]\s+`)
 
 func cleanFallbackLine(line string) string {
-	return strings.TrimSpace(fallbackOrdinalPrefix.ReplaceAllString(line, ""))
+	line = strings.TrimSpace(fallbackOrdinalPrefix.ReplaceAllString(line, ""))
+	line = fallbackHTMLTagPattern.ReplaceAllString(line, "")
+	return strings.TrimSpace(line)
 }
+
+var fallbackHTMLTagPattern = regexp.MustCompile(`</?(?:strong|b|em|i)\b[^>]*>`)
 
 func prioritizeCurrentWeatherLines(lines []string) []string {
 	if len(lines) < 2 {
@@ -571,6 +576,18 @@ func filterGenericWebResultLines(lines []string, limit int) []string {
 	return kept
 }
 
+func hasOnlyGenericWebEvidence(lines []string) bool {
+	if len(lines) == 0 {
+		return false
+	}
+	for _, line := range lines {
+		if !isGenericWebResultLine(line) || hasSnippetBackedWebStory(line) {
+			return false
+		}
+	}
+	return true
+}
+
 func webResultFallbackPriority(line string) int {
 	if isGenericWebResultLine(line) {
 		return 3
@@ -626,6 +643,8 @@ func isGenericWebSnippet(snippet string) bool {
 		"breaking news, analysis",
 		"coverage of",
 		"company news and announcements",
+		"industry coverage and topic pages",
+		"news and campus articles tagged",
 	}
 	for _, term := range genericSnippetTerms {
 		if strings.Contains(snippet, term) {
@@ -648,6 +667,8 @@ func isGenericWebResultLine(line string) bool {
 		"theguardian.com/technology/artificialintelligenceai",
 		"reuters.com/technology/artificial-intelligence",
 		"tech.yahoo.com/ai",
+		"news.mit.edu/topic/artificial-intelligence",
+		"aimagazine.com",
 		"yahoo.com/news/tag/artificial-intelligence",
 		"yahoo.com/tech/ai",
 		"yahoo.com/tech/tag/artificial-intelligence",


### PR DESCRIPTION
## Summary
- Treat AI-news web fallbacks made only of directory/category evidence as limited evidence instead of promoting them into latest-news leads.
- Strip inline emphasis HTML from fallback lines so source bullets stay clean.
- Add regression coverage for directory-only AI-news evidence and nested strong markup.

Closes #1144
Closes #1146

## Testing
- go test ./agent -run 'TestCompleteToolAnswer(TreatsDirectoryOnlyAINewsAsLimitedEvidence|StripsInlineHTMLFromFallbackBullets|PrefersArticlesOverYahooAndReutersAINewsCategoryPages)' -count=1\n- go build ./...\n- go test ./... -short\n- go vet ./...