### PR TITLE
Filter broad finance from AI news

### DIFF
--- a/news/news.go
+++ b/news/news.go
@@ -2068,8 +2068,13 @@ func liveFeedSearch(query string, limit int) []*Post {
 	requireAI := newsQueryRequiresArtificialIntelligence(query)
 	for _, post := range currentFeed {
 		haystack := newsSearchHaystack(post.Title, post.Description, post.Content, post.Category)
-		if requireAI && !newsHaystackMatchesArtificialIntelligence(haystack) {
-			continue
+		if requireAI {
+			if !newsHaystackMatchesArtificialIntelligence(haystack) {
+				continue
+			}
+			if newsAIArticleIsBroadFinance(post.Title, post.Description, post.Content, post.Category) {
+				continue
+			}
 		}
 		score := 0
 		for _, term := range terms {
@@ -2107,8 +2112,18 @@ func articleMatchesNewsQuery(query string, article map[string]interface{}) bool 
 		fmt.Sprintf("%v", article["description"]),
 		fmt.Sprintf("%v", article["category"]),
 	)
-	if newsQueryRequiresArtificialIntelligence(query) && !newsHaystackMatchesArtificialIntelligence(haystack) {
-		return false
+	if newsQueryRequiresArtificialIntelligence(query) {
+		if !newsHaystackMatchesArtificialIntelligence(haystack) {
+			return false
+		}
+		if newsAIArticleIsBroadFinance(
+			fmt.Sprintf("%v", article["title"]),
+			fmt.Sprintf("%v", article["description"]),
+			fmt.Sprintf("%v", article["content"]),
+			fmt.Sprintf("%v", article["category"]),
+		) {
+			return false
+		}
 	}
 	for _, term := range terms {
 		if newsSearchTermMatches(haystack, term) {
@@ -2139,6 +2154,39 @@ func newsHaystackMatchesArtificialIntelligence(haystack string) bool {
 		}
 	}
 	return false
+}
+
+func newsAIArticleIsBroadFinance(parts ...string) bool {
+	haystack := newsSearchHaystack(parts...)
+	if haystack == "" {
+		return false
+	}
+	financeTerms := []string{
+		"business", "finance", "financial", "market", "markets", "stock", "stocks", "shares", "equities",
+		"mover", "movers", "trading", "trader", "investor", "investors", "wall street", "nasdaq", "dow",
+		"s&p", "rate", "rates", "earnings", "futures", "crypto", "bitcoin",
+	}
+	hasFinance := false
+	for _, term := range financeTerms {
+		if newsSearchTermMatches(haystack, term) {
+			hasFinance = true
+			break
+		}
+	}
+	if !hasFinance {
+		return false
+	}
+	strongAITerms := []string{
+		"artificial intelligence", "machine learning", "large language model", "generative ai", "openai", "anthropic",
+		"llm", "model", "models", "chip", "chips", "semiconductor", "data center", "datacenter",
+		"startup", "assistant", "product", "platform", "developer", "research", "robot", "robotics",
+	}
+	for _, term := range strongAITerms {
+		if newsSearchTermMatches(haystack, term) {
+			return false
+		}
+	}
+	return true
 }
 
 func newsSearchTermMatches(haystack, term string) bool {

--- a/news/news_test.go
+++ b/news/news_test.go
@@ -426,6 +426,67 @@ func TestNewsSearchArticlesFreshAIQueryKeepsUnrelatedSameDayItemsBehindTopicMatc
 	}
 }
 
+func TestNewsSearchArticlesFreshAIQueryFiltersBroadFinanceMovers(t *testing.T) {
+	oldFeed := feed
+	defer func() {
+		mutex.Lock()
+		feed = oldFeed
+		mutex.Unlock()
+	}()
+
+	today := time.Date(2026, 7, 9, 9, 0, 0, 0, time.UTC)
+	mutex.Lock()
+	feed = []*Post{
+		{
+			ID:          "market-movers-ai",
+			Title:       "Midday stock movers: AI shares join broader rally",
+			Description: "A broad markets brief lists trading moves across equities.",
+			URL:         "https://example.com/stock-movers",
+			Category:    "Markets",
+			PostedAt:    today.Add(2 * time.Hour),
+		},
+		{
+			ID:          "ai-data-center",
+			Title:       "AI data center startup expands inference platform",
+			Description: "The artificial intelligence company announced new model-serving capacity.",
+			URL:         "https://example.com/ai-data-center",
+			Category:    "Technology",
+			PostedAt:    today.Add(time.Hour),
+		},
+	}
+	mutex.Unlock()
+
+	got := newsSearchArticles("Find today's AI news", nil, 8)
+	if len(got) != 1 {
+		t.Fatalf("expected broad finance AI-adjacent mover to be filtered, got %#v", got)
+	}
+	if got[0]["title"] != "AI data center startup expands inference platform" {
+		t.Fatalf("expected core AI story, got %#v", got[0])
+	}
+}
+
+func TestNewsSearchArticlesFreshAIQueryKeepsSpecificAIChipMarketStory(t *testing.T) {
+	indexed := []*data.IndexEntry{
+		{
+			ID:      "ai-chip-market",
+			Title:   "AI chip shares climb after new inference accelerator launch",
+			Content: "The semiconductor company said the processor targets model-serving workloads.",
+			Metadata: map[string]interface{}{
+				"url":      "https://example.com/ai-chip-market",
+				"category": "Markets",
+			},
+		},
+	}
+
+	got := newsSearchArticles("Find today's AI news", indexed, 8)
+	if len(got) != 1 {
+		t.Fatalf("expected specific AI chip market story to remain, got %#v", got)
+	}
+	if got[0]["title"] != "AI chip shares climb after new inference accelerator launch" {
+		t.Fatalf("expected specific AI chip story, got %#v", got[0])
+	}
+}
+
 func TestNewsSearchFreshnessSummaryCaveatsStaleTodayResults(t *testing.T) {
 	articles := []map[string]interface{}{{
 		"title":     "AI startup raises funding",


### PR DESCRIPTION
## Summary
- Filter broad finance/stock-mover items out of AI-news search candidates unless they include substantive AI context.
- Add regression coverage for broad finance leakage while preserving specific AI chip market stories.

## Testing
- go build ./...
- go test ./... -short
- go vet ./...

Closes #1336
Closes #1338