### PR TITLE
OpenRouter is a first-class AI provider

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ Built on go-micro: every capability is a go-micro service, the assistant is a go
 - **Agents** — `agent/micro/` contains specialised micro-agents per domain, routed by keyword + LLM
 - **Channels** — Discord (`client/discord/`), Telegram (`client/telegram/`), WhatsApp (`client/whatsapp/`)
 - **Protocols** — MCP server at `/mcp`, A2A at `/a2a`, x402 crypto payments
-- **AI** — `internal/ai/` supports Anthropic Claude, Atlas Cloud (DeepSeek), and local models (Ollama)
+- **AI** — `internal/ai/` supports Anthropic Claude, Atlas Cloud (DeepSeek), OpenRouter, and local models (Ollama)
 - **Config** — `internal/settings/` for live-reloadable settings, admin UI at `/admin/env`
 
 ## Key Packages
@@ -30,7 +30,7 @@ Built on go-micro: every capability is a go-micro service, the assistant is a go
 | `service/markets/` | Crypto, stocks, futures, commodities, currencies via CoinGecko/Yahoo |
 | `service/mail/` | SMTP server, DKIM, inbound filtering |
 | `service/blog/` | Microblogging with AI-generated daily digests |
-| `internal/ai/` | LLM abstraction — Anthropic, Atlas Cloud, local models |
+| `internal/ai/` | LLM abstraction — Anthropic, Atlas Cloud, OpenRouter, local models |
 | `internal/api/` | MCP server, tool registry |
 | `internal/app/` | Web UI framework, templates, middleware |
 | `internal/auth/` | Account system, sessions, passkeys |

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ It runs with no configuration. A few things need an API key.
 
 | For | Set | Notes |
 |---|---|---|
-| AI features | `ANTHROPIC_API_KEY`, `ATLAS_API_KEY`, or `OPENAI_BASE_URL` | free if you run Ollama locally |
+| AI features | `ANTHROPIC_API_KEY`, `ATLAS_API_KEY`, `OPENROUTER_API_KEY`, or `OPENAI_BASE_URL` | free if you run Ollama locally |
 | Web search | `BRAVE_API_KEY` | Brave has a free tier |
 | Video | `YOUTUBE_API_KEY` | free quota |
 

--- a/admin/diagnostics.go
+++ b/admin/diagnostics.go
@@ -134,25 +134,27 @@ func runHealthChecks() []healthCheck {
 }
 
 func checkAI() healthCheck {
-	key := settings.Get("ANTHROPIC_API_KEY")
-	localURL := settings.Get("OPENAI_BASE_URL")
-
-	if key == "" && localURL == "" && !ai.LocalModelAvailable() {
+	if !ai.Configured() {
 		return healthCheck{
 			Name:   "AI Provider",
 			Status: "error",
 			Detail: "No AI provider configured",
-			Fix:    "Set ANTHROPIC_API_KEY or OPENAI_BASE_URL in /admin/env, or install Ollama",
+			Fix:    "Set ANTHROPIC_API_KEY, ATLAS_API_KEY, OPENROUTER_API_KEY or OPENAI_BASE_URL in /admin/env, or install Ollama",
 		}
 	}
 
 	provider := "Anthropic Claude"
-	if key == "" {
-		if localURL != "" {
-			provider = "Local model (" + localURL + ")"
-		} else {
-			provider = "Ollama (auto-detected)"
-		}
+	switch {
+	case settings.Get("ANTHROPIC_API_KEY") != "":
+		provider = "Anthropic Claude"
+	case settings.Get("ATLAS_API_KEY") != "":
+		provider = "Atlas Cloud"
+	case settings.Get("OPENROUTER_API_KEY") != "":
+		provider = "OpenRouter"
+	case settings.Get("OPENAI_BASE_URL") != "":
+		provider = "Local model (" + settings.Get("OPENAI_BASE_URL") + ")"
+	default:
+		provider = "Ollama (auto-detected)"
 	}
 
 	return healthCheck{

--- a/admin/env.go
+++ b/admin/env.go
@@ -20,6 +20,8 @@ var settingGroups = []settingGroup{
 		"ANTHROPIC_API_KEY",
 		"ANTHROPIC_MODEL",
 		"ATLAS_API_KEY",
+		"OPENROUTER_API_KEY",
+		"OPENROUTER_MODEL",
 		"OPENAI_BASE_URL",
 		"OPENAI_API_KEY",
 	}},

--- a/agent/native.go
+++ b/agent/native.go
@@ -206,8 +206,8 @@ func nativeToolCallKey(call gmai.ToolCall) string {
 // prompt) shared by queryNative and streamNative. ok is false when no native
 // provider is configured, signalling the caller to fall back.
 func buildNativeAgent(accountID, prompt string, opts QueryOpts, wrappers ...gmai.ToolWrapper) (a gmagent.Agent, question string, ok bool) {
-	key := settings.Get("ATLAS_API_KEY")
-	if key == "" {
+	provider, key, model, ok := nativeLLM()
+	if !ok {
 		return nil, "", false
 	}
 
@@ -264,11 +264,25 @@ func buildNativeAgent(accountID, prompt string, opts QueryOpts, wrappers ...gmai
 	// per-agent conversation state keyed by name, so reusing a stable "assistant"
 	// name can leak prior independent prompts into fresh guest requests.
 	toolWrappers := append([]gmai.ToolWrapper{blockDestructiveTools(), injectAccount(accountID), dedupeNativeToolCalls()}, wrappers...)
-	a = service.NewAgent(nativeAgentInstanceName(), sys, "atlascloud", key, filterServices(nativeServices(opts.Public), opts.Tools),
-		gmagent.Model(ai.ModelDeepSeekPro),
+	a = service.NewAgent(nativeAgentInstanceName(), sys, provider, key, filterServices(nativeServices(opts.Public), opts.Tools),
+		gmagent.Model(model),
 		gmagent.MaxSteps(6),
 		gmagent.WrapTool(toolWrappers...))
 	return a, question, true
+}
+
+// nativeLLM picks the go-micro provider the native agent talks to. Atlas
+// stays first — that is today's hosted default. OpenRouter is the other
+// first-class cloud option. Local Ollama is not wired here: the go-micro
+// agent cannot set a BaseURL, so a local server would hit api.openai.com.
+func nativeLLM() (provider, key, model string, ok bool) {
+	if key := settings.Get("ATLAS_API_KEY"); key != "" {
+		return "atlascloud", key, ai.ModelDeepSeekPro, true
+	}
+	if key := ai.OpenRouterKey(); key != "" {
+		return "openrouter", key, ai.OpenRouterModel(), true
+	}
+	return "", "", "", false
 }
 
 func nativeAgentInstanceName() string {

--- a/agent/native_default_test.go
+++ b/agent/native_default_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"mu/internal/ai"
 	"mu/internal/settings"
 )
 
@@ -24,6 +25,40 @@ func TestNativeEnabledDefault(t *testing.T) {
 	settings.Set("AGENT_NATIVE", "on")
 	if !nativeEnabled() {
 		t.Fatal("AGENT_NATIVE=on should keep it enabled")
+	}
+}
+
+func TestNativeLLM_OpenRouter(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	for _, k := range []string{"ATLAS_API_KEY", "OPENROUTER_API_KEY", "OPENROUTER_MODEL", "ANTHROPIC_API_KEY", "ANTHROPIC_MODEL"} {
+		t.Setenv(k, "")
+	}
+	prevAtlas := settings.Get("ATLAS_API_KEY")
+	prevOR := settings.Get("OPENROUTER_API_KEY")
+	prevModel := settings.Get("OPENROUTER_MODEL")
+	t.Cleanup(func() {
+		settings.Set("ATLAS_API_KEY", prevAtlas)
+		settings.Set("OPENROUTER_API_KEY", prevOR)
+		settings.Set("OPENROUTER_MODEL", prevModel)
+	})
+	settings.Set("ATLAS_API_KEY", "")
+	settings.Set("OPENROUTER_API_KEY", "")
+	settings.Set("OPENROUTER_MODEL", "")
+
+	if _, _, _, ok := nativeLLM(); ok {
+		t.Fatal("no cloud key: nativeLLM should be off")
+	}
+
+	settings.Set("OPENROUTER_API_KEY", "sk-or-test")
+	provider, key, model, ok := nativeLLM()
+	if !ok || provider != "openrouter" || key != "sk-or-test" || model != ai.ModelOpenRouter {
+		t.Fatalf("openrouter: provider=%q key=%q model=%q ok=%v", provider, key, model, ok)
+	}
+
+	settings.Set("ATLAS_API_KEY", "atlas-test")
+	provider, key, model, ok = nativeLLM()
+	if !ok || provider != "atlascloud" || key != "atlas-test" || model != ai.ModelDeepSeekPro {
+		t.Fatalf("atlas still wins: provider=%q key=%q model=%q ok=%v", provider, key, model, ok)
 	}
 }
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -37,6 +37,7 @@ admin, so the environment is for the things you want fixed at deploy time.
 # An AI provider — one of these, for the agent, chat and summaries
 export ANTHROPIC_API_KEY="your-key"   # Claude, from console.anthropic.com
 # export ATLAS_API_KEY="your-key"     # Atlas Cloud (DeepSeek, Qwen), also images
+# export OPENROUTER_API_KEY="your-key" # OpenRouter (one key, many models)
 # export OPENAI_BASE_URL="http://localhost:11434/v1"  # Ollama or any compatible endpoint
 
 # Video
@@ -328,6 +329,8 @@ one, the agent, chat and AI summaries are off and everything else works.
 | `ANTHROPIC_API_KEY` | Claude |
 | `ANTHROPIC_MODEL` · `ANTHROPIC_PREMIUM_MODEL` | Override the default models |
 | `ATLAS_API_KEY` | Atlas Cloud (DeepSeek, Qwen) — also image generation |
+| `OPENROUTER_API_KEY` | OpenRouter — one key for Claude, GPT, Gemini and the rest of their catalogue |
+| `OPENROUTER_MODEL` | Override the OpenRouter slug (default `openai/gpt-4o-mini`) |
 | `IMAGE_MODEL` | Override the image model |
 | `OPENAI_BASE_URL` · `OPENAI_API_KEY` | Any OpenAI-compatible endpoint — Ollama, vLLM, llama.cpp |
 | `AGENT_NATIVE` | `off` falls back to the hand-rolled planner |

--- a/internal/ai/ai.go
+++ b/internal/ai/ai.go
@@ -1,4 +1,5 @@
-// Package ai provides LLM integration for the Mu platform via Anthropic Claude.
+// Package ai provides LLM integration for the Mu platform — Anthropic,
+// Atlas Cloud, OpenRouter, and local OpenAI-compatible servers.
 package ai
 
 import (

--- a/internal/ai/micro.go
+++ b/internal/ai/micro.go
@@ -17,14 +17,21 @@ import (
 )
 
 // resolveProvider picks the go-micro ai provider and credentials for a model,
-// mirroring mu's existing routing: Atlas Cloud for its models, then Anthropic
-// if a key is set, otherwise a local OpenAI-compatible server (Ollama).
+// mirroring mu's existing routing: Atlas Cloud for its models, OpenRouter
+// for provider/model slugs, then Anthropic if a key is set, then OpenRouter
+// as the remaining cloud option, otherwise a local OpenAI-compatible server.
 func resolveProvider(model string) (provider, apiKey, baseURL string, err error) {
 	if isAtlasModel(model) && getAtlasAPIKey() != "" {
 		return "atlascloud", getAtlasAPIKey(), "", nil
 	}
+	if isOpenRouterModel(model) && getOpenRouterAPIKey() != "" {
+		return "openrouter", getOpenRouterAPIKey(), openRouterBaseURL, nil
+	}
 	if key := settings.Get("ANTHROPIC_API_KEY"); key != "" {
 		return "anthropic", key, "", nil
+	}
+	if key := getOpenRouterAPIKey(); key != "" {
+		return "openrouter", key, openRouterBaseURL, nil
 	}
 	localURL := settings.Get("OPENAI_BASE_URL")
 	localKey := settings.Get("OPENAI_API_KEY")
@@ -37,7 +44,7 @@ func resolveProvider(model string) (provider, apiKey, baseURL string, err error)
 		}
 		return "openai", localKey, localURL, nil
 	}
-	return "", "", "", fmt.Errorf("no AI provider configured — set ANTHROPIC_API_KEY, ATLAS_API_KEY or OPENAI_BASE_URL (Ollama)")
+	return "", "", "", fmt.Errorf("no AI provider configured — set ANTHROPIC_API_KEY, ATLAS_API_KEY, OPENROUTER_API_KEY or OPENAI_BASE_URL (Ollama)")
 }
 
 // generateViaMicro routes an LLM request through go-micro's ai package — the

--- a/internal/ai/openrouter.go
+++ b/internal/ai/openrouter.go
@@ -1,0 +1,58 @@
+package ai
+
+import (
+	"strings"
+
+	gmai "go-micro.dev/v6/ai"
+	"go-micro.dev/v6/ai/openai"
+
+	"mu/internal/settings"
+)
+
+// OpenRouter is an OpenAI-compatible aggregator. go-micro has no OpenRouter
+// provider and its agent cannot set a BaseURL, so Mu registers one itself —
+// the same pattern as Atlas/Anthropic, kept in this repo rather than pushed
+// upstream because Mu needed it.
+//
+// go-micro's openai client appends /v1/chat/completions, so the host is
+// https://openrouter.ai/api and not the /api/v1 base the OpenRouter docs
+// show for the OpenAI SDK.
+const openRouterBaseURL = "https://openrouter.ai/api"
+
+// ModelOpenRouter is the default OpenRouter slug for interactive and
+// background calls. Override with OPENROUTER_MODEL. It has to be a
+// provider/model slug OpenRouter recognises — not a bare Claude id —
+// and it has to support tool calling, because the native agent uses it.
+const ModelOpenRouter = "openai/gpt-4o-mini"
+
+func init() {
+	gmai.Register("openrouter", func(opts ...gmai.Option) gmai.Model {
+		opts = append([]gmai.Option{gmai.WithBaseURL(openRouterBaseURL)}, opts...)
+		return openai.NewProvider(opts...)
+	})
+	gmai.RegisterStream("openrouter")
+}
+
+func getOpenRouterAPIKey() string {
+	return settings.Get("OPENROUTER_API_KEY")
+}
+
+// OpenRouterKey is the configured OpenRouter API key, if any.
+func OpenRouterKey() string {
+	return getOpenRouterAPIKey()
+}
+
+// OpenRouterModel is the model slug sent to OpenRouter.
+func OpenRouterModel() string {
+	if m := settings.Get("OPENROUTER_MODEL"); m != "" {
+		return m
+	}
+	return ModelOpenRouter
+}
+
+// isOpenRouterModel reports whether the model id looks like an OpenRouter
+// slug (provider/model). Atlas slugs also contain a slash; those are
+// claimed first when an Atlas key is set.
+func isOpenRouterModel(model string) bool {
+	return strings.Contains(model, "/")
+}

--- a/internal/ai/openrouter_test.go
+++ b/internal/ai/openrouter_test.go
@@ -1,0 +1,139 @@
+package ai
+
+import (
+	"testing"
+
+	gmai "go-micro.dev/v6/ai"
+
+	"mu/internal/settings"
+)
+
+var providerSettingKeys = []string{
+	"ANTHROPIC_API_KEY",
+	"ANTHROPIC_MODEL",
+	"ATLAS_API_KEY",
+	"OPENAI_API_KEY",
+	"OPENAI_BASE_URL",
+	"OPENROUTER_API_KEY",
+	"OPENROUTER_MODEL",
+}
+
+// isolateProviderEnv points settings at a temp HOME and clears every AI
+// provider key, so these tests do not read the operator's env or write
+// their settings.json.
+func isolateProviderEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv("HOME", t.TempDir())
+	stored := map[string]string{}
+	for _, k := range providerSettingKeys {
+		t.Setenv(k, "")
+		stored[k] = settings.Get(k)
+		settings.Set(k, "")
+	}
+	t.Cleanup(func() {
+		for k, v := range stored {
+			settings.Set(k, v)
+		}
+	})
+}
+
+func TestOpenRouterProviderRegistered(t *testing.T) {
+	m := gmai.New("openrouter", gmai.WithAPIKey("sk-or-test"))
+	if m == nil {
+		t.Fatal("openrouter provider was not registered")
+	}
+	if m.String() != "openai" {
+		// The wrapper is go-micro's openai client pointed at OpenRouter.
+		t.Fatalf("String() = %q, want openai (wrapped client)", m.String())
+	}
+	if got := m.Options().BaseURL; got != openRouterBaseURL {
+		t.Fatalf("BaseURL = %q, want %q", got, openRouterBaseURL)
+	}
+}
+
+func TestConfigured_OpenRouter(t *testing.T) {
+	isolateProviderEnv(t)
+	settings.Set("OPENROUTER_API_KEY", "sk-or-test")
+	if !Configured() {
+		t.Fatal("OPENROUTER_API_KEY should count as configured")
+	}
+}
+
+func TestDefaultModel_OpenRouter(t *testing.T) {
+	isolateProviderEnv(t)
+
+	if got := DefaultModel(); got != "claude-sonnet-4-6" {
+		t.Fatalf("no cloud key: DefaultModel = %q, want claude-sonnet-4-6", got)
+	}
+
+	settings.Set("OPENROUTER_API_KEY", "sk-or-test")
+	if got := DefaultModel(); got != ModelOpenRouter {
+		t.Fatalf("openrouter only: DefaultModel = %q, want %q", got, ModelOpenRouter)
+	}
+
+	settings.Set("OPENROUTER_MODEL", "anthropic/claude-sonnet-4")
+	if got := DefaultModel(); got != "anthropic/claude-sonnet-4" {
+		t.Fatalf("OPENROUTER_MODEL: DefaultModel = %q", got)
+	}
+
+	settings.Set("ANTHROPIC_API_KEY", "sk-ant-test")
+	if got := DefaultModel(); got != "claude-sonnet-4-6" {
+		t.Fatalf("anthropic wins interactive: DefaultModel = %q, want claude-sonnet-4-6", got)
+	}
+}
+
+func TestBackgroundModel_OpenRouter(t *testing.T) {
+	isolateProviderEnv(t)
+	settings.Set("OPENROUTER_API_KEY", "sk-or-test")
+	if got := BackgroundModel(); got != ModelOpenRouter {
+		t.Fatalf("BackgroundModel = %q, want %q", got, ModelOpenRouter)
+	}
+	settings.Set("ATLAS_API_KEY", "atlas-test")
+	if got := BackgroundModel(); got != ModelDeepSeekFlash {
+		t.Fatalf("atlas still wins background: BackgroundModel = %q", got)
+	}
+}
+
+func TestResolveProvider_OpenRouter(t *testing.T) {
+	isolateProviderEnv(t)
+	settings.Set("OPENROUTER_API_KEY", "sk-or-test")
+
+	provider, key, base, err := resolveProvider(ModelOpenRouter)
+	if err != nil {
+		t.Fatalf("resolveProvider: %v", err)
+	}
+	if provider != "openrouter" || key != "sk-or-test" || base != openRouterBaseURL {
+		t.Fatalf("got provider=%q key=%q base=%q", provider, key, base)
+	}
+
+	// A bare Claude id still goes to OpenRouter when that is the only key —
+	// DefaultModel has already remapped, but a leftover caller must not
+	// fall through to "no provider".
+	provider, _, _, err = resolveProvider("claude-sonnet-4-6")
+	if err != nil || provider != "openrouter" {
+		t.Fatalf("bare claude id with only OpenRouter: provider=%q err=%v", provider, err)
+	}
+}
+
+func TestResolveProvider_OpenRouterDoesNotStealAtlas(t *testing.T) {
+	isolateProviderEnv(t)
+	settings.Set("ATLAS_API_KEY", "atlas-test")
+	settings.Set("OPENROUTER_API_KEY", "sk-or-test")
+
+	provider, key, _, err := resolveProvider(ModelDeepSeekFlash)
+	if err != nil {
+		t.Fatalf("resolveProvider: %v", err)
+	}
+	if provider != "atlascloud" || key != "atlas-test" {
+		t.Fatalf("atlas model should stay on Atlas, got provider=%q key=%q", provider, key)
+	}
+}
+
+func TestProviderName_OpenRouter(t *testing.T) {
+	if got := providerName("openai/gpt-4o-mini"); got != "openrouter" {
+		t.Fatalf("providerName = %q, want openrouter", got)
+	}
+	if got := providerName("deepseek-ai/deepseek-v4-flash"); got != "atlas" {
+		t.Fatalf("atlas slug should still be atlas, got %q", got)
+	}
+}

--- a/internal/ai/providers.go
+++ b/internal/ai/providers.go
@@ -45,6 +45,9 @@ func Configured() bool {
 	if getAtlasAPIKey() != "" {
 		return true
 	}
+	if getOpenRouterAPIKey() != "" {
+		return true
+	}
 	if settings.Get("OPENAI_BASE_URL") != "" {
 		return true
 	}
@@ -61,11 +64,15 @@ const (
 )
 
 // DefaultModel is the model used for interactive queries (chat, agent).
-// Always uses Anthropic for speed — Atlas Cloud is for background only.
+// Anthropic wins when its key is set. OpenRouter is the interactive
+// default only when it is the cloud provider in play — its slugs are
+// provider/model, and a bare Claude id would 400.
 func DefaultModel() string {
-	m := settings.Get("ANTHROPIC_MODEL")
-	if m != "" {
+	if m := settings.Get("ANTHROPIC_MODEL"); m != "" {
 		return m
+	}
+	if getOpenRouterAPIKey() != "" && settings.Get("ANTHROPIC_API_KEY") == "" {
+		return OpenRouterModel()
 	}
 	return "claude-sonnet-4-6"
 }
@@ -75,6 +82,9 @@ func DefaultModel() string {
 func BackgroundModel() string {
 	if getAtlasAPIKey() != "" {
 		return ModelDeepSeekFlash
+	}
+	if getOpenRouterAPIKey() != "" {
+		return OpenRouterModel()
 	}
 	return "claude-haiku-4-5-20251001"
 }

--- a/internal/ai/usage.go
+++ b/internal/ai/usage.go
@@ -58,6 +58,9 @@ func providerName(model string) string {
 		strings.Contains(model, "kimi") {
 		return "atlas"
 	}
+	if strings.Contains(model, "/") {
+		return "openrouter"
+	}
 	return "claude"
 }
 

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"mu/internal/settings"
+	"mu/internal/setup"
 )
 
 // runSetup is the `mu setup` wizard: a headless-friendly companion to the web
@@ -21,31 +22,29 @@ func runSetup(_ []string) int {
 	fmt.Println()
 	fmt.Println("  1) Anthropic Claude")
 	fmt.Println("  2) Atlas Cloud / DeepSeek")
-	fmt.Println("  3) Ollama / OpenAI-compatible (local)")
-	choice := prompt(in, "Provider [1-3]: ")
+	fmt.Println("  3) OpenRouter")
+	fmt.Println("  4) Ollama / OpenAI-compatible (local)")
+	choice := prompt(in, "Provider [1-4]: ")
 
+	var provider, key, baseURL string
 	switch choice {
 	case "1":
-		key := prompt(in, "Anthropic API key: ")
-		if key == "" {
-			return setupErr("no key entered")
-		}
-		settings.Set("ANTHROPIC_API_KEY", key)
+		provider = "claude"
+		key = prompt(in, "Anthropic API key: ")
 	case "2":
-		key := prompt(in, "Atlas Cloud API key: ")
-		if key == "" {
-			return setupErr("no key entered")
-		}
-		settings.Set("ATLAS_API_KEY", key)
+		provider = "atlas"
+		key = prompt(in, "Atlas Cloud API key: ")
 	case "3":
-		url := prompt(in, "Base URL [http://localhost:11434/v1]: ")
-		if url == "" {
-			url = "http://localhost:11434/v1"
-		}
-		settings.Set("OPENAI_BASE_URL", url)
-		settings.Set("OPENAI_API_KEY", "ollama")
+		provider = "openrouter"
+		key = prompt(in, "OpenRouter API key: ")
+	case "4":
+		provider = "ollama"
+		baseURL = prompt(in, "Base URL [http://localhost:11434/v1]: ")
 	default:
-		return setupErr("pick 1, 2 or 3")
+		return setupErr("pick 1, 2, 3 or 4")
+	}
+	if err := setup.ApplyProvider(provider, key, baseURL); err != nil {
+		return setupErr(err.Error())
 	}
 
 	fmt.Println()

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -5,6 +5,7 @@
 package setup
 
 import (
+	"errors"
 	"html"
 	"net/http"
 	"strings"
@@ -56,28 +57,8 @@ func applySetup(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Resolve the AI provider into the settings keys the runtime reads.
-	switch provider {
-	case "claude":
-		if key == "" {
-			w.Write([]byte(render("Enter your Anthropic API key, or pick another provider.")))
-			return
-		}
-		settings.Set("ANTHROPIC_API_KEY", key)
-	case "atlas":
-		if key == "" {
-			w.Write([]byte(render("Enter your Atlas Cloud API key, or pick another provider.")))
-			return
-		}
-		settings.Set("ATLAS_API_KEY", key)
-	case "ollama":
-		if baseURL == "" {
-			baseURL = "http://localhost:11434/v1"
-		}
-		settings.Set("OPENAI_BASE_URL", baseURL)
-		settings.Set("OPENAI_API_KEY", "ollama")
-	default:
-		w.Write([]byte(render("Pick an AI provider.")))
+	if err := ApplyProvider(provider, key, baseURL); err != nil {
+		w.Write([]byte(render(err.Error())))
 		return
 	}
 
@@ -105,6 +86,37 @@ func applySetup(w http.ResponseWriter, r *http.Request) {
 	http.Redirect(w, r, "/home", http.StatusSeeOther)
 }
 
+// ApplyProvider writes the chosen AI provider into the settings keys the
+// runtime reads. Shared by the web wizard and `mu setup`.
+func ApplyProvider(provider, key, baseURL string) error {
+	switch provider {
+	case "claude":
+		if key == "" {
+			return errors.New("Enter your Anthropic API key, or pick another provider.")
+		}
+		settings.Set("ANTHROPIC_API_KEY", key)
+	case "atlas":
+		if key == "" {
+			return errors.New("Enter your Atlas Cloud API key, or pick another provider.")
+		}
+		settings.Set("ATLAS_API_KEY", key)
+	case "openrouter":
+		if key == "" {
+			return errors.New("Enter your OpenRouter API key, or pick another provider.")
+		}
+		settings.Set("OPENROUTER_API_KEY", key)
+	case "ollama":
+		if baseURL == "" {
+			baseURL = "http://localhost:11434/v1"
+		}
+		settings.Set("OPENAI_BASE_URL", baseURL)
+		settings.Set("OPENAI_API_KEY", "ollama")
+	default:
+		return errors.New("Pick an AI provider.")
+	}
+	return nil
+}
+
 func render(errMsg string) string {
 	errHTML := ""
 	if errMsg != "" {
@@ -124,8 +136,9 @@ func render(errMsg string) string {
     <h3 style="margin:0 0 8px;font-size:1em">2 · AI provider</h3>
     <label style="display:block;margin:0 0 6px"><input type="radio" name="provider" value="claude" checked> Anthropic Claude</label>
     <label style="display:block;margin:0 0 6px"><input type="radio" name="provider" value="atlas"> Atlas Cloud / DeepSeek</label>
+    <label style="display:block;margin:0 0 6px"><input type="radio" name="provider" value="openrouter"> OpenRouter</label>
     <label style="display:block;margin:0 0 12px"><input type="radio" name="provider" value="ollama"> Ollama / OpenAI-compatible (local)</label>
-    <input name="key" placeholder="API key (Claude or Atlas)"
+    <input name="key" placeholder="API key (Claude, Atlas or OpenRouter)"
       style="width:100%;padding:10px;margin:0 0 8px;border:1px solid #ddd;border-radius:6px;font-size:15px">
     <input name="base_url" placeholder="Ollama base URL (default http://localhost:11434/v1)"
       style="width:100%;padding:10px;margin:0 0 20px;border:1px solid #ddd;border-radius:6px;font-size:15px">

--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -1,0 +1,31 @@
+package setup
+
+import (
+	"testing"
+
+	"mu/internal/settings"
+)
+
+func TestApplyProvider_OpenRouter(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("OPENROUTER_API_KEY", "")
+	prev := settings.Get("OPENROUTER_API_KEY")
+	t.Cleanup(func() { settings.Set("OPENROUTER_API_KEY", prev) })
+	settings.Set("OPENROUTER_API_KEY", "")
+
+	if err := ApplyProvider("openrouter", "", ""); err == nil {
+		t.Fatal("empty key should fail")
+	}
+	if err := ApplyProvider("openrouter", "sk-or-test", ""); err != nil {
+		t.Fatalf("ApplyProvider: %v", err)
+	}
+	if got := settings.Get("OPENROUTER_API_KEY"); got != "sk-or-test" {
+		t.Fatalf("OPENROUTER_API_KEY = %q", got)
+	}
+}
+
+func TestApplyProvider_Unknown(t *testing.T) {
+	if err := ApplyProvider("nope", "k", ""); err == nil {
+		t.Fatal("unknown provider should fail")
+	}
+}


### PR DESCRIPTION
A self-hosted instance could already point OPENAI_BASE_URL at an OpenAI-compatible host, but that path remapped Claude ids to a local model, treated OPENAI_API_KEY as Atlas, and never reached the native agent — go-micro's agent cannot set a BaseURL. OpenRouter is now its own key and provider, registered in Mu rather than pushed upstream, so setup, chat, summaries and the native agent all work with one key.