### PR TITLE
Tighten AI-chip finance AI-news filtering

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -1316,6 +1316,48 @@ Sources:
 	}
 }
 
+func TestCompleteToolAnswerFiltersAdjacentAIChipFinanceFromAINewsLead(t *testing.T) {
+	rag := []string{`### news_search
+` + unavailableToolMessage("news_search"), `### web_search
+Current request date: Friday, 10 July 2026 (2026-07-10, UTC).
+Search results for "AI news":
+Sources:
+1. SK Hynix shares jump before Nasdaq IPO — Investors cite Nvidia demand and the broad AI chip boom. (https://example.com/hynix-ipo)
+2. AI governance bill advances — Lawmakers moved the proposal after model-risk hearings. (https://example.com/ai-governance)
+3. Agent payments startup launches checkout tool — The company released an AI agent payment flow today. (https://example.com/agent-payments)`}
+
+	got := completeToolAnswer("Here are the search results I found.", rag)
+	firstLine, _, _ := strings.Cut(got, "\n")
+	if strings.Contains(got, "SK Hynix") || strings.Contains(firstLine, "AI chip boom") {
+		t.Fatalf("expected broad AI-chip finance to be filtered when concrete AI stories exist, got %q", got)
+	}
+	if !strings.Contains(firstLine, "Latest source-backed items for Friday, 10 July 2026 (2026-07-10): Agent payments startup launches checkout tool; AI governance bill advances.") {
+		t.Fatalf("expected concrete AI action/governance stories to lead, got %q", got)
+	}
+}
+
+func TestCompleteToolAnswerFramesOnlyAdjacentAIChipFinanceAsLimitedEvidence(t *testing.T) {
+	rag := []string{`### news_search
+` + unavailableToolMessage("news_search"), `### web_search
+Current request date: Friday, 10 July 2026 (2026-07-10, UTC).
+Search results for "AI news":
+Sources:
+1. SK Hynix IPO draws investor attention — The listing is framed by Nvidia demand and the broad AI chip boom. (https://example.com/hynix-ipo)
+2. Semiconductor shares climb — Markets rallied around expectations for artificial intelligence chip sales. (https://example.com/chip-stocks)`}
+
+	got := completeToolAnswer("Here are the search results I found.", rag)
+	firstLine, _, _ := strings.Cut(got, "\n")
+	if !strings.Contains(firstLine, "limited source-backed evidence") {
+		t.Fatalf("expected adjacent-only AI-chip finance to be caveated as limited evidence, got %q", got)
+	}
+	if strings.Contains(firstLine, "Latest source-backed items") {
+		t.Fatalf("expected no normal latest-AI-news lead from adjacent finance only, got %q", got)
+	}
+	if !strings.Contains(got, "SK Hynix IPO draws investor attention") {
+		t.Fatalf("expected limited adjacent evidence to remain visible after caveat, got %q", got)
+	}
+}
+
 func TestCompleteToolAnswerFramesSnippetOnlyAINewsCategoryPageAsLimitedEvidence(t *testing.T) {
 	rag := []string{`### news_search
 ` + unavailableToolMessage("news_search"), `### web_search

--- a/agent/answer_guard.go
+++ b/agent/answer_guard.go
@@ -272,12 +272,14 @@ func formatWebSearchFallbackSection(body string) string {
 	lines := meaningfulLines(body, 6)
 	lines = prioritizeSnippetBackedWebLines(lines)
 	genericOnly := hasOnlyGenericWebEvidence(lines)
+	adjacentOnly := hasOnlyAdjacentAIChipFinanceEvidence(lines)
+	lines = filterAdjacentAIChipFinanceLines(lines, 4)
 	lines = filterGenericWebResultLines(lines, 4)
 	if len(lines) == 0 {
 		return ""
 	}
 
-	limited := hasLowConfidenceWebEvidence(body) || genericOnly
+	limited := hasLowConfidenceWebEvidence(body) || genericOnly || adjacentOnly
 	requestDate := fallbackRequestDate(body)
 	if !limited {
 		if summary := webSearchAnswerLead(lines, requestDate); summary != "" {
@@ -743,6 +745,25 @@ func filterGenericWebResultLines(lines []string, limit int) []string {
 	return kept
 }
 
+func filterAdjacentAIChipFinanceLines(lines []string, limit int) []string {
+	if len(lines) == 0 {
+		return lines
+	}
+	kept := make([]string, 0, len(lines))
+	for _, line := range lines {
+		if !isAdjacentAIChipFinanceLine(line) {
+			kept = append(kept, line)
+		}
+	}
+	if len(kept) == 0 {
+		kept = lines
+	}
+	if len(kept) > limit {
+		kept = kept[:limit]
+	}
+	return kept
+}
+
 func hasOnlyGenericWebEvidence(lines []string) bool {
 	if len(lines) == 0 {
 		return false
@@ -755,7 +776,22 @@ func hasOnlyGenericWebEvidence(lines []string) bool {
 	return true
 }
 
+func hasOnlyAdjacentAIChipFinanceEvidence(lines []string) bool {
+	if len(lines) == 0 {
+		return false
+	}
+	for _, line := range lines {
+		if !isAdjacentAIChipFinanceLine(line) {
+			return false
+		}
+	}
+	return true
+}
+
 func webResultFallbackPriority(line string) int {
+	if isAdjacentAIChipFinanceLine(line) {
+		return 3
+	}
 	if isGenericWebResultLine(line) {
 		return 3
 	}
@@ -793,6 +829,35 @@ func isDatedWebStoryLine(line string) bool {
 		}
 	}
 	return webStoryNumericDatePattern.MatchString(lower) || webStoryMonthDatePattern.MatchString(lower)
+}
+
+func isAdjacentAIChipFinanceLine(line string) bool {
+	lower := strings.ToLower(cleanFallbackLine(line))
+	if !containsAny(lower, []string{"ai chip", "ai-chip", "artificial intelligence chip", "accelerator", "gpu", "nvidia", "semiconductor", "sk hynix", "hynix"}) {
+		return false
+	}
+	if !containsAny(lower, []string{"ipo", "nasdaq", "stock", "stocks", "share", "shares", "valuation", "market", "investor", "revenue", "sales", "profit", "earnings"}) {
+		return false
+	}
+	return !hasConcreteAIAction(lower)
+}
+
+func hasConcreteAIAction(lower string) bool {
+	concreteTerms := []string{
+		"ai model", "model update", "assistant", "agent", "training", "inference", "data center", "datacenter",
+		"accelerator customers", "gpu cluster", "capacity", "supply deal", "pilot", "deploy", "deployed",
+		"launch", "launched", "release", "released", "unveiled", "rollout", "rolls out", "tool",
+	}
+	return containsAny(lower, concreteTerms)
+}
+
+func containsAny(s string, terms []string) bool {
+	for _, term := range terms {
+		if strings.Contains(s, term) {
+			return true
+		}
+	}
+	return false
 }
 
 var (


### PR DESCRIPTION
## Summary
- Demote broad AI-chip finance stories from AI-news web fallback leads unless they include concrete AI action.
- Caveat adjacent-only AI-chip finance evidence as limited source-backed evidence.
- Add regression tests for mixed concrete AI stories and adjacent-only AI-chip finance results.

Closes #1386
Closes #1388

## Testing
- go build ./...
- go test ./... -short
- go vet ./...