### PR TITLE
Lead stale news answers with freshness caveat

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -1467,6 +1467,34 @@ func TestFormatToolResultNewsSearchSurfacesFreshnessCaveat(t *testing.T) {
 	}
 }
 
+func TestCompleteToolAnswerPrependsStaleNewsCaveatToSubstantiveAnswer(t *testing.T) {
+	rag := []string{`### news_search
+News results for "AI news":
+Freshness caveat: No same-day news_search results were available for 2026-07-06; the freshest result is from 2026-05-20, so lead with a freshness caveat before older items.
+1. AI startup raises funding (category: Tech; posted: 20 May 2026 12:00 UTC; source: https://example.com/old-ai) — Archive story.`}
+	answer := "1. AI startup raises funding — an older archive item from May."
+	got := completeToolAnswer(answer, rag)
+	firstLine, _, _ := strings.Cut(got, "\n")
+	if !strings.Contains(firstLine, "No current news_search results:") || !strings.Contains(firstLine, "No same-day news_search results were available for 2026-07-06") {
+		t.Fatalf("expected stale-only disclosure before story list, got %q", got)
+	}
+	if strings.Index(got, "No current news_search results:") > strings.Index(got, "1. AI startup raises funding") {
+		t.Fatalf("expected stale-only disclosure to precede stories, got %q", got)
+	}
+}
+
+func TestCompleteToolAnswerDoesNotDuplicateLeadingStaleNewsCaveat(t *testing.T) {
+	rag := []string{`### news_search
+News results for "AI news":
+Freshness caveat: No same-day news_search results were available for 2026-07-06; the freshest result is from 2026-05-20, so lead with a freshness caveat before older items.
+1. AI startup raises funding (category: Tech; posted: 20 May 2026 12:00 UTC; source: https://example.com/old-ai) — Archive story.`}
+	answer := "No same-day news_search results were available for 2026-07-06. The freshest item is older."
+	got := completeToolAnswer(answer, rag)
+	if got != answer {
+		t.Fatalf("expected existing leading caveat to be preserved without duplication, got %q", got)
+	}
+}
+
 func TestCompleteToolAnswerKeepsSubstantiveAnswer(t *testing.T) {
 	want := "BTC is at $100,000, and the latest news says it reached a new high."
 	got := completeToolAnswer(want, []string{"### markets\nBTC: $100,000"})

--- a/agent/answer_guard.go
+++ b/agent/answer_guard.go
@@ -23,11 +23,50 @@ func completeToolAnswer(answer string, ragParts []string) string {
 	if len(ragParts) == 0 {
 		return answer
 	}
+	if caveat := staleNewsFreshnessCaveat(ragParts); caveat != "" && !answerLeadsWithFreshnessCaveat(trimmed) {
+		if trimmed == "" {
+			return caveat
+		}
+		return caveat + "\n\n" + trimmed
+	}
+
 	if !isProgressOnlyAnswer(trimmed) && !isRawToolPayloadAnswer(trimmed) && !hasOperationalFallbackLead(trimmed) {
 		return answer
 	}
 
 	return synthesizeToolFallback(ragParts)
+}
+
+func staleNewsFreshnessCaveat(ragParts []string) string {
+	for _, part := range ragParts {
+		title, body := splitRAGPart(part)
+		if canonicalToolTitle(title) != "news" {
+			continue
+		}
+		for _, raw := range strings.Split(body, "\n") {
+			line := strings.TrimSpace(strings.TrimLeft(raw, "-• "))
+			if line == "" {
+				continue
+			}
+			lower := strings.ToLower(line)
+			if strings.HasPrefix(lower, "freshness caveat:") {
+				return "No current news_search results: " + strings.TrimSpace(line[len("Freshness caveat:"):])
+			}
+		}
+	}
+	return ""
+}
+
+func answerLeadsWithFreshnessCaveat(answer string) bool {
+	for _, raw := range strings.Split(answer, "\n") {
+		line := strings.TrimSpace(strings.TrimLeft(raw, "-•#* "))
+		if line == "" {
+			continue
+		}
+		lower := strings.ToLower(line)
+		return strings.Contains(lower, "no current") || strings.Contains(lower, "no same-day") || strings.Contains(lower, "freshness caveat") || strings.Contains(lower, "stale")
+	}
+	return false
 }
 
 func synthesizeToolFallback(ragParts []string) string {


### PR DESCRIPTION
## Summary
- Prepend an explicit no-current-results disclosure when news_search only provides stale dated evidence and the final answer would otherwise lead with older stories.
- Add regression coverage for stale-only news answers and preserving an existing leading caveat.

## Testing
- go build ./...
- go test ./... -short
- go vet ./...

Closes #1187
Closes #1192