### PR TITLE
Tighten same-day AI news focus

### DIFF
--- a/news/news.go
+++ b/news/news.go
@@ -2114,6 +2114,9 @@ func liveFeedSearch(query string, limit int) []*Post {
 			if newsAIArticleIsBroadFinance(post.Title, post.Description, post.Content, post.Category) {
 				continue
 			}
+			if newsAIArticleIsWeakAdjacentBackground(post.Title, post.Description, post.Content, post.Category) {
+				continue
+			}
 		}
 		score := 0
 		for _, term := range terms {
@@ -2156,6 +2159,14 @@ func articleMatchesNewsQuery(query string, article map[string]interface{}) bool 
 			return false
 		}
 		if newsAIArticleIsBroadFinance(
+			fmt.Sprintf("%v", article["title"]),
+			fmt.Sprintf("%v", article["description"]),
+			fmt.Sprintf("%v", article["content"]),
+			fmt.Sprintf("%v", article["category"]),
+		) {
+			return false
+		}
+		if newsAIArticleIsWeakAdjacentBackground(
 			fmt.Sprintf("%v", article["title"]),
 			fmt.Sprintf("%v", article["description"]),
 			fmt.Sprintf("%v", article["content"]),
@@ -2210,6 +2221,39 @@ func newsHaystackHasExplicitAIRelevance(haystack string) bool {
 		}
 	}
 	return false
+}
+
+func newsAIArticleIsWeakAdjacentBackground(parts ...string) bool {
+	haystack := newsSearchHaystack(parts...)
+	if haystack == "" {
+		return false
+	}
+	weakFrames := []string{
+		"essay", "opinion", "column", "maintainable code", "coding", "programming", "software engineering",
+		"windows tool", "utility", "gadget", "advertising", "ads", "election", "campaign", "parliament", "politics",
+	}
+	hasWeakFrame := false
+	for _, term := range weakFrames {
+		if newsSearchTermMatches(haystack, term) {
+			hasWeakFrame = true
+			break
+		}
+	}
+	if !hasWeakFrame {
+		return false
+	}
+	strongAITerms := []string{
+		"artificial intelligence", "machine learning", "large language model", "generative ai", "openai", "anthropic",
+		"llm", "ai model", "language model", "foundation model", "model-serving", "model serving",
+		"ai agent", "ai assistant", "ai lab", "ai startup", "ai chip", "ai accelerator", "ai infrastructure",
+		"ai regulation", "ai regulator", "ai policy", "ai safety", "ai research", "ai product",
+	}
+	for _, term := range strongAITerms {
+		if newsSearchTermMatches(haystack, term) {
+			return false
+		}
+	}
+	return true
 }
 
 func newsAIArticleIsBroadFinance(parts ...string) bool {

--- a/news/news_test.go
+++ b/news/news_test.go
@@ -721,6 +721,53 @@ func TestNewsSearchArticlesFreshAIQueryRequiresExplicitAIRelevance(t *testing.T)
 	}
 }
 
+func TestNewsSearchArticlesFreshAIQueryFiltersWeakAdjacentSameDayBackground(t *testing.T) {
+	oldFeed := feed
+	defer func() {
+		mutex.Lock()
+		feed = oldFeed
+		mutex.Unlock()
+	}()
+
+	today := time.Date(2026, 7, 10, 9, 0, 0, 0, time.UTC)
+	mutex.Lock()
+	feed = []*Post{
+		{
+			ID:          "maintainable-code-ai-era",
+			Title:       "Writing maintainable code in the AI era",
+			Description: "A same-day software engineering essay for developers with only broad AI-era framing.",
+			URL:         "https://example.com/maintainable-code-ai-era",
+			Category:    "Software",
+			PostedAt:    today.Add(3 * time.Hour),
+		},
+		{
+			ID:          "ir-tv-ai-tool",
+			Title:       "Windows IR TV-volume utility uses AI images in demo",
+			Description: "A same-day gadget tooling brief with weak artificial-intelligence evidence.",
+			URL:         "https://example.com/ir-tv-ai-tool",
+			Category:    "Tools",
+			PostedAt:    today.Add(2 * time.Hour),
+		},
+		{
+			ID:          "openai-agent-startup",
+			Title:       "OpenAI agent startup adds safer browsing controls",
+			Description: "The AI assistant product release gives developers new controls for agent workflows.",
+			URL:         "https://example.com/openai-agent-startup",
+			Category:    "Technology",
+			PostedAt:    today,
+		},
+	}
+	mutex.Unlock()
+
+	got := newsSearchArticles("Find today's AI news", nil, 8)
+	if len(got) != 1 {
+		t.Fatalf("expected weak adjacent same-day background to be filtered, got %#v", got)
+	}
+	if got[0]["title"] != "OpenAI agent startup adds safer browsing controls" {
+		t.Fatalf("expected explicit AI story, got %#v", got[0])
+	}
+}
+
 func TestNewsSearchFreshnessSummaryCaveatsStaleTodayResults(t *testing.T) {
 	articles := []map[string]interface{}{{
 		"title":     "AI startup raises funding",


### PR DESCRIPTION
## Summary
- Filter weak adjacent same-day AI-news candidates such as broad software essays, gadget/tooling blurbs, ads, and politics background unless they include concrete AI evidence.
- Add a regression test for weak adjacent same-day background yielding to an explicit OpenAI agent story.

Closes #1376
Closes #1378

## Testing
- go build ./...
- go test ./... -short
- go vet ./...