### PR TITLE
Guard stale news native streaming

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -1501,6 +1501,20 @@ Freshness caveat: No same-day news_search results were available for 2026-07-06;
 	}
 }
 
+func TestShouldBufferNativeTokenForStaleNewsCaveat(t *testing.T) {
+	recorder := newNativeToolRecorder()
+	if shouldBufferNativeToken(recorder) {
+		t.Fatal("empty recorder should not buffer native tokens")
+	}
+	recorder.parts = append(recorder.parts, `### news
+News results for "AI news":
+Freshness caveat: No same-day news_search results were available for 2026-07-06; the freshest result is from 2026-05-20, so lead with a freshness caveat before older items.
+1. AI startup raises funding (category: Tech; posted: 20 May 2026 12:00 UTC; source: https://example.com/old-ai) — Archive story.`)
+	if !shouldBufferNativeToken(recorder) {
+		t.Fatal("stale-only news recorder should buffer native tokens until the guarded final response")
+	}
+}
+
 func TestCompleteToolAnswerDoesNotDuplicateLeadingStaleNewsCaveat(t *testing.T) {
 	rag := []string{`### news_search
 News results for "AI news":

--- a/agent/native.go
+++ b/agent/native.go
@@ -290,6 +290,9 @@ func streamNative(accountID, prompt string, opts QueryOpts, hooks StreamHooks) (
 			}
 		case gmagent.StreamEventToken:
 			reply.WriteString(ev.Token)
+			if shouldBufferNativeToken(recorder) {
+				continue
+			}
 			if hooks.Token != nil {
 				hooks.Token(ev.Token)
 			}
@@ -318,6 +321,17 @@ type nativeToolRecorder struct {
 
 func newNativeToolRecorder() *nativeToolRecorder {
 	return &nativeToolRecorder{}
+}
+
+func shouldBufferNativeToken(recorder *nativeToolRecorder) bool {
+	if recorder == nil {
+		return false
+	}
+	// Stale-only news answers need the guard to prepend an unmistakable caveat
+	// before any older story. Native streaming emits model tokens before the
+	// final answer guard runs, so buffer those tokens and let the final response
+	// replace them once the stale-news caveat/background labels are applied.
+	return staleNewsFreshnessCaveat(recorder.ragParts()) != ""
 }
 
 func (r *nativeToolRecorder) wrap(next gmai.ToolHandler) gmai.ToolHandler {


### PR DESCRIPTION
## Summary
- Buffer native streamed model tokens when news_search context contains a stale-only freshness caveat, so the guarded final response can lead with the no-current-results disclosure before older stories.
- Add regression coverage for stale-news native token buffering.

Closes #1202
Closes #1204

## Testing
- go test ./agent -run 'Test(ShouldBufferNativeTokenForStaleNewsCaveat|SynthesizeToolFallbackLeadsStaleNewsWithCaveat|CompleteToolAnswerPrependsStaleNewsCaveatToSubstantiveAnswer)' -count=1
- go build ./...
- go test ./... -short
- go vet ./...