### PR TITLE
Guard stale AI-news answers

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -1478,8 +1478,26 @@ Freshness caveat: No same-day news_search results were available for 2026-07-06;
 	if !strings.Contains(firstLine, "No current news_search results:") || !strings.Contains(firstLine, "No same-day news_search results were available for 2026-07-06") {
 		t.Fatalf("expected stale-only disclosure before story list, got %q", got)
 	}
-	if strings.Index(got, "No current news_search results:") > strings.Index(got, "1. AI startup raises funding") {
-		t.Fatalf("expected stale-only disclosure to precede stories, got %q", got)
+	if strings.Index(got, "No current news_search results:") > strings.Index(got, "Background: 1. AI startup raises funding") {
+		t.Fatalf("expected stale-only disclosure to precede background-labeled stories, got %q", got)
+	}
+	if !strings.Contains(got, "Background: 1. AI startup raises funding") {
+		t.Fatalf("expected stale-only substantive answer stories to be labeled as background, got %q", got)
+	}
+}
+
+func TestCompleteToolAnswerLabelsExistingStaleNewsCaveatStories(t *testing.T) {
+	rag := []string{`### news_search
+News results for "AI news":
+Freshness caveat: No same-day news_search results were available for 2026-07-06; the freshest result is from 2026-05-20, so lead with a freshness caveat before older items.
+1. AI startup raises funding (category: Tech; posted: 20 May 2026 12:00 UTC; source: https://example.com/old-ai) — Archive story.`}
+	answer := "No same-day news_search results were available for 2026-07-06. Older items only:\n- 1. AI startup raises funding — an archive item from May."
+	got := completeToolAnswer(answer, rag)
+	if strings.Count(got, "No current news_search results:") != 0 {
+		t.Fatalf("did not expect duplicate no-current caveat, got %q", got)
+	}
+	if !strings.Contains(got, "- Background: 1. AI startup raises funding") {
+		t.Fatalf("expected existing caveat answer stories to be labeled as background, got %q", got)
 	}
 }
 

--- a/agent/answer_guard.go
+++ b/agent/answer_guard.go
@@ -23,11 +23,15 @@ func completeToolAnswer(answer string, ragParts []string) string {
 	if len(ragParts) == 0 {
 		return answer
 	}
-	if caveat := staleNewsFreshnessCaveat(ragParts); caveat != "" && !answerLeadsWithFreshnessCaveat(trimmed) {
-		if trimmed == "" {
+	if caveat := staleNewsFreshnessCaveat(ragParts); caveat != "" {
+		guarded := labelStaleNewsAnswerStories(trimmed)
+		if answerLeadsWithFreshnessCaveat(trimmed) {
+			return guarded
+		}
+		if guarded == "" {
 			return caveat
 		}
-		return caveat + "\n\n" + trimmed
+		return caveat + "\n\n" + guarded
 	}
 
 	if !isProgressOnlyAnswer(trimmed) && !isRawToolPayloadAnswer(trimmed) && !hasOperationalFallbackLead(trimmed) {
@@ -55,6 +59,42 @@ func staleNewsFreshnessCaveat(ragParts []string) string {
 		}
 	}
 	return ""
+}
+
+func labelStaleNewsAnswerStories(answer string) string {
+	if strings.TrimSpace(answer) == "" {
+		return ""
+	}
+	lines := strings.Split(answer, "\n")
+	changed := false
+	for i, raw := range lines {
+		trimmed := strings.TrimSpace(raw)
+		if trimmed == "" {
+			continue
+		}
+		marker := ""
+		content := trimmed
+		for _, prefix := range []string{"- ", "* ", "• "} {
+			if strings.HasPrefix(content, prefix) {
+				marker = prefix
+				content = strings.TrimSpace(strings.TrimPrefix(content, prefix))
+				break
+			}
+		}
+		lower := strings.ToLower(content)
+		if strings.HasPrefix(lower, "background:") || strings.HasPrefix(lower, "no current") || strings.Contains(lower, "no same-day") || strings.Contains(lower, "freshness caveat") {
+			continue
+		}
+		if looksLikeNewsStoryLine(content) || regexp.MustCompile(`^\d+[.)]\s+`).MatchString(content) {
+			indent := raw[:len(raw)-len(strings.TrimLeft(raw, " \t"))]
+			lines[i] = indent + marker + "Background: " + content
+			changed = true
+		}
+	}
+	if !changed {
+		return answer
+	}
+	return strings.Join(lines, "\n")
 }
 
 func answerLeadsWithFreshnessCaveat(answer string) bool {


### PR DESCRIPTION
## Summary
- Label stale-only news answer story lines as background when the freshness guard is active.
- Keep no-current/same-day caveats at the front without duplicating them.
- Add regression coverage for substantive and already-caveated stale news answers.

Closes #1212
Closes #1214