### PR TITLE
Polish AI-news story labels

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -2007,33 +2007,54 @@ func formatNewsResult(result string) string {
 	}
 	for i, a := range items {
 		line := fmt.Sprintf("%d. %s", i+1, a.Title)
-		var meta []string
-		if a.Category != "" {
-			meta = append(meta, "category: "+a.Category)
-		}
-		if a.PostedAt != "" {
-			if t, err := time.Parse(time.RFC3339, a.PostedAt); err == nil {
-				meta = append(meta, "posted: "+t.Format("2 Jan 2006 15:04 UTC"))
-			}
-		} else if a.Published != "" {
-			meta = append(meta, "published: "+a.Published)
-		}
-		if a.URL != "" {
-			meta = append(meta, "source: "+a.URL)
-		}
-		if len(meta) > 0 {
-			line += " (" + strings.Join(meta, "; ") + ")"
-		}
-		if a.Description != "" {
-			desc := a.Description
-			if len(desc) > 150 {
-				desc = desc[:150] + "…"
-			}
+		if desc := cleanNewsDescription(a.Description); desc != "" {
 			line += " — " + desc
+		}
+		if label := conciseNewsSourceDateLabel(a); label != "" {
+			line += " (" + label + ")"
 		}
 		sb.WriteString(line + "\n")
 	}
 	return sb.String()
+}
+
+func cleanNewsDescription(desc string) string {
+	desc = strings.TrimSpace(desc)
+	if desc == "" {
+		return ""
+	}
+	desc = strings.TrimRight(desc, " \t\n\r")
+	for strings.HasSuffix(desc, "...") || strings.HasSuffix(desc, "…") {
+		desc = strings.TrimSpace(strings.TrimSuffix(strings.TrimSuffix(desc, "..."), "…"))
+	}
+	return desc
+}
+
+func conciseNewsSourceDateLabel(item formattedNewsItem) string {
+	var parts []string
+	if source := newsSourceLabel(item.URL); source != "" {
+		parts = append(parts, source)
+	}
+	if date := newsDateLabel(item); date != "" {
+		parts = append(parts, date)
+	}
+	return strings.Join(parts, ", ")
+}
+
+func newsSourceLabel(rawURL string) string {
+	parsed, err := url.Parse(strings.TrimSpace(rawURL))
+	if err != nil || parsed.Hostname() == "" {
+		return ""
+	}
+	host := strings.TrimPrefix(strings.ToLower(parsed.Hostname()), "www.")
+	return host
+}
+
+func newsDateLabel(item formattedNewsItem) string {
+	if t := newsResultItemTime(item); !t.IsZero() {
+		return t.Format("2 Jan 2006")
+	}
+	return ""
 }
 
 type formattedNewsItem struct {

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -143,9 +143,6 @@ func TestFormatNewsResult_Feed(t *testing.T) {
 	if !strings.Contains(got, "Bitcoin hits new high") {
 		t.Errorf("expected article title, got %q", got)
 	}
-	if !strings.Contains(got, "crypto") {
-		t.Errorf("expected category, got %q", got)
-	}
 	if !strings.Contains(got, "BTC reaches $100k") {
 		t.Errorf("expected description, got %q", got)
 	}
@@ -620,14 +617,16 @@ func TestFormatNewsResult_SearchWithTimestamp(t *testing.T) {
 	}
 }
 
-func TestFormatNewsResultUsesCleanMetadataLabels(t *testing.T) {
-	result := `{"query":"AI news","results":[{"title":"AI lab ships update","description":"Fresh details","category":"Tech","url":"https://example.com/ai","posted_at":"2026-07-05T12:00:00Z"}],"count":1}`
+func TestFormatNewsResultUsesCleanStoryLabels(t *testing.T) {
+	result := `{"query":"AI news","results":[{"title":"AI lab ships update","description":"Fresh details...","category":"Tech","url":"https://www.example.com/ai","posted_at":"2026-07-05T12:00:00Z"}],"count":1}`
 	got := formatNewsResult(result)
-	if !strings.Contains(got, "category: Tech; posted: 5 Jul 2026 12:00 UTC; source: https://example.com/ai") {
-		t.Fatalf("expected category/date/source metadata labels, got %q", got)
+	if !strings.Contains(got, "1. AI lab ships update — Fresh details (example.com, 5 Jul 2026)") {
+		t.Fatalf("expected clean story source/date label, got %q", got)
 	}
-	if strings.Contains(got, "[Tech]") {
-		t.Fatalf("expected metadata not to use markdown-link-like category brackets, got %q", got)
+	for _, rough := range []string{"category:", "posted:", "source: http", "Fresh details..."} {
+		if strings.Contains(got, rough) {
+			t.Fatalf("expected polished story labels without %q, got %q", rough, got)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- Format news search result bullets as clean story lines with concise source/date labels instead of provider-style category/posted/source metadata.
- Keep freshness caveats in front of stale AI-news result lists while making the story rows easier to read.

Closes #1354
Closes #1356

## Testing
- go build ./...
- go test ./... -short
- go vet ./...