### PR TITLE
Filter broad AI chip finance from news cards

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1584,6 +1584,7 @@ func renderResultCard(toolName, result string, args map[string]any) string {
 
 func renderNewsCard(result string) string {
 	var data struct {
+		Query     string     `json:"query"`
 		Feed      []newsItem `json:"feed"`
 		Results   []newsItem `json:"results"`
 		Freshness struct {
@@ -1597,6 +1598,12 @@ func renderNewsCard(result string) string {
 	items := data.Results
 	if len(items) == 0 {
 		items = data.Feed
+	}
+	if len(items) == 0 {
+		return ""
+	}
+	if newsCardQueryRequiresAI(data.Query) {
+		items = filterNewsCardAIItems(items)
 	}
 	if len(items) == 0 {
 		return ""
@@ -1636,10 +1643,84 @@ func newsFreshnessCardLead(status string) string {
 }
 
 type newsItem struct {
-	ID       string `json:"id"`
-	Title    string `json:"title"`
-	URL      string `json:"url"`
-	Category string `json:"category"`
+	ID          string `json:"id"`
+	Title       string `json:"title"`
+	Description string `json:"description"`
+	Content     string `json:"content"`
+	URL         string `json:"url"`
+	Category    string `json:"category"`
+}
+
+func filterNewsCardAIItems(items []newsItem) []newsItem {
+	filtered := items[:0]
+	for _, item := range items {
+		if newsCardAIItemIsBroadChipFinance(item) {
+			continue
+		}
+		filtered = append(filtered, item)
+	}
+	return filtered
+}
+
+func newsCardQueryRequiresAI(query string) bool {
+	clean := strings.NewReplacer("-", " ", "_", " ", "/", " ", "'", "", "’", "").Replace(strings.ToLower(query))
+	return newsCardTermMatches(clean, "ai") || strings.Contains(clean, "artificial intelligence") || strings.Contains(clean, "machine learning") || newsCardTermMatches(clean, "llm")
+}
+
+func newsCardAIItemIsBroadChipFinance(item newsItem) bool {
+	haystack := strings.ToLower(strings.Join([]string{item.Title, item.Description, item.Content, item.Category}, " "))
+	if haystack == "" {
+		return false
+	}
+	hasChipFrame := false
+	for _, term := range []string{"chip", "chips", "semiconductor", "sk hynix", "nvidia", "data center", "datacenter"} {
+		if newsCardTermMatches(haystack, term) || strings.Contains(haystack, term) {
+			hasChipFrame = true
+			break
+		}
+	}
+	if !hasChipFrame {
+		return false
+	}
+	hasFinanceFrame := false
+	for _, term := range []string{"market", "markets", "stock", "stocks", "shares", "trading", "investor", "investors", "nasdaq", "ipo", "valuation", "rally", "climb", "debut"} {
+		if newsCardTermMatches(haystack, term) {
+			hasFinanceFrame = true
+			break
+		}
+	}
+	if !hasFinanceFrame {
+		return false
+	}
+	for _, term := range []string{
+		"launch", "launches", "launched", "release", "releases", "released", "unveil", "unveils", "unveiled",
+		"deploy", "deploys", "deployed", "deployment", "build", "builds", "built", "capacity", "processor",
+		"accelerator", "gpu", "server", "inference", "training", "model serving", "model-serving", "cloud",
+		"ai product", "ai model", "ai agent", "ai assistant", "ai safety", "ai governance", "ai infrastructure",
+	} {
+		if newsCardTermMatches(haystack, term) || strings.Contains(haystack, term) {
+			return false
+		}
+	}
+	return true
+}
+
+func newsCardTermMatches(haystack, term string) bool {
+	term = strings.TrimSpace(strings.ToLower(term))
+	if term == "" {
+		return false
+	}
+	if strings.Contains(term, " ") {
+		return strings.Contains(haystack, term)
+	}
+	for _, token := range strings.FieldsFunc(haystack, func(r rune) bool {
+		return (r < 'a' || r > 'z') && (r < '0' || r > '9')
+	}) {
+		if token == term {
+			return true
+		}
+	}
+	return false
 }
 
 func renderVideoCard(result string) string {

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -1623,6 +1623,28 @@ Freshness caveat: No same-day news_search results were available for 2026-07-06;
 	}
 }
 
+func TestRenderNewsCardFiltersBroadAIChipFinanceForAIQueries(t *testing.T) {
+	result := `{"query":"Find today's AI news","freshness":{"status":"stale","notice":"No same-day news_search results were available for 2026-07-11."},"results":[{"title":"SK Hynix Nasdaq debut draws investors as AI demand lifts chip shares","description":"A broad finance brief tracks IPO demand, valuation, trading, and market sentiment.","category":"Markets","url":"https://example.com/sk-hynix"},{"title":"AI agent platform adds model-risk governance controls","description":"The assistant product release gives enterprise users audit controls for agent workflows.","category":"Technology","url":"https://example.com/ai-agent"}]}`
+	got := renderNewsCard(result)
+	if strings.Contains(got, "SK Hynix Nasdaq debut") {
+		t.Fatalf("expected broad AI-chip finance story to be hidden from AI-news card, got %q", got)
+	}
+	if !strings.Contains(got, "AI agent platform adds model-risk governance controls") {
+		t.Fatalf("expected substantive AI story to remain in card, got %q", got)
+	}
+	if !strings.Contains(got, "No current news_search results: No same-day news_search results") {
+		t.Fatalf("expected freshness caveat to remain above filtered stories, got %q", got)
+	}
+}
+
+func TestRenderNewsCardKeepsConcreteAIChipInfrastructureStory(t *testing.T) {
+	result := `{"query":"Find today's AI news","results":[{"title":"AI chip startup launches faster inference server","description":"The semiconductor company released a new accelerator for model-serving workloads.","category":"Markets","url":"https://example.com/ai-chip"}]}`
+	got := renderNewsCard(result)
+	if !strings.Contains(got, "AI chip startup launches faster inference server") {
+		t.Fatalf("expected concrete AI infrastructure story to remain in card, got %q", got)
+	}
+}
+
 func TestRenderNewsCardSurfacesMostlyStaleFreshnessCaveat(t *testing.T) {
 	result := `{"query":"AI news","freshness":{"status":"mostly_stale","notice":"Only 1 of 3 dated news_search results are from 2026-07-07; lead with a freshness caveat before listing older context as today's news."},"results":[{"title":"AI lab ships current update","category":"Tech","url":"https://example.com/current-ai"}]}`
 	got := renderNewsCard(result)


### PR DESCRIPTION
## Summary
- Hide broad AI-chip finance rows from AI-news result cards when the news_search query is AI-focused.
- Preserve freshness caveats and keep concrete AI product, model, agent, governance, safety, and infrastructure stories visible.
- Add card-rendering regression coverage for stale SK Hynix-style finance rows and concrete AI-chip infrastructure stories.

Closes #1421
Closes #1423