### PR TITLE
Filter broad AI chip market movers

### DIFF
--- a/news/news.go
+++ b/news/news.go
@@ -2218,7 +2218,7 @@ func newsAIArticleIsBroadFinance(parts ...string) bool {
 	}
 	strongAITerms := []string{
 		"artificial intelligence", "machine learning", "large language model", "generative ai", "openai", "anthropic",
-		"llm", "ai model", "language model", "foundation model", "model-serving", "model serving", "chip", "chips", "semiconductor", "data center", "datacenter",
+		"llm", "ai model", "language model", "foundation model", "model-serving", "model serving",
 		"startup", "assistant", "product", "platform", "developer", "research", "robot", "robotics",
 	}
 	for _, term := range strongAITerms {
@@ -2226,7 +2226,32 @@ func newsAIArticleIsBroadFinance(parts ...string) bool {
 			return false
 		}
 	}
+
+	// Chip and data-center wording is common in broad market-mover copy
+	// ("AI chip stocks", "data-center shares") that mentions AI only as a
+	// trading theme. Keep those stories only when they describe concrete AI
+	// infrastructure or product activity, not just share-price movement.
+	if newsHaystackHasAIInfrastructureTerm(haystack) {
+		for _, term := range []string{
+			"launch", "launches", "launched", "release", "releases", "released", "unveil", "unveils", "unveiled",
+			"expand", "expands", "expanded", "build", "builds", "built", "capacity", "processor", "accelerator",
+			"gpu", "server", "inference", "training", "model serving", "model-serving", "cloud",
+		} {
+			if newsSearchTermMatches(haystack, term) {
+				return false
+			}
+		}
+	}
 	return true
+}
+
+func newsHaystackHasAIInfrastructureTerm(haystack string) bool {
+	for _, term := range []string{"chip", "chips", "semiconductor", "data center", "datacenter"} {
+		if newsSearchTermMatches(haystack, term) {
+			return true
+		}
+	}
+	return false
 }
 
 func newsSearchTermMatches(haystack, term string) bool {

--- a/news/news_test.go
+++ b/news/news_test.go
@@ -543,6 +543,45 @@ func TestNewsSearchArticlesFreshAIQueryFiltersAIThemedTokenModelPortfolio(t *tes
 	}
 }
 
+func TestNewsSearchArticlesFreshAIQueryFiltersAIChipStockMovers(t *testing.T) {
+	oldFeed := feed
+	defer func() {
+		mutex.Lock()
+		feed = oldFeed
+		mutex.Unlock()
+	}()
+
+	today := time.Date(2026, 7, 10, 9, 0, 0, 0, time.UTC)
+	mutex.Lock()
+	feed = []*Post{
+		{
+			ID:          "sk-hynix-stock",
+			Title:       "SK Hynix shares rally as AI chip stocks lift markets",
+			Description: "A broad finance brief tracks stock movers, investor rotation, and market sentiment.",
+			URL:         "https://example.com/sk-hynix-stock",
+			Category:    "Markets",
+			PostedAt:    today.Add(2 * time.Hour),
+		},
+		{
+			ID:          "ai-chip-launch",
+			Title:       "AI chip startup launches faster inference server",
+			Description: "The semiconductor company released a new accelerator for model-serving workloads.",
+			URL:         "https://example.com/ai-chip-launch",
+			Category:    "Technology",
+			PostedAt:    today.Add(time.Hour),
+		},
+	}
+	mutex.Unlock()
+
+	got := newsSearchArticles("Find today's AI news", nil, 8)
+	if len(got) != 1 {
+		t.Fatalf("expected broad AI-chip stock mover to be filtered, got %#v", got)
+	}
+	if got[0]["title"] != "AI chip startup launches faster inference server" {
+		t.Fatalf("expected concrete AI chip launch story, got %#v", got[0])
+	}
+}
+
 func TestNewsSearchArticlesFreshAIQueryKeepsSpecificAIChipMarketStory(t *testing.T) {
 	indexed := []*data.IndexEntry{
 		{


### PR DESCRIPTION
## Summary
- Tighten AI-news broad-finance filtering so generic AI chip/data-center stock-mover items are excluded unless they describe concrete AI infrastructure/product activity.
- Add regression coverage for SK Hynix-style AI-chip stock mover leakage while preserving concrete AI chip launch stories.

## Testing
- go test ./news -run TestNewsSearchArticlesFreshAIQueryFiltersAIChipStockMovers -count=1 -v -timeout 30s
- go build ./...
- go test ./... -short
- go vet ./...

Closes #1359
Closes #1361