### PR TITLE
Guard native AI-news freshness caveats

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -1702,6 +1702,25 @@ Freshness caveat: Only 1 of 3 dated news_search results are from 2026-07-08; lea
 	}
 }
 
+func TestCompleteToolAnswerGuardsDottedNativeNewsSearchFreshness(t *testing.T) {
+	rag := []string{`### go.micro.service.news.Search
+News results for "AI news":
+Freshness caveat: Only 1 of 3 dated news_search results are from 2026-07-08; lead with a freshness caveat before listing older context as today's news.
+1. AI startup raises funding (category: Tech; posted: 20 May 2026 12:00 UTC; source: https://example.com/old-ai) — Archive story.
+2. AI chips adoption grows (category: Tech; posted: 14 Mar 2026 12:00 UTC; source: https://example.com/older-ai) — Older archive story.
+3. AI lab ships current update (category: Tech; posted: 8 Jul 2026 12:00 UTC; source: https://example.com/current-ai) — Current story.`}
+	got := completeToolAnswer("AI startup raises funding in May. AI lab ships current update today.", rag)
+	if !strings.HasPrefix(got, "- Mostly stale news_search results:") {
+		t.Fatalf("expected dotted native news_search result to lead with freshness caveat, got %q", got)
+	}
+	current := strings.Index(got, "Background: AI lab ships current update")
+	may := strings.Index(got, "Background: AI startup raises funding")
+	march := strings.Index(got, "Background: AI chips adoption grows")
+	if current < 0 || may < 0 || march < 0 || current > may || may > march {
+		t.Fatalf("expected dotted native fallback to keep fresh dated item first, got %q", got)
+	}
+}
+
 func TestCompleteToolAnswerKeepsSubstantiveAnswer(t *testing.T) {
 	want := "BTC is at $100,000, and the latest news says it reached a new high."
 	got := completeToolAnswer(want, []string{"### markets\nBTC: $100,000"})

--- a/agent/answer_guard.go
+++ b/agent/answer_guard.go
@@ -1052,14 +1052,26 @@ func isRawToolPayloadAnswer(answer string) bool {
 }
 
 func canonicalToolTitle(title string) string {
-	switch strings.TrimSpace(title) {
+	trimmed := strings.TrimSpace(title)
+	lower := strings.ToLower(trimmed)
+	switch lower {
 	case "weather_forecast":
 		return "weather"
-	case "news_search", "news_headlines", "news_read":
+	case "news", "news_search", "news_headlines", "news_read":
 		return "news"
 	case "web_search":
 		return "web_search"
-	default:
-		return strings.TrimSpace(title)
 	}
+
+	// Native go-micro tool names can arrive with service/method wrappers rather
+	// than the public MCP tool name (for example dotted service labels around
+	// news.Search). Treat those as news too so freshness caveats from the model-
+	// ready news_search payload are enforced consistently in streaming/final
+	// answer guards.
+	compact := strings.NewReplacer("-", "_", ".", "_", " ", "_", "/", "_").Replace(lower)
+	if strings.Contains(compact, "news_search") || strings.Contains(compact, "news_headlines") || strings.Contains(compact, "news_read") || strings.HasSuffix(compact, "_news") || strings.Contains(compact, "_news_") {
+		return "news"
+	}
+
+	return trimmed
 }


### PR DESCRIPTION
Guard the native/dotted news-search answer path so stale or mostly-stale AI-news evidence cannot lead the user-facing answer before the required freshness disclosure.

Changes:
- Canonicalize wrapped/dotted native news tool names as news in answer guards.
- Add regression coverage for a go-micro native news.Search payload that must replay the freshness-sorted fallback with the current item first.

Verification:
- go build ./...
- go test ./... -short
- go vet ./...

Closes #1309
Closes #1311