### PR TITLE
Tighten AI news topic filtering

### DIFF
--- a/news/news.go
+++ b/news/news.go
@@ -2117,6 +2117,9 @@ func liveFeedSearch(query string, limit int) []*Post {
 			if newsAIArticleIsWeakAdjacentBackground(post.Title, post.Description, post.Content, post.Category) {
 				continue
 			}
+			if newsAIArticleIsGenericHiringBackground(post.Title, post.Description, post.Content, post.Category) {
+				continue
+			}
 		}
 		score := 0
 		for _, term := range terms {
@@ -2167,6 +2170,14 @@ func articleMatchesNewsQuery(query string, article map[string]interface{}) bool 
 			return false
 		}
 		if newsAIArticleIsWeakAdjacentBackground(
+			fmt.Sprintf("%v", article["title"]),
+			fmt.Sprintf("%v", article["description"]),
+			fmt.Sprintf("%v", article["content"]),
+			fmt.Sprintf("%v", article["category"]),
+		) {
+			return false
+		}
+		if newsAIArticleIsGenericHiringBackground(
 			fmt.Sprintf("%v", article["title"]),
 			fmt.Sprintf("%v", article["description"]),
 			fmt.Sprintf("%v", article["content"]),
@@ -2249,6 +2260,42 @@ func newsAIArticleIsWeakAdjacentBackground(parts ...string) bool {
 		"ai regulation", "ai regulator", "ai policy", "ai safety", "ai research", "ai product",
 	}
 	for _, term := range strongAITerms {
+		if newsSearchTermMatches(haystack, term) {
+			return false
+		}
+	}
+	return true
+}
+
+func newsAIArticleIsGenericHiringBackground(parts ...string) bool {
+	haystack := newsSearchHaystack(parts...)
+	if haystack == "" {
+		return false
+	}
+	hiringTerms := []string{
+		"hiring", "hire", "hires", "jobs", "job", "careers", "recruiting", "recruit", "talent",
+		"job board", "job-board", "y combinator", "yc companies", "startup jobs",
+	}
+	hasHiringFrame := false
+	for _, term := range hiringTerms {
+		if newsSearchTermMatches(haystack, term) {
+			hasHiringFrame = true
+			break
+		}
+	}
+	if !hasHiringFrame {
+		return false
+	}
+
+	// Hiring roundups are usually generic company/background posts. Keep them
+	// only when the hiring item is also about a concrete AI release, model,
+	// safety/governance action, infrastructure launch, or user-impact change.
+	for _, term := range []string{
+		"launch", "launches", "launched", "release", "releases", "released", "rollout", "rolls out",
+		"unveil", "unveils", "unveiled", "open source", "model release", "benchmark", "evaluation",
+		"ai safety", "ai regulation", "ai regulator", "ai governance", "frontier model", "foundation model",
+		"ai chip", "ai accelerator", "inference server", "training cluster", "agent workflow", "assistant update",
+	} {
 		if newsSearchTermMatches(haystack, term) {
 			return false
 		}

--- a/news/news_test.go
+++ b/news/news_test.go
@@ -800,6 +800,53 @@ func TestNewsSearchArticlesFreshAIQueryFiltersAIChipStockMovers(t *testing.T) {
 	}
 }
 
+func TestNewsSearchArticlesFreshAIQueryFiltersGenericHiringAndChipFinance(t *testing.T) {
+	oldFeed := feed
+	defer func() {
+		mutex.Lock()
+		feed = oldFeed
+		mutex.Unlock()
+	}()
+
+	today := time.Date(2026, 7, 10, 9, 0, 0, 0, time.UTC)
+	mutex.Lock()
+	feed = []*Post{
+		{
+			ID:          "yc-hiring-ai",
+			Title:       "YC companies hiring for AI roles this summer",
+			Description: "A job-board roundup lists startups recruiting engineers and product talent.",
+			URL:         "https://example.com/yc-hiring-ai",
+			Category:    "Startups",
+			PostedAt:    today.Add(3 * time.Hour),
+		},
+		{
+			ID:          "sk-hynix-nasdaq",
+			Title:       "SK Hynix Nasdaq debut draws investors as AI demand lifts chip shares",
+			Description: "A broad finance brief tracks IPO demand, valuation, trading, and market sentiment.",
+			URL:         "https://example.com/sk-hynix-nasdaq",
+			Category:    "Markets",
+			PostedAt:    today.Add(2 * time.Hour),
+		},
+		{
+			ID:          "gemini-model-update",
+			Title:       "Gemini model update adds safer agent controls",
+			Description: "The AI model release gives developers new controls for assistant workflows.",
+			URL:         "https://example.com/gemini-model-update",
+			Category:    "Technology",
+			PostedAt:    today,
+		},
+	}
+	mutex.Unlock()
+
+	got := newsSearchArticles("Find today's AI news", nil, 8)
+	if len(got) != 1 {
+		t.Fatalf("expected generic hiring and chip-finance items to be filtered, got %#v", got)
+	}
+	if got[0]["title"] != "Gemini model update adds safer agent controls" {
+		t.Fatalf("expected concrete AI model story, got %#v", got[0])
+	}
+}
+
 func TestNewsSearchArticlesFreshAIQueryKeepsSpecificAIChipMarketStory(t *testing.T) {
 	indexed := []*data.IndexEntry{
 		{


### PR DESCRIPTION
## Summary
- Filter generic AI hiring roundups from fresh AI-news results unless they include concrete AI release, model, governance, safety, infrastructure, or user-impact evidence.
- Add regression coverage for generic YC hiring and broad SK Hynix Nasdaq/IPO finance items so concrete model updates lead instead.

Closes #1396
Closes #1399

## Testing
- go build ./...
- go test ./... -short
- go vet ./...