### PR TITLE
Lead stale AI-news fallbacks with caveats

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -1483,6 +1483,24 @@ Freshness caveat: No same-day news_search results were available for 2026-07-06;
 	}
 }
 
+func TestSynthesizeToolFallbackLeadsStaleNewsWithCaveat(t *testing.T) {
+	rag := []string{`### news_search
+News results for "AI news":
+Freshness caveat: No same-day news_search results were available for 2026-07-06; the freshest result is from 2026-05-20, so lead with a freshness caveat before older items.
+1. AI startup raises funding (category: Tech; posted: 20 May 2026 12:00 UTC; source: https://example.com/old-ai) — Archive story.`}
+	got := synthesizeToolFallback(rag)
+	firstLine, _, _ := strings.Cut(got, "\n")
+	if !strings.Contains(firstLine, "No current news_search results:") {
+		t.Fatalf("expected stale-only disclosure to lead fallback answer, got %q", got)
+	}
+	if strings.Contains(got, "- News results for") {
+		t.Fatalf("did not expect tool-style news heading in fallback answer, got %q", got)
+	}
+	if !strings.Contains(got, "Background: AI startup raises funding") {
+		t.Fatalf("expected older stale stories to be labeled as background, got %q", got)
+	}
+}
+
 func TestCompleteToolAnswerDoesNotDuplicateLeadingStaleNewsCaveat(t *testing.T) {
 	rag := []string{`### news_search
 News results for "AI news":
@@ -1538,7 +1556,7 @@ func TestNativeToolRecorderFormatsNewsPayloads(t *testing.T) {
 	if strings.Contains(strings.ToLower(got), "let me search") {
 		t.Fatalf("expected native progress narration to be replaced, got %q", got)
 	}
-	if !strings.Contains(got, "News results for") || !strings.Contains(got, "AI headline") || strings.Contains(got, `{"query"`) {
+	if !strings.Contains(got, "AI headline") || !strings.Contains(got, "Useful context") || strings.Contains(got, `{"query"`) {
 		t.Fatalf("expected native fallback to use formatted news results, got %q", got)
 	}
 }

--- a/agent/answer_guard.go
+++ b/agent/answer_guard.go
@@ -173,6 +173,9 @@ func formatFallbackSection(title, body string) string {
 	}
 
 	lines := meaningfulLines(body, 6)
+	if canonical == "news" {
+		lines = prioritizeStaleNewsCaveatLines(lines)
+	}
 	if canonical == "weather" {
 		lines = prioritizeCurrentWeatherLines(lines)
 		if summary := weatherAnswerLead(lines); summary != "" {
@@ -274,6 +277,48 @@ func webSearchAnswerLead(lines []string, requestDate string) string {
 		prefix += " for " + requestDate
 	}
 	return prefix + ": " + first + "; " + second + "."
+}
+
+func prioritizeStaleNewsCaveatLines(lines []string) []string {
+	if len(lines) == 0 {
+		return lines
+	}
+	caveatIndex := -1
+	for i, line := range lines {
+		if strings.HasPrefix(strings.ToLower(strings.TrimSpace(line)), "freshness caveat:") {
+			caveatIndex = i
+			break
+		}
+	}
+	if caveatIndex < 0 {
+		return lines
+	}
+	out := make([]string, 0, len(lines))
+	caveat := strings.TrimSpace(lines[caveatIndex])
+	caveat = strings.TrimSpace(caveat[len("Freshness caveat:"):])
+	out = append(out, "No current news_search results: "+caveat)
+	for i, line := range lines {
+		if i == caveatIndex {
+			continue
+		}
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || isSearchResultHeading(trimmed) {
+			continue
+		}
+		if looksLikeNewsStoryLine(trimmed) && !strings.HasPrefix(strings.ToLower(trimmed), "background:") {
+			trimmed = "Background: " + trimmed
+		}
+		out = append(out, trimmed)
+	}
+	return out
+}
+
+func looksLikeNewsStoryLine(line string) bool {
+	lower := strings.ToLower(strings.TrimSpace(line))
+	if lower == "" || strings.HasPrefix(lower, "no current") || strings.HasPrefix(lower, "freshness caveat:") {
+		return false
+	}
+	return strings.Contains(lower, "posted:") || strings.Contains(lower, "source: http") || strings.Contains(line, " — ")
 }
 
 func fallbackRequestDate(body string) string {
@@ -466,7 +511,7 @@ func isFallbackSecondaryContextLine(line string) bool {
 
 func isSearchResultHeading(line string) bool {
 	lower := strings.ToLower(strings.TrimSpace(line))
-	return strings.HasPrefix(lower, "search results for ") || lower == "search results:" || strings.HasPrefix(lower, "web results for ") || strings.HasPrefix(lower, "top results")
+	return strings.HasPrefix(lower, "search results for ") || lower == "search results:" || strings.HasPrefix(lower, "web results for ") || strings.HasPrefix(lower, "news results for ") || strings.HasPrefix(lower, "top results")
 }
 
 func isGenericSearchFallbackIntro(line string) bool {


### PR DESCRIPTION
## Summary
- Lead stale-only news fallback answers with a no-current-results caveat instead of a tool-style heading.
- Label older news items as background when freshness metadata shows no same-day results.
- Add regression coverage for the fast fallback path.

Closes #1197
Closes #1199