### PR TITLE
Add freshness metadata to news search API

### DIFF
--- a/news/news.go
+++ b/news/news.go
@@ -1776,20 +1776,12 @@ func handleAPISearch(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Search indexed news articles first, then merge in the live in-memory feed.
-	// The live feed powers /news and is the most truthful fallback when the
-	// search index is cold or stale, which can happen just after startup.
-	results := data.Search(query, 20, data.WithType("news"), data.WithKeywordOnly())
-	articles := newsSearchArticles(query, results, 20)
+	payload := newsSearchPayload(query, 20)
 
 	// Consume quota after successful search
 	wallet.ConsumeQuota(sess.Account, wallet.OpNewsSearch)
 
-	app.RespondJSON(w, map[string]interface{}{
-		"query":   query,
-		"results": articles,
-		"count":   len(articles),
-	})
+	app.RespondJSON(w, payload)
 }
 
 // SearchToolText returns model-ready JSON for news_search tool calls. It uses
@@ -1804,8 +1796,20 @@ func SearchToolText(query string) (string, error) {
 	if len(query) > 256 {
 		return "", fmt.Errorf("search query must not exceed 256 characters")
 	}
-	results := data.Search(query, 8, data.WithType("news"), data.WithKeywordOnly())
-	articles := newsSearchArticles(query, results, 8)
+	payload := newsSearchPayload(query, 8)
+	b, err := json.Marshal(payload)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
+func newsSearchPayload(query string, limit int) map[string]interface{} {
+	// Search indexed news articles first, then merge in the live in-memory feed.
+	// The live feed powers /news and is the most truthful fallback when the
+	// search index is cold or stale, which can happen just after startup.
+	results := data.Search(query, limit, data.WithType("news"), data.WithKeywordOnly())
+	articles := newsSearchArticles(query, results, limit)
 	payload := map[string]interface{}{
 		"query":   query,
 		"results": articles,
@@ -1814,11 +1818,7 @@ func SearchToolText(query string) (string, error) {
 	if freshness := newsSearchFreshnessSummary(query, articles, time.Now().UTC()); freshness != nil {
 		payload["freshness"] = freshness
 	}
-	b, err := json.Marshal(payload)
-	if err != nil {
-		return "", err
-	}
-	return string(b), nil
+	return payload
 }
 
 func newsSearchArticles(query string, indexed []*data.IndexEntry, limit int) []map[string]interface{} {

--- a/news/news_test.go
+++ b/news/news_test.go
@@ -1023,3 +1023,35 @@ func TestCleanNewsArticleURLRejectsImageAssets(t *testing.T) {
 		t.Fatalf("expected article URL to be preserved, got %q", got)
 	}
 }
+
+func TestNewsSearchPayloadIncludesFreshnessForAPIPath(t *testing.T) {
+	oldFeed := feed
+	defer func() {
+		mutex.Lock()
+		feed = oldFeed
+		mutex.Unlock()
+	}()
+
+	mutex.Lock()
+	feed = []*Post{{
+		ID:          "old-ai",
+		Title:       "AI archive funding story",
+		Description: "Older artificial intelligence funding context.",
+		URL:         "https://example.com/old-ai",
+		Category:    "Tech",
+		PostedAt:    time.Now().UTC().AddDate(0, -2, 0),
+	}}
+	mutex.Unlock()
+
+	payload := newsSearchPayload("Find today's AI news", 20)
+	freshness, ok := payload["freshness"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected freshness metadata in shared news_search payload, got %#v", payload)
+	}
+	if freshness["status"] != "stale" {
+		t.Fatalf("expected stale freshness status for old API-path results, got %#v", freshness)
+	}
+	if !strings.Contains(fmt.Sprint(freshness["notice"]), "No same-day news_search results") {
+		t.Fatalf("expected API-path same-day caveat notice, got %#v", freshness)
+	}
+}


### PR DESCRIPTION
## Summary
- Share the news_search payload builder between the authenticated API path and agent tool text.
- Include freshness metadata/caveats in the API response so stale or mostly-stale current-news results carry the same guardrails as deployed agent answers.
- Add regression coverage for the API/shared payload path.

Closes #1248
Closes #1250

## Testing
- go test ./news -run 'TestNewsSearchPayloadIncludesFreshnessForAPIPath|TestSearchToolTextReturnsLiveFeedResultsForAgent|TestNewsSearchArticlesFreshQueries'
- go build ./...
- go test ./... -short
- go vet ./...