### PR TITLE
Use direct news search provider for agent tool calls

### DIFF
--- a/internal/api/mcp.go
+++ b/internal/api/mcp.go
@@ -610,6 +610,15 @@ var tools = []Tool{
 // ExecuteToolAs calls a tool on behalf of a user account (no HTTP request needed).
 // Creates a temporary session for auth. Used by background agents.
 func ExecuteToolAs(accountID, name string, args map[string]any) (string, bool, error) {
+	if name == "news_search" && GuestNewsSearch != nil {
+		query := strings.TrimSpace(fmt.Sprintf("%v", args["query"]))
+		if query == "" {
+			return "query required", true, fmt.Errorf("query required")
+		}
+		text, err := GuestNewsSearch(query)
+		return text, err != nil, err
+	}
+
 	sess, err := auth.CreateSession(accountID)
 	if err != nil {
 		return "", true, fmt.Errorf("failed to create session: %v", err)

--- a/internal/api/mcp_test.go
+++ b/internal/api/mcp_test.go
@@ -681,3 +681,22 @@ func TestReminderAPIHelpersUseConfiguredBaseAndClient(t *testing.T) {
 		t.Fatalf("unexpected body: %s", got)
 	}
 }
+
+func TestExecuteToolAsUsesDirectNewsSearchProvider(t *testing.T) {
+	oldGuestNewsSearch := GuestNewsSearch
+	GuestNewsSearch = func(query string) (string, error) {
+		if query != "AI news" {
+			t.Fatalf("expected trimmed query to reach news provider, got %q", query)
+		}
+		return `{"results":[{"title":"AI story","url":"https://example.com/ai"}]}`, nil
+	}
+	defer func() { GuestNewsSearch = oldGuestNewsSearch }()
+
+	text, isErr, err := ExecuteToolAs("guest-account-without-session", "news_search", map[string]any{"query": " AI news "})
+	if err != nil || isErr {
+		t.Fatalf("expected direct news_search provider to succeed, isErr=%v err=%v", isErr, err)
+	}
+	if !strings.Contains(text, "AI story") || !strings.Contains(text, "https://example.com/ai") {
+		t.Fatalf("expected provider text with source-linked article, got %s", text)
+	}
+}


### PR DESCRIPTION
## Summary
- Route ExecuteToolAs news_search calls through the wired live news provider before creating a synthetic session.
- Add coverage that background/agent news_search calls preserve trimmed queries and source-linked provider output.

Closes #1159