### PR TITLE
Filter weak AI-news job-market and compiler posts

### DIFF
--- a/news/news.go
+++ b/news/news.go
@@ -2252,7 +2252,7 @@ func newsAIArticleIsWeakAdjacentBackground(parts ...string) bool {
 	}
 	weakFrames := []string{
 		"essay", "opinion", "column", "maintainable code", "coding", "programming", "software engineering",
-		"windows tool", "utility", "tooling", "developer tool", "browser", "freecad", "gadget", "advertising", "ads", "election", "campaign", "parliament", "politics",
+		"compiler", "jit", "runtime", "windows tool", "utility", "tooling", "developer tool", "browser", "freecad", "gadget", "advertising", "ads", "election", "campaign", "parliament", "politics",
 	}
 	hasWeakFrame := false
 	for _, term := range weakFrames {
@@ -2323,7 +2323,8 @@ func newsAIArticleIsGenericHiringBackground(parts ...string) bool {
 	}
 	hiringTerms := []string{
 		"hiring", "hire", "hires", "jobs", "job", "careers", "recruiting", "recruit", "talent",
-		"job board", "job-board", "y combinator", "yc companies", "startup jobs",
+		"job market", "job board", "job-board", "layoff", "layoffs", "laid off", "workforce", "headcount",
+		"y combinator", "yc companies", "startup jobs",
 	}
 	hasHiringFrame := false
 	for _, term := range hiringTerms {

--- a/news/news_test.go
+++ b/news/news_test.go
@@ -1111,6 +1111,53 @@ func TestNewsSearchArticlesFreshAIQueryFiltersGenericSoftwareToolPosts(t *testin
 	}
 }
 
+func TestNewsSearchArticlesFreshAIQueryFiltersGenericJobMarketAndCompilerPosts(t *testing.T) {
+	oldFeed := feed
+	defer func() {
+		mutex.Lock()
+		feed = oldFeed
+		mutex.Unlock()
+	}()
+
+	today := time.Date(2026, 7, 11, 9, 0, 0, 0, time.UTC)
+	mutex.Lock()
+	feed = []*Post{
+		{
+			ID:          "amazon-ai-job-market",
+			Title:       "Amazon layoffs renew debate over AI and the job market",
+			Description: "A same-day labor-market brief tracks headcount cuts, job listings, and hiring sentiment.",
+			URL:         "https://example.com/amazon-ai-job-market",
+			Category:    "Business",
+			PostedAt:    today.Add(3 * time.Hour),
+		},
+		{
+			ID:          "hotspot-jit-ai",
+			Title:       "HotSpot JIT compiler tuning in the AI era",
+			Description: "A same-day compiler and runtime post mentions AI-era developer workflows without reporting a substantive artificial-intelligence change.",
+			URL:         "https://example.com/hotspot-jit-ai",
+			Category:    "Software",
+			PostedAt:    today.Add(2 * time.Hour),
+		},
+		{
+			ID:          "ai-agent-platform",
+			Title:       "AI agent platform adds model-risk governance controls",
+			Description: "The AI product release gives teams new evaluation and safety controls for agent workflows.",
+			URL:         "https://example.com/ai-agent-platform",
+			Category:    "Technology",
+			PostedAt:    today,
+		},
+	}
+	mutex.Unlock()
+
+	got := newsSearchArticles("Find today's AI news", nil, 8)
+	if len(got) != 1 {
+		t.Fatalf("expected generic job-market and compiler posts to be filtered, got %#v", got)
+	}
+	if got[0]["title"] != "AI agent platform adds model-risk governance controls" {
+		t.Fatalf("expected concrete AI governance story, got %#v", got[0])
+	}
+}
+
 func TestNewsSearchFreshnessSummaryCaveatsStaleTodayResults(t *testing.T) {
 	articles := []map[string]interface{}{{
 		"title":     "AI startup raises funding",


### PR DESCRIPTION
Refines AI-news relevance filtering for today/latest prompts so generic job-market layoffs and compiler/runtime posts do not outrank concrete AI product/governance items.

Closes #1431
Closes #1433