### PR TITLE
Filter generic finance policy from AI news

### DIFF
--- a/news/news.go
+++ b/news/news.go
@@ -2265,7 +2265,8 @@ func newsAIArticleIsBroadFinance(parts ...string) bool {
 		"business", "finance", "financial", "market", "markets", "stock", "stocks", "shares", "equities",
 		"mover", "movers", "trading", "trader", "investor", "investors", "wall street", "nasdaq", "dow",
 		"s&p", "rate", "rates", "earnings", "futures", "crypto", "bitcoin", "blockchain", "token",
-		"tokens", "digital asset", "digital assets", "ipo", "valuation",
+		"tokens", "digital asset", "digital assets", "stablecoin", "stablecoins", "ipo", "valuation",
+		"export control", "export controls", "sanctions", "cbdc", "central-bank",
 	}
 	hasFinance := false
 	for _, term := range financeTerms {
@@ -2278,6 +2279,9 @@ func newsAIArticleIsBroadFinance(parts ...string) bool {
 		return false
 	}
 	if newsAIArticleIsCryptoMarketBackground(haystack) {
+		return true
+	}
+	if newsAIArticleIsGenericFinancePolicyBackground(haystack) {
 		return true
 	}
 
@@ -2298,6 +2302,41 @@ func newsAIArticleIsBroadFinance(parts ...string) bool {
 	}
 	if newsAIArticleHasConcreteStoryEvidence(haystack) {
 		return false
+	}
+	return true
+}
+
+func newsAIArticleIsGenericFinancePolicyBackground(haystack string) bool {
+	policyTerms := []string{
+		"export control", "export controls", "sanctions", "stablecoin", "stablecoins", "binance",
+		"cbdc", "central-bank", "central bank", "digital asset", "digital assets", "crypto policy",
+	}
+	hasPolicyFrame := false
+	for _, term := range policyTerms {
+		if newsSearchTermMatches(haystack, term) {
+			hasPolicyFrame = true
+			break
+		}
+	}
+	if !hasPolicyFrame {
+		return false
+	}
+
+	// Keep true AI-governance stories, but do not let generic finance, crypto,
+	// or export-control policy pieces lead AI news just because they mention AI
+	// governance in passing. The story needs concrete AI actors, models,
+	// products, safety/evaluation work, or explicit AI-sector controls.
+	for _, term := range []string{
+		"openai", "anthropic", "ai lab", "ai startup", "ai company", "ai companies",
+		"artificial intelligence company", "artificial intelligence companies",
+		"ai model", "language model", "foundation model", "large language model", "llm",
+		"model evaluation", "model-evaluation", "benchmark", "frontier system", "frontier systems",
+		"ai safety", "ai agent", "ai assistant", "ai product", "ai platform",
+		"ai chip export", "ai chips export", "ai export control", "ai export controls",
+	} {
+		if newsSearchTermMatches(haystack, term) {
+			return false
+		}
 	}
 	return true
 }

--- a/news/news_test.go
+++ b/news/news_test.go
@@ -660,6 +660,76 @@ func TestNewsSearchArticlesFreshAIQueryFiltersCryptoPolicyBackground(t *testing.
 	}
 }
 
+func TestNewsSearchArticlesFreshAIQueryFiltersGenericFinancePolicyBackground(t *testing.T) {
+	oldFeed := feed
+	defer func() {
+		mutex.Lock()
+		feed = oldFeed
+		mutex.Unlock()
+	}()
+
+	today := time.Date(2026, 7, 10, 9, 0, 0, 0, time.UTC)
+	mutex.Lock()
+	feed = []*Post{
+		{
+			ID:          "uae-binance-policy",
+			Title:       "UAE export-control debate and Binance stablecoin rules test AI governance",
+			Description: "A finance-policy brief tracks sanctions, digital assets, and investor reaction while noting AI governance concerns.",
+			URL:         "https://example.com/uae-binance-policy",
+			Category:    "Policy",
+			PostedAt:    today.Add(2 * time.Hour),
+		},
+		{
+			ID:          "ai-agent-payments",
+			Title:       "AI agent startup launches payment controls for assistants",
+			Description: "The artificial intelligence product update lets developers govern autonomous checkout workflows.",
+			URL:         "https://example.com/ai-agent-payments",
+			Category:    "Technology",
+			PostedAt:    today.Add(time.Hour),
+		},
+	}
+	mutex.Unlock()
+
+	got := newsSearchArticles("Find today's AI news", nil, 8)
+	if len(got) != 1 {
+		t.Fatalf("expected generic finance-policy background to be filtered, got %#v", got)
+	}
+	if got[0]["title"] != "AI agent startup launches payment controls for assistants" {
+		t.Fatalf("expected concrete AI-agent payment story, got %#v", got[0])
+	}
+}
+
+func TestNewsSearchArticlesFreshAIQueryKeepsExplicitAIGovernancePolicy(t *testing.T) {
+	oldFeed := feed
+	defer func() {
+		mutex.Lock()
+		feed = oldFeed
+		mutex.Unlock()
+	}()
+
+	today := time.Date(2026, 7, 10, 9, 0, 0, 0, time.UTC)
+	mutex.Lock()
+	feed = []*Post{
+		{
+			ID:          "ai-export-controls",
+			Title:       "AI export controls target frontier model training clusters",
+			Description: "Regulators proposed artificial intelligence safeguards for frontier systems and model-evaluation reporting.",
+			URL:         "https://example.com/ai-export-controls",
+			Category:    "Policy",
+			PostedAt:    today.Add(time.Hour),
+		},
+	}
+	mutex.Unlock()
+
+	got := newsSearchArticles("Find today's AI news", nil, 8)
+	if len(got) != 1 {
+		t.Fatalf("expected explicit AI-governance policy to remain, got %#v", got)
+	}
+	if got[0]["title"] != "AI export controls target frontier model training clusters" {
+		t.Fatalf("expected explicit AI-governance story, got %#v", got[0])
+	}
+}
+
 func TestNewsSearchArticlesFreshAIQueryKeepsConcreteAICryptoStory(t *testing.T) {
 	oldFeed := feed
 	defer func() {


### PR DESCRIPTION
## Summary
- filter generic finance, crypto-policy, stablecoin, sanctions, and export-control background out of AI-news results unless the story has concrete AI substance
- keep explicit AI-governance policy stories when they involve AI actors, models, safety/evaluation work, products, or AI-sector controls
- add regression coverage for the generic finance-policy leak and the explicit-governance allowed path

Closes #1391
Closes #1393