### PR TITLE
wallet: two tools an agent shouldn't have, and two that were one

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -730,8 +730,7 @@ const agentToolsDesc = `Available tools (use exact name):
 - apps_build: build a small app (a tracker, checklist, or counter) from a description (args: {"prompt":"an expense tracker"})
 - apps_edit: Edit an existing app (args: {"slug":"app-slug","html":"<new html>","name":"New Name"})
 - apps_run: Run JavaScript code and return the result (args: {"code":"return 2+2"})
-- wallet_balance: Check your wallet credit balance (no args)
-- wallet: Get your Base wallet address and USDC balance (no args). Sending USDC there tops up credits.
+- wallet_balance: Check your balance — credits, plus your Base address and USDC for topping up (no args). To add credits, point the user at /wallet/topup; there is no tool for it.
 - pay: Call a paid tool on ANOTHER MCP server and settle it from your Base wallet (args: {"tool":"news_search","server":"example.com","arguments":{"query":"ai"}}). Tools on this instance are called directly and draw credits — do not use pay for them.
 - stream: Read the public event stream (no args)`
 
@@ -808,7 +807,7 @@ func handleQuery(w http.ResponseWriter, r *http.Request) {
 	if !isGuest && QuotaCheck != nil {
 		canProceed, _, err := QuotaCheck(r, model.WalletOp)
 		if !canProceed {
-			msg := "Insufficient credits for agent query. Top up at /wallet."
+			msg := "Insufficient credits for agent query. Top up at /wallet/topup."
 			if err != nil {
 				msg = err.Error()
 			}
@@ -1245,10 +1244,10 @@ func shortcutToolCalls(prompt string) []shortcutToolCall {
 		"search the web for the latest ai news":         {{Tool: "web_search", Args: map[string]any{"q": "latest AI news"}}},
 		"show me today's islamic reminder":              {{Tool: "islam", Args: map[string]any{}}},
 		// Wallet
-		"my wallet":      {{Tool: "wallet", Args: map[string]any{}}},
-		"wallet":         {{Tool: "wallet", Args: map[string]any{}}},
-		"wallet balance": {{Tool: "wallet", Args: map[string]any{}}},
-		"wallet address": {{Tool: "wallet", Args: map[string]any{}}},
+		"my wallet":      {{Tool: "wallet_balance", Args: map[string]any{}}},
+		"wallet":         {{Tool: "wallet_balance", Args: map[string]any{}}},
+		"wallet balance": {{Tool: "wallet_balance", Args: map[string]any{}}},
+		"wallet address": {{Tool: "wallet_balance", Args: map[string]any{}}},
 	}
 	lower := strings.ToLower(strings.TrimSpace(prompt))
 	if tc, ok := aliases[lower]; ok {
@@ -1534,8 +1533,6 @@ func toolLabel(tool string) string {
 		return "📝 Reading blog posts"
 	case "wallet_balance":
 		return "💳 Checking wallet balance"
-	case "wallet_topup":
-		return "💳 Getting topup options"
 	case "apps_search":
 		return "📱 Searching apps"
 	case "apps_read":
@@ -1878,8 +1875,6 @@ func formatToolResult(toolName, result string, args map[string]any) string {
 		return formatPlacesResult(result, args)
 	case "wallet_balance":
 		return formatWalletBalanceResult(result)
-	case "wallet_topup":
-		return formatWalletTopupResult(result)
 	case "apps_search":
 		return formatAppsSearchResult(result)
 	case "apps_read":
@@ -2394,44 +2389,34 @@ type placeItem struct {
 
 // formatWalletBalanceResult converts a raw JSON wallet balance result into
 // human-readable text for the AI synthesis RAG context.
+//
+// One tool answers the whole question now, so this renders credits and the
+// deposit address together. "balance" is the key the old path-backed tool
+// returned; it is still read so an answer built before this change formats.
 func formatWalletBalanceResult(result string) string {
 	var data struct {
-		Balance int `json:"balance"`
+		Credits *int   `json:"credits"`
+		Balance *int   `json:"balance"`
+		Address string `json:"address"`
+		USDC    string `json:"usdc"`
 	}
 	if err := json.Unmarshal([]byte(result), &data); err != nil {
 		return result
 	}
-	pounds := data.Balance / 100
-	pence := data.Balance % 100
-	return fmt.Sprintf("Wallet balance: %d credits (£%d.%02d). Top up at /wallet/topup.\n", data.Balance, pounds, pence)
-}
+	credits := 0
+	switch {
+	case data.Credits != nil:
+		credits = *data.Credits
+	case data.Balance != nil:
+		credits = *data.Balance
+	default:
+		return result
+	}
 
-// formatWalletTopupResult converts a raw JSON wallet topup methods result into
-// human-readable text for the AI synthesis RAG context.
-func formatWalletTopupResult(result string) string {
-	var data struct {
-		Methods []struct {
-			Type  string `json:"type"`
-			Tiers []struct {
-				Amount  int    `json:"amount"`
-				Credits int    `json:"credits"`
-				Label   string `json:"label"`
-			} `json:"tiers"`
-		} `json:"methods"`
-	}
-	if err := json.Unmarshal([]byte(result), &data); err != nil {
-		return result
-	}
-	if len(data.Methods) == 0 {
-		return "No topup methods available. Visit /wallet/topup to add credits."
-	}
 	var sb strings.Builder
-	sb.WriteString("Wallet topup options (visit /wallet/topup to add credits):\n")
-	for _, m := range data.Methods {
-		sb.WriteString(fmt.Sprintf("%s payment:\n", m.Type))
-		for _, t := range m.Tiers {
-			sb.WriteString(fmt.Sprintf("- %s: %d credits\n", t.Label, t.Credits))
-		}
+	fmt.Fprintf(&sb, "Wallet balance: %d credits (£%d.%02d). Top up at /wallet/topup.\n", credits, credits/100, credits%100)
+	if data.Address != "" {
+		fmt.Fprintf(&sb, "Base address for USDC top-ups: %s (holding $%s USDC).\n", data.Address, data.USDC)
 	}
 	return sb.String()
 }

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -559,38 +559,8 @@ func TestFormatWalletBalanceResult_InvalidJSON(t *testing.T) {
 	}
 }
 
-func TestFormatWalletTopupResult_WithMethods(t *testing.T) {
-	result := `{"methods":[{"type":"card","tiers":[{"amount":1000,"credits":1000,"label":"£10"},{"amount":5000,"credits":5000,"label":"£50"}]}]}`
-	got := formatWalletTopupResult(result)
-	if !strings.Contains(got, "/wallet/topup") {
-		t.Errorf("expected topup URL in output, got %q", got)
-	}
-	if !strings.Contains(got, "card payment") && !strings.Contains(got, "card") {
-		t.Errorf("expected card payment label in output, got %q", got)
-	}
-	if !strings.Contains(got, "£10") {
-		t.Errorf("expected tier label in output, got %q", got)
-	}
-	if !strings.Contains(got, "1000 credits") {
-		t.Errorf("expected credits in output, got %q", got)
-	}
-}
 
-func TestFormatWalletTopupResult_NoMethods(t *testing.T) {
-	result := `{"methods":[]}`
-	got := formatWalletTopupResult(result)
-	if !strings.Contains(got, "/wallet/topup") {
-		t.Errorf("expected topup URL in no-methods output, got %q", got)
-	}
-}
 
-func TestFormatWalletTopupResult_InvalidJSON(t *testing.T) {
-	result := `not json`
-	got := formatWalletTopupResult(result)
-	if got != result {
-		t.Errorf("expected original result as fallback, got %q", got)
-	}
-}
 
 func TestFormatNewsResult_WithTimestamps(t *testing.T) {
 	result := `{"feed":[{"title":"Iran crisis","description":"Conflict escalates","category":"world","url":"/news?id=1","posted_at":"2026-03-02T10:00:00Z","published":"Sun, 02 Mar 2026 10:00:00 +0000"},{"title":"Peace talks","description":"Negotiations begin","category":"world","url":"/news?id=2","posted_at":"2026-03-01T08:00:00Z"}]}`
@@ -667,16 +637,17 @@ func TestRenderToolCallRef_Category(t *testing.T) {
 }
 
 func TestFormatToolResult_WalletDispatch(t *testing.T) {
-	balanceResult := `{"balance":500}`
-	got := formatToolResult("wallet_balance", balanceResult, nil)
-	if !strings.Contains(got, "500 credits") {
-		t.Errorf("expected wallet_balance formatter to be called, got %q", got)
+	// One tool answers the whole question: credits, and where to send USDC.
+	got := formatToolResult("wallet_balance", `{"credits":500,"address":"0xabc","usdc":"1.50","network":"base"}`, nil)
+	for _, want := range []string{"500 credits", "0xabc", "/wallet/topup"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("wallet_balance output is missing %q, got %q", want, got)
+		}
 	}
 
-	topupResult := `{"methods":[{"type":"card","tiers":[{"amount":1000,"credits":1000,"label":"£10"}]}]}`
-	got = formatToolResult("wallet_topup", topupResult, nil)
-	if !strings.Contains(got, "topup") {
-		t.Errorf("expected wallet_topup formatter to be called, got %q", got)
+	// An answer built before the merge used "balance" for the same number.
+	if got := formatToolResult("wallet_balance", `{"balance":500}`, nil); !strings.Contains(got, "500 credits") {
+		t.Errorf("the old balance key no longer formats, got %q", got)
 	}
 }
 

--- a/internal/api/mcp.go
+++ b/internal/api/mcp.go
@@ -467,31 +467,22 @@ var tools = []Tool{
 			{Name: "body", Type: "string", Description: "Message body", Required: true},
 		},
 	},
-	{
-		Name:        "wallet_balance",
-		Description: "Get wallet credit balance",
-		Method:      "GET",
-		Path:        "/wallet",
-		// No params. It carried one — "balance: set to 1 to get balance" —
-		// which made a tool called wallet_balance return the balance only if
-		// the caller guessed a flag, and the whole wallet web page otherwise.
-	},
-	{
-		Name:        "wallet_transfer",
-		Description: "Transfer credits to another user by username",
-		Method:      "POST",
-		Path:        "/wallet/transfer",
-		Params: []ToolParam{
-			{Name: "to", Type: "string", Description: "Recipient username", Required: true},
-			{Name: "amount", Type: "number", Description: "Number of credits to transfer", Required: true},
-		},
-	},
-	{
-		Name:        "wallet_topup",
-		Description: "Get available wallet topup payment methods with crypto deposit address and card payment tiers",
-		Method:      "GET",
-		Path:        "/wallet/topup",
-	},
+	// wallet_balance is registered in main.go, where the wallet package is
+	// reachable — it answers credits, deposit address and USDC in one call.
+	//
+	// Three tools used to live here. wallet_transfer moved credits to another
+	// user by username, irreversibly, in a single call with no confirmation.
+	// The same agent holds mail_inbox, news_read, web_fetch and db_list — four
+	// ways to read text somebody else wrote — and nothing downstream could tell
+	// "the user asked" from "the agent read it in an email". Transferring
+	// credits is a thing a person does a handful of times, deliberately, and
+	// /wallet/transfer already does it with a form and a CSRF token. It is not
+	// a capability an agent should be granted, so it is not a tool.
+	//
+	// wallet_topup returned card tiers to a caller that cannot complete a card
+	// purchase. Its only real output was "tell your human where to go", which
+	// belongs in the message you get when a call fails for want of credits, not
+	// in a tool an agent has to know to call.
 	// Stream (console)
 	{
 		Name:        "stream_list",

--- a/internal/api/mcp_test.go
+++ b/internal/api/mcp_test.go
@@ -131,11 +131,13 @@ func TestMCPHandler_ToolsList(t *testing.T) {
 	// video_list, markets_list, social_list and weather_forecast are registered
 	// dynamically in main.go (AI-first handlers), so they are not part of this
 	// package's static tool list.
+	// wallet_balance moved to main.go with the rest of the wallet surface, so
+	// it is no longer static either.
 	expectedTools := map[string]bool{
 		"chat": false, "news_search": false,
 		"blog_read": false, "blog_create": false,
 		"video_search": false, "mail_inbox": false,
-		"stream_list": false, "wallet_balance": false,
+		"stream_list": false,
 	}
 	for _, item := range toolsList {
 		tool, ok := item.(map[string]any)

--- a/internal/api/money_test.go
+++ b/internal/api/money_test.go
@@ -1,0 +1,55 @@
+package api
+
+import (
+	"strings"
+	"testing"
+)
+
+// No tool moves money to somebody else.
+//
+// wallet_transfer used to. It sent credits to another user by username,
+// irreversibly, in one call with no confirmation — and the same agent holds
+// mail_inbox, news_read, web_fetch and db_list, four ways to read text a
+// stranger wrote. Nothing downstream could tell "the user asked" from "the
+// agent read it in an email", and the web form's CSRF token does not apply to a
+// caller holding a bearer token.
+//
+// The `pay` tool is the deliberate exception and is named here rather than
+// pattern-matched: it settles a call to another MCP server against the caller's
+// own wallet, which is buying something rather than giving it away, and it is
+// bounded by the spend limit.
+func TestNoToolTransfersCreditsToAnotherAccount(t *testing.T) {
+	allowed := map[string]bool{"pay": true}
+
+	for _, tool := range sortedTools() {
+		if allowed[tool.Name] {
+			continue
+		}
+		name := strings.ToLower(tool.Name)
+		for _, verb := range []string{"transfer", "send_credits", "withdraw", "gift"} {
+			if strings.Contains(name, verb) {
+				t.Errorf("%q looks like it moves money out of an account; that is a form on a page, not an agent tool", tool.Name)
+			}
+		}
+		if strings.Contains(strings.ToLower(tool.Description), "transfer credits") {
+			t.Errorf("%q transfers credits; that is a form on a page, not an agent tool", tool.Name)
+		}
+	}
+}
+
+// The wallet surface is one read-only tool. Two tools answering "what is in my
+// wallet" gave the planner a coin to flip, and a tool returning card tiers gave
+// an agent a purchase flow it cannot complete.
+func TestWalletSurfaceIsOneTool(t *testing.T) {
+	var found []string
+	for _, tool := range sortedTools() {
+		if strings.HasPrefix(tool.Name, "wallet") {
+			found = append(found, tool.Name)
+		}
+	}
+	// wallet_balance is registered by main.go, so in this package's own tool
+	// list the expected count is zero. Either way it must never be more than one.
+	if len(found) > 1 {
+		t.Errorf("the wallet surface is %v; it should be wallet_balance alone", found)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -1220,18 +1220,28 @@ func main() {
 		return answer, nil
 	})
 
-	// Wallet: the user's Base wallet — address + USDC balance. It funds credits;
-	// it is not what calls to this instance are charged against.
+	// Wallet: one tool, one answer about your money.
+	//
+	// There were two — wallet_balance for credits and wallet for the Base
+	// address — so "what's in my wallet" had two answers depending on which the
+	// planner picked. Credits are what calls are charged in and USDC is how you
+	// top them up, which makes them two fields of one thing, not two tools. The
+	// old name stays as an alias so "my wallet" still resolves.
+	//
+	// It is also no longer path-backed. Pointing a tool at /wallet meant
+	// scraping the wallet web page for data, which is how it came to return
+	// 20KB of HTML to anyone who didn't pass a magic query flag.
 	api.RegisterToolWithAuth(api.Tool{
-		Name:        "wallet",
-		Description: "Get your Base wallet address and USDC balance. Send USDC here to top up your credits.",
+		Name:        "wallet_balance",
+		Aliases:     []string{"wallet"},
+		Description: "Get your balance: credits (what calls are charged in), plus your Base address and USDC balance for topping up.",
 	}, func(args map[string]any, accountID string) (string, error) {
-		bw, err := wallet.GetOrCreateWallet(accountID)
-		if err != nil {
-			return "", err
+		out := map[string]any{"credits": wallet.GetBalance(accountID)}
+		if bw, err := wallet.GetOrCreateWallet(accountID); err == nil {
+			usdc, _ := wallet.USDCBalance(bw.Address)
+			out["address"], out["network"], out["usdc"] = bw.Address, "base", usdc
 		}
-		usdc, _ := wallet.USDCBalance(bw.Address)
-		b, _ := json.Marshal(map[string]any{"address": bw.Address, "network": "base", "usdc": usdc})
+		b, _ := json.Marshal(out)
 		return string(b), nil
 	})
 
@@ -1813,7 +1823,7 @@ func main() {
 						}
 						canProceed, _, cost, _ := wallet.CheckQuota(sess.Account, op)
 						if !canProceed {
-							http.Error(w, fmt.Sprintf("This costs %d credit(s). Top up at /wallet", cost), http.StatusPaymentRequired)
+							http.Error(w, fmt.Sprintf("This costs %d credit(s). Top up at /wallet/topup", cost), http.StatusPaymentRequired)
 							return
 						}
 						if err := wallet.ConsumeQuota(sess.Account, op); err != nil {
@@ -1873,7 +1883,7 @@ func main() {
 				}
 				canProceed, _, cost, _ := wallet.CheckQuota(sess.Account, op)
 				if !canProceed {
-					http.Error(w, fmt.Sprintf("This costs %d credit(s). Top up at /wallet", cost), http.StatusPaymentRequired)
+					http.Error(w, fmt.Sprintf("This costs %d credit(s). Top up at /wallet/topup", cost), http.StatusPaymentRequired)
 					return
 				}
 				// Charge up-front. The handler runs only if the

--- a/service/mail/mail.go
+++ b/service/mail/mail.go
@@ -466,7 +466,7 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 			if !acc.Admin {
 				canProceed, useFree, cost, err := wallet.CheckQuota(acc.ID, wallet.OpExternalEmail)
 				if err != nil || !canProceed {
-					http.Error(w, fmt.Sprintf("External email requires %d credits. Top up at /wallet", cost), http.StatusPaymentRequired)
+					http.Error(w, fmt.Sprintf("External email requires %d credits. Top up at /wallet/topup", cost), http.StatusPaymentRequired)
 					return
 				}
 				// Consume quota after successful send (deferred below)
@@ -505,7 +505,7 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 			if !acc.Admin {
 				canProceed, _, cost, _ := wallet.CheckQuota(acc.ID, wallet.OpMailSend)
 				if !canProceed {
-					http.Error(w, fmt.Sprintf("Sending mail requires %d credits. Top up at /wallet", cost), http.StatusPaymentRequired)
+					http.Error(w, fmt.Sprintf("Sending mail requires %d credits. Top up at /wallet/topup", cost), http.StatusPaymentRequired)
 					return
 				}
 			}


### PR DESCRIPTION
The wallet surface was five tools. It is now one, plus `pay`.

wallet_transfer moved credits to another account by username, irreversibly, in a single call with no confirmation step. The same agent holds mail_inbox, news_read, web_fetch and db_list — four ways to read text a stranger wrote — and nothing downstream could tell "the user asked" from "the agent read it in an email". The web form's CSRF token does not apply to a caller holding a bearer token, so the caps were the only thing between an injected instruction and £100 a day. Transferring credits is something a person does a handful of times, deliberately, and /wallet/transfer already does it well. It is not a capability an agent should be granted, so it is no longer a tool. The page is untouched.

wallet_topup returned card tiers to a caller that cannot complete a card purchase. Its only real output was "tell your human where to go", which belongs in the message you get when a call fails for want of credits — so those messages now name /wallet/topup, the page that actually sells credits, rather than /wallet.

wallet and wallet_balance both answered "what is in my wallet" with different halves of the answer, which left the planner flipping a coin. Credits are what calls are charged in and USDC is how you top them up: two fields of one thing. They are merged into wallet_balance, with `wallet` kept as an alias so "my wallet" still resolves, and it is no longer path-backed — pointing a tool at /wallet is what made it scrape the wallet web page for data in the first place.

A test now fails if any tool moves money out of an account. `pay` is named as the deliberate exception rather than pattern-matched: settling a call to another server against your own wallet is buying something, not giving it away, and the spend limit bounds it.

Verified against a running binary: 56 tools listed, wallet_transfer and wallet_topup answer "Tool not found", the `wallet` alias still resolves, and /wallet, /wallet/transfer and /wallet/topup all still serve.


Claude-Session: https://claude.ai/code/session_01KdcPjN9ndJwMGKQSRrAGPE