### PR TITLE
Hold native news streams for freshness guard

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1326,7 +1326,8 @@ func shouldHoldNativeNewsStreamTokens(prompt string, nativeTools []string) bool 
 		return false
 	}
 	for _, tool := range nativeTools {
-		if canonicalToolTitle(tool) == "news" {
+		lowerTool := strings.ToLower(strings.TrimSpace(tool))
+		if canonicalToolTitle(lowerTool) == "news" || strings.Contains(lowerTool, "news") || strings.Contains(lowerTool, "headline") {
 			return true
 		}
 	}

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -1578,6 +1578,9 @@ func TestShouldHoldNativeNewsStreamTokensForLatestNewsPrompt(t *testing.T) {
 	if !shouldHoldNativeNewsStreamTokens("Find today's AI news", []string{"news"}) {
 		t.Fatal("expected native latest-news tokens to be held once news tool starts")
 	}
+	if !shouldHoldNativeNewsStreamTokens("Find today's AI news", []string{"📰 Scanning headlines"}) {
+		t.Fatal("expected user-facing native news labels to hold latest-news tokens")
+	}
 	if shouldHoldNativeNewsStreamTokens("Find today's AI news", []string{"weather"}) {
 		t.Fatal("did not expect non-news native tool tokens to be held")
 	}


### PR DESCRIPTION
## Summary
- Hold native latest-news SSE tokens when the user-facing native news progress label is active so stale/mostly-stale freshness guards can lead the first visible answer.
- Add regression coverage for the live native label path.

Closes #1232
Closes #1234