### PR TITLE
Hold native AI-news streams for freshness guard

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -605,6 +605,10 @@ func streamNativeSSE(w http.ResponseWriter, accountID, prompt string, opts Query
 			sse(w, map[string]any{"type": "tool_done", "name": label, "message": label + " — done"})
 		},
 		Token: func(tok string) {
+			if shouldHoldNativeNewsStreamTokens(prompt, nativeTools) {
+				captured.WriteString(tok)
+				return
+			}
 			if !streaming {
 				streaming = true
 				emitted = true
@@ -637,6 +641,12 @@ func streamNativeSSE(w http.ResponseWriter, accountID, prompt string, opts Query
 	}
 	answer = completeNativeToolAnswer(answer, nativeTools)
 	answer = app.NormalizeAnswerMarkdown(answer)
+	if !streaming && captured.Len() > 0 {
+		streaming = true
+		emitted = true
+		sse(w, map[string]any{"type": "stream_start"})
+		sse(w, map[string]any{"type": "stream_token", "token": answer})
+	}
 	rendered := app.RenderString(answer)
 	html := `<div class="card" id="agent-response">` + rendered + `</div>`
 	updateFlow(flow.ID, func(f *Flow) {
@@ -1307,6 +1317,18 @@ func useFastToolFallback(prompt string, isGuest bool, hasMarketsTool bool, hasWe
 	}
 	if isLatestTechnologyNewsPrompt(strings.ToLower(prompt)) {
 		return hasNewsSearchTool || (hasWebSearchTool && hasUnavailableNewsSearch)
+	}
+	return false
+}
+
+func shouldHoldNativeNewsStreamTokens(prompt string, nativeTools []string) bool {
+	if !isLatestTechnologyNewsPrompt(strings.ToLower(prompt)) {
+		return false
+	}
+	for _, tool := range nativeTools {
+		if canonicalToolTitle(tool) == "news" {
+			return true
+		}
 	}
 	return false
 }

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -1515,6 +1515,18 @@ Freshness caveat: No same-day news_search results were available for 2026-07-06;
 	}
 }
 
+func TestShouldHoldNativeNewsStreamTokensForLatestNewsPrompt(t *testing.T) {
+	if !shouldHoldNativeNewsStreamTokens("Find today's AI news", []string{"news"}) {
+		t.Fatal("expected native latest-news tokens to be held once news tool starts")
+	}
+	if shouldHoldNativeNewsStreamTokens("Find today's AI news", []string{"weather"}) {
+		t.Fatal("did not expect non-news native tool tokens to be held")
+	}
+	if shouldHoldNativeNewsStreamTokens("What is moving in markets?", []string{"news"}) {
+		t.Fatal("did not expect non-latest-news prompts to hold native tokens")
+	}
+}
+
 func TestCompleteToolAnswerDoesNotDuplicateLeadingStaleNewsCaveat(t *testing.T) {
 	rag := []string{`### news_search
 News results for "AI news":


### PR DESCRIPTION
## Summary
- Hold native streamed tokens for latest AI-news prompts after the news tool starts so stale-only results can be guarded before any story text reaches the client.
- Emit the guarded final answer as the stream token when native news streaming was held.
- Add regression coverage for holding latest-news native stream tokens only after news tool use.

Closes #1207
Closes #1209

## Testing
- go test ./agent -short
- go build ./...
- go test ./... -short
- go vet ./...