### PR TITLE
Tighten AI news relevance filtering

### DIFF
--- a/news/news.go
+++ b/news/news.go
@@ -2108,7 +2108,7 @@ func liveFeedSearch(query string, limit int) []*Post {
 	for _, post := range currentFeed {
 		haystack := newsSearchHaystack(post.Title, post.Description, post.Content, post.Category)
 		if requireAI {
-			if !newsHaystackMatchesArtificialIntelligence(haystack) {
+			if !newsHaystackHasExplicitAIRelevance(haystack) {
 				continue
 			}
 			if newsAIArticleIsBroadFinance(post.Title, post.Description, post.Content, post.Category) {
@@ -2152,7 +2152,7 @@ func articleMatchesNewsQuery(query string, article map[string]interface{}) bool 
 		fmt.Sprintf("%v", article["category"]),
 	)
 	if newsQueryRequiresArtificialIntelligence(query) {
-		if !newsHaystackMatchesArtificialIntelligence(haystack) {
+		if !newsHaystackHasExplicitAIRelevance(haystack) {
 			return false
 		}
 		if newsAIArticleIsBroadFinance(
@@ -2186,8 +2186,25 @@ func newsQueryRequiresArtificialIntelligence(query string) bool {
 	return false
 }
 
-func newsHaystackMatchesArtificialIntelligence(haystack string) bool {
-	for _, term := range []string{"ai", "artificial intelligence", "machine learning", "llm", "large language model", "generative ai", "openai", "anthropic"} {
+func newsHaystackHasExplicitAIRelevance(haystack string) bool {
+	for _, term := range []string{
+		"artificial intelligence", "machine learning", "large language model", "generative ai",
+		"openai", "anthropic", "llm", "ai model", "language model", "foundation model",
+		"model-serving", "model serving", "ai agent", "ai assistant", "ai lab", "ai startup",
+		"ai chip", "ai accelerator", "ai infrastructure", "ai data center", "ai datacenter",
+	} {
+		if newsSearchTermMatches(haystack, term) {
+			return true
+		}
+	}
+	if !newsSearchTermMatches(haystack, "ai") {
+		return false
+	}
+	for _, term := range []string{
+		"model", "models", "assistant", "agent", "agents", "lab", "labs", "startup", "developer", "research",
+		"robot", "robotics", "chip", "chips", "semiconductor", "accelerator", "inference", "training",
+		"data center", "datacenter", "gpu", "cloud", "safety", "benchmark", "regulation", "regulator",
+	} {
 		if newsSearchTermMatches(haystack, term) {
 			return true
 		}
@@ -2204,7 +2221,7 @@ func newsAIArticleIsBroadFinance(parts ...string) bool {
 		"business", "finance", "financial", "market", "markets", "stock", "stocks", "shares", "equities",
 		"mover", "movers", "trading", "trader", "investor", "investors", "wall street", "nasdaq", "dow",
 		"s&p", "rate", "rates", "earnings", "futures", "crypto", "bitcoin", "blockchain", "token",
-		"tokens", "digital asset", "digital assets",
+		"tokens", "digital asset", "digital assets", "ipo", "valuation",
 	}
 	hasFinance := false
 	for _, term := range financeTerms {

--- a/news/news_test.go
+++ b/news/news_test.go
@@ -604,6 +604,53 @@ func TestNewsSearchArticlesFreshAIQueryKeepsSpecificAIChipMarketStory(t *testing
 	}
 }
 
+func TestNewsSearchArticlesFreshAIQueryRequiresExplicitAIRelevance(t *testing.T) {
+	oldFeed := feed
+	defer func() {
+		mutex.Lock()
+		feed = oldFeed
+		mutex.Unlock()
+	}()
+
+	today := time.Date(2026, 7, 10, 9, 0, 0, 0, time.UTC)
+	mutex.Lock()
+	feed = []*Post{
+		{
+			ID:          "ai-ad-spam",
+			Title:       "Fake portable air-conditioner ads use AI images online",
+			Description: "A consumer-advertising brief tracks misleading internet ads for home gadgets.",
+			URL:         "https://example.com/ai-ad-spam",
+			Category:    "Internet",
+			PostedAt:    today.Add(2 * time.Hour),
+		},
+		{
+			ID:          "sk-hynix-ipo",
+			Title:       "SK Hynix IPO plans draw attention as AI demand lifts valuation",
+			Description: "A finance brief tracks investor appetite, shares, and market sentiment.",
+			URL:         "https://example.com/sk-hynix-ipo",
+			Category:    "Finance",
+			PostedAt:    today.Add(time.Hour),
+		},
+		{
+			ID:          "ai-agent-story",
+			Title:       "OpenAI agent update adds safer browsing controls",
+			Description: "The AI assistant release gives developers new controls for agent workflows.",
+			URL:         "https://example.com/ai-agent-story",
+			Category:    "Technology",
+			PostedAt:    today,
+		},
+	}
+	mutex.Unlock()
+
+	got := newsSearchArticles("Find today's AI news", nil, 8)
+	if len(got) != 1 {
+		t.Fatalf("expected only explicitly AI-relevant news, got %#v", got)
+	}
+	if got[0]["title"] != "OpenAI agent update adds safer browsing controls" {
+		t.Fatalf("expected concrete AI-agent story, got %#v", got[0])
+	}
+}
+
 func TestNewsSearchFreshnessSummaryCaveatsStaleTodayResults(t *testing.T) {
 	articles := []map[string]interface{}{{
 		"title":     "AI startup raises funding",


### PR DESCRIPTION
## Summary
- Require AI-news candidates to show explicit AI relevance instead of matching a bare AI mention.
- Filter weak adjacent finance/ad items while preserving concrete AI agent, assistant, model, chip, and infrastructure stories.
- Add regression coverage for AI-ad and IPO leakage ahead of a concrete OpenAI agent story.

Closes #1364
Closes #1366

## Testing
- go test ./news -short
- go build ./...
- go test ./... -short
- go vet ./...