### PR TITLE
Restore guest news search provider path

### DIFF
--- a/internal/api/mcp.go
+++ b/internal/api/mcp.go
@@ -172,6 +172,13 @@ var ToolGuard func(r *http.Request, toolName string) error
 // requirements. Returns nil if x402 is not enabled. Set by main.go.
 var PaymentRequiredResponse func(w http.ResponseWriter, op string, resource string)
 
+// GuestNewsSearch handles agent-initiated guest news_search calls without
+// routing through the authenticated HTML/API search endpoint. It is wired by
+// main.go to the news package so guest core-loop prompts can use the same live
+// feed-backed provider path as signed-in users while MCP/REST quota gates stay
+// unchanged.
+var GuestNewsSearch func(query string) (string, error)
+
 // ToolParam defines a parameter for an MCP tool
 type ToolParam struct {
 	Name        string `json:"name"`
@@ -627,6 +634,17 @@ func ExecuteTool(r *http.Request, name string, args map[string]any) (string, boo
 	}
 	if tool == nil {
 		return "", true, fmt.Errorf("unknown tool: %s", name)
+	}
+
+	if name == "news_search" && GuestNewsSearch != nil {
+		if _, _, err := auth.RequireSession(r); err != nil {
+			query := strings.TrimSpace(fmt.Sprintf("%v", args["query"]))
+			if query == "" {
+				return "query required", true, fmt.Errorf("query required")
+			}
+			text, err := GuestNewsSearch(query)
+			return text, err != nil, err
+		}
 	}
 
 	if tool.HandleAuth != nil {

--- a/main.go
+++ b/main.go
@@ -481,6 +481,9 @@ func main() {
 	// system account (low cadence; disable with NOTES=off).
 	blog.StartNotes()
 
+	// Wire guest agent news search directly to the live feed-backed provider path.
+	api.GuestNewsSearch = news.SearchToolText
+
 	// Wire MCP quota checking using wallet credit system
 	api.QuotaCheck = func(r *http.Request, op string) (bool, int, error) {
 		// Check for x402 payment (bypasses auth + credits).

--- a/news/news.go
+++ b/news/news.go
@@ -1792,6 +1792,31 @@ func handleAPISearch(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+// SearchToolText returns model-ready JSON for news_search tool calls. It uses
+// the same indexed-plus-live-feed result selection as the authenticated /news
+// API search, but performs no quota mutation itself; callers that expose it over
+// public protocols remain responsible for auth/quota gates.
+func SearchToolText(query string) (string, error) {
+	query = strings.TrimSpace(query)
+	if query == "" {
+		return "", fmt.Errorf("query required")
+	}
+	if len(query) > 256 {
+		return "", fmt.Errorf("search query must not exceed 256 characters")
+	}
+	results := data.Search(query, 20, data.WithType("news"), data.WithKeywordOnly())
+	articles := newsSearchArticles(query, results, 20)
+	b, err := json.Marshal(map[string]interface{}{
+		"query":   query,
+		"results": articles,
+		"count":   len(articles),
+	})
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
 func newsSearchArticles(query string, indexed []*data.IndexEntry, limit int) []map[string]interface{} {
 	if limit <= 0 {
 		limit = 20

--- a/news/news_test.go
+++ b/news/news_test.go
@@ -254,6 +254,38 @@ func TestNewsSearchArticlesFallsBackToLiveFeed(t *testing.T) {
 	}
 }
 
+func TestSearchToolTextReturnsLiveFeedResultsForAgent(t *testing.T) {
+	oldFeed := feed
+	defer func() {
+		mutex.Lock()
+		feed = oldFeed
+		mutex.Unlock()
+	}()
+
+	now := time.Date(2026, 7, 5, 12, 0, 0, 0, time.UTC)
+	mutex.Lock()
+	feed = []*Post{{
+		ID:          "ai-live",
+		Title:       "AI lab releases safer assistant",
+		Description: "The release includes source-linked evaluation notes.",
+		URL:         "https://example.com/ai-live",
+		Category:    "Technology",
+		PostedAt:    now,
+	}}
+	mutex.Unlock()
+
+	text, err := SearchToolText("latest AI news")
+	if err != nil {
+		t.Fatalf("SearchToolText returned error: %v", err)
+	}
+	if !strings.Contains(text, "AI lab releases safer assistant") {
+		t.Fatalf("expected live feed headline in tool text, got %s", text)
+	}
+	if !strings.Contains(text, "https://example.com/ai-live") {
+		t.Fatalf("expected source URL in tool text, got %s", text)
+	}
+}
+
 func TestNewsSearchArticlesFiltersAdjacentIndexedResults(t *testing.T) {
 	indexed := []*data.IndexEntry{
 		{


### PR DESCRIPTION
## Summary
- Wire guest agent news_search execution to the live feed-backed news search provider instead of the authenticated /news API endpoint.
- Add a model-ready news search helper and regression test for source-linked live feed results.

Closes #1154
Closes #1156

## Testing
- go build ./...
- go test ./... -short
- go vet ./...