### PR TITLE
Filter novelty AI-news demo pages

### DIFF
--- a/news/news.go
+++ b/news/news.go
@@ -2120,6 +2120,9 @@ func liveFeedSearch(query string, limit int) []*Post {
 			if newsAIArticleIsGenericHiringBackground(post.Title, post.Description, post.Content, post.Category) {
 				continue
 			}
+			if newsAIArticleIsNoveltyDemoBackground(post.Title, post.Description, post.Content, post.Category) {
+				continue
+			}
 		}
 		score := 0
 		for _, term := range terms {
@@ -2178,6 +2181,14 @@ func articleMatchesNewsQuery(query string, article map[string]interface{}) bool 
 			return false
 		}
 		if newsAIArticleIsGenericHiringBackground(
+			fmt.Sprintf("%v", article["title"]),
+			fmt.Sprintf("%v", article["description"]),
+			fmt.Sprintf("%v", article["content"]),
+			fmt.Sprintf("%v", article["category"]),
+		) {
+			return false
+		}
+		if newsAIArticleIsNoveltyDemoBackground(
 			fmt.Sprintf("%v", article["title"]),
 			fmt.Sprintf("%v", article["description"]),
 			fmt.Sprintf("%v", article["content"]),
@@ -2260,6 +2271,44 @@ func newsAIArticleIsWeakAdjacentBackground(parts ...string) bool {
 		"ai regulation", "ai regulator", "ai policy", "ai safety", "ai research", "ai product", "ai-powered", "ai powered",
 	}
 	for _, term := range strongAITerms {
+		if newsSearchTermMatches(haystack, term) {
+			return false
+		}
+	}
+	return true
+}
+
+func newsAIArticleIsNoveltyDemoBackground(parts ...string) bool {
+	haystack := newsSearchHaystack(parts...)
+	if haystack == "" {
+		return false
+	}
+	noveltyTerms := []string{
+		"font", "fonts", "typeface", "typography", "demo", "demos", "prototype", "showcase",
+		"experiment", "toy", "novelty", "anti ai", "anti-ai", "gimmick", "art project",
+	}
+	hasNoveltyFrame := false
+	for _, term := range noveltyTerms {
+		if newsSearchTermMatches(haystack, term) {
+			hasNoveltyFrame = true
+			break
+		}
+	}
+	if !hasNoveltyFrame {
+		return false
+	}
+
+	// Same-day AI searches should not promote novelty/demo pages as top news just
+	// because they mention AI. Keep them only when the item also reports concrete
+	// product, model, agent, infrastructure, governance, safety, or user-impact
+	// activity.
+	for _, term := range []string{
+		"open source model", "model release", "benchmark", "evaluation",
+		"ai safety", "ai regulation", "ai regulator", "ai governance", "frontier model", "foundation model",
+		"ai model", "language model", "large language model", "llm", "ai agent", "ai assistant",
+		"ai product", "ai platform", "ai infrastructure", "ai chip", "ai accelerator", "training cluster",
+		"inference server", "data center", "datacenter", "deploy", "deployed", "user impact", "customer",
+	} {
 		if newsSearchTermMatches(haystack, term) {
 			return false
 		}

--- a/news/news_test.go
+++ b/news/news_test.go
@@ -1033,6 +1033,45 @@ func TestNewsSearchArticlesFreshAIQueryFiltersWeakAdjacentSameDayBackground(t *t
 	}
 }
 
+func TestNewsSearchArticlesFreshAIQueryFiltersNoveltyDemoPages(t *testing.T) {
+	oldFeed := feed
+	defer func() {
+		mutex.Lock()
+		feed = oldFeed
+		mutex.Unlock()
+	}()
+
+	today := time.Date(2026, 7, 11, 9, 0, 0, 0, time.UTC)
+	mutex.Lock()
+	feed = []*Post{
+		{
+			ID:          "anti-ai-font",
+			Title:       "Designer releases anti-AI font demo",
+			Description: "A same-day typography showcase says the font confuses artificial intelligence scrapers.",
+			URL:         "https://example.com/anti-ai-font",
+			Category:    "Design",
+			PostedAt:    today.Add(2 * time.Hour),
+		},
+		{
+			ID:          "ai-governance-story",
+			Title:       "AI agent platform adds model-governance controls",
+			Description: "The AI product release gives teams new safety and evaluation controls for agent workflows.",
+			URL:         "https://example.com/ai-governance-story",
+			Category:    "Technology",
+			PostedAt:    today,
+		},
+	}
+	mutex.Unlock()
+
+	got := newsSearchArticles("Find today's AI news", nil, 8)
+	if len(got) != 1 {
+		t.Fatalf("expected novelty/demo page to be filtered, got %#v", got)
+	}
+	if got[0]["title"] != "AI agent platform adds model-governance controls" {
+		t.Fatalf("expected concrete AI governance story, got %#v", got[0])
+	}
+}
+
 func TestNewsSearchArticlesFreshAIQueryFiltersGenericSoftwareToolPosts(t *testing.T) {
 	oldFeed := feed
 	defer func() {


### PR DESCRIPTION
## Summary
- Filter novelty/demo-style AI-adjacent pages from AI-news search results unless they include concrete AI product, model, agent, infrastructure, governance, safety, or user-impact substance.
- Add regression coverage for an anti-AI font demo being omitted in favor of a substantive AI governance story.

Closes #1426
Closes #1428

## Testing
- go build ./...
- go test ./... -short
- go vet ./...