### PR TITLE
Hold native news streams for freshness guard

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1325,6 +1325,14 @@ func shouldHoldNativeNewsStreamTokens(prompt string, nativeTools []string) bool 
 	if !isLatestTechnologyNewsPrompt(strings.ToLower(prompt)) {
 		return false
 	}
+	// Latest-news prompts are sensitive to recency caveats: the native model can
+	// emit answer text before the news.Search/dotted news tool payload has been
+	// recorded and guarded. Hold the stream from the first token, then emit the
+	// final guarded answer once completeToolAnswer has had a chance to prepend
+	// stale/mostly-stale disclosures.
+	if len(nativeTools) == 0 {
+		return true
+	}
 	for _, tool := range nativeTools {
 		lowerTool := strings.ToLower(strings.TrimSpace(tool))
 		if canonicalToolTitle(lowerTool) == "news" || strings.Contains(lowerTool, "news") || strings.Contains(lowerTool, "headline") {

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -1593,6 +1593,9 @@ Freshness caveat: No same-day news_search results were available for 2026-07-06;
 }
 
 func TestShouldHoldNativeNewsStreamTokensForLatestNewsPrompt(t *testing.T) {
+	if !shouldHoldNativeNewsStreamTokens("Find today's AI news", nil) {
+		t.Fatal("expected native latest-news tokens to be held before the news tool result is available")
+	}
 	if !shouldHoldNativeNewsStreamTokens("Find today's AI news", []string{"news"}) {
 		t.Fatal("expected native latest-news tokens to be held once news tool starts")
 	}


### PR DESCRIPTION
## Summary
- Hold native streaming tokens from the start of latest-news prompts so stale/mostly-stale news freshness guards can prepend the final caveat before any answer text is shown.
- Add regression coverage for pre-tool native latest-news token holding.

Closes #1270
Closes #1272

## Testing
- go build ./...
- go test ./... -short
- go vet ./...