### PR TITLE
Make the product tell the truth about what it will let you do

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -5,6 +5,7 @@ package agent
 import (
 	"encoding/json"
 	"fmt"
+	htmlpkg "html"
 	"net/http"
 	"net/url"
 	"os"
@@ -1240,6 +1241,34 @@ func handleQuery(w http.ResponseWriter, r *http.Request) {
 	})
 	if err != nil {
 		updateFlow(flow.ID, func(f *Flow) { f.Status = "error"; f.Error = err.Error() })
+		// The tools have already run and their results are in hand. Discarding
+		// them because the model could not write the prose around them gets the
+		// trade backwards: calling the tools is the expensive, fallible half and
+		// it succeeded — the user asked for the weather and we have the weather.
+		// So say the summary failed and show what came back.
+		var raw strings.Builder
+		for _, res := range results {
+			if card := renderResultCard(res.Name, res.Result, res.Args); card != "" {
+				raw.WriteString(card)
+				continue
+			}
+			text := res.Formatted
+			if strings.TrimSpace(text) == "" {
+				text = res.Result
+			}
+			if strings.TrimSpace(text) == "" {
+				continue
+			}
+			raw.WriteString(`<div class="card"><h4>` + htmlpkg.EscapeString(strings.ReplaceAll(res.Name, "_", " ")) +
+				`</h4><pre style="white-space:pre-wrap;margin:0">` + htmlpkg.EscapeString(text) + `</pre></div>`)
+		}
+		if raw.Len() > 0 {
+			sse(w, map[string]any{"type": "error",
+				"message": "Could not write a summary (" + err.Error() + "). Here is what the tools returned."})
+			sse(w, map[string]any{"type": "response", "flow_id": flow.ID, "html": raw.String()})
+			sse(w, map[string]any{"type": "done"})
+			return
+		}
 		sse(w, map[string]any{"type": "error", "message": "Could not generate response: " + err.Error()})
 		sse(w, map[string]any{"type": "done"})
 		return

--- a/agent/agents.go
+++ b/agent/agents.go
@@ -54,23 +54,33 @@ func AgentsHandler(w http.ResponseWriter, r *http.Request) {
 				_ = json.NewEncoder(w).Encode(map[string]any{"error": "name and prompt are required"})
 				return
 			}
-			// Into the roster, the one store. An agent made here is hosted —
-			// you built it to talk to — and gets no token until asked for one
-			// on /agents, because nothing here needs to authenticate.
+			// Into the roster, the one store — and this is now the only place
+			// an agent is made. The kind rides along because it is the one
+			// question the form this replaced asked and the builder did not:
+			// where does it run, and therefore does it need a credential.
 			desc := strings.TrimSpace(r.FormValue("description"))
+			kind := r.FormValue("kind")
 			var saved *Agent
+			var secret string
 			var err error
 			if id := r.FormValue("id"); id != "" && AgentFor(acc.ID, id) != nil {
 				saved, err = UpdateAgent(acc.ID, id, name, prompt, desc, r.Form["tools"])
 			} else {
-				saved, _, err = CreateAgent(acc.ID, name, Hosted, prompt, desc, r.Form["tools"], false)
+				saved, secret, err = CreateAgent(acc.ID, name, kind, prompt, desc, r.Form["tools"], issuesToken(kind))
 			}
 			if err != nil {
 				w.WriteHeader(http.StatusBadRequest)
 				_ = json.NewEncoder(w).Encode(map[string]any{"error": err.Error()})
 				return
 			}
-			_ = json.NewEncoder(w).Encode(saved.AsMicro())
+			out := map[string]any{"id": saved.ID, "name": saved.Name, "kind": saved.Kind}
+			// The secret goes back exactly once, and only far enough to reach
+			// the page that shows it. It is stored hashed and cannot be read
+			// again — the same one-shot handoff /agents already did.
+			if secret != "" {
+				out["secret"] = secret
+			}
+			_ = json.NewEncoder(w).Encode(out)
 			return
 		}
 	}
@@ -89,9 +99,30 @@ func AgentsHandler(w http.ResponseWriter, r *http.Request) {
 	var mine []lite
 	for _, a := range Agents(acc.ID) {
 		m := a.AsMicro()
-		mine = append(mine, lite{m.ID, m.Name, m.Description, m.SystemPrompt, m.Tools})
+		// AsMicro falls back to the system prompt when there is no description,
+		// which is right for the router — it needs a sentence to route on — and
+		// wrong here, where this becomes a tooltip and a subtitle. A nine-line
+		// prompt rendered as an agent's one-line description is not a
+		// description, it is the whole agent spilled onto the list.
+		mine = append(mine, lite{m.ID, m.Name, firstLine(a.Description, m.Description), m.SystemPrompt, m.Tools})
 	}
 	_ = json.NewEncoder(w).Encode(map[string]any{"agents": mine, "tools": AllAgentTools()})
+}
+
+// firstLine returns the stored description if there is one, otherwise the
+// opening line of the fallback, trimmed to something that fits on a row.
+func firstLine(stored, fallback string) string {
+	if s := strings.TrimSpace(stored); s != "" {
+		return s
+	}
+	s := strings.TrimSpace(fallback)
+	if i := strings.IndexAny(s, ".\n"); i > 0 {
+		s = s[:i+1]
+	}
+	if len(s) > 140 {
+		s = strings.TrimSpace(s[:140]) + "…"
+	}
+	return s
 }
 
 // generateAgentSpec turns a one-line brief into a full agent spec (name,
@@ -236,8 +267,20 @@ func NewAgentHandler(w http.ResponseWriter, r *http.Request) {
 			`><span>` + html.EscapeString(AgentToolLabel(t)) + `</span></label>`)
 	}
 
+	// Where it runs is only asked when there is something to decide. Editing an
+	// existing agent does not move it, and changing the answer under someone
+	// would either revoke a live token or mint one they did not ask for.
+	kindHTML := ""
+	if editID == "" {
+		kindHTML = `<label class="b-label">Where does it run?</label>
+    <div class="pick-row">
+      <label class="pick"><input type="radio" name="kind" value="hosted" checked><span><strong>Here</strong>Give it standing instructions and this instance executes them</span></label>
+      <label class="pick"><input type="radio" name="kind" value="external"><span><strong>Elsewhere</strong>Claude, Cursor, or your own program, calling in with its token</span></label>
+    </div>`
+	}
+
 	b := `<div class="builder">
-  <p class="builder-sub">Describe an agent and Mu will draft it, or write the system prompt yourself. Pick which tools it may use.</p>
+  <p class="builder-sub">Describe an agent and Mu will draft it, or write the system prompt yourself. Pick what it may reach — it will be refused everything else, even though it is your account behind it.</p>
   <form id="bform" onsubmit="return bSave(event)">
     <input type="hidden" id="b-id" value="` + html.EscapeString(editID) + `">
     <input type="hidden" id="b-fork" value="` + html.EscapeString(forkFrom) + `">
@@ -252,11 +295,12 @@ func NewAgentHandler(w http.ResponseWriter, r *http.Request) {
     <input id="b-desc" maxlength="140" value="` + html.EscapeString(desc) + `">
     <label class="b-label">System prompt</label>
     <textarea id="b-prompt" rows="9" required>` + html.EscapeString(prompt) + `</textarea>
-    <label class="b-label">Tools <span class="b-hint">— none selected means all tools</span></label>
+    ` + kindHTML + `
+    <label class="b-label">What may it reach? <span class="b-hint">— none selected means everything you can</span></label>
     <div class="b-tools">` + toolsHTML.String() + `</div>
     <div class="b-actions">
       <button type="submit" class="b-save">Save agent</button>
-      <a class="b-cancel" href="/agent">Cancel</a>
+      <a class="b-cancel" href="/agents">Cancel</a>
     </div>
   </form>
 </div>
@@ -297,10 +341,16 @@ function bSave(e){e.preventDefault();
   b.append('name',document.getElementById('b-name').value);
   b.append('description',document.getElementById('b-desc').value);
   b.append('prompt',document.getElementById('b-prompt').value);
+  var k=document.querySelector('input[name="kind"]:checked');if(k)b.append('kind',k.value);
   document.querySelectorAll('.b-tools input:checked').forEach(function(el){b.append('tools',el.value);});
   fetch('/agents/data',{method:'POST',headers:{'Content-Type':'application/x-www-form-urlencoded','X-CSRF-Token':bCsrf()},body:b.toString()})
     .then(function(r){return r.json();}).then(function(a){if(a.error){alert(a.error);return;}
-      location.href='/agent'+(a.id?('?agent='+encodeURIComponent(a.id)):'');}).catch(function(){});
+      if(!a.id){location.href='/agents';return;}
+      // One that runs elsewhere has a secret to hand over, and /agents is the
+      // page that shows it once. One that runs here has nothing to copy, so go
+      // straight to the thing you just built and talk to it.
+      if(a.secret){location.href='/agents?created='+encodeURIComponent(a.id)+'&secret='+encodeURIComponent(a.secret);return;}
+      location.href='/agent?id='+encodeURIComponent(a.id);}).catch(function(){});
   return false;}
 </script>`
 

--- a/agent/roster_page.go
+++ b/agent/roster_page.go
@@ -2,21 +2,19 @@ package agent
 
 // The agents page: what acts for you, and what each one may touch.
 //
-// The create form leads with the scope rather than burying it in an "advanced"
-// fold, because the scope is the decision. Everything else on the form is a
-// label. A page that asks for a name and hands back a credential with your whole
-// account behind it is the thing this replaces.
+// It lists and it revokes; it does not create. Making an agent happens in one
+// place, the builder at /agent/new, because this page used to carry a second
+// create form that asked different questions and issued a different result.
 //
-// Nothing here is checked twice: the scope chosen here is written into the
-// token's permissions, and the MCP boundary enforces it against every call. This
-// page cannot grant more than it shows, because it is not the thing doing the
-// granting.
+// Nothing here is checked twice: the scope chosen in the builder is written into
+// the token's permissions, and the MCP boundary enforces it against every call.
+// This page cannot grant more than it shows, because it is not the thing doing
+// the granting.
 
 import (
 	"fmt"
 	"html"
 	"net/http"
-	"sort"
 	"strings"
 
 	"mu/internal/app"
@@ -35,33 +33,6 @@ func RosterHandler(w http.ResponseWriter, r *http.Request) {
 
 	if r.Method == http.MethodPost {
 		switch r.FormValue("action") {
-		case "create":
-			// The kind decides whether a credential is issued, because the kind
-			// is a statement about where the agent runs.
-			//
-			// "Runs elsewhere" is Claude or your own program calling in, and a
-			// token is the only way it can: withholding one would ship
-			// something that cannot work. "Runs here" is standing instructions
-			// this instance executes — nothing outside needs to call it, so
-			// minting a credential and printing an MCP endpoint answers a
-			// question nobody asked and leaves a live secret lying around.
-			//
-			// Both options used to get a token anyway, which made the choice
-			// cosmetic and made "Issue token" on the row unreachable. Now it is
-			// there for the case it was written for: a local agent you later
-			// decide to call from outside.
-			kind := r.FormValue("kind")
-			a, secret, err := CreateAgent(owner, r.FormValue("name"), kind,
-				r.FormValue("prompt"), "", r.Form["services"], issuesToken(kind))
-			if err != nil {
-				http.Redirect(w, r, "/agents?error="+urlSafe(err.Error()), http.StatusSeeOther)
-				return
-			}
-			// The secret rides back in the URL once. It is never stored in
-			// readable form and cannot be shown again, which is the whole
-			// reason this page has a "copy it now" state at all.
-			http.Redirect(w, r, "/agents?created="+a.ID+"&secret="+urlSafe(secret), http.StatusSeeOther)
-			return
 		case "delete":
 			_ = RemoveAgent(owner, r.FormValue("id"))
 			http.Redirect(w, r, "/agents?removed=1", http.StatusSeeOther)
@@ -122,7 +93,12 @@ func RosterHandler(w http.ResponseWriter, r *http.Request) {
 		b.WriteString(`</div>`)
 	}
 
-	b.WriteString(createForm(csrf))
+	// One way to make an agent. This page used to carry its own create form
+	// alongside the builder at /agent/new, and the two disagreed: one asked for
+	// services and issued a token, the other asked for tools and a system prompt
+	// and issued nothing, and neither linked to the other. The builder took the
+	// missing question ("where does it run?") so this could become a link.
+	b.WriteString(app.ActionLink("/agent/new", "+ New agent"))
 	b.WriteString(agentsCSS)
 	w.Write([]byte(app.RenderHTMLForRequest("Agents", "The agents that act for you, and what each one may reach", b.String(), r)))
 }
@@ -229,54 +205,6 @@ func agentRow(a *Agent, csrf, base string) string {
 		html.EscapeString(csrf), html.EscapeString(a.ID))
 }
 
-// createForm leads with the scope, because the scope is the decision.
-func createForm(csrf string) string {
-	var b strings.Builder
-	b.WriteString(`<div class="card"><h4 style="margin:0 0 4px;font-size:14px">New agent</h4>`)
-	b.WriteString(`<p class="text-sm text-muted" style="margin:0 0 12px">One that runs elsewhere gets its own ` +
-		`token; one that runs here does not need one. Either way, pick what it may reach — it will be refused ` +
-		`everything else, even though it is your account behind it.</p>`)
-	b.WriteString(`<form method="POST" action="/agents">`)
-	b.WriteString(`<input type="hidden" name="_csrf" value="` + html.EscapeString(csrf) + `">`)
-	b.WriteString(`<input type="hidden" name="action" value="create">`)
-	b.WriteString(`<input name="name" placeholder="What is it called? e.g. Morning briefer" required maxlength="60" class="agent-input">`)
-
-	// A segmented control rather than two radios. An inline <input> next to
-	// text never lines up: the box sits on the text baseline, its height is the
-	// browser's rather than the line's, and every fix is a different magic
-	// number per browser. Hiding the input and styling its label removes the
-	// alignment problem instead of tuning it — there is nothing inline left to
-	// align, and the whole row is the hit target.
-	b.WriteString(`<div class="pick-row">`)
-	b.WriteString(`<label class="pick"><input type="radio" name="kind" value="external" checked>` +
-		`<span><strong>Runs elsewhere</strong>Claude, Cursor, or your own program, calling in with its token</span></label>`)
-	b.WriteString(`<label class="pick"><input type="radio" name="kind" value="hosted">` +
-		`<span><strong>Runs here</strong>Give it standing instructions and this instance executes them</span></label>`)
-	b.WriteString(`</div>`)
-
-	b.WriteString(`<input name="prompt" placeholder="What is it for? (optional)" maxlength="500" class="agent-input">`)
-
-	b.WriteString(`<div class="agent-scope-pick"><strong>What may it reach?</strong>`)
-	b.WriteString(`<p class="text-sm text-muted" style="margin:2px 0 8px">Choose nothing and it reaches everything you can — which is what a plain token does, and rarely what you meant.</p>`)
-	b.WriteString(`<div class="agent-services">`)
-	for _, s := range scopeChoices() {
-		b.WriteString(`<label class="chip"><input type="checkbox" name="services" value="` +
-			html.EscapeString(s.Name) + `"><span>` + html.EscapeString(s.NavLabel()) + `</span></label>`)
-	}
-	b.WriteString(`</div></div>`)
-
-	b.WriteString(`<button type="submit">Create agent</button>`)
-	b.WriteString(`</form></div>`)
-	return b.String()
-}
-
-// scopeChoices is every service that can be named in a scope, by label.
-func scopeChoices() []service.Spec {
-	specs := service.Specs()
-	sort.Slice(specs, func(i, j int) bool { return specs[i].NavLabel() < specs[j].NavLabel() })
-	return specs
-}
-
 const agentsCSS = `<style>
 .agent-row{display:flex;align-items:center;gap:12px;border:1px solid #eee;border-radius:8px;padding:10px 14px}
 .agent-kind{font-size:11px;color:#999;font-weight:400;margin-left:4px}
@@ -300,16 +228,7 @@ const agentsCSS = `<style>
 .agent-remove:hover{color:#b00;text-decoration:underline}
 .agent-secret{background:#f5f5f5;padding:10px 12px;font-size:12px;overflow-x:auto;border-radius:6px;margin:0;word-break:break-all}
 .agent-input{display:block;width:100%;padding:9px 11px;border:1px solid #d1d5db;border-radius:6px;font-size:14px;font-family:inherit;margin:0 0 10px}
-.pick-row{display:grid;grid-template-columns:1fr 1fr;gap:8px;margin:0 0 14px}
-.pick span{display:block;height:100%;border:1px solid #ddd;border-radius:8px;padding:10px 12px;
-  cursor:pointer;font-size:12px;color:#666;line-height:1.4}
-.pick strong{display:block;font-size:13px;color:#111;margin:0 0 2px}
-.pick span:hover{border-color:#bbb}
-.pick input:checked+span{border-color:#111;background:#fafafa}
-.pick input:checked+span strong::after{content:" ✓";color:#0a7d33}
-
 .agent-scope-pick{border-top:1px solid #eee;padding-top:12px;margin:0 0 14px}
-@media only screen and (max-width:600px){.pick-row{grid-template-columns:1fr}}
 </style>` + chipCSS
 
 // chipCSS is the selection control both agent pages use.
@@ -323,6 +242,10 @@ const agentsCSS = `<style>
 // Shared because /agents was built this way and /agent/new was not, so the same
 // choice — which services or tools may this agent reach — was a row of neat
 // chips on one page and a column of drifting checkboxes on the other.
+// The segmented "where does it run" control moved in here with the chips when
+// creating an agent stopped happening in two places: the builder is the one
+// form now, so the styles it needs have to travel with it rather than living
+// on the roster page that used to own the other copy.
 const chipCSS = `<style>
 .pick input,.chip input{position:absolute;opacity:0;width:0;height:0}
 .pick input:focus-visible+span,.chip input:focus-visible+span{outline:2px solid #111;outline-offset:2px}
@@ -331,4 +254,12 @@ const chipCSS = `<style>
   cursor:pointer;font-size:13px;color:#444;white-space:nowrap}
 .chip span:hover{border-color:#bbb}
 .chip input:checked+span{background:#111;border-color:#111;color:#fff}
+.pick-row{display:grid;grid-template-columns:1fr 1fr;gap:8px;margin:0 0 14px}
+.pick span{display:block;height:100%;border:1px solid #ddd;border-radius:8px;padding:10px 12px;
+  cursor:pointer;font-size:12px;color:#666;line-height:1.4}
+.pick strong{display:block;font-size:13px;color:#111;margin:0 0 2px}
+.pick span:hover{border-color:#bbb}
+.pick input:checked+span{border-color:#111;background:#fafafa}
+.pick input:checked+span strong::after{content:" ✓";color:#0a7d33}
+@media only screen and (max-width:600px){.pick-row{grid-template-columns:1fr}}
 </style>`

--- a/home/home.go
+++ b/home/home.go
@@ -759,13 +759,25 @@ function fetchW(la,lo){
 
 	// Signed out, the home screen is a showcase: the instance's own default
 	// order, because a visitor has expressed no preference to honour.
+	//
+	// A brand-new account is in exactly the same position, and used to get the
+	// opposite treatment: HomeCardOrder is empty until you save preferences, so
+	// signing up turned the showcase into a blank page and asked you to go and
+	// pick cards before anything would happen. auth.ShowHomeCard already says
+	// "no customization yet → all defaults show"; this is the same rule applied
+	// to the order, so the two stop disagreeing.
+	defaultOrder := func() []string {
+		ids := make([]string, 0, len(Cards))
+		for _, card := range Cards {
+			ids = append(ids, card.ID)
+		}
+		return ids
+	}
 	order := []string{}
 	if viewerAcc == nil {
-		for _, card := range Cards {
-			order = append(order, card.ID)
-		}
-	} else {
-		order = viewerAcc.HomeCardOrder()
+		order = defaultOrder()
+	} else if order = viewerAcc.HomeCardOrder(); len(order) == 0 {
+		order = defaultOrder()
 	}
 
 	var shown []rendered

--- a/internal/ai/health.go
+++ b/internal/ai/health.go
@@ -1,0 +1,89 @@
+package ai
+
+// Whether the model actually answers, as opposed to whether a key is set.
+//
+// /status reported the agent healthy whenever Configured() was true, which is a
+// statement about this process's environment and not about the world. An
+// instance pointed at an Ollama that is not running, or carrying an API key that
+// has expired or run out of credit, was green while every question a user asked
+// came back "Could not generate response". Configuration is the one thing a
+// status page can check without leaving the building, and it is the one thing
+// that is almost never what broke.
+//
+// So the signal is the last real call. Nothing synthetic is sent — no probe to
+// pay for, no timeout to tune, no traffic on an idle instance. Until something
+// has been asked we fall back to Configured(), because "not tried yet" is not
+// the same as broken.
+
+import (
+	"sync"
+	"time"
+)
+
+var health struct {
+	sync.Mutex
+	tried bool
+	ok    bool
+	err   string
+	at    time.Time
+}
+
+// recordHealth notes the outcome of a real model call. Called from the two
+// paths that talk to a provider, so anything that reaches a model updates it
+// and nothing has to remember to.
+func recordHealth(err error) {
+	health.Lock()
+	defer health.Unlock()
+	health.tried = true
+	health.ok = err == nil
+	health.at = time.Now()
+	if err != nil {
+		health.err = err.Error()
+	} else {
+		health.err = ""
+	}
+}
+
+// Status describes the model to an operator: which provider and model an
+// interactive question would actually go to, and whether it is answering.
+//
+// It resolves the provider the same way a real call does rather than reading
+// one env var. The status page used to look only for ANTHROPIC_API_KEY, so a
+// perfectly healthy instance running on Atlas Cloud or a local Ollama reported
+// "Not configured" and dragged the whole instance's health down with it.
+func Status() (string, bool) {
+	ok, why := Healthy()
+	model := DefaultModel()
+	provider, _, baseURL, err := resolveProvider(model)
+	if err != nil {
+		return "Not configured", false
+	}
+	if provider == "openai" {
+		// A local server: the URL is the identifying thing, not "openai".
+		provider = "local"
+		if baseURL != "" {
+			provider = "local (" + baseURL + ")"
+		}
+	}
+	desc := provider + "/" + model
+	if !ok && why != "" {
+		desc += " — " + why
+	}
+	return desc, ok
+}
+
+// Healthy reports whether the model is answering, and why not when it is not.
+func Healthy() (bool, string) {
+	health.Lock()
+	defer health.Unlock()
+	if !health.tried {
+		if Configured() {
+			return true, ""
+		}
+		return false, "no AI provider configured"
+	}
+	if health.ok {
+		return true, ""
+	}
+	return false, health.err
+}

--- a/internal/ai/health_test.go
+++ b/internal/ai/health_test.go
@@ -1,0 +1,62 @@
+package ai
+
+import (
+	"errors"
+	"testing"
+)
+
+// The status page asks whether the model answers, not whether a key is set.
+//
+// It used to ask Configured(), which is a statement about this process's
+// environment: an instance pointed at an Ollama that is not running, or holding
+// a key that has expired, reported "All systems operational" while every
+// question a user asked came back "Could not generate response".
+func TestHealthyReportsTheLastRealCall(t *testing.T) {
+	defer resetHealth()
+
+	// Nothing tried yet: fall back to configuration, because "not asked" is not
+	// the same as "broken".
+	health.tried = false
+	if ok, _ := Healthy(); ok != Configured() {
+		t.Fatal("with no call yet, health should follow configuration")
+	}
+
+	recordHealth(errors.New("connection refused"))
+	ok, why := Healthy()
+	if ok {
+		t.Fatal("a failed call should make the agent unhealthy")
+	}
+	if why != "connection refused" {
+		t.Fatalf("expected the reason to be carried through, got %q", why)
+	}
+
+	// And it recovers on the next success rather than latching.
+	recordHealth(nil)
+	if ok, why := Healthy(); !ok || why != "" {
+		t.Fatalf("a successful call should clear the failure, got ok=%v why=%q", ok, why)
+	}
+}
+
+// Status names the provider a question would actually go to. It used to look
+// only for ANTHROPIC_API_KEY, so a healthy Atlas Cloud or local instance
+// reported "Not configured" and dragged the whole instance's health down.
+func TestStatusFollowsHealth(t *testing.T) {
+	defer resetHealth()
+
+	recordHealth(errors.New("boom"))
+	desc, ok := Status()
+	if ok {
+		t.Fatal("Status should report unhealthy after a failed call")
+	}
+	if desc == "" {
+		t.Fatal("Status should always describe something")
+	}
+}
+
+// resetHealth puts the recorder back to "nothing tried yet" so tests do not
+// leak a verdict into each other.
+func resetHealth() {
+	health.Lock()
+	defer health.Unlock()
+	health.tried, health.ok, health.err = false, false, ""
+}

--- a/internal/ai/micro.go
+++ b/internal/ai/micro.go
@@ -47,7 +47,10 @@ func resolveProvider(model string) (provider, apiKey, baseURL string, err error)
 //
 // maxTok caps the response length (via go-micro's WithMaxTokens). Cheap
 // background callers get a tighter cap to reduce latency and cost.
-func generateViaMicro(model, systemPrompt string, messages []map[string]string, caller string, maxTok int) (string, error) {
+func generateViaMicro(model, systemPrompt string, messages []map[string]string, caller string, maxTok int) (reply string, err error) {
+	// Every exit from this function is a verdict on whether the model answers.
+	defer func() { recordHealth(err) }()
+
 	provider, apiKey, baseURL, err := resolveProvider(model)
 	if err != nil {
 		return "", err
@@ -112,7 +115,9 @@ func generateViaMicro(model, systemPrompt string, messages []map[string]string, 
 // for each content chunk and returning the full text. If the provider does not
 // support streaming, it falls back to a single Generate call and emits the
 // whole reply at once — so every caller works regardless of provider.
-func streamViaMicro(model, systemPrompt string, messages []map[string]string, caller string, maxTok int, onToken func(string)) (string, error) {
+func streamViaMicro(model, systemPrompt string, messages []map[string]string, caller string, maxTok int, onToken func(string)) (reply string, err error) {
+	defer func() { recordHealth(err) }()
+
 	provider, apiKey, baseURL, err := resolveProvider(model)
 	if err != nil {
 		return "", err

--- a/internal/api/listscope_test.go
+++ b/internal/api/listscope_test.go
@@ -1,0 +1,81 @@
+package api
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"mu/internal/auth"
+)
+
+// A scoped token should be shown the tools it may use, and no others.
+//
+// Scoping was enforced at dispatch and ignored by tools/list, so an agent you
+// had deliberately confined to two services was handed every tool definition on
+// the instance and found out by trial and error that almost all of them were
+// refused. That is the worst of both: the context cost of the whole catalogue
+// and none of its use.
+func TestToolsListFollowsTheTokenScope(t *testing.T) {
+	secret := scopedTokenFor(t, "listscope", "scopeallowed")
+
+	r, _ := http.NewRequest("POST", "/mcp", nil)
+	r.Header.Set("Authorization", "Bearer "+secret)
+	if got := scopeFrom(r); len(got) != 1 || got[0] != "scopeallowed" {
+		t.Fatalf("expected the listing to follow the token's scope, got %v", got)
+	}
+
+	// An explicit ?tools= still wins, because it can only narrow further — and
+	// every name in it is checked against the token when called anyway.
+	r2, _ := http.NewRequest("POST", "/mcp?tools=news", nil)
+	r2.Header.Set("Authorization", "Bearer "+secret)
+	if got := scopeFrom(r2); len(got) != 1 || got[0] != "news" {
+		t.Fatalf("expected the explicit ?tools= list to win, got %v", got)
+	}
+
+	// A caller with no token is not confined at all.
+	plain, _ := http.NewRequest("POST", "/mcp", nil)
+	if got := scopeFrom(plain); len(got) != 0 {
+		t.Fatalf("expected an unconfined caller to see everything, got %v", got)
+	}
+}
+
+// The filter the listing applies must agree with the check dispatch applies. If
+// they disagree the catalogue either promises what the boundary refuses, or
+// hides what it would have allowed.
+func TestListedToolsAreExactlyTheCallableOnes(t *testing.T) {
+	secret := scopedTokenFor(t, "listagree", "scopeallowed")
+	r, _ := http.NewRequest("POST", "/mcp", nil)
+	r.Header.Set("Authorization", "Bearer "+secret)
+
+	scope := scopeFrom(r)
+	checked := 0
+	for _, tool := range mcpTools() {
+		listed := inScope(tool, scope)
+		callable := checkTokenScope(r, tool.Name) == nil
+		if listed != callable {
+			t.Errorf("%s: listed=%v callable=%v — the catalogue and the boundary disagree",
+				tool.Name, listed, callable)
+		}
+		checked++
+	}
+	if checked == 0 {
+		t.Fatal("no tools were registered, so this proved nothing")
+	}
+}
+
+// scopedTokenFor mints a token confined to the named services and returns its
+// secret, using the same probe services as the dispatch scope tests so the
+// result does not depend on which service packages this binary happens to link.
+func scopedTokenFor(t *testing.T, account string, services ...string) string {
+	t.Helper()
+	registerScopeProbes(t)
+	acc := &auth.Account{ID: account, Name: account, Secret: "s"}
+	if err := auth.Create(acc); err != nil {
+		t.Fatal(err)
+	}
+	_, secret, err := auth.CreateToken(acc.ID, "agent: "+account, auth.ScopeFor(services), time.Time{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return secret
+}

--- a/internal/api/mcp.go
+++ b/internal/api/mcp.go
@@ -847,6 +847,21 @@ func ExecuteTool(r *http.Request, name string, args map[string]any) (string, boo
 		return "", true, fmt.Errorf("unknown tool: %s", name)
 	}
 
+	// A scoped token reaches only the services it names.
+	//
+	// This is what makes an agent an agent rather than a copy of you: you hand
+	// a program a credential, and the credential is smaller than your account.
+	// Without the check here the scope would be a label on a settings page and
+	// nothing else, since every branch below dispatches on the account alone.
+	//
+	// First, before the usage counter and before the argument check. A caller
+	// who may not use a tool should learn that and nothing else — otherwise the
+	// refusal doubles as a schema oracle ("db_list requires collection"), and a
+	// call that never happened is counted as if it had.
+	if err := checkTokenScope(r, tool.Name); err != nil {
+		return err.Error(), true, err
+	}
+
 	// Count the call by tool name. Every MCP request is a POST to /mcp, so the
 	// HTTP layer sees one endpoint for the whole protocol and can say nothing
 	// about which tool is busy. Recorded under the canonical name, so an alias
@@ -868,20 +883,6 @@ func ExecuteTool(r *http.Request, name string, args map[string]any) (string, boo
 			text, err := GuestNewsSearch(query)
 			return text, err != nil, err
 		}
-	}
-
-	// A scoped token reaches only the services it names.
-	//
-	// This is what makes an agent an agent rather than a copy of you: you hand
-	// a program a credential, and the credential is smaller than your account.
-	// Without the check here the scope would be a label on a settings page and
-	// nothing else, since every branch below dispatches on the account alone.
-	//
-	// Placed above every branch for the same reason as the wallet guard below:
-	// tools reach dispatch by three different routes, and a check inside one of
-	// them silently exempts the other two.
-	if err := checkTokenScope(r, tool.Name); err != nil {
-		return err.Error(), true, err
 	}
 
 	// Refuse a paid wallet on an account-only tool before any dispatch. This has

--- a/internal/api/scope.go
+++ b/internal/api/scope.go
@@ -29,19 +29,47 @@ import (
 	"net/http"
 	"strings"
 
+	"mu/internal/auth"
 	"mu/internal/service"
 )
 
 // scopeParam is the query parameter naming the services a connection wants.
 const scopeParam = "tools"
 
-// scopeFrom reads the requested services from a request. An empty result means
-// no scope: everything is listed, which is what an unscoped URL has always done.
+// scopeFrom reads the services this connection should see: the ?tools= list if
+// the caller named one, otherwise the scope carried by the token they presented.
+// An empty result means no scope — everything is listed, which is what an
+// unscoped URL with an unscoped token has always done.
+//
+// The token fallback is the important half. A scoped token was already refused
+// at dispatch, but tools/list ignored it, so an agent you had deliberately
+// confined to news and weather was handed all seventy-eight tool definitions and
+// discovered by trial and error that seventy-six of them were refused. The
+// listing now says what the credential actually permits, which is both the
+// honest answer and much the smaller one.
+//
+// A ?tools= list still wins where it is given, because it can only narrow: it
+// filters the listing, and every name in it is still checked against the token
+// when called.
 func scopeFrom(r *http.Request) []string {
 	if r == nil {
 		return nil
 	}
-	return parseScope(r.URL.Query().Get(scopeParam))
+	if s := parseScope(r.URL.Query().Get(scopeParam)); len(s) > 0 {
+		return s
+	}
+	return tokenScope(r)
+}
+
+// tokenScope returns the services a presented token is confined to, or nil for
+// a caller who is not confined — a cookie session, a settled payment, or one of
+// the unscoped tokens issued before scopes existed.
+func tokenScope(r *http.Request) []string {
+	tok := auth.TokenFromRequest(r)
+	if tok == nil || !tok.Scoped() {
+		return nil
+	}
+	return tok.Services()
 }
 
 // parseScope splits a scope string. Commas or spaces, any case.

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -182,13 +182,86 @@ func RespondError(w http.ResponseWriter, status int, message string) {
 	json.NewEncoder(w).Encode(map[string]string{"error": message})
 }
 
-// Error writes an error response, using JSON if the client expects it, otherwise plain text
+// Error writes an error response: JSON if the client expects it, otherwise a
+// rendered page.
+//
+// The page matters. This is the single exit for every Forbidden, Unauthorized
+// and BadRequest in the product, and it used to be http.Error — so a person
+// who hit any of them was dropped onto a white screen with one line of text,
+// no nav, and no way back except the browser's own button. The refusal is
+// often the most important thing we ever say to a new user ("verify your
+// email and you can post"), and it was the one thing said worst.
 func Error(w http.ResponseWriter, r *http.Request, status int, message string) {
-	if WantsJSON(r) || SendsJSON(r) {
+	if WantsJSON(r) || SendsJSON(r) || isFetch(r) {
 		RespondError(w, status, message)
 		return
 	}
-	http.Error(w, message, status)
+	if message == "" {
+		message = http.StatusText(status)
+	}
+	body := `<div class="notice"><p>` + htmlpkg.EscapeString(message) + `</p></div>` +
+		`<p><a class="link" href="` + htmlpkg.EscapeString(errorBackTo(r)) + `">Back</a></p>`
+	// Rendered without the standing banners. They exist to interrupt an ordinary
+	// page with something you should know; here the something-you-should-know is
+	// the page, and a banner repeating the message word for word above it just
+	// says the same thing twice.
+	_, acc := auth.TrySession(r)
+	page := RenderHTMLWithLangAndAuth(errorTitle(status), message, body, GetUserLanguage(r), acc)
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.WriteHeader(status)
+	w.Write([]byte(page))
+}
+
+// isFetch reports whether this request came from script rather than from the
+// address bar or a form submit.
+//
+// Only a navigation can display a page, and a fetch() that asks for one gets
+// several kilobytes of markup where it expected a sentence — which is exactly
+// what happened the first time the console's compose box showed a refusal: it
+// printed the <head> of an error page into the notice area. Browsers label the
+// difference themselves in Sec-Fetch-Mode ("navigate" for a page load or form
+// post, "cors"/"same-origin" for fetch and XHR), so nothing has to be guessed
+// and no call site has to remember to set a header. Absent header — curl, an
+// old browser — is treated as a navigation, which is the safe assumption for a
+// human-readable response.
+func isFetch(r *http.Request) bool {
+	mode := r.Header.Get("Sec-Fetch-Mode")
+	return mode != "" && mode != "navigate"
+}
+
+// errorTitle heads the page with what happened in plain words. The HTTP status
+// text is written for a proxy log — "Forbidden" over a sentence explaining how
+// to start posting reads as a scolding rather than an answer.
+func errorTitle(status int) string {
+	switch status {
+	case http.StatusUnauthorized:
+		return "Sign in"
+	case http.StatusForbidden:
+		return "Not yet"
+	case http.StatusPaymentRequired:
+		return "Needs credit"
+	case http.StatusTooManyRequests:
+		return "Slow down"
+	case http.StatusNotFound:
+		return "Not found"
+	case http.StatusBadRequest:
+		return "That did not work"
+	}
+	return http.StatusText(status)
+}
+
+// errorBackTo picks where "Back" goes: the page the request came from when it
+// is one of ours, otherwise home. A refused POST has no useful URL of its own —
+// the form lives at the referer.
+func errorBackTo(r *http.Request) string {
+	ref := r.Referer()
+	if strings.HasPrefix(ref, "/") && !strings.HasPrefix(ref, "//") {
+		return ref
+	}
+	if u, err := url.Parse(ref); err == nil && u.Path != "" && u.Host == r.Host {
+		return u.Path
+	}
+	return "/"
 }
 
 // Unauthorized writes a 401 error response
@@ -1576,27 +1649,39 @@ func RenderHTMLForRequest(title, desc, html string, r *http.Request) string {
 	return out
 }
 
-// VerifyBanner returns banner HTML inviting the user to verify their
-// email address, or an empty string if the banner doesn't apply (no
-// session, admin, already verified, or verification not required on
-// this instance).
+// VerifyBanner says, before you write anything, that you cannot post yet and
+// what to do about it. Empty for anyone who can.
+//
+// It asks auth.CanPost rather than re-deriving the rule, because it used to
+// carry its own copy — verification only, and only on instances with mail
+// configured — while the actual gate also blocked every account under 24 hours
+// old, on every instance. The two disagreed in the worst direction: the block
+// was wider than the warning, so a new user met it for the first time as a
+// rejected POST after writing a post, creating an app, or filling in a form.
+// Anything the gate refuses, this now announces.
 func VerifyBanner(r *http.Request) string {
-	if EmailSender == nil {
-		return ""
-	}
 	_, acc := auth.TrySession(r)
-	if acc == nil || acc.Admin || acc.Approved || acc.EmailVerified {
+	if acc == nil {
 		return ""
 	}
-	// Don't show the banner on the account page itself — the verify
-	// form is right there.
-	if r.URL.Path == "/account" || r.URL.Path == "/verify" {
+	reason := auth.PostBlockReason(acc.ID)
+	if reason == "" {
 		return ""
+	}
+	// Not on the pages that are the way out of it — the form is right there.
+	switch r.URL.Path {
+	case "/account", "/verify", "/wallet", "/wallet/topup":
+		return ""
+	}
+	action, href := "Verify →", "/account"
+	if auth.VerificationRequired == nil || !auth.VerificationRequired() {
+		// No mail on this instance, so verifying is not on offer: credit is.
+		action, href = "Add credit →", "/wallet"
 	}
 	return `<div class="verify-banner" style="background:#fff8e1;border:1px solid #f1d68c;border-radius:6px;padding:10px 14px;margin:0 0 14px;font-size:14px;color:#5b4a00;display:flex;align-items:center;gap:10px;flex-wrap:wrap">
-<strong>Verify your email to post.</strong>
-<span>Add and confirm an email on your account to unlock status updates, replies, comments and posts.</span>
-<a href="/account" style="margin-left:auto;background:#000;color:#fff;text-decoration:none;padding:6px 14px;border-radius:6px">Verify →</a>
+<strong>You cannot post yet.</strong>
+<span>` + htmlpkg.EscapeString(reason) + `</span>
+<a href="` + href + `" style="margin-left:auto;background:#000;color:#fff;text-decoration:none;padding:6px 14px;border-radius:6px">` + action + `</a>
 </div>`
 }
 

--- a/internal/app/status.go
+++ b/internal/app/status.go
@@ -383,15 +383,16 @@ func formatDKIMDetails(enabled bool, domain, selector string) string {
 	return fmt.Sprintf("%s (selector: %s)", domain, selector)
 }
 
+// LLMStatus is set by main.go to internal/ai's own view of the model: which
+// provider a question would go to, and whether it is answering. A hook because
+// internal/ai imports this package, so the dependency cannot run the other way.
+var LLMStatus func() (string, bool)
+
 func checkLLMConfig() (provider string, configured bool) {
-	if os.Getenv("ANTHROPIC_API_KEY") == "" {
-		return "Not configured", false
+	if LLMStatus != nil {
+		return LLMStatus()
 	}
-	model := os.Getenv("ANTHROPIC_MODEL")
-	if model == "" {
-		model = "claude-sonnet-4-6"
-	}
-	return fmt.Sprintf("Anthropic/%s", model), true
+	return "Not configured", false
 }
 
 // getDiskUsage returns disk usage for the data directory

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -702,22 +702,61 @@ func GetOnlineUsers() []string {
 // so self-hosters without mail aren't accidentally locked out.
 var VerificationRequired func() bool
 
-// CanPost checks if an account is allowed to create content.
-// Rules:
-//   - Admins and approved accounts can always post.
-//   - If verification is not required on this instance (no mail
-//     configured), any account can post.
-//   - Otherwise the account must have a verified email address.
-func CanPost(accountID string) bool {
+// HasCredit is set by main.go and reports whether an account has a positive
+// credit balance. Kept as a hook because the wallet imports auth, not the
+// other way round.
+var HasCredit func(accountID string) bool
+
+// trusted reports whether an account has shown it is a person rather than a
+// signup script. Three things count, and any one of them is enough:
+//
+//   - an admin said so (Admin, Approved),
+//   - a verified email address,
+//   - money in the wallet.
+//
+// The 24-hour wait is not a fourth signal, it is what we fall back on when we
+// have none of these. Waiting proves nothing about a bot — it costs a script
+// nothing and costs a new user their whole first session — so anything that
+// does carry signal has to be able to skip it.
+//
+// Takes a copy, not the live account, because it calls out to HasCredit and
+// must not do that under auth's mutex: the wallet reads accounts, so holding
+// the lock across the call would deadlock the first time someone checked a
+// balance. Callers snapshot under the lock and evaluate after releasing it.
+func trusted(acc Account) bool {
+	if acc.Admin || acc.Approved || acc.EmailVerified {
+		return true
+	}
+	return HasCredit != nil && HasCredit(acc.ID)
+}
+
+// snapshot returns a copy of an account, or false if there is no such account.
+// The copy is what the trust rules below run against, so they can call out to
+// the wallet without holding the lock.
+func snapshot(accountID string) (Account, bool) {
 	mutex.Lock()
 	defer mutex.Unlock()
-
 	acc, exists := accounts[accountID]
+	if !exists {
+		return Account{}, false
+	}
+	return *acc, true
+}
+
+// CanPost checks if an account is allowed to create content.
+// Rules:
+//   - A trusted account (see above) can always post.
+//   - Otherwise it waits out its first 24 hours.
+//   - After that, if this instance requires verification, it still needs a
+//     verified address — which trusted() already covers, so reaching here
+//     unverified on such an instance means no.
+func CanPost(accountID string) bool {
+	acc, exists := snapshot(accountID)
 	if !exists {
 		return false
 	}
 
-	if acc.Admin || acc.Approved {
+	if trusted(acc) {
 		return true
 	}
 
@@ -726,51 +765,52 @@ func CanPost(accountID string) bool {
 		return false
 	}
 
-	if VerificationRequired == nil || !VerificationRequired() {
-		return true
-	}
-
-	return acc.EmailVerified
+	return VerificationRequired == nil || !VerificationRequired()
 }
 
 // PostBlockReason returns a human-readable reason an account cannot post,
 // or an empty string if it can. Used by handlers to render helpful errors.
 func PostBlockReason(accountID string) string {
-	mutex.Lock()
-	defer mutex.Unlock()
-
-	acc, exists := accounts[accountID]
+	acc, exists := snapshot(accountID)
 	if !exists {
 		return "Account not found"
 	}
-	if acc.Admin || acc.Approved {
+	if trusted(acc) {
 		return ""
 	}
+	// Lead with the way out. The wait is the fallback, not the instruction —
+	// a reason that only says "come back tomorrow" reads as a dead end when
+	// two doors are open right now.
 	if time.Since(acc.Created) < 24*time.Hour {
 		remaining := (24*time.Hour - time.Since(acc.Created)).Round(time.Minute)
-		return fmt.Sprintf("New accounts must wait 24 hours before posting. %s remaining.", remaining)
+		return fmt.Sprintf("Verify your email address on /account, or add credit on /wallet, and you can post straight away. Otherwise a new account waits 24 hours — %s remaining.", remaining)
 	}
-	if VerificationRequired != nil && VerificationRequired() && !acc.EmailVerified {
-		return "Verify your email at /account before posting."
+	if VerificationRequired != nil && VerificationRequired() {
+		return "Verify your email address on /account before posting."
 	}
 	return ""
 }
 
-// IsNewAccount checks if account is less than 24 hours old
+// IsNewAccount reports whether we still know nothing about this account.
+//
+// The blog hides posts by a new account from its lists, which is the right
+// instinct — a spam run should not reach the front page — but it has to mean
+// the same thing as CanPost or the product contradicts itself: the post is
+// accepted, charged, indexed, the author is redirected to the list, and the
+// post is not on it. Nothing says why, because from the writer's side nothing
+// went wrong.
+//
+// So "new" is the same question as "untrusted", asked once. An account that has
+// verified an address or put money in its wallet is not new to us, whatever the
+// clock says.
 func IsNewAccount(accountID string) bool {
-	mutex.Lock()
-	defer mutex.Unlock()
-
-	acc, exists := accounts[accountID]
+	acc, exists := snapshot(accountID)
 	if !exists {
 		return false
 	}
-
-	// Admins and approved accounts are never considered "new"
-	if acc.Admin || acc.Approved {
+	if trusted(acc) {
 		return false
 	}
-
 	return time.Since(acc.Created) < 24*time.Hour
 }
 

--- a/internal/auth/post_rules_test.go
+++ b/internal/auth/post_rules_test.go
@@ -46,7 +46,10 @@ func TestCanPostAccountAgeAndVerificationRules(t *testing.T) {
 	}
 }
 
-func TestPostBlockReasonExplainsAccountAgeBeforeVerification(t *testing.T) {
+// A blocked new account is told how to unblock itself, not just how long to
+// wait. The wait used to be the whole message, which reads as a dead end when
+// two doors are open right now.
+func TestPostBlockReasonOffersTheWayOut(t *testing.T) {
 	originalVerificationRequired := VerificationRequired
 	t.Cleanup(func() {
 		mutex.Lock()
@@ -61,10 +64,109 @@ func TestPostBlockReasonExplainsAccountAgeBeforeVerification(t *testing.T) {
 	VerificationRequired = func() bool { return true }
 
 	reason := PostBlockReason("blocked-user")
-	if !strings.Contains(reason, "New accounts must wait 24 hours") {
-		t.Fatalf("expected age-based block reason, got %q", reason)
+	for _, want := range []string{"/account", "/wallet", "24 hours"} {
+		if !strings.Contains(reason, want) {
+			t.Fatalf("expected the reason to mention %q, got %q", want, reason)
+		}
 	}
-	if strings.Contains(reason, "Verify your email") {
-		t.Fatalf("expected age restriction to be reported before verification, got %q", reason)
+}
+
+// The 24-hour wait is a fallback for an account we know nothing about. A
+// verified address or a funded wallet is the signal it was standing in for, so
+// either one lets a brand-new account post immediately.
+func TestTrustSignalsSkipTheWait(t *testing.T) {
+	originalVerificationRequired := VerificationRequired
+	originalHasCredit := HasCredit
+	t.Cleanup(func() {
+		mutex.Lock()
+		delete(accounts, "fresh-verified")
+		delete(accounts, "fresh-funded")
+		delete(accounts, "fresh-broke")
+		mutex.Unlock()
+		VerificationRequired = originalVerificationRequired
+		HasCredit = originalHasCredit
+	})
+
+	now := time.Now()
+	mutex.Lock()
+	accounts["fresh-verified"] = &Account{ID: "fresh-verified", Created: now, EmailVerified: true}
+	accounts["fresh-funded"] = &Account{ID: "fresh-funded", Created: now}
+	accounts["fresh-broke"] = &Account{ID: "fresh-broke", Created: now}
+	mutex.Unlock()
+
+	VerificationRequired = func() bool { return true }
+	HasCredit = func(id string) bool { return id == "fresh-funded" }
+
+	if !CanPost("fresh-verified") {
+		t.Fatal("a verified address should clear the new-account wait")
+	}
+	if !CanPost("fresh-funded") {
+		t.Fatal("credit in the wallet should clear the new-account wait")
+	}
+	if CanPost("fresh-broke") {
+		t.Fatal("an account with neither signal should still wait")
+	}
+	if PostBlockReason("fresh-verified") != "" {
+		t.Fatal("a trusted account should have no block reason")
+	}
+
+	// Whatever accepts a post must also show it. The blog hides posts by a
+	// "new" account from its lists, so if IsNewAccount and CanPost disagree the
+	// write succeeds, is charged, and then silently vanishes from the page the
+	// author is redirected to.
+	for _, id := range []string{"fresh-verified", "fresh-funded", "fresh-broke"} {
+		if IsNewAccount(id) == CanPost(id) {
+			t.Fatalf("%s: IsNewAccount and CanPost disagree — a post would be accepted and then hidden", id)
+		}
+	}
+
+	// And the tight new-account rate cap follows the same signal: a trusted
+	// account is capped at the established rate, not the bot-defence rate.
+	mutex.Lock()
+	trustedAcc := *accounts["fresh-funded"]
+	untrusted := *accounts["fresh-broke"]
+	mutex.Unlock()
+	if trustedMax, _ := postLimitFor(trustedAcc); trustedMax <= 10 {
+		t.Fatalf("expected a trusted new account off the new-account cap, got %d", trustedMax)
+	}
+	if untrustedMax, _ := postLimitFor(untrusted); untrustedMax > 10 {
+		t.Fatalf("expected an untrusted new account on the tight cap, got %d", untrustedMax)
+	}
+}
+
+// HasCredit reaches into the wallet, which reads accounts. Calling it under
+// auth's own mutex would deadlock the first time anyone posted, so the trust
+// rules snapshot the account and evaluate after releasing the lock. This test
+// fails by hanging if that ever regresses.
+func TestTrustRulesDoNotHoldTheLock(t *testing.T) {
+	originalHasCredit := HasCredit
+	t.Cleanup(func() {
+		mutex.Lock()
+		delete(accounts, "reentrant")
+		mutex.Unlock()
+		HasCredit = originalHasCredit
+	})
+
+	mutex.Lock()
+	accounts["reentrant"] = &Account{ID: "reentrant", Created: time.Now()}
+	mutex.Unlock()
+
+	HasCredit = func(id string) bool {
+		// What the wallet does: look the account up again.
+		mutex.Lock()
+		_, ok := accounts[id]
+		mutex.Unlock()
+		return ok
+	}
+
+	done := make(chan bool, 1)
+	go func() { done <- CanPost("reentrant") }()
+	select {
+	case ok := <-done:
+		if !ok {
+			t.Fatal("expected the funded account to be allowed to post")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("CanPost deadlocked: the trust rules are calling out under auth's mutex")
 	}
 }

--- a/internal/auth/postlimit.go
+++ b/internal/auth/postlimit.go
@@ -35,9 +35,15 @@ var (
 // During the first 24 hours after signup an account is on a tight cap;
 // after that it gets a generous hourly cap that still throttles abuse.
 // Admins and approved accounts are unlimited.
-func postLimitFor(acc *Account) (int, time.Duration) {
+func postLimitFor(acc Account) (int, time.Duration) {
 	if acc.Admin || acc.Approved {
 		return 1<<31 - 1, time.Hour
+	}
+	// A verified address or a funded wallet clears the new-account cap for the
+	// same reason it clears the 24-hour wait in CanPost: it is the signal the
+	// cap was standing in for. Still capped, just at the established rate.
+	if trusted(acc) {
+		return envIntAuth("POST_LIMIT_PER_HOUR", 60), time.Hour
 	}
 	if time.Since(acc.Created) < 24*time.Hour {
 		// New account: 10 actions per hour by default, so a 240 ceiling over
@@ -53,9 +59,7 @@ func postLimitFor(acc *Account) (int, time.Duration) {
 // This is a sliding-bucket limiter: the count resets after the window
 // elapses from the first action in the bucket.
 func CheckPostRate(accountID string) error {
-	mutex.Lock()
-	acc, exists := accounts[accountID]
-	mutex.Unlock()
+	acc, exists := snapshot(accountID)
 	if !exists {
 		return errors.New("account not found")
 	}

--- a/main.go
+++ b/main.go
@@ -747,6 +747,16 @@ func main() {
 		return app.EmailSender != nil
 	}
 
+	// Money is a trust signal, so auth needs to be able to see it. Wired as a
+	// hook because the wallet imports auth and cannot be imported back.
+	auth.HasCredit = func(accountID string) bool {
+		return wallet.GetBalance(accountID) > 0
+	}
+
+	// The status page asks the AI package what the model is doing rather than
+	// guessing from one env var.
+	app.LLMStatus = ai.Status
+
 	// Signup and login are not tools. Creating an account and exchanging
 	// credentials for a session are how a caller comes to exist, not something
 	// an existing caller can be granted — they live on the HTTP boundary (the
@@ -2362,24 +2372,25 @@ func main() {
 						op := wallet.OpSocialPost
 						sess, err := auth.GetSession(r)
 						if err != nil {
-							http.Error(w, "authentication required", http.StatusUnauthorized)
+							app.Unauthorized(w, r)
 							return
 						}
 						if !auth.CanPost(sess.Account) {
-							http.Error(w, auth.PostBlockReason(sess.Account), http.StatusForbidden)
+							app.Forbidden(w, r, auth.PostBlockReason(sess.Account))
 							return
 						}
 						if err := auth.CheckPostRate(sess.Account); err != nil {
-							http.Error(w, err.Error(), http.StatusTooManyRequests)
+							app.TooManyRequests(w, r, err.Error())
 							return
 						}
 						canProceed, _, cost, _ := wallet.CheckQuota(sess.Account, op)
 						if !canProceed {
-							http.Error(w, fmt.Sprintf("This costs %d credit(s). Top up at /wallet/topup", cost), http.StatusPaymentRequired)
+							app.Error(w, r, http.StatusPaymentRequired,
+								fmt.Sprintf("This costs %d credit(s). Top up at /wallet/topup", cost))
 							return
 						}
 						if err := wallet.ConsumeQuota(sess.Account, op); err != nil {
-							http.Error(w, err.Error(), http.StatusPaymentRequired)
+							app.Error(w, r, http.StatusPaymentRequired, err.Error())
 							return
 						}
 						app.Log("wallet", "Charged %s %d credit(s) for POST /@%s status", sess.Account, wallet.GetOperationCost(op), rest)
@@ -2419,23 +2430,27 @@ func main() {
 			// NOT call CheckQuota/ConsumeQuota — the middleware does
 			// it so nothing can be forgotten.
 			if op := chargedWriteOp(r); op != "" {
+				// Refusals go through app.Error, not http.Error: this is a
+				// person who just pressed a button in a browser, and a bare
+				// white page carrying one line of text is the worst possible
+				// way to tell them what was refused and what to do about it.
 				sess, err := auth.GetSession(r)
 				if err != nil {
-					http.Error(w, "authentication required", http.StatusUnauthorized)
+					app.Unauthorized(w, r)
 					return
 				}
 				if !auth.CanPost(sess.Account) {
-					msg := auth.PostBlockReason(sess.Account)
-					http.Error(w, msg, http.StatusForbidden)
+					app.Forbidden(w, r, auth.PostBlockReason(sess.Account))
 					return
 				}
 				if err := auth.CheckPostRate(sess.Account); err != nil {
-					http.Error(w, err.Error(), http.StatusTooManyRequests)
+					app.TooManyRequests(w, r, err.Error())
 					return
 				}
 				canProceed, _, cost, _ := wallet.CheckQuota(sess.Account, op)
 				if !canProceed {
-					http.Error(w, fmt.Sprintf("This costs %d credit(s). Top up at /wallet/topup", cost), http.StatusPaymentRequired)
+					app.Error(w, r, http.StatusPaymentRequired,
+						fmt.Sprintf("This costs %d credit(s). Top up at /wallet/topup", cost))
 					return
 				}
 				// Charge up-front. The handler runs only if the
@@ -2444,7 +2459,7 @@ func main() {
 				// acceptable — and it's the only way to guarantee
 				// we never forget to charge.
 				if err := wallet.ConsumeQuota(sess.Account, op); err != nil {
-					http.Error(w, err.Error(), http.StatusPaymentRequired)
+					app.Error(w, r, http.StatusPaymentRequired, err.Error())
 					return
 				}
 				app.Log("wallet", "Charged %s %d credit(s) for %s %s", sess.Account, wallet.GetOperationCost(op), r.Method, r.URL.Path)
@@ -2776,13 +2791,15 @@ func runHealthChecks() []app.ServiceHealth {
 		if fn == nil {
 			fn = func() bool { return true } // registered and serving
 		}
-		checks = append(checks,
-			check{name: strings.ToUpper(name[:1]) + name[1:], path: path, fn: fn})
+		// The service's own label, not a capitalised id — otherwise /status is
+		// the one page in the product that calls the database "Db".
+		checks = append(checks, check{name: service.Label(name), path: path, fn: fn})
 	}
 
 	// Cross-cutting checks that aren't domain services.
 	checks = append(checks,
-		check{"Agent", "/agent", func() bool { return ai.Configured() }},
+		// Whether it answers, not whether a key is set. See internal/ai/health.go.
+		check{"Agent", "/agent", func() bool { ok, _ := ai.Healthy(); return ok }},
 		// Named for what the reader is being told, not for the library behind
 		// it — /status is linked from every page footer.
 		check{"runtime", "/version", func() bool { return len(service.Services()) > 0 }},

--- a/service/stream/handlers.go
+++ b/service/stream/handlers.go
@@ -285,6 +285,17 @@ const streamScript = `<script>
     return m ? decodeURIComponent(m[1]) : '';
   }
 
+  function showStreamError(msg) {
+    var el = document.getElementById('stream-error');
+    if (!el) {
+      el = document.createElement('div');
+      el.id = 'stream-error';
+      el.className = 'notice';
+      formEl.parentNode.insertBefore(el, formEl.nextSibling);
+    }
+    el.textContent = String(msg).trim();
+  }
+
   function refresh(clear) {
     if (inflight) return;
     inflight = true;
@@ -318,8 +329,21 @@ const streamScript = `<script>
         credentials: 'same-origin',
         headers: headers,
         body: body.toString()
-      }).then(function(){ refresh(true); })
-        .catch(function(){ formEl.submit(); });
+      }).then(function(r){
+        // A refusal is a response, not a network error, so the old .then(ok)
+        // swallowed it: the post was rejected, the box had already been
+        // cleared, and the page redrew as if nothing had happened. Whatever
+        // the server said is the most useful thing on the screen at that
+        // moment — and the text goes back in the box so it is not lost.
+        if (!r.ok) {
+          return r.text().then(function(msg){
+            input.value = text;
+            try { var j = JSON.parse(msg); if (j && j.error) msg = j.error; } catch (e) {}
+            showStreamError(msg || ('Could not post (' + r.status + ')'));
+          });
+        }
+        refresh(true);
+      }).catch(function(){ input.value = text; formEl.submit(); });
     });
   }
 

--- a/service/wallet/freewrite_test.go
+++ b/service/wallet/freewrite_test.go
@@ -1,0 +1,62 @@
+package wallet
+
+import (
+	"testing"
+	"time"
+
+	"mu/internal/auth"
+)
+
+// Charging zero must succeed.
+//
+// Every content write — blog post, comment, reply, status, console note, app —
+// is deliberately priced at zero, because it only touches this instance's own
+// storage. ConsumeQuota passed that zero to DeductCredits, which rejects any
+// non-positive amount, and the centralised write gate turned the rejection into
+// a 402 Payment Required. So the whole free half of the product was refused for
+// want of credit nobody was being asked for.
+//
+// It stayed hidden because the two groups who could have found it never got
+// there: admins skip the charge, and a new account was stopped by the 24-hour
+// post gate before it reached this line. What was left was every ordinary
+// established user, on every single write.
+func TestFreeOperationsAreNotRefused(t *testing.T) {
+	// The first account on an empty instance is bootstrapped to admin, and an
+	// admin skips the charge — which is exactly the blind spot this test exists
+	// to cover. So burn one, then test with the second.
+	_ = auth.Create(&auth.Account{ID: "free-write-first", Name: "first", Secret: "x", Created: time.Now()})
+
+	const id = "free-write-user"
+	acc := &auth.Account{ID: id, Name: id, Secret: "x", Created: time.Now()}
+	if err := auth.Create(acc); err != nil {
+		t.Skipf("cannot create an account in this environment: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = auth.DeleteAccount(id)
+		_ = auth.DeleteAccount("free-write-first")
+	})
+	if acc.Admin {
+		t.Skip("test account was bootstrapped to admin; admins skip the charge")
+	}
+
+	free := []string{
+		OpBlogCreate, OpBlogComment, OpSocialPost,
+		OpSocialReply, OpAppCreate, OpStreamPost,
+	}
+	for _, op := range free {
+		if cost := GetOperationCost(op); cost != 0 {
+			t.Fatalf("%s is priced at %d, not free — update this test or the price", op, cost)
+		}
+		if err := ConsumeQuota(id, op); err != nil {
+			t.Fatalf("charging a free operation failed: %s: %v", op, err)
+		}
+	}
+
+	// Free must not have become a bypass: a priced operation on an empty wallet
+	// is still refused.
+	if GetOperationCost(OpImageGenerate) > 0 {
+		if err := ConsumeQuota(id, OpImageGenerate); err == nil {
+			t.Fatal("a priced operation was allowed through on an empty wallet")
+		}
+	}
+}

--- a/service/wallet/wallet.go
+++ b/service/wallet/wallet.go
@@ -662,8 +662,19 @@ func ConsumeQuota(userID string, operation string) error {
 		return nil
 	}
 
-	// Deduct credits
+	// A free operation is free: record it and stop. Handing a zero to
+	// DeductCredits gets "amount must be positive" back, which the write gate
+	// turns into a 402 — so every blog post, comment, reply, status, console
+	// note and app, all of which are deliberately priced at zero because they
+	// only touch this instance's own storage, was refused for want of credit
+	// nobody was being asked for. Admins skip the charge entirely and new
+	// accounts were stopped by the post gate first, so the one group who hit it
+	// was ordinary established users, on every single write.
 	cost := GetOperationCost(operation)
+	if cost <= 0 {
+		RecordUsage(userID, operation)
+		return nil
+	}
 	return DeductCredits(userID, cost, operation, nil)
 }
 


### PR DESCRIPTION
An audit of a fresh instance, signed up as an ordinary user rather than as the admin who built it, found the first five minutes broken in a way that is invisible from an admin account.

A new account could not post, create an app, write to the console or set a status for 24 hours. It found out by writing the thing first: the refusal was a bare 403 with one line of text, no navigation, no way back. The wait was also pointless — it costs a signup script nothing and costs a person their whole first session. So the rule is now the question it was standing in for: an admin-approved account, a verified address or credit in the wallet can post immediately, and only an account we know nothing about waits. Anything the gate refuses is now said before you write, by the banner that already sits on every page, instead of after.

Underneath that were two bugs the gate had been hiding.

Every content write is priced at zero, and charging zero returned "amount must be positive", which the write gate turned into 402 Payment Required. So every post, comment, reply, status, console note and app was refused for want of credit nobody was being asked for. Admins skip the charge and new accounts were stopped earlier, which left exactly the ordinary established user, on every write.

And the blog hides posts by a "new" account from its lists using a different definition of new from the one that decides who may post. With the gate open the two disagreed: the post was accepted, charged, indexed, the author was redirected to the list, and the post was not on it. "New" and "untrusted" are now one question asked once.

MCP: a token scoped to two services was listed all seventy-eight tools and discovered by trial and error that seventy-six were refused — the context cost of the whole catalogue and none of its use. tools/list now follows the token. The scope check also moved above argument validation, so a refusal stops being a schema oracle and an out-of-scope attempt stops being counted as a call.

Agents had two create surfaces that asked different questions, produced different results and did not link to each other. There is one now: the builder took the question the roster form owned (where does it run, and therefore does it need a token) and the roster became a list with a link.

Status said "All systems operational" while the agent could not answer a single question, because it asked whether a key was set rather than whether the model replies. It now reports the last real call, and names the provider a question would actually go to — it only knew how to look for Anthropic, so a healthy Atlas Cloud or local instance reported "Not configured".

Also: the agent keeps its tool results when the model cannot write the prose around them, rather than throwing away a forecast it already has; the console shows a refused post instead of clearing the box and redrawing as if nothing happened; a signed-in home screen shows the default cards instead of an empty page asking you to go and choose some; /status calls the database Database.

Verified against a running instance with a real model and a real SMTP server: the agent answers end to end, mail arrives over SMTP, plus-addressed mail filters to the right agent in the UI and over MCP, and a scoped token lists four tools instead of seventy-eight.


Claude-Session: https://claude.ai/code/session_01KdcPjN9ndJwMGKQSRrAGPE