### PR TITLE
Polish guest AI news search answers

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1031,6 +1031,7 @@ func handleQuery(w http.ResponseWriter, r *http.Request) {
 	hasMarketsTool := false
 	hasWeatherTool := false
 	hasWebSearchTool := false
+	hasNewsSearchTool := false
 	for _, tc := range toolCalls {
 		switch tc.Tool {
 		case "markets":
@@ -1039,6 +1040,8 @@ func handleQuery(w http.ResponseWriter, r *http.Request) {
 			hasWeatherTool = true
 		case "web_search":
 			hasWebSearchTool = true
+		case "news_search":
+			hasNewsSearchTool = true
 		}
 	}
 	hasUnavailableNewsSearch := false
@@ -1048,7 +1051,7 @@ func handleQuery(w http.ResponseWriter, r *http.Request) {
 			break
 		}
 	}
-	if useFastToolFallback(req.Prompt, isGuest, hasMarketsTool, hasWeatherTool, hasWebSearchTool, hasUnavailableNewsSearch, ragParts) {
+	if useFastToolFallback(req.Prompt, isGuest, hasMarketsTool, hasWeatherTool, hasWebSearchTool, hasNewsSearchTool, hasUnavailableNewsSearch, ragParts) {
 		answer := app.NormalizeAnswerMarkdown(app.StripLatexDollars(synthesizeToolFallback(ragParts)))
 		rendered := app.RenderString(answer)
 		html := `<div class="card" id="agent-response">` + rendered + `</div>`
@@ -1292,7 +1295,7 @@ func isLatestTechnologyNewsPrompt(lower string) bool {
 	return false
 }
 
-func useFastToolFallback(prompt string, isGuest bool, hasMarketsTool bool, hasWeatherTool bool, hasWebSearchTool bool, hasUnavailableNewsSearch bool, ragParts []string) bool {
+func useFastToolFallback(prompt string, isGuest bool, hasMarketsTool bool, hasWeatherTool bool, hasWebSearchTool bool, hasNewsSearchTool bool, hasUnavailableNewsSearch bool, ragParts []string) bool {
 	if !isGuest || len(ragParts) == 0 {
 		return false
 	}
@@ -1302,7 +1305,10 @@ func useFastToolFallback(prompt string, isGuest bool, hasMarketsTool bool, hasWe
 	if hasWeatherTool && isSimpleWeatherPrompt(prompt) {
 		return true
 	}
-	return hasWebSearchTool && hasUnavailableNewsSearch && isLatestTechnologyNewsPrompt(strings.ToLower(prompt))
+	if isLatestTechnologyNewsPrompt(strings.ToLower(prompt)) {
+		return hasNewsSearchTool || (hasWebSearchTool && hasUnavailableNewsSearch)
+	}
+	return false
 }
 
 func isSimpleWeatherPrompt(prompt string) bool {

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -352,35 +352,35 @@ func TestShortcutToolCallsMarketMoverExplanationUsesPlanner(t *testing.T) {
 
 func TestUseFastToolFallbackOnlyForGuestMarketMovers(t *testing.T) {
 	rag := []string{"### markets\nLive crypto prices:\nBTC: $97000.00 (+1.23% 24h)"}
-	if !useFastToolFallback("What is moving in markets today?", true, true, false, false, false, rag) {
+	if !useFastToolFallback("What is moving in markets today?", true, true, false, false, false, false, rag) {
 		t.Fatal("expected guest market-mover prompts with market data to use the fast fallback")
 	}
-	if useFastToolFallback("What is moving in markets today?", false, true, false, false, false, rag) {
+	if useFastToolFallback("What is moving in markets today?", false, true, false, false, false, false, rag) {
 		t.Fatal("authenticated users should keep full synthesis")
 	}
-	if useFastToolFallback("Why is Bitcoin moving today?", true, true, false, false, false, rag) {
+	if useFastToolFallback("Why is Bitcoin moving today?", true, true, false, false, false, false, rag) {
 		t.Fatal("explanation prompts should keep full synthesis")
 	}
-	if useFastToolFallback("What is moving in markets today?", true, false, false, false, false, rag) {
+	if useFastToolFallback("What is moving in markets today?", true, false, false, false, false, false, rag) {
 		t.Fatal("fallback requires a market tool result")
 	}
-	if useFastToolFallback("What is moving in markets today?", true, true, false, false, false, nil) {
+	if useFastToolFallback("What is moving in markets today?", true, true, false, false, false, false, nil) {
 		t.Fatal("fallback requires result context")
 	}
 }
 
 func TestUseFastToolFallbackForGuestSimpleWeather(t *testing.T) {
 	rag := []string{"### weather_forecast\nWeather for New York.\nNow: 21°C, partly cloudy.\nFreshness/source: source Google Weather; generated at 2026-07-02 12:00 UTC."}
-	if !useFastToolFallback("Weather in New York today", true, false, true, false, false, rag) {
+	if !useFastToolFallback("Weather in New York today", true, false, true, false, false, false, rag) {
 		t.Fatal("expected simple guest weather prompts with weather data to use the fast fallback")
 	}
-	if useFastToolFallback("Compare weather in New York and London", true, false, true, false, false, rag) {
+	if useFastToolFallback("Compare weather in New York and London", true, false, true, false, false, false, rag) {
 		t.Fatal("comparative weather prompts should keep full synthesis")
 	}
-	if useFastToolFallback("Weather in New York today", false, false, true, false, false, rag) {
+	if useFastToolFallback("Weather in New York today", false, false, true, false, false, false, rag) {
 		t.Fatal("authenticated users should keep full synthesis")
 	}
-	if useFastToolFallback("Weather in New York today", true, false, false, false, false, rag) {
+	if useFastToolFallback("Weather in New York today", true, false, false, false, false, false, rag) {
 		t.Fatal("fallback requires a weather tool result")
 	}
 }
@@ -390,20 +390,24 @@ func TestUseFastToolFallbackForGuestUnavailableNewsWebFallback(t *testing.T) {
 		"### web_search\nCurrent date context: request date is 2026-07-02 UTC.\nSearch results for \"AI news\":\n1. AI story — snippet grounded in the web result (https://example.com/ai)",
 		"### news_search\nnews_search is unavailable right now. Use any other available live results to answer, and mention this unavailable source briefly without exposing internal payloads.",
 	}
-	if !useFastToolFallback("Find today's AI news", true, false, false, true, true, rag) {
+	if !useFastToolFallback("Find today's AI news", true, false, false, true, false, true, rag) {
 		t.Fatal("expected guest latest-news web fallback to skip LLM synthesis")
 	}
-	if useFastToolFallback("Find today's AI news", false, false, false, true, true, rag) {
+	if useFastToolFallback("Find today's AI news", false, false, false, true, false, true, rag) {
 		t.Fatal("authenticated users should keep full synthesis")
 	}
-	if useFastToolFallback("Find today's AI news", true, false, false, true, false, rag) {
+	if useFastToolFallback("Find today's AI news", true, false, false, true, false, false, rag) {
 		t.Fatal("fallback requires unavailable news_search disclosure")
 	}
-	if useFastToolFallback("Find today's AI news", true, false, false, false, true, rag) {
+	if useFastToolFallback("Find today's AI news", true, false, false, false, false, true, rag) {
 		t.Fatal("fallback requires available web_search context")
 	}
-	if useFastToolFallback("Find saved AI article", true, false, false, true, true, rag) {
+	if useFastToolFallback("Find saved AI article", true, false, false, true, false, true, rag) {
 		t.Fatal("non-current news prompts should keep full synthesis")
+	}
+
+	if !useFastToolFallback("Find today's AI news", true, false, false, false, true, false, []string{"### news_search\nNews results for \"AI news\":\n1. AI story https://example.com/ai"}) {
+		t.Fatal("expected successful guest news_search results to skip LLM synthesis")
 	}
 }
 

--- a/news/news.go
+++ b/news/news.go
@@ -1804,8 +1804,8 @@ func SearchToolText(query string) (string, error) {
 	if len(query) > 256 {
 		return "", fmt.Errorf("search query must not exceed 256 characters")
 	}
-	results := data.Search(query, 20, data.WithType("news"), data.WithKeywordOnly())
-	articles := newsSearchArticles(query, results, 20)
+	results := data.Search(query, 8, data.WithType("news"), data.WithKeywordOnly())
+	articles := newsSearchArticles(query, results, 8)
 	b, err := json.Marshal(map[string]interface{}{
 		"query":   query,
 		"results": articles,
@@ -1847,9 +1847,8 @@ func newsSearchArticles(query string, indexed []*data.IndexEntry, limit int) []m
 			"id":          entry.ID,
 			"title":       entry.Title,
 			"description": htmlToText(entry.Content),
-			"url":         entry.Metadata["url"],
+			"url":         cleanNewsArticleURL(entry.Metadata["url"]),
 			"category":    entry.Metadata["category"],
-			"image":       entry.Metadata["image"],
 			"posted_at":   entry.Metadata["posted_at"],
 		}
 		if articleMatchesNewsQuery(query, article) {
@@ -1862,13 +1861,30 @@ func newsSearchArticles(query string, indexed []*data.IndexEntry, limit int) []m
 			"id":          post.ID,
 			"title":       post.Title,
 			"description": htmlToText(post.Description),
-			"url":         post.URL,
+			"url":         cleanNewsArticleURL(post.URL),
 			"category":    post.Category,
-			"image":       post.Image,
 			"posted_at":   post.PostedAt,
 		})
 	}
 	return articles
+}
+
+func cleanNewsArticleURL(raw interface{}) string {
+	u := strings.TrimSpace(fmt.Sprintf("%v", raw))
+	if u == "" || strings.EqualFold(u, "<nil>") {
+		return ""
+	}
+	withoutQuery := u
+	if parsed, err := url.Parse(u); err == nil {
+		withoutQuery = parsed.Path
+	}
+	lower := strings.ToLower(withoutQuery)
+	for _, suffix := range []string{".jpg", ".jpeg", ".png", ".gif", ".webp", ".svg", ".avif"} {
+		if strings.HasSuffix(lower, suffix) {
+			return ""
+		}
+	}
+	return u
 }
 
 func liveFeedSearch(query string, limit int) []*Post {

--- a/news/news_test.go
+++ b/news/news_test.go
@@ -849,3 +849,12 @@ func TestGetFeedReturnsDedupedFeedForAgentContext(t *testing.T) {
 		t.Fatalf("expected agent-facing feed to collapse duplicates, got %#v", got)
 	}
 }
+
+func TestCleanNewsArticleURLRejectsImageAssets(t *testing.T) {
+	if got := cleanNewsArticleURL("https://cdn.example.com/story.jpg?width=1200"); got != "" {
+		t.Fatalf("expected image asset URL to be dropped, got %q", got)
+	}
+	if got := cleanNewsArticleURL("https://example.com/ai/story?ref=mu"); got != "https://example.com/ai/story?ref=mu" {
+		t.Fatalf("expected article URL to be preserved, got %q", got)
+	}
+}


### PR DESCRIPTION
## Summary
- Use the fast synthesized guest answer path when news_search succeeds for latest AI/technology news prompts, avoiding an extra LLM synthesis round-trip.
- Keep news_search tool payloads bounded and drop image-asset URLs from article source URLs before they reach references/cards.
- Add regression coverage for successful news_search fast fallback and image URL filtering.

Closes #1162
Closes #1164

## Testing
- go build ./...
- go test ./... -short
- go vet ./...