### PR TITLE
Improve AI news freshness and metadata labels

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1851,18 +1851,22 @@ func formatNewsResult(result string) string {
 	}
 	for i, a := range items {
 		line := fmt.Sprintf("%d. %s", i+1, a.Title)
+		var meta []string
 		if a.Category != "" {
-			line += fmt.Sprintf(" [%s]", a.Category)
+			meta = append(meta, "category: "+a.Category)
 		}
 		if a.PostedAt != "" {
 			if t, err := time.Parse(time.RFC3339, a.PostedAt); err == nil {
-				line += fmt.Sprintf(" (%s)", t.Format("2 Jan 2006 15:04 UTC"))
+				meta = append(meta, "posted: "+t.Format("2 Jan 2006 15:04 UTC"))
 			}
 		} else if a.Published != "" {
-			line += fmt.Sprintf(" (%s)", a.Published)
+			meta = append(meta, "published: "+a.Published)
 		}
 		if a.URL != "" {
-			line += " " + a.URL
+			meta = append(meta, "source: "+a.URL)
+		}
+		if len(meta) > 0 {
+			line += " (" + strings.Join(meta, "; ") + ")"
 		}
 		if a.Description != "" {
 			desc := a.Description

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -592,6 +592,17 @@ func TestFormatNewsResult_SearchWithTimestamp(t *testing.T) {
 	}
 }
 
+func TestFormatNewsResultUsesCleanMetadataLabels(t *testing.T) {
+	result := `{"query":"AI news","results":[{"title":"AI lab ships update","description":"Fresh details","category":"Tech","url":"https://example.com/ai","posted_at":"2026-07-05T12:00:00Z"}],"count":1}`
+	got := formatNewsResult(result)
+	if !strings.Contains(got, "category: Tech; posted: 5 Jul 2026 12:00 UTC; source: https://example.com/ai") {
+		t.Fatalf("expected category/date/source metadata labels, got %q", got)
+	}
+	if strings.Contains(got, "[Tech]") {
+		t.Fatalf("expected metadata not to use markdown-link-like category brackets, got %q", got)
+	}
+}
+
 func TestRenderToolCallRef_NewsSearch(t *testing.T) {
 	args := map[string]any{"query": "Iran"}
 	formatted := "News results for \"Iran\":\n1. Iran crisis [world] (2 Mar 2026 10:00) — Conflict escalates\n"

--- a/news/news.go
+++ b/news/news.go
@@ -1842,6 +1842,7 @@ func newsSearchArticles(query string, indexed []*data.IndexEntry, limit int) []m
 		articles = append(articles, article)
 	}
 
+	var candidates []map[string]interface{}
 	for _, entry := range indexed {
 		article := map[string]interface{}{
 			"id":          entry.ID,
@@ -1852,12 +1853,12 @@ func newsSearchArticles(query string, indexed []*data.IndexEntry, limit int) []m
 			"posted_at":   entry.Metadata["posted_at"],
 		}
 		if articleMatchesNewsQuery(query, article) {
-			add(article)
+			candidates = append(candidates, article)
 		}
 	}
 
 	for _, post := range liveFeedSearch(query, limit) {
-		add(map[string]interface{}{
+		candidates = append(candidates, map[string]interface{}{
 			"id":          post.ID,
 			"title":       post.Title,
 			"description": htmlToText(post.Description),
@@ -1866,7 +1867,39 @@ func newsSearchArticles(query string, indexed []*data.IndexEntry, limit int) []m
 			"posted_at":   post.PostedAt,
 		})
 	}
+
+	if newsQueryWantsFreshness(query) {
+		sort.SliceStable(candidates, func(i, j int) bool {
+			return articlePostedAt(candidates[i]).After(articlePostedAt(candidates[j]))
+		})
+	}
+
+	for _, article := range candidates {
+		add(article)
+	}
 	return articles
+}
+
+func newsQueryWantsFreshness(query string) bool {
+	lower := strings.ToLower(query)
+	for _, token := range []string{"today", "latest", "current", "fresh", "recent"} {
+		if strings.Contains(lower, token) {
+			return true
+		}
+	}
+	return false
+}
+
+func articlePostedAt(article map[string]interface{}) time.Time {
+	switch v := article["posted_at"].(type) {
+	case time.Time:
+		return v
+	case string:
+		if t, err := time.Parse(time.RFC3339, v); err == nil {
+			return t
+		}
+	}
+	return time.Time{}
 }
 
 func cleanNewsArticleURL(raw interface{}) string {

--- a/news/news_test.go
+++ b/news/news_test.go
@@ -254,6 +254,47 @@ func TestNewsSearchArticlesFallsBackToLiveFeed(t *testing.T) {
 	}
 }
 
+func TestNewsSearchArticlesFreshQueriesPreferNewestMatches(t *testing.T) {
+	oldFeed := feed
+	defer func() {
+		mutex.Lock()
+		feed = oldFeed
+		mutex.Unlock()
+	}()
+
+	newer := time.Date(2026, 7, 5, 12, 0, 0, 0, time.UTC)
+	older := time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC)
+	indexed := []*data.IndexEntry{{
+		ID:      "old-ai",
+		Title:   "AI startup raises funding",
+		Content: "Artificial intelligence funding story from the archive.",
+		Metadata: map[string]interface{}{
+			"url":       "https://example.com/old-ai",
+			"category":  "Tech",
+			"posted_at": older.Format(time.RFC3339),
+		},
+	}}
+
+	mutex.Lock()
+	feed = []*Post{{
+		ID:          "new-ai",
+		Title:       "AI lab ships today's assistant update",
+		Description: "Fresh release notes for today's AI update.",
+		URL:         "https://example.com/new-ai",
+		Category:    "Tech",
+		PostedAt:    newer,
+	}}
+	mutex.Unlock()
+
+	got := newsSearchArticles("Find today's AI news", indexed, 20)
+	if len(got) < 2 {
+		t.Fatalf("expected indexed and live results, got %#v", got)
+	}
+	if got[0]["title"] != "AI lab ships today's assistant update" {
+		t.Fatalf("expected newest matching item first for freshness query, got %#v", got)
+	}
+}
+
 func TestSearchToolTextReturnsLiveFeedResultsForAgent(t *testing.T) {
 	oldFeed := feed
 	defer func() {


### PR DESCRIPTION
## Summary
- Prefer newest dated articles for freshness-oriented news searches such as today's/latest AI news.
- Render news result metadata with explicit category, posted, and source labels to avoid malformed category/date links.
- Add regression coverage for fresh AI-news ordering and clean metadata labels.

Closes #1167
Closes #1169