### PR TITLE
Polish AI-news answer bullets

### DIFF
--- a/news/news.go
+++ b/news/news.go
@@ -1811,9 +1811,10 @@ func newsSearchPayload(query string, limit int) map[string]interface{} {
 	results := data.Search(query, limit, data.WithType("news"), data.WithKeywordOnly())
 	articles := newsSearchArticles(query, results, limit)
 	payload := map[string]interface{}{
-		"query":   query,
-		"results": articles,
-		"count":   len(articles),
+		"query":        query,
+		"results":      articles,
+		"count":        len(articles),
+		"presentation": "Write concise source-linked news bullets: link the title or source name, do not expose category/feed metadata, raw URLs, ids, or clipped snippet fragments.",
 	}
 	if freshness := newsSearchFreshnessSummary(query, articles, time.Now().UTC()); freshness != nil {
 		payload["freshness"] = freshness
@@ -1851,7 +1852,7 @@ func newsSearchArticles(query string, indexed []*data.IndexEntry, limit int) []m
 		article := map[string]interface{}{
 			"id":          entry.ID,
 			"title":       entry.Title,
-			"description": htmlToText(entry.Content),
+			"description": newsSearchBriefDescription(entry.Content),
 			"url":         cleanNewsArticleURL(entry.Metadata["url"]),
 			"category":    entry.Metadata["category"],
 			"posted_at":   indexedNewsArticlePostedAt(entry),
@@ -1874,7 +1875,7 @@ func newsSearchArticles(query string, indexed []*data.IndexEntry, limit int) []m
 		candidates = append(candidates, map[string]interface{}{
 			"id":          post.ID,
 			"title":       post.Title,
-			"description": htmlToText(post.Description),
+			"description": newsSearchBriefDescription(post.Description),
 			"url":         cleanNewsArticleURL(post.URL),
 			"category":    post.Category,
 			"posted_at":   post.PostedAt,
@@ -1896,6 +1897,44 @@ func newsSearchArticles(query string, indexed []*data.IndexEntry, limit int) []m
 		add(article)
 	}
 	return articles
+}
+
+func newsSearchBriefDescription(raw string) string {
+	desc := strings.TrimSpace(htmlToText(raw))
+	if desc == "" {
+		return ""
+	}
+	clipped := false
+	for _, marker := range []string{"...", "…"} {
+		if idx := strings.Index(desc, marker); idx >= 0 {
+			desc = strings.TrimSpace(desc[:idx])
+			clipped = true
+			break
+		}
+	}
+	if clipped && !strings.ContainsAny(desc, ".!?") {
+		return ""
+	}
+	const maxRunes = 180
+	runes := []rune(desc)
+	if len(runes) <= maxRunes {
+		return desc
+	}
+	window := string(runes[:maxRunes])
+	lastSentence := -1
+	for _, mark := range []string{". ", "! ", "? ", ".\n", "!\n", "?\n"} {
+		if idx := strings.LastIndex(window, mark); idx > lastSentence {
+			lastSentence = idx
+		}
+	}
+	if lastSentence > 0 {
+		return strings.TrimSpace(window[:lastSentence+1])
+	}
+	lastSpace := strings.LastIndex(window, " ")
+	if lastSpace > 80 {
+		return strings.TrimSpace(window[:lastSpace])
+	}
+	return strings.TrimSpace(window)
 }
 
 func indexedNewsArticlePostedAt(entry *data.IndexEntry) interface{} {

--- a/news/news_test.go
+++ b/news/news_test.go
@@ -624,6 +624,40 @@ func TestSearchToolTextReturnsLiveFeedResultsForAgent(t *testing.T) {
 	}
 }
 
+func TestSearchToolTextGuidesReadableAINewsBullets(t *testing.T) {
+	oldFeed := feed
+	defer func() {
+		mutex.Lock()
+		feed = oldFeed
+		mutex.Unlock()
+	}()
+
+	mutex.Lock()
+	feed = []*Post{{
+		ID:          "ai-readable",
+		Title:       "AI lab ships safer assistant",
+		Description: "The rollout adds public evaluations for developers using your pu...",
+		URL:         "https://example.com/ai-readable?utm_source=rss#fragment",
+		Category:    "Technology",
+		PostedAt:    time.Date(2026, 7, 9, 12, 0, 0, 0, time.UTC),
+	}}
+	mutex.Unlock()
+
+	text, err := SearchToolText("Find today's AI news")
+	if err != nil {
+		t.Fatalf("SearchToolText returned error: %v", err)
+	}
+	if !strings.Contains(text, "concise source-linked news bullets") {
+		t.Fatalf("expected presentation guidance for readable answer bullets, got %s", text)
+	}
+	if strings.Contains(text, "using your pu") || strings.Contains(text, "...") {
+		t.Fatalf("expected clipped snippet fragments to be removed, got %s", text)
+	}
+	if !strings.Contains(text, "https://example.com/ai-readable") {
+		t.Fatalf("expected clean article URL to remain available for source links, got %s", text)
+	}
+}
+
 func TestNewsSearchArticlesFiltersAdjacentIndexedResults(t *testing.T) {
 	indexed := []*data.IndexEntry{
 		{


### PR DESCRIPTION
## Summary
- add presentation guidance for news_search so AI-news answers render as concise source-linked bullets instead of raw feed rows
- trim clipped feed snippets before they reach agent-facing news_search payloads
- add regression coverage for readable AI-news bullet guidance and clipped snippet cleanup

Closes #1341
Closes #1343