### PR TITLE
Replay guarded native news answers

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -641,7 +641,7 @@ func streamNativeSSE(w http.ResponseWriter, accountID, prompt string, opts Query
 	}
 	answer = completeNativeToolAnswer(answer, nativeTools)
 	answer = app.NormalizeAnswerMarkdown(answer)
-	if !streaming && captured.Len() > 0 {
+	if !streaming && shouldReplayFinalNativeAnswer(prompt, nativeTools, captured.Len()) {
 		streaming = true
 		emitted = true
 		sse(w, map[string]any{"type": "stream_start"})
@@ -1319,6 +1319,17 @@ func useFastToolFallback(prompt string, isGuest bool, hasMarketsTool bool, hasWe
 		return hasNewsSearchTool || (hasWebSearchTool && hasUnavailableNewsSearch)
 	}
 	return false
+}
+
+func shouldReplayFinalNativeAnswer(prompt string, nativeTools []string, capturedLen int) bool {
+	if capturedLen > 0 {
+		return true
+	}
+	// streamNative buffers stale-news tokens internally once the tool payload
+	// proves a freshness caveat is needed. In that case streamNativeSSE's local
+	// capture is empty, so replay the guarded final answer as the first streamed
+	// text instead of relying only on the later response replacement event.
+	return shouldHoldNativeNewsStreamTokens(prompt, nativeTools)
 }
 
 func shouldHoldNativeNewsStreamTokens(prompt string, nativeTools []string) bool {

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -1592,6 +1592,18 @@ Freshness caveat: No same-day news_search results were available for 2026-07-06;
 	}
 }
 
+func TestShouldReplayFinalNativeAnswerForBufferedLatestNews(t *testing.T) {
+	if !shouldReplayFinalNativeAnswer("Find today's AI news", []string{"news"}, 0) {
+		t.Fatal("expected buffered native latest-news answers to replay guarded final text")
+	}
+	if !shouldReplayFinalNativeAnswer("Weather in New York today", []string{"weather"}, 12) {
+		t.Fatal("expected captured native text to be replayed")
+	}
+	if shouldReplayFinalNativeAnswer("Weather in New York today", []string{"weather"}, 0) {
+		t.Fatal("did not expect unrelated empty native captures to replay")
+	}
+}
+
 func TestShouldHoldNativeNewsStreamTokensForLatestNewsPrompt(t *testing.T) {
 	if !shouldHoldNativeNewsStreamTokens("Find today's AI news", nil) {
 		t.Fatal("expected native latest-news tokens to be held before the news tool result is available")


### PR DESCRIPTION
## Summary
- Replay the guarded final native answer when latest-news streaming was fully buffered for freshness caveats, so the first streamed answer text includes stale/mostly-stale disclosures.
- Add coverage for replaying buffered native latest-news answers without changing unrelated native streams.

Closes #1275
Closes #1277

## Testing
- go test ./agent -run 'TestShouldReplayFinalNativeAnswerForBufferedLatestNews|TestShouldBufferNativeTokenForStaleNewsCaveat|TestFormatToolResultNewsSearchUnwrapsNativeServiceText'\n- go build ./...\n- go test ./... -short\n- go vet ./...