### PR TITLE
Keep stale AI-news fallbacks freshness sorted

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -1640,6 +1640,25 @@ Freshness caveat: Only 1 of 3 dated news_search results are from 2026-07-08; lea
 	}
 }
 
+func TestCompleteToolAnswerSortsMostlyStaleNewsFallbackByFreshness(t *testing.T) {
+	rag := []string{`### news_search
+News results for "AI news":
+Freshness caveat: Only 1 of 3 dated news_search results are from 2026-07-08; lead with a freshness caveat before listing older context as today's news.
+1. AI startup raises funding (category: Tech; posted: 20 May 2026 12:00 UTC; source: https://example.com/old-ai) — Archive story.
+2. AI chips adoption grows (category: Tech; posted: 14 Mar 2026 12:00 UTC; source: https://example.com/older-ai) — Older archive story.
+3. AI lab ships current update (category: Tech; posted: 8 Jul 2026 12:00 UTC; source: https://example.com/current-ai) — Current story.`}
+	got := completeToolAnswer("AI startup raises funding in May. AI chips adoption grew in March. AI lab ships current update today.", rag)
+	if !strings.HasPrefix(got, "- Mostly stale news_search results:") {
+		t.Fatalf("expected guarded fallback caveat to lead answer, got %q", got)
+	}
+	current := strings.Index(got, "Background: AI lab ships current update")
+	may := strings.Index(got, "Background: AI startup raises funding")
+	march := strings.Index(got, "Background: AI chips adoption grows")
+	if current < 0 || may < 0 || march < 0 || current > may || may > march {
+		t.Fatalf("expected freshness-sorted background items after caveat, got %q", got)
+	}
+}
+
 func TestCompleteToolAnswerDoesNotDuplicateLeadingStaleNewsCaveat(t *testing.T) {
 	rag := []string{`### news_search
 News results for "AI news":

--- a/agent/answer_guard.go
+++ b/agent/answer_guard.go
@@ -2,7 +2,9 @@ package agent
 
 import (
 	"regexp"
+	"sort"
 	"strings"
+	"time"
 )
 
 func unavailableToolMessage(tool string) string {
@@ -348,6 +350,8 @@ func prioritizeStaleNewsCaveatLines(lines []string) []string {
 	} else {
 		out = append(out, "No current news_search results: "+caveat)
 	}
+	var storyLines []string
+	var otherLines []string
 	for i, line := range lines {
 		if i == caveatIndex {
 			continue
@@ -356,12 +360,47 @@ func prioritizeStaleNewsCaveatLines(lines []string) []string {
 		if trimmed == "" || isSearchResultHeading(trimmed) {
 			continue
 		}
-		if looksLikeNewsStoryLine(trimmed) && !strings.HasPrefix(strings.ToLower(trimmed), "background:") {
-			trimmed = "Background: " + trimmed
+		if looksLikeNewsStoryLine(trimmed) {
+			if !strings.HasPrefix(strings.ToLower(trimmed), "background:") {
+				trimmed = "Background: " + trimmed
+			}
+			storyLines = append(storyLines, trimmed)
+			continue
 		}
-		out = append(out, trimmed)
+		otherLines = append(otherLines, trimmed)
 	}
+	sort.SliceStable(storyLines, func(i, j int) bool {
+		left := fallbackNewsPostedAt(storyLines[i])
+		right := fallbackNewsPostedAt(storyLines[j])
+		if left.IsZero() || right.IsZero() {
+			return false
+		}
+		return left.After(right)
+	})
+	out = append(out, storyLines...)
+	out = append(out, otherLines...)
 	return out
+}
+
+func fallbackNewsPostedAt(line string) time.Time {
+	lower := strings.ToLower(line)
+	idx := strings.Index(lower, "posted:")
+	if idx < 0 {
+		return time.Time{}
+	}
+	posted := strings.TrimSpace(line[idx+len("posted:"):])
+	for _, sep := range []string{";", ")", " — "} {
+		if cut := strings.Index(posted, sep); cut >= 0 {
+			posted = strings.TrimSpace(posted[:cut])
+		}
+	}
+	posted = strings.TrimSpace(strings.Trim(posted, ".,"))
+	for _, layout := range []string{time.RFC3339, "2 Jan 2006 15:04 MST", "2 Jan 2006", "2006-01-02", "Jan 2, 2006"} {
+		if t, err := time.Parse(layout, posted); err == nil {
+			return t.UTC()
+		}
+	}
+	return time.Time{}
 }
 
 func looksLikeNewsStoryLine(line string) bool {


### PR DESCRIPTION
## Summary
- Sort stale/mostly-stale news fallback story lines by parsed posted date after the required freshness caveat.
- Add regression coverage for mostly-stale AI-news fallbacks that arrive with older stories before a same-day item.

Closes #1287
Closes #1289

## Verification
- go build ./...
- go test ./... -short
- go vet ./...