### PR TITLE
Preserve recency in AI news shortcut queries

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1277,17 +1277,29 @@ func fallbackNewsSearchToolCall(prompt, tool string, args map[string]any) (short
 }
 
 func newsTopicQuery(lower string) string {
-	if strings.Contains(lower, "artificial intelligence") {
-		return "artificial intelligence news"
+	prefix := ""
+	switch {
+	case strings.Contains(lower, "today"):
+		prefix = "today "
+	case strings.Contains(lower, "latest"):
+		prefix = "latest "
+	case strings.Contains(lower, "current") || strings.Contains(lower, "happening"):
+		prefix = "current "
 	}
-	for _, token := range strings.FieldsFunc(lower, func(r rune) bool {
-		return (r < 'a' || r > 'z') && (r < '0' || r > '9')
-	}) {
-		if token == "ai" {
-			return "AI news"
+	topic := "technology news"
+	if strings.Contains(lower, "artificial intelligence") {
+		topic = "artificial intelligence news"
+	} else {
+		for _, token := range strings.FieldsFunc(lower, func(r rune) bool {
+			return (r < 'a' || r > 'z') && (r < '0' || r > '9')
+		}) {
+			if token == "ai" {
+				topic = "AI news"
+				break
+			}
 		}
 	}
-	return "technology news"
+	return prefix + topic
 }
 
 func isLatestTechnologyNewsPrompt(lower string) bool {

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -422,9 +422,9 @@ func TestShortcutToolCallsLatestTechnologyNews(t *testing.T) {
 		prompt string
 		query  string
 	}{
-		{prompt: "latest technology news", query: "technology news"},
-		{prompt: "What is the latest AI news today?", query: "AI news"},
-		{prompt: "current artificial intelligence news", query: "artificial intelligence news"},
+		{prompt: "latest technology news", query: "latest technology news"},
+		{prompt: "What is the latest AI news today?", query: "today AI news"},
+		{prompt: "current artificial intelligence news", query: "current artificial intelligence news"},
 	} {
 		got := shortcutToolCalls(tt.prompt)
 		if len(got) != 1 {
@@ -447,7 +447,7 @@ func TestFallbackNewsSearchToolCallUsesWebSearchForLatestAINews(t *testing.T) {
 	if got.Tool != "web_search" {
 		t.Fatalf("expected web_search fallback, got %#v", got)
 	}
-	if got.Args["q"] != "AI news" {
+	if got.Args["q"] != "today AI news" {
 		t.Fatalf("expected fallback to preserve prompt topic, got %#v", got.Args)
 	}
 }


### PR DESCRIPTION
## Summary
- Preserve today/latest/current wording when building shortcut news_search queries so native AI-news answers keep freshness metadata and freshness-first ordering.
- Update shortcut and fallback tests to guard date-sensitive AI-news query construction.

Closes #1314
Closes #1316

## Testing
- go build ./...
- go test ./... -short
- go vet ./...