### PR TITLE
Filter crypto market background from AI news

### DIFF
--- a/news/news.go
+++ b/news/news.go
@@ -2233,6 +2233,9 @@ func newsAIArticleIsBroadFinance(parts ...string) bool {
 	if !hasFinance {
 		return false
 	}
+	if newsAIArticleIsCryptoMarketBackground(haystack) {
+		return true
+	}
 	strongAITerms := []string{
 		"artificial intelligence", "machine learning", "large language model", "generative ai", "openai", "anthropic",
 		"llm", "ai model", "language model", "foundation model", "model-serving", "model serving",
@@ -2257,6 +2260,50 @@ func newsAIArticleIsBroadFinance(parts ...string) bool {
 			if newsSearchTermMatches(haystack, term) {
 				return false
 			}
+		}
+	}
+	return true
+}
+
+func newsAIArticleIsCryptoMarketBackground(haystack string) bool {
+	cryptoTerms := []string{
+		"crypto", "bitcoin", "blockchain", "token", "tokens", "digital asset", "digital assets",
+		"ethereum", "ether", "stablecoin", "altcoin", "defi",
+	}
+	hasCrypto := false
+	for _, term := range cryptoTerms {
+		if newsSearchTermMatches(haystack, term) {
+			hasCrypto = true
+			break
+		}
+	}
+	if !hasCrypto {
+		return false
+	}
+
+	marketTerms := []string{
+		"market", "markets", "mover", "movers", "price", "prices", "rally", "climb", "climbs",
+		"drop", "drops", "trading", "trader", "traders", "investor", "investors", "portfolio",
+	}
+	hasMarketFrame := false
+	for _, term := range marketTerms {
+		if newsSearchTermMatches(haystack, term) {
+			hasMarketFrame = true
+			break
+		}
+	}
+	if !hasMarketFrame {
+		return false
+	}
+
+	concreteAITerms := []string{
+		"artificial intelligence", "machine learning", "large language model", "generative ai",
+		"openai", "anthropic", "llm", "ai model", "language model", "foundation model",
+		"ai agent", "ai assistant", "ai lab", "model-serving", "model serving",
+	}
+	for _, term := range concreteAITerms {
+		if newsSearchTermMatches(haystack, term) {
+			return false
 		}
 	}
 	return true

--- a/news/news_test.go
+++ b/news/news_test.go
@@ -543,6 +543,76 @@ func TestNewsSearchArticlesFreshAIQueryFiltersAIThemedTokenModelPortfolio(t *tes
 	}
 }
 
+func TestNewsSearchArticlesFreshAIQueryFiltersCryptoMarketBackground(t *testing.T) {
+	oldFeed := feed
+	defer func() {
+		mutex.Lock()
+		feed = oldFeed
+		mutex.Unlock()
+	}()
+
+	today := time.Date(2026, 7, 10, 9, 0, 0, 0, time.UTC)
+	mutex.Lock()
+	feed = []*Post{
+		{
+			ID:          "crypto-market-background",
+			Title:       "Crypto market movers rally as AI-themed tokens climb",
+			Description: "A broad digital-assets background brief tracks bitcoin prices, trader rotation, and token market sentiment.",
+			URL:         "https://example.com/crypto-market-background",
+			Category:    "Crypto",
+			PostedAt:    today.Add(2 * time.Hour),
+		},
+		{
+			ID:          "openai-agent-controls",
+			Title:       "OpenAI agent update adds safer browsing controls",
+			Description: "The AI assistant release gives developers new controls for agent workflows.",
+			URL:         "https://example.com/openai-agent-controls",
+			Category:    "Technology",
+			PostedAt:    today.Add(time.Hour),
+		},
+	}
+	mutex.Unlock()
+
+	got := newsSearchArticles("Find today's AI news", nil, 8)
+	if len(got) != 1 {
+		t.Fatalf("expected crypto market background to be filtered, got %#v", got)
+	}
+	if got[0]["title"] != "OpenAI agent update adds safer browsing controls" {
+		t.Fatalf("expected concrete AI-agent story, got %#v", got[0])
+	}
+}
+
+func TestNewsSearchArticlesFreshAIQueryKeepsConcreteAICryptoStory(t *testing.T) {
+	oldFeed := feed
+	defer func() {
+		mutex.Lock()
+		feed = oldFeed
+		mutex.Unlock()
+	}()
+
+	today := time.Date(2026, 7, 10, 9, 0, 0, 0, time.UTC)
+	mutex.Lock()
+	feed = []*Post{
+		{
+			ID:          "ai-agent-crypto",
+			Title:       "AI agent startup launches crypto wallet assistant",
+			Description: "The artificial intelligence product helps developers test blockchain payment workflows.",
+			URL:         "https://example.com/ai-agent-crypto",
+			Category:    "Technology",
+			PostedAt:    today.Add(time.Hour),
+		},
+	}
+	mutex.Unlock()
+
+	got := newsSearchArticles("Find today's AI news", nil, 8)
+	if len(got) != 1 {
+		t.Fatalf("expected concrete AI crypto story to remain, got %#v", got)
+	}
+	if got[0]["title"] != "AI agent startup launches crypto wallet assistant" {
+		t.Fatalf("expected concrete AI crypto story, got %#v", got[0])
+	}
+}
+
 func TestNewsSearchArticlesFreshAIQueryFiltersAIChipStockMovers(t *testing.T) {
 	oldFeed := feed
 	defer func() {


### PR DESCRIPTION
## Summary
- Filter broad crypto market-background items from AI-news searches unless the item has concrete AI evidence.
- Add regression coverage for filtering AI-themed crypto market background while preserving concrete AI crypto stories.

Closes #1371
Closes #1373

## Verification
- go build ./...
- go test ./... -short
- go vet ./...