### PR TITLE
Keep AI news category fallback limited

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -1274,7 +1274,7 @@ Sources:
 	}
 }
 
-func TestCompleteToolAnswerPromotesSnippetStoryFromAINewsCategoryPage(t *testing.T) {
+func TestCompleteToolAnswerFramesSnippetOnlyAINewsCategoryPageAsLimitedEvidence(t *testing.T) {
 	rag := []string{`### news_search
 ` + unavailableToolMessage("news_search"), `### web_search
 Current request date: Saturday, 4 July 2026 (2026-07-04, UTC).
@@ -1285,11 +1285,32 @@ Sources:
 
 	got := completeToolAnswer("Here are the search results I found.", rag)
 	firstLine, _, _ := strings.Cut(got, "\n")
-	if !strings.Contains(firstLine, "Meta announced new AI glasses today with an on-device assistant for live translation") {
-		t.Fatalf("expected snippet-supported story lead instead of generic category title, got %q", got)
+	if !strings.Contains(firstLine, "limited source-backed evidence") {
+		t.Fatalf("expected category-page snippet evidence to stay limited instead of becoming a lead story, got %q", got)
 	}
-	if strings.Contains(firstLine, "AI News, Updates, Products and Reviews | Yahoo Tech") || strings.Contains(firstLine, "Artificial Intelligence News") {
-		t.Fatalf("expected generic AI category titles to stay out of the answer lead, got %q", got)
+	if strings.Contains(firstLine, "Latest source-backed items") || strings.Contains(firstLine, "Meta announced new AI glasses") {
+		t.Fatalf("expected no latest-story lead from category-only evidence, got %q", got)
+	}
+}
+
+func TestCompleteToolAnswerKeepsYahooAICategorySnippetLimitedAndUnduplicated(t *testing.T) {
+	rag := []string{`### news_search
+` + unavailableToolMessage("news_search"), `### web_search
+Current request date: Sunday, 5 July 2026 (2026-07-05, UTC).
+Search results for "AI news":
+Sources:
+1. AI News, Updates, Products and Reviews | Yahoo Tech — Meta announced new AI glasses today with an on-device assistant for live translation. (https://tech.yahoo.com/ai/)`}
+
+	got := completeToolAnswer("Top results:\n1. AI News, Updates, Products and Reviews | Yahoo Tech", rag)
+	firstLine, _, _ := strings.Cut(got, "\n")
+	if !strings.Contains(firstLine, "limited source-backed evidence") {
+		t.Fatalf("expected Yahoo AI category fallback to use limited-evidence framing, got %q", got)
+	}
+	if strings.Contains(firstLine, "Latest source-backed items") {
+		t.Fatalf("expected no promoted lead story from category URL evidence, got %q", got)
+	}
+	if strings.Contains(got, "Meta announced new AI glasses today with an on-device assistant for live translation — Meta announced new AI glasses today") {
+		t.Fatalf("expected category snippet not to be duplicated around an em dash, got %q", got)
 	}
 }
 

--- a/agent/answer_guard.go
+++ b/agent/answer_guard.go
@@ -159,7 +159,6 @@ func formatFallbackSection(title, body string) string {
 
 func formatWebSearchFallbackSection(body string) string {
 	lines := meaningfulLines(body, 6)
-	lines = promoteSnippetBackedGenericWebStories(lines)
 	lines = prioritizeSnippetBackedWebLines(lines)
 	genericOnly := hasOnlyGenericWebEvidence(lines)
 	lines = filterGenericWebResultLines(lines, 4)
@@ -439,42 +438,16 @@ func isGenericSearchFallbackIntro(line string) bool {
 		strings.HasPrefix(lower, "these search results")
 }
 
-func promoteSnippetBackedGenericWebStories(lines []string) []string {
-	out := make([]string, 0, len(lines))
-	for _, line := range lines {
-		out = append(out, snippetBackedGenericWebStoryLine(line))
-	}
-	return out
-}
-
 func hasSnippetBackedWebStory(line string) bool {
+	if isGenericWebResultLine(line) {
+		return false
+	}
 	cleaned := cleanFallbackLine(line)
 	_, snippet, hasSnippet := strings.Cut(cleaned, " — ")
 	if !hasSnippet {
 		_, snippet, hasSnippet = strings.Cut(cleaned, " - ")
 	}
 	return hasSnippet && !isGenericWebSnippet(snippet) && snippetStoryLead(snippet) != ""
-}
-
-func snippetBackedGenericWebStoryLine(line string) string {
-	cleaned := cleanFallbackLine(line)
-	_, snippet, hasSnippet := strings.Cut(cleaned, " — ")
-	if !hasSnippet {
-		_, snippet, hasSnippet = strings.Cut(cleaned, " - ")
-	}
-	if !hasSnippet || !isGenericWebResultLine(line) || isGenericWebSnippet(snippet) {
-		return line
-	}
-	snippet = strings.TrimSpace(strings.TrimSuffix(snippet, " ("+fallbackLineURL(cleaned)+")"))
-	story := snippetStoryLead(snippet)
-	if story == "" {
-		return line
-	}
-	url := fallbackLineURL(cleaned)
-	if url != "" {
-		return story + " — " + strings.TrimSpace(snippet) + " (" + url + ")"
-	}
-	return story + " — " + strings.TrimSpace(snippet)
 }
 
 func snippetStoryLead(snippet string) string {


### PR DESCRIPTION
## Summary
- Keep generic AI news category/root results from being treated as snippet-backed lead stories when the only evidence is a directory-style page.
- Add regression coverage for Yahoo AI category fallback framing and duplicate-snippet prevention.

Closes #1149
Closes #1151

## Testing
- go build ./...
- go test ./... -short
- go vet ./...