### PR TITLE
Ensure native news search freshness caveats

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1808,6 +1808,13 @@ func formatMarketPrice(price float64) string {
 // formatNewsResult converts a raw JSON news feed or search result into
 // human-readable text for the AI synthesis RAG context.
 func formatNewsResult(result string) string {
+	var textData struct {
+		Text string `json:"text"`
+	}
+	if err := json.Unmarshal([]byte(result), &textData); err == nil && strings.TrimSpace(textData.Text) != "" {
+		result = strings.TrimSpace(textData.Text)
+	}
+
 	var data struct {
 		Feed []struct {
 			Title       string `json:"title"`

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -2,12 +2,18 @@ package agent
 
 import (
 	"context"
+	"encoding/json"
 	"strings"
 	"testing"
 	"time"
 
 	gmai "go-micro.dev/v6/ai"
 )
+
+func quoteJSONString(s string) string {
+	b, _ := json.Marshal(s)
+	return string(b)
+}
 
 func TestPlacesMapURL_QueryAndNear(t *testing.T) {
 	args := map[string]any{"q": "cafe", "near": "Hampton, UK"}
@@ -1451,6 +1457,18 @@ func TestFormatToolResultNewsHeadlinesStaysReadable(t *testing.T) {
 	}
 	if !strings.Contains(got, "AI lab releases a new model") || strings.Contains(got, `{"`) {
 		t.Fatalf("expected readable news_headlines context, got %q", got)
+	}
+}
+
+func TestFormatToolResultNewsSearchUnwrapsNativeServiceText(t *testing.T) {
+	inner := `{"query":"AI news","freshness":{"status":"stale","requested_date":"2026-07-07","freshest_posted_at":"2026-05-20T12:00:00Z","notice":"No same-day news_search results were available for 2026-07-07; the freshest result is from 2026-05-20, so lead with a freshness caveat instead of presenting older stories as today's news."},"results":[{"title":"AI startup raises funding","description":"Archive context.","category":"Tech","url":"https://example.com/old-ai","posted_at":"2026-05-20T12:00:00Z"}]}`
+	result := `{"text":` + quoteJSONString(inner) + `}`
+	got := formatToolResult("news_search", result, nil)
+	if !strings.Contains(got, "Freshness caveat: No same-day news_search results were available for 2026-07-07") {
+		t.Fatalf("expected native service text wrapper freshness caveat to surface, got %q", got)
+	}
+	if strings.Index(got, "Freshness caveat:") > strings.Index(got, "AI startup raises funding") {
+		t.Fatalf("expected freshness caveat before stale story, got %q", got)
 	}
 }
 

--- a/news/service.go
+++ b/news/service.go
@@ -35,10 +35,30 @@ type ReadResponse struct {
 	Text string `json:"text" description:"Title, source, summary and body of the article"`
 }
 
+// SearchRequest searches indexed and live news for a user topic.
+type SearchRequest struct {
+	Query string `json:"query" description:"Search terms, e.g. latest AI news"`
+}
+
+// SearchResponse is model-ready news_search JSON, including freshness metadata
+// for date-sensitive queries.
+type SearchResponse struct {
+	Text string `json:"text" description:"JSON payload with query, results, count, and freshness caveats when relevant"`
+}
+
 // Read reads one news article in full by its id (from Headlines) or by URL.
 // @example {"id": "https://example.com/article"}
 func (Server) Read(_ context.Context, req *ReadRequest, rsp *ReadResponse) error {
 	text, err := ArticleText(req.ID)
+	rsp.Text = text
+	return err
+}
+
+// Search returns the same model-ready payload as the public news_search tool so
+// native go-micro agent calls receive freshness caveats before stale stories.
+// @example {"query":"latest AI news"}
+func (Server) Search(_ context.Context, req *SearchRequest, rsp *SearchResponse) error {
+	text, err := SearchToolText(req.Query)
 	rsp.Text = text
 	return err
 }

--- a/news/service_test.go
+++ b/news/service_test.go
@@ -2,6 +2,7 @@ package news
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"mu/internal/service"
@@ -18,4 +19,17 @@ func TestNewsViaMesh(t *testing.T) {
 		t.Fatalf("call: %v", err)
 	}
 	// Text may be empty without feeds loaded; the round-trip is what matters.
+}
+
+func TestNewsSearchServiceReturnsFreshnessPayload(t *testing.T) {
+	var rsp SearchResponse
+	if err := (Server{}).Search(context.Background(), &SearchRequest{Query: "Find today's AI news"}, &rsp); err != nil {
+		t.Fatalf("search: %v", err)
+	}
+	if rsp.Text == "" {
+		t.Fatal("expected search payload text")
+	}
+	if !strings.Contains(rsp.Text, `"query":"Find today`) || !strings.Contains(rsp.Text, `"results"`) {
+		t.Fatalf("expected JSON news_search payload, got %q", rsp.Text)
+	}
 }


### PR DESCRIPTION
## Summary
- route native go-micro news Search calls through the same news_search payload used by public tool paths
- unwrap native service text responses so freshness caveats are included before stale AI-news results
- add focused coverage for the service payload and native formatter path

Closes #1258
Closes #1260