### PR TITLE
Keep stale AI-news results freshness-sorted

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"sort"
 	"strings"
 	"time"
 
@@ -1861,25 +1862,31 @@ func formatNewsResult(result string) string {
 	if err := json.Unmarshal([]byte(result), &data); err != nil {
 		return result
 	}
-	type item struct {
-		Title       string
-		Description string
-		Category    string
-		URL         string
-		PostedAt    string
-		Published   string
-	}
-	var items []item
+	var items []formattedNewsItem
 	for _, a := range data.Results {
-		items = append(items, item{a.Title, a.Description, a.Category, a.URL, a.PostedAt, ""})
+		items = append(items, formattedNewsItem{a.Title, a.Description, a.Category, a.URL, a.PostedAt, ""})
 	}
 	if len(items) == 0 {
 		for _, a := range data.Feed {
-			items = append(items, item{a.Title, a.Description, a.Category, a.URL, a.PostedAt, a.Published})
+			items = append(items, formattedNewsItem{a.Title, a.Description, a.Category, a.URL, a.PostedAt, a.Published})
 		}
 	}
 	if len(items) == 0 {
 		return "No news available."
+	}
+
+	// Freshness-sensitive searches feed both the fast guest fallback and the
+	// native streaming/final synthesis paths. Keep dated current items ahead of
+	// older replayed context before any model sees the result list.
+	if data.Query != "" && (data.Freshness.Status == "mostly_stale" || data.Freshness.Status == "stale" || strings.TrimSpace(data.Freshness.Notice) != "") {
+		sort.SliceStable(items, func(i, j int) bool {
+			left := newsResultItemTime(items[i])
+			right := newsResultItemTime(items[j])
+			if left.IsZero() || right.IsZero() {
+				return false
+			}
+			return left.After(right)
+		})
 	}
 
 	// Interleave items across categories round-robin to ensure diversity.
@@ -1888,7 +1895,7 @@ func formatNewsResult(result string) string {
 	// round-robin order.
 	if data.Query == "" {
 		catOrder := []string{}
-		catItems := map[string][]item{}
+		catItems := map[string][]formattedNewsItem{}
 		for _, a := range items {
 			cat := a.Category
 			if cat == "" {
@@ -1899,7 +1906,7 @@ func formatNewsResult(result string) string {
 			}
 			catItems[cat] = append(catItems[cat], a)
 		}
-		var mixed []item
+		var mixed []formattedNewsItem
 		maxPerCat := 3
 		for round := 0; round < maxPerCat; round++ {
 			for _, cat := range catOrder {
@@ -1972,6 +1979,30 @@ func formatNewsResult(result string) string {
 		sb.WriteString(line + "\n")
 	}
 	return sb.String()
+}
+
+type formattedNewsItem struct {
+	Title       string
+	Description string
+	Category    string
+	URL         string
+	PostedAt    string
+	Published   string
+}
+
+func newsResultItemTime(item formattedNewsItem) time.Time {
+	for _, value := range []string{item.PostedAt, item.Published} {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		for _, layout := range []string{time.RFC3339, "2 Jan 2006 15:04 MST", "2 Jan 2006", "2006-01-02", "Jan 2, 2006"} {
+			if t, err := time.Parse(layout, value); err == nil {
+				return t.UTC()
+			}
+		}
+	}
+	return time.Time{}
 }
 
 // formatVideoResult converts a raw JSON video search result into

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -1485,6 +1485,17 @@ func TestFormatToolResultNewsSearchSurfacesFreshnessCaveat(t *testing.T) {
 	}
 }
 
+func TestFormatToolResultNewsSearchSortsMostlyStaleResultsByFreshness(t *testing.T) {
+	result := `{"query":"AI news","freshness":{"status":"mostly_stale","requested_date":"2026-07-08","same_day_results":1,"dated_results":3,"freshest_posted_at":"2026-07-08T12:00:00Z","notice":"Only 1 of 3 dated news_search results are from 2026-07-08; lead with a freshness caveat before listing older context as today's news."},"results":[{"title":"AI startup raises funding","description":"Archive story.","category":"Tech","url":"https://example.com/old-ai","posted_at":"2026-05-20T12:00:00Z"},{"title":"AI chips adoption grows","description":"Older archive story.","category":"Tech","url":"https://example.com/older-ai","posted_at":"2026-03-14T12:00:00Z"},{"title":"AI lab ships current update","description":"Current story.","category":"Tech","url":"https://example.com/current-ai","posted_at":"2026-07-08T12:00:00Z"}]}`
+	got := formatToolResult("news_search", result, nil)
+	current := strings.Index(got, "1. AI lab ships current update")
+	may := strings.Index(got, "2. AI startup raises funding")
+	march := strings.Index(got, "3. AI chips adoption grows")
+	if current < 0 || may < 0 || march < 0 || current > may || may > march {
+		t.Fatalf("expected mostly-stale news_search context to be sorted freshest first, got %q", got)
+	}
+}
+
 func TestFormatToolResultNewsSearchSurfacesMostlyStaleFreshnessCaveat(t *testing.T) {
 	result := `{"query":"AI news","freshness":{"status":"mostly_stale","requested_date":"2026-07-05","same_day_results":1,"dated_results":3,"freshest_posted_at":"2026-07-05T12:00:00Z","notice":"Only 1 of 3 dated news_search results are from 2026-07-05; lead with a freshness caveat before listing older context as today's news."},"results":[{"title":"AI lab ships today's assistant update","description":"Current AI story.","category":"Tech","url":"https://example.com/current-ai","posted_at":"2026-07-05T12:00:00Z"},{"title":"AI startup raises funding","description":"Archive story.","category":"Tech","url":"https://example.com/old-ai","posted_at":"2026-05-20T12:00:00Z"}]}`
 	got := formatToolResult("news_search", result, nil)


### PR DESCRIPTION
## Summary
- Sort freshness-sensitive news_search result context by parsed publication time before synthesis so dated current items lead stale replayed context.
- Add regression coverage for mostly-stale AI-news search results that arrive out of order.

Closes #1304
Closes #1306