### PR TITLE
Use indexed timestamps for news freshness

### DIFF
--- a/news/news.go
+++ b/news/news.go
@@ -1854,7 +1854,7 @@ func newsSearchArticles(query string, indexed []*data.IndexEntry, limit int) []m
 			"description": htmlToText(entry.Content),
 			"url":         cleanNewsArticleURL(entry.Metadata["url"]),
 			"category":    entry.Metadata["category"],
-			"posted_at":   entry.Metadata["posted_at"],
+			"posted_at":   indexedNewsArticlePostedAt(entry),
 		}
 		if articleMatchesNewsQuery(query, article) {
 			candidates = append(candidates, article)
@@ -1891,6 +1891,21 @@ func newsSearchArticles(query string, indexed []*data.IndexEntry, limit int) []m
 		add(article)
 	}
 	return articles
+}
+
+func indexedNewsArticlePostedAt(entry *data.IndexEntry) interface{} {
+	if entry == nil {
+		return nil
+	}
+	if entry.Metadata != nil {
+		if postedAt := entry.Metadata["posted_at"]; postedAt != nil {
+			return postedAt
+		}
+	}
+	if !entry.IndexedAt.IsZero() {
+		return entry.IndexedAt
+	}
+	return nil
 }
 
 func newsSearchFreshCandidateLimit(limit int) int {

--- a/news/news_test.go
+++ b/news/news_test.go
@@ -419,6 +419,31 @@ func TestNewsSearchArticlesSortsNonRFCPostedAtForFreshnessQueries(t *testing.T) 
 	}
 }
 
+func TestNewsSearchArticlesFreshQueriesUseIndexedAtFallback(t *testing.T) {
+	older := time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC)
+	today := time.Date(2026, 7, 7, 9, 0, 0, 0, time.UTC)
+	indexed := []*data.IndexEntry{
+		{ID: "old-ai", Title: "AI model archive", Content: "Older artificial intelligence model background.", IndexedAt: older, Metadata: map[string]interface{}{
+			"url": "https://example.com/old-ai", "category": "Tech", "posted_at": older.Format(time.RFC3339),
+		}},
+		{ID: "same-day-ai", Title: "AI lab ships current assistant update", Content: "Fresh artificial intelligence assistant update.", IndexedAt: today, Metadata: map[string]interface{}{
+			"url": "https://example.com/same-day-ai", "category": "Tech",
+		}},
+	}
+
+	got := newsSearchArticles("Find today's AI news", indexed, 8)
+	if len(got) < 2 {
+		t.Fatalf("expected indexed results, got %#v", got)
+	}
+	if got[0]["title"] != "AI lab ships current assistant update" {
+		t.Fatalf("expected IndexedAt fallback to let same-day result lead, got %#v", got)
+	}
+	freshness := newsSearchFreshnessSummary("Find today's AI news", got, time.Date(2026, 7, 7, 13, 0, 0, 0, time.UTC))
+	if freshness == nil || freshness["freshest_posted_at"] == nil {
+		t.Fatalf("expected freshness metadata from IndexedAt fallback, got %#v", freshness)
+	}
+}
+
 func TestSearchToolTextReturnsLiveFeedResultsForAgent(t *testing.T) {
 	oldFeed := feed
 	defer func() {


### PR DESCRIPTION
## Summary
- Use each indexed news entry's IndexedAt timestamp when posted_at metadata is missing so freshness-oriented news_search sorting and caveats still see a date after metadata merges.
- Add regression coverage for same-day indexed AI-news results without posted_at metadata leading stale archived stories.

Closes #1253
Closes #1255

## Testing
- go test ./news -short -run 'TestNewsSearchArticlesFreshQueriesUseIndexedAtFallback|TestNewsSearchArticlesFreshQueriesPreferNewestMatches|TestNewsSearchArticlesSortsNonRFCPostedAtForFreshnessQueries' -count=1 -timeout=60s\n- go build ./...\n- go test ./... -short\n- go vet ./...