### PR TITLE
Prioritize current news search candidates

### DIFF
--- a/news/news.go
+++ b/news/news.go
@@ -1861,7 +1861,16 @@ func newsSearchArticles(query string, indexed []*data.IndexEntry, limit int) []m
 		}
 	}
 
-	for _, post := range liveFeedSearch(query, limit) {
+	liveLimit := limit
+	if newsQueryWantsFreshness(query) {
+		// Freshness prompts ("today", "latest", "current") need a wider live-feed
+		// candidate pool than the final response size. liveFeedSearch ranks by
+		// textual relevance first, so a same-day story with a narrower term match
+		// can otherwise be trimmed before the final recency sort gets a chance to
+		// promote it above older, broader matches.
+		liveLimit = newsSearchFreshCandidateLimit(limit)
+	}
+	for _, post := range liveFeedSearch(query, liveLimit) {
 		candidates = append(candidates, map[string]interface{}{
 			"id":          post.ID,
 			"title":       post.Title,
@@ -1882,6 +1891,17 @@ func newsSearchArticles(query string, indexed []*data.IndexEntry, limit int) []m
 		add(article)
 	}
 	return articles
+}
+
+func newsSearchFreshCandidateLimit(limit int) int {
+	if limit <= 0 {
+		limit = 20
+	}
+	widened := limit * 4
+	if widened < 50 {
+		widened = 50
+	}
+	return widened
 }
 
 func newsSearchFreshnessSummary(query string, articles []map[string]interface{}, now time.Time) map[string]interface{} {

--- a/news/news_test.go
+++ b/news/news_test.go
@@ -296,6 +296,49 @@ func TestNewsSearchArticlesFreshQueriesPreferNewestMatches(t *testing.T) {
 	}
 }
 
+func TestNewsSearchArticlesFreshQueriesWidenLiveCandidatePool(t *testing.T) {
+	oldFeed := feed
+	defer func() {
+		mutex.Lock()
+		feed = oldFeed
+		mutex.Unlock()
+	}()
+
+	older := time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC)
+	today := time.Date(2026, 7, 6, 9, 0, 0, 0, time.UTC)
+	var posts []*Post
+	for i := 0; i < 12; i++ {
+		posts = append(posts, &Post{
+			ID:          fmt.Sprintf("old-ai-model-%d", i),
+			Title:       fmt.Sprintf("AI model archive item %d", i),
+			Description: "Older artificial intelligence model background.",
+			URL:         fmt.Sprintf("https://example.com/old-ai-model-%d", i),
+			Category:    "Tech",
+			PostedAt:    older.Add(time.Duration(i) * time.Hour),
+		})
+	}
+	posts = append(posts, &Post{
+		ID:          "same-day-ai",
+		Title:       "AI startup ships same-day assistant update",
+		Description: "Fresh AI product news from today.",
+		URL:         "https://example.com/same-day-ai",
+		Category:    "Tech",
+		PostedAt:    today,
+	})
+
+	mutex.Lock()
+	feed = posts
+	mutex.Unlock()
+
+	got := newsSearchArticles("Find today's AI news", nil, 8)
+	if len(got) == 0 {
+		t.Fatal("expected live feed results")
+	}
+	if got[0]["title"] != "AI startup ships same-day assistant update" {
+		t.Fatalf("expected widened candidate pool to let same-day AI news lead, got %#v", got)
+	}
+}
+
 func TestNewsSearchFreshnessSummaryCaveatsStaleTodayResults(t *testing.T) {
 	articles := []map[string]interface{}{{
 		"title":     "AI startup raises funding",


### PR DESCRIPTION
## Summary
- widen the live-feed candidate pool for freshness-oriented news_search queries before final recency sorting
- add regression coverage for same-day AI news being trimmed behind older high-relevance archive items

Closes #1172
Closes #1183

## Testing
- go build ./...
- go test ./... -short
- go vet ./...