### PR TITLE
Surface news freshness caveats in agent answers

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1785,6 +1785,12 @@ func formatNewsResult(result string) string {
 			URL         string `json:"url"`
 			PostedAt    string `json:"posted_at"`
 		} `json:"results"`
+		Freshness struct {
+			Status           string `json:"status"`
+			Notice           string `json:"notice"`
+			RequestedDate    string `json:"requested_date"`
+			FreshestPostedAt string `json:"freshest_posted_at"`
+		} `json:"freshness"`
 		Query string `json:"query"`
 	}
 	if err := json.Unmarshal([]byte(result), &data); err != nil {
@@ -1848,6 +1854,29 @@ func formatNewsResult(result string) string {
 		sb.WriteString(fmt.Sprintf("News results for %q:\n", data.Query))
 	} else {
 		sb.WriteString("Latest news:\n")
+	}
+	if freshnessNotice := strings.TrimSpace(data.Freshness.Notice); freshnessNotice != "" {
+		sb.WriteString("Freshness caveat: " + freshnessNotice + "\n")
+	} else if data.Freshness.Status == "stale" || data.Freshness.Status == "no_dated_results" {
+		requestedDate := strings.TrimSpace(data.Freshness.RequestedDate)
+		if requestedDate == "" {
+			requestedDate = "the requested date"
+		}
+		if data.Freshness.Status == "no_dated_results" {
+			sb.WriteString("Freshness caveat: No dated news results were available for " + requestedDate + "; do not present these results as today's news without that caveat.\n")
+		} else {
+			freshest := strings.TrimSpace(data.Freshness.FreshestPostedAt)
+			if freshest != "" {
+				if t, err := time.Parse(time.RFC3339, freshest); err == nil {
+					freshest = t.UTC().Format("2006-01-02")
+				}
+			}
+			if freshest == "" {
+				sb.WriteString("Freshness caveat: No same-day news results were available for " + requestedDate + "; lead with a freshness caveat before older items.\n")
+			} else {
+				sb.WriteString("Freshness caveat: No same-day news results were available for " + requestedDate + "; the freshest result is from " + freshest + ", so lead with a freshness caveat before older items.\n")
+			}
+		}
 	}
 	for i, a := range items {
 		line := fmt.Sprintf("%d. %s", i+1, a.Title)

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -1454,6 +1454,19 @@ func TestFormatToolResultNewsHeadlinesStaysReadable(t *testing.T) {
 	}
 }
 
+func TestFormatToolResultNewsSearchSurfacesFreshnessCaveat(t *testing.T) {
+	result := `{"query":"AI news","freshness":{"status":"stale","requested_date":"2026-07-05","freshest_posted_at":"2026-05-20T12:00:00Z","notice":"No same-day news_search results were available for 2026-07-05; the freshest result is from 2026-05-20, so lead with a freshness caveat instead of presenting older stories as today's news."},"results":[{"title":"AI startup raises funding","description":"Artificial intelligence funding story from the archive.","category":"Tech","url":"https://example.com/old-ai","posted_at":"2026-05-20T12:00:00Z"}]}`
+	got := formatToolResult("news_search", result, nil)
+	firstCaveat := strings.Index(got, "Freshness caveat:")
+	firstStory := strings.Index(got, "1. AI startup raises funding")
+	if firstCaveat < 0 {
+		t.Fatalf("expected freshness caveat in news_search context, got %q", got)
+	}
+	if firstStory < 0 || firstStory < firstCaveat {
+		t.Fatalf("expected freshness caveat before older fallback stories, got %q", got)
+	}
+}
+
 func TestCompleteToolAnswerKeepsSubstantiveAnswer(t *testing.T) {
 	want := "BTC is at $100,000, and the latest news says it reached a new high."
 	got := completeToolAnswer(want, []string{"### markets\nBTC: $100,000"})


### PR DESCRIPTION
## Summary
- Surface news_search freshness metadata in formatted agent context before older fallback stories.
- Add coverage that stale AI-news search results lead with the freshness caveat.

Closes #1177
Closes #1179

## Testing
- go build ./...
- go test ./... -short
- go vet ./...