### PR TITLE
Handle native news freshness for dotted tools

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -1667,6 +1667,25 @@ func TestNativeToolRecorderFormatsNewsPayloads(t *testing.T) {
 	}
 }
 
+func TestNativeToolRecorderFormatsDottedNewsSearchPayloads(t *testing.T) {
+	recorder := newNativeToolRecorder()
+	handler := recorder.wrap(func(_ context.Context, call gmai.ToolCall) gmai.ToolResult {
+		return gmai.ToolResult{Content: `{"query":"AI news","freshness":{"status":"stale","notice":"No same-day news_search results were available for 2026-07-07; the freshest result is from 2026-05-20, so lead with a freshness caveat instead of presenting older stories as today's news."},"results":[{"title":"AI startup raises funding","description":"Archive context","category":"Tech","url":"https://example.com/old-ai","posted_at":"2026-05-20T12:00:00Z"}]}`}
+	})
+
+	handler(context.Background(), gmai.ToolCall{Name: "news.Search"})
+	got := completeToolAnswer("1. AI startup raises funding — Archive context.", recorder.ragParts())
+	if !strings.Contains(got, "No current news_search results: No same-day news_search results were available for 2026-07-07") {
+		t.Fatalf("expected dotted native news tool name to surface stale caveat, got %q", got)
+	}
+	if strings.Index(got, "No current news_search results:") > strings.Index(got, "Background: 1. AI startup raises funding") {
+		t.Fatalf("expected stale caveat to precede old story, got %q", got)
+	}
+	if strings.Contains(got, `{"query"`) {
+		t.Fatalf("expected dotted native news payload to be formatted, got %q", got)
+	}
+}
+
 func TestCompleteNativeToolAnswerReplacesProgressWithUnavailableState(t *testing.T) {
 	got := completeNativeToolAnswer("I'll check the latest market and news data now.", []string{"📈 Checking market prices", "📰 Scanning headlines"})
 	if strings.Contains(strings.ToLower(got), "i'll check") {

--- a/agent/native.go
+++ b/agent/native.go
@@ -358,7 +358,7 @@ func (r *nativeToolRecorder) ragParts() []string {
 }
 
 func nativeToolFormatterName(name string) string {
-	parts := strings.Split(strings.ToLower(strings.TrimSpace(name)), "_")
+	parts := nativeToolNameParts(name)
 	if len(parts) >= 2 {
 		svc, method := parts[0], parts[1]
 		switch svc {
@@ -382,11 +382,11 @@ func nativeToolFormatterName(name string) string {
 }
 
 func nativeToolTitle(name string) string {
-	svc := name
-	if i := strings.IndexByte(name, '_'); i > 0 {
-		svc = name[:i]
+	parts := nativeToolNameParts(name)
+	svc := strings.ToLower(strings.TrimSpace(name))
+	if len(parts) > 0 && parts[0] != "" {
+		svc = parts[0]
 	}
-	svc = strings.ToLower(svc)
 	switch svc {
 	case "weather":
 		return "weather"
@@ -423,9 +423,10 @@ func nativeToolLabel(name string) (label string, show bool) {
 	case "plan", "delegate", "human_input", "":
 		return "", false
 	}
-	svc := name
-	if i := strings.IndexByte(name, '_'); i > 0 {
-		svc = name[:i]
+	parts := nativeToolNameParts(name)
+	svc := strings.ToLower(strings.TrimSpace(name))
+	if len(parts) > 0 && parts[0] != "" {
+		svc = parts[0]
 	}
 	switch svc {
 	case "weather":
@@ -452,4 +453,10 @@ func nativeToolLabel(name string) (label string, show bool) {
 		return "📬 Checking your mail", true
 	}
 	return "⚙️ Working", true
+}
+
+func nativeToolNameParts(name string) []string {
+	return strings.FieldsFunc(strings.ToLower(strings.TrimSpace(name)), func(r rune) bool {
+		return r == '_' || r == '.' || r == '/'
+	})
 }


### PR DESCRIPTION
## Summary
- Normalize native go-micro tool names that arrive with dot or slash separators so news.Search payloads are recognized as news_search context.
- Preserve stale AI-news freshness caveats before older stories in native answers.

Closes #1263
Closes #1267

## Testing
- go build ./...
- go test ./... -short
- go vet ./...