### PR TITLE
Guard mostly stale AI-news answers

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1508,8 +1508,12 @@ func renderResultCard(toolName, result string, args map[string]any) string {
 
 func renderNewsCard(result string) string {
 	var data struct {
-		Feed    []newsItem `json:"feed"`
-		Results []newsItem `json:"results"`
+		Feed      []newsItem `json:"feed"`
+		Results   []newsItem `json:"results"`
+		Freshness struct {
+			Status string `json:"status"`
+			Notice string `json:"notice"`
+		} `json:"freshness"`
 	}
 	if err := json.Unmarshal([]byte(result), &data); err != nil {
 		return ""
@@ -1527,6 +1531,11 @@ func renderNewsCard(result string) string {
 
 	var b strings.Builder
 	b.WriteString(`<div class="card"><h4>📰 News</h4>`)
+	if notice := strings.TrimSpace(data.Freshness.Notice); notice != "" && (data.Freshness.Status == "stale" || data.Freshness.Status == "mostly_stale" || data.Freshness.Status == "no_dated_results") {
+		b.WriteString(`<div style="margin:0 0 8px;padding:8px;border-radius:4px;background:#fff7ed;color:#7c2d12;font-size:12px;">`)
+		b.WriteString(htmlEsc(newsFreshnessCardLead(data.Freshness.Status) + notice))
+		b.WriteString(`</div>`)
+	}
 	for _, item := range items {
 		link := item.URL
 		if item.ID != "" {
@@ -1541,6 +1550,13 @@ func renderNewsCard(result string) string {
 	}
 	b.WriteString(`<a href="/news" class="link" style="display:inline-block;margin-top:8px;">More news →</a></div>`)
 	return b.String()
+}
+
+func newsFreshnessCardLead(status string) string {
+	if status == "mostly_stale" {
+		return "Mostly stale news_search results: "
+	}
+	return "No current news_search results: "
 }
 
 type newsItem struct {

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -1499,6 +1499,23 @@ Freshness caveat: No same-day news_search results were available for 2026-07-06;
 	}
 }
 
+func TestCompleteToolAnswerPrependsMostlyStaleNewsCaveatToSubstantiveAnswer(t *testing.T) {
+	rag := []string{`### news_search
+News results for "AI news":
+Freshness caveat: Only 1 of 3 dated news_search results are from 2026-07-07; lead with a freshness caveat before listing older context as today's news.
+1. AI lab ships current update (category: Tech; posted: 07 Jul 2026 12:00 UTC; source: https://example.com/current-ai) — Current story.
+2. AI startup raises funding (category: Tech; posted: 20 May 2026 12:00 UTC; source: https://example.com/old-ai) — Archive story.`}
+	answer := "1. AI lab ships current update — current story.\n2. AI startup raises funding — older archive context."
+	got := completeToolAnswer(answer, rag)
+	firstLine, _, _ := strings.Cut(got, "\n")
+	if !strings.Contains(firstLine, "Mostly stale news_search results:") || !strings.Contains(firstLine, "Only 1 of 3 dated news_search results") {
+		t.Fatalf("expected mostly-stale disclosure before story list, got %q", got)
+	}
+	if strings.Index(got, "Mostly stale news_search results:") > strings.Index(got, "Background: 1. AI lab ships current update") {
+		t.Fatalf("expected mostly-stale disclosure to precede background-labeled stories, got %q", got)
+	}
+}
+
 func TestCompleteToolAnswerLabelsExistingStaleNewsCaveatStories(t *testing.T) {
 	rag := []string{`### news_search
 News results for "AI news":
@@ -1511,6 +1528,17 @@ Freshness caveat: No same-day news_search results were available for 2026-07-06;
 	}
 	if !strings.Contains(got, "- Background: 1. AI startup raises funding") {
 		t.Fatalf("expected existing caveat answer stories to be labeled as background, got %q", got)
+	}
+}
+
+func TestRenderNewsCardSurfacesMostlyStaleFreshnessCaveat(t *testing.T) {
+	result := `{"query":"AI news","freshness":{"status":"mostly_stale","notice":"Only 1 of 3 dated news_search results are from 2026-07-07; lead with a freshness caveat before listing older context as today's news."},"results":[{"title":"AI lab ships current update","category":"Tech","url":"https://example.com/current-ai"}]}`
+	got := renderNewsCard(result)
+	if !strings.Contains(got, "Mostly stale news_search results: Only 1 of 3 dated news_search results") {
+		t.Fatalf("expected mostly-stale caveat in news card html, got %q", got)
+	}
+	if strings.Index(got, "Mostly stale news_search results:") > strings.Index(got, "AI lab ships current update") {
+		t.Fatalf("expected news card caveat before story links, got %q", got)
 	}
 }
 

--- a/agent/answer_guard.go
+++ b/agent/answer_guard.go
@@ -54,7 +54,11 @@ func staleNewsFreshnessCaveat(ragParts []string) string {
 			}
 			lower := strings.ToLower(line)
 			if strings.HasPrefix(lower, "freshness caveat:") {
-				return "No current news_search results: " + strings.TrimSpace(line[len("Freshness caveat:"):])
+				notice := strings.TrimSpace(line[len("Freshness caveat:"):])
+				if strings.Contains(lower, "only ") && strings.Contains(lower, " dated news_search results") {
+					return "Mostly stale news_search results: " + notice
+				}
+				return "No current news_search results: " + notice
 			}
 		}
 	}
@@ -336,7 +340,11 @@ func prioritizeStaleNewsCaveatLines(lines []string) []string {
 	out := make([]string, 0, len(lines))
 	caveat := strings.TrimSpace(lines[caveatIndex])
 	caveat = strings.TrimSpace(caveat[len("Freshness caveat:"):])
-	out = append(out, "No current news_search results: "+caveat)
+	if lower := strings.ToLower(caveat); strings.Contains(lower, "only ") && strings.Contains(lower, " dated news_search results") {
+		out = append(out, "Mostly stale news_search results: "+caveat)
+	} else {
+		out = append(out, "No current news_search results: "+caveat)
+	}
 	for i, line := range lines {
 		if i == caveatIndex {
 			continue


### PR DESCRIPTION
## Summary
- Lead mostly stale news_search answers with an explicit mostly-stale caveat before story bullets.
- Surface freshness caveats in the attached news card HTML before links.
- Add regression coverage for mostly stale AI-news answers and card rendering.

Closes #1226
Closes #1228