### PR TITLE
Keep AI news searches topic-relevant

### DIFF
--- a/news/news.go
+++ b/news/news.go
@@ -2069,7 +2069,7 @@ func liveFeedSearch(query string, limit int) []*Post {
 		haystack := newsSearchHaystack(post.Title, post.Description, post.Content, post.Category)
 		score := 0
 		for _, term := range terms {
-			if strings.Contains(haystack, term) {
+			if newsSearchTermMatches(haystack, term) {
 				score++
 			}
 		}
@@ -2104,7 +2104,7 @@ func articleMatchesNewsQuery(query string, article map[string]interface{}) bool 
 		fmt.Sprintf("%v", article["category"]),
 	)
 	for _, term := range terms {
-		if strings.Contains(haystack, term) {
+		if newsSearchTermMatches(haystack, term) {
 			return true
 		}
 	}
@@ -2113,6 +2113,24 @@ func articleMatchesNewsQuery(query string, article map[string]interface{}) bool 
 
 func newsSearchHaystack(parts ...string) string {
 	return strings.ToLower(strings.Join(parts, " "))
+}
+
+func newsSearchTermMatches(haystack, term string) bool {
+	term = strings.TrimSpace(strings.ToLower(term))
+	if term == "" {
+		return false
+	}
+	if strings.Contains(term, " ") {
+		return strings.Contains(haystack, term)
+	}
+	for _, token := range strings.FieldsFunc(haystack, func(r rune) bool {
+		return (r < 'a' || r > 'z') && (r < '0' || r > '9')
+	}) {
+		if token == term {
+			return true
+		}
+	}
+	return false
 }
 
 func meaningfulNewsQueryTerms(query string) []string {

--- a/news/news_test.go
+++ b/news/news_test.go
@@ -378,6 +378,54 @@ func TestNewsSearchArticlesFreshQueriesWidenLiveCandidatePool(t *testing.T) {
 	}
 }
 
+func TestNewsSearchArticlesFreshAIQueryKeepsUnrelatedSameDayItemsBehindTopicMatches(t *testing.T) {
+	oldFeed := feed
+	defer func() {
+		mutex.Lock()
+		feed = oldFeed
+		mutex.Unlock()
+	}()
+
+	today := time.Date(2026, 7, 9, 9, 0, 0, 0, time.UTC)
+	yesterday := today.Add(-24 * time.Hour)
+	mutex.Lock()
+	feed = []*Post{
+		{
+			ID:          "faith-reminder",
+			Title:       "Daily Quran and hadith reminder",
+			Description: "A same-day reflection item with no technology reporting.",
+			URL:         "https://example.com/faith",
+			Category:    "Faith",
+			PostedAt:    today.Add(2 * time.Hour),
+		},
+		{
+			ID:          "finance-brief",
+			Title:       "Finance leaders await rate decision",
+			Description: "A same-day markets brief about rates and equities.",
+			URL:         "https://example.com/finance",
+			Category:    "Business",
+			PostedAt:    today.Add(time.Hour),
+		},
+		{
+			ID:          "ai-story",
+			Title:       "AI lab ships safer assistant",
+			Description: "Artificial intelligence product news from the latest release.",
+			URL:         "https://example.com/ai-story",
+			Category:    "Tech",
+			PostedAt:    yesterday,
+		},
+	}
+	mutex.Unlock()
+
+	got := newsSearchArticles("Find today's AI news", nil, 8)
+	if len(got) != 1 {
+		t.Fatalf("expected only topic-relevant AI news, got %#v", got)
+	}
+	if got[0]["title"] != "AI lab ships safer assistant" {
+		t.Fatalf("expected AI topic match ahead of unrelated same-day items, got %#v", got)
+	}
+}
+
 func TestNewsSearchFreshnessSummaryCaveatsStaleTodayResults(t *testing.T) {
 	articles := []map[string]interface{}{{
 		"title":     "AI startup raises funding",


### PR DESCRIPTION
## Summary
- Tighten news search term matching so short topic terms like AI match whole tokens instead of substrings inside unrelated words.
- Add a regression test ensuring fresh but unrelated faith/finance feed items do not displace an older AI-topic result for today's AI news.

## Testing
- go build ./...
- go test ./... -short
- go vet ./...

Closes #1319
Closes #1321