### PR TITLE
Filter generic software posts from AI news

### DIFF
--- a/news/news.go
+++ b/news/news.go
@@ -2241,7 +2241,7 @@ func newsAIArticleIsWeakAdjacentBackground(parts ...string) bool {
 	}
 	weakFrames := []string{
 		"essay", "opinion", "column", "maintainable code", "coding", "programming", "software engineering",
-		"windows tool", "utility", "gadget", "advertising", "ads", "election", "campaign", "parliament", "politics",
+		"windows tool", "utility", "tooling", "developer tool", "browser", "freecad", "gadget", "advertising", "ads", "election", "campaign", "parliament", "politics",
 	}
 	hasWeakFrame := false
 	for _, term := range weakFrames {
@@ -2257,7 +2257,7 @@ func newsAIArticleIsWeakAdjacentBackground(parts ...string) bool {
 		"artificial intelligence", "machine learning", "large language model", "generative ai", "openai", "anthropic",
 		"llm", "ai model", "language model", "foundation model", "model-serving", "model serving",
 		"ai agent", "ai assistant", "ai lab", "ai startup", "ai chip", "ai accelerator", "ai infrastructure",
-		"ai regulation", "ai regulator", "ai policy", "ai safety", "ai research", "ai product",
+		"ai regulation", "ai regulator", "ai policy", "ai safety", "ai research", "ai product", "ai-powered", "ai powered",
 	}
 	for _, term := range strongAITerms {
 		if newsSearchTermMatches(haystack, term) {

--- a/news/news_test.go
+++ b/news/news_test.go
@@ -994,6 +994,45 @@ func TestNewsSearchArticlesFreshAIQueryFiltersWeakAdjacentSameDayBackground(t *t
 	}
 }
 
+func TestNewsSearchArticlesFreshAIQueryFiltersGenericSoftwareToolPosts(t *testing.T) {
+	oldFeed := feed
+	defer func() {
+		mutex.Lock()
+		feed = oldFeed
+		mutex.Unlock()
+	}()
+
+	today := time.Date(2026, 7, 11, 9, 0, 0, 0, time.UTC)
+	mutex.Lock()
+	feed = []*Post{
+		{
+			ID:          "freecad-browser",
+			Title:       "FreeCAD in the Browser",
+			Description: "A developer-tool post mentions AI-era workflows but is mainly about running CAD software in a web browser.",
+			URL:         "https://example.com/freecad-browser",
+			Category:    "Software",
+			PostedAt:    today.Add(2 * time.Hour),
+		},
+		{
+			ID:          "ai-model-story",
+			Title:       "AI lab ships safer model controls",
+			Description: "The AI model release gives developers new controls for assistant workflows.",
+			URL:         "https://example.com/ai-model-story",
+			Category:    "Technology",
+			PostedAt:    today,
+		},
+	}
+	mutex.Unlock()
+
+	got := newsSearchArticles("Find today's AI news", nil, 8)
+	if len(got) != 1 {
+		t.Fatalf("expected generic software tool post to be filtered, got %#v", got)
+	}
+	if got[0]["title"] != "AI lab ships safer model controls" {
+		t.Fatalf("expected concrete AI model story, got %#v", got[0])
+	}
+}
+
 func TestNewsSearchFreshnessSummaryCaveatsStaleTodayResults(t *testing.T) {
 	articles := []map[string]interface{}{{
 		"title":     "AI startup raises funding",


### PR DESCRIPTION
## Summary
- Treat generic browser/software-tool posts as weak adjacent background for fresh AI-news queries unless they include concrete AI product, model, governance, safety, infrastructure, or user-impact evidence.
- Add regression coverage for a FreeCAD in the Browser-style result so concrete AI model news remains while generic tool posts are filtered.

Closes #1404
Closes #1406

## Testing
- go test ./news -run 'FreshAIQuery|FreshnessSummary' -short
- go build ./... && go test ./... -short && go vet ./...