### PR TITLE
fix(data): close SQLite handle after migration tests

### DIFF
--- a/internal/data/sqlite_test.go
+++ b/internal/data/sqlite_test.go
@@ -9,18 +9,23 @@ import (
 
 var sqliteTestMu sync.Mutex
 
-func resetSQLiteTestDB(t *testing.T) string {
-	t.Helper()
-	sqliteTestMu.Lock()
-	t.Cleanup(sqliteTestMu.Unlock)
-	tempDir := t.TempDir()
-	t.Setenv("HOME", tempDir)
+func closeSQLiteDB() {
 	if db != nil {
 		_ = db.Close()
 	}
 	dbOnce = sync.Once{}
 	db = nil
 	dbPath = ""
+}
+
+func resetSQLiteTestDB(t *testing.T) string {
+	t.Helper()
+	sqliteTestMu.Lock()
+	t.Cleanup(sqliteTestMu.Unlock)
+	tempDir := t.TempDir()
+	t.Setenv("HOME", tempDir)
+	closeSQLiteDB()
+	t.Cleanup(closeSQLiteDB)
 	return tempDir
 }
 


### PR DESCRIPTION
## Summary

TestSQLiteMigration left the global SQLite handle open until TempDir cleanup, which fails on Windows and can flake under CI. Close and reset the handle in test cleanup via `closeSQLiteDB()` registered on `t.Cleanup`.

## Verify

```bash
go test ./internal/data/ -run TestSQLiteMigration -count=3
```

Local verify exited **0** after this change.

## Context

- Upstream CI signal: https://github.com/micro/mu/actions/runs/31570266120
- Target: `micro/mu`

## Notes

Minimal fix only — test teardown only, no production logic changes.

---
*This change was made by **kramlipi code-agent** automation.*

Co-authored-by: kramlipi ai-code-agent <cluevion@gmail.com>

Questions: cluevion@gmail.com · https://www.kramlipi.com · https://kramlipi.github.io/