### PR TITLE
Guard mostly stale AI news freshness

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -1467,6 +1467,19 @@ func TestFormatToolResultNewsSearchSurfacesFreshnessCaveat(t *testing.T) {
 	}
 }
 
+func TestFormatToolResultNewsSearchSurfacesMostlyStaleFreshnessCaveat(t *testing.T) {
+	result := `{"query":"AI news","freshness":{"status":"mostly_stale","requested_date":"2026-07-05","same_day_results":1,"dated_results":3,"freshest_posted_at":"2026-07-05T12:00:00Z","notice":"Only 1 of 3 dated news_search results are from 2026-07-05; lead with a freshness caveat before listing older context as today's news."},"results":[{"title":"AI lab ships today's assistant update","description":"Current AI story.","category":"Tech","url":"https://example.com/current-ai","posted_at":"2026-07-05T12:00:00Z"},{"title":"AI startup raises funding","description":"Archive story.","category":"Tech","url":"https://example.com/old-ai","posted_at":"2026-05-20T12:00:00Z"}]}`
+	got := formatToolResult("news_search", result, nil)
+	firstCaveat := strings.Index(got, "Freshness caveat:")
+	firstStory := strings.Index(got, "1. AI lab ships today's assistant update")
+	if firstCaveat < 0 || !strings.Contains(got, "Only 1 of 3 dated news_search results") {
+		t.Fatalf("expected mostly-stale freshness caveat in news_search context, got %q", got)
+	}
+	if firstStory < 0 || firstStory < firstCaveat {
+		t.Fatalf("expected mostly-stale caveat before story list, got %q", got)
+	}
+}
+
 func TestCompleteToolAnswerPrependsStaleNewsCaveatToSubstantiveAnswer(t *testing.T) {
 	rag := []string{`### news_search
 News results for "AI news":

--- a/news/news.go
+++ b/news/news.go
@@ -1913,8 +1913,18 @@ func newsSearchFreshnessSummary(query string, articles []map[string]interface{},
 	}
 	now = now.UTC()
 	freshest := time.Time{}
+	dated := 0
+	sameDay := 0
 	for _, article := range articles {
 		posted := articlePostedAt(article)
+		if posted.IsZero() {
+			continue
+		}
+		posted = posted.UTC()
+		dated++
+		if posted.Format("2006-01-02") == now.Format("2006-01-02") {
+			sameDay++
+		}
 		if posted.After(freshest) {
 			freshest = posted
 		}
@@ -1932,6 +1942,13 @@ func newsSearchFreshnessSummary(query string, articles []map[string]interface{},
 	freshest = freshest.UTC()
 	freshness["freshest_posted_at"] = freshest.Format(time.RFC3339)
 	if freshest.Format("2006-01-02") == requestedDate {
+		freshness["same_day_results"] = sameDay
+		freshness["dated_results"] = dated
+		if dated > 1 && sameDay*2 < dated {
+			freshness["status"] = "mostly_stale"
+			freshness["notice"] = fmt.Sprintf("Only %d of %d dated news_search results are from %s; lead with a freshness caveat before listing older context as today's news.", sameDay, dated, requestedDate)
+			return freshness
+		}
 		freshness["status"] = "current"
 		return freshness
 	}

--- a/news/news_test.go
+++ b/news/news_test.go
@@ -373,6 +373,33 @@ func TestNewsSearchFreshnessSummaryCurrentForSameDayResults(t *testing.T) {
 	}
 }
 
+func TestNewsSearchFreshnessSummaryCaveatsMostlyStaleTodayResults(t *testing.T) {
+	articles := []map[string]interface{}{
+		{
+			"title":     "AI lab ships today's assistant update",
+			"posted_at": time.Date(2026, 7, 5, 12, 0, 0, 0, time.UTC),
+		},
+		{
+			"title":     "AI startup raises funding",
+			"posted_at": time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC),
+		},
+		{
+			"title":     "AI chip demand grows",
+			"posted_at": time.Date(2026, 3, 14, 12, 0, 0, 0, time.UTC),
+		},
+	}
+	freshness := newsSearchFreshnessSummary("Find today's AI news", articles, time.Date(2026, 7, 5, 13, 0, 0, 0, time.UTC))
+	if freshness == nil {
+		t.Fatal("expected freshness summary for today query")
+	}
+	if freshness["status"] != "mostly_stale" {
+		t.Fatalf("expected mostly_stale status, got %#v", freshness)
+	}
+	if !strings.Contains(fmt.Sprint(freshness["notice"]), "Only 1 of 3 dated news_search results") {
+		t.Fatalf("expected mostly-stale caveat notice, got %#v", freshness)
+	}
+}
+
 func TestSearchToolTextReturnsLiveFeedResultsForAgent(t *testing.T) {
 	oldFeed := feed
 	defer func() {


### PR DESCRIPTION
## Summary
- Treat current-news search payloads as mostly stale when only a minority of dated results are from the request date.
- Surface that freshness caveat ahead of AI-news story lists in agent-ready context.
- Add regression coverage for freshness metadata and formatted news_search synthesis context.

Closes #1221
Closes #1223

## Testing
- go build ./...
- go test ./... -short
- go vet ./...