### PR TITLE
Filter broad AI-chip finance from AI news

### DIFF
--- a/news/news.go
+++ b/news/news.go
@@ -2335,17 +2335,22 @@ func newsAIArticleIsBroadFinance(parts ...string) bool {
 	// Chip and data-center wording is common in broad market-mover copy
 	// ("AI chip stocks", "data-center shares") that mentions AI only as a
 	// trading theme. Keep those stories only when they describe concrete AI
-	// infrastructure or product activity, not just share-price movement.
+	// infrastructure or product activity, not just share-price movement. Generic
+	// phrases such as "artificial intelligence chip sales" are still finance
+	// background unless the item names a launch, deployment, capacity buildout,
+	// accelerator/customer deal, or similar AI-infrastructure action.
 	if newsHaystackHasAIInfrastructureTerm(haystack) {
 		for _, term := range []string{
 			"launch", "launches", "launched", "release", "releases", "released", "unveil", "unveils", "unveiled",
 			"expand", "expands", "expanded", "build", "builds", "built", "capacity", "processor", "accelerator",
-			"gpu", "server", "inference", "training", "model serving", "model-serving", "cloud",
+			"gpu", "server", "inference", "training", "model serving", "model-serving", "cloud", "supply deal",
+			"accelerator customer", "accelerator customers", "deployment", "deploy", "deployed",
 		} {
 			if newsSearchTermMatches(haystack, term) {
 				return false
 			}
 		}
+		return true
 	}
 	if newsAIArticleHasConcreteStoryEvidence(haystack) {
 		return false

--- a/news/news_test.go
+++ b/news/news_test.go
@@ -847,6 +847,45 @@ func TestNewsSearchArticlesFreshAIQueryFiltersGenericHiringAndChipFinance(t *tes
 	}
 }
 
+func TestNewsSearchArticlesFreshAIQueryFiltersGenericArtificialIntelligenceChipSales(t *testing.T) {
+	oldFeed := feed
+	defer func() {
+		mutex.Lock()
+		feed = oldFeed
+		mutex.Unlock()
+	}()
+
+	today := time.Date(2026, 7, 11, 9, 0, 0, 0, time.UTC)
+	mutex.Lock()
+	feed = []*Post{
+		{
+			ID:          "chip-stocks-sales",
+			Title:       "Semiconductor shares climb on artificial intelligence chip sales optimism",
+			Description: "Markets rallied around investor expectations, valuation, and trading momentum for chipmakers.",
+			URL:         "https://example.com/chip-stocks-sales",
+			Category:    "Markets",
+			PostedAt:    today.Add(2 * time.Hour),
+		},
+		{
+			ID:          "ai-agent-governance",
+			Title:       "AI agent platform adds model-risk governance controls",
+			Description: "The assistant product release gives enterprise users audit controls for agent workflows.",
+			URL:         "https://example.com/ai-agent-governance",
+			Category:    "Technology",
+			PostedAt:    today,
+		},
+	}
+	mutex.Unlock()
+
+	got := newsSearchArticles("Find today's AI news", nil, 8)
+	if len(got) != 1 {
+		t.Fatalf("expected generic artificial-intelligence chip-sales finance item to be filtered, got %#v", got)
+	}
+	if got[0]["title"] != "AI agent platform adds model-risk governance controls" {
+		t.Fatalf("expected concrete AI agent/governance story, got %#v", got[0])
+	}
+}
+
 func TestNewsSearchArticlesFreshAIQueryKeepsSpecificAIChipMarketStory(t *testing.T) {
 	indexed := []*data.IndexEntry{
 		{


### PR DESCRIPTION
## Summary
- Treat generic AI-chip finance and stock-mover framing as background unless it includes concrete AI infrastructure/product action.
- Add regression coverage for artificial-intelligence chip-sales market stories so concrete AI agent/governance stories lead instead.

Closes #1409
Closes #1411

## Testing
- go build ./...
- go test ./... -short
- go vet ./...