### PR TITLE
Keep AI news freshness sorting robust

### DIFF
--- a/news/news.go
+++ b/news/news.go
@@ -1972,8 +1972,36 @@ func articlePostedAt(article map[string]interface{}) time.Time {
 	case time.Time:
 		return v
 	case string:
-		if t, err := time.Parse(time.RFC3339, v); err == nil {
-			return t
+		return parseNewsArticleTime(v)
+	}
+	return time.Time{}
+}
+
+func parseNewsArticleTime(raw string) time.Time {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return time.Time{}
+	}
+	for _, layout := range []string{
+		time.RFC3339,
+		time.RFC3339Nano,
+		"2006-01-02 15:04:05 -0700 MST",
+		"2006-01-02 15:04:05 -0700",
+		"2006-01-02 15:04:05 MST",
+		"2006-01-02 15:04:05",
+		"2006-01-02 15:04",
+		"2006-01-02",
+		time.RFC1123Z,
+		time.RFC1123,
+		time.RFC822Z,
+		time.RFC822,
+		"2 Jan 2006 15:04 UTC",
+		"2 Jan 2006",
+		"Jan 2, 2006",
+		"January 2, 2006",
+	} {
+		if t, err := time.Parse(layout, raw); err == nil {
+			return t.UTC()
 		}
 	}
 	return time.Time{}

--- a/news/news_test.go
+++ b/news/news_test.go
@@ -400,6 +400,25 @@ func TestNewsSearchFreshnessSummaryCaveatsMostlyStaleTodayResults(t *testing.T) 
 	}
 }
 
+func TestNewsSearchArticlesSortsNonRFCPostedAtForFreshnessQueries(t *testing.T) {
+	indexed := []*data.IndexEntry{
+		{ID: "older-ai", Title: "AI model archive", Content: "Older artificial intelligence model background.", Metadata: map[string]interface{}{
+			"url": "https://example.com/older-ai", "category": "Tech", "posted_at": "May 20, 2026",
+		}},
+		{ID: "newer-ai", Title: "AI lab ships July update", Content: "Newer artificial intelligence assistant update.", Metadata: map[string]interface{}{
+			"url": "https://example.com/newer-ai", "category": "Tech", "posted_at": "2026-07-02 09:00:00 +0000 UTC",
+		}},
+	}
+
+	got := newsSearchArticles("Find today's AI news", indexed, 8)
+	if len(got) < 2 {
+		t.Fatalf("expected indexed results, got %#v", got)
+	}
+	if got[0]["title"] != "AI lab ships July update" {
+		t.Fatalf("expected non-RFC posted_at to sort newest first, got %#v", got)
+	}
+}
+
 func TestSearchToolTextReturnsLiveFeedResultsForAgent(t *testing.T) {
 	oldFeed := feed
 	defer func() {


### PR DESCRIPTION
## Summary
- Parse common non-RFC news posted_at timestamp formats before recency sorting freshness-sensitive news_search results.
- Add regression coverage so newer July AI-news items lead older May archive items even when timestamps come from indexed metadata formats.

Closes #1243
Closes #1245

## Testing
- go build ./...
- go test ./... -short
- go vet ./...