### PR TITLE
Analyse running the model on one host

### DIFF
--- a/docs/MODEL.md
+++ b/docs/MODEL.md
@@ -77,6 +77,156 @@ Stated plainly, because a roadmap that only lists strengths is marketing.
   34 services hand-build a page; 15 render an at-a-glance card. Uniformity
   underneath produces neither.
 
+## Running the model on one host
+
+This means **inference**, not training a foundation model. Training something
+comparable to the models from Anthropic, Google, or OpenAI is a cluster-scale
+research programme: data, pre-training, post-training, evaluations, safety, and
+repeated failed runs. One machine can serve an open-weight model and adapt it;
+it cannot reproduce that programme.
+
+"Comparable" also needs a boundary. One host can be comparable for Mu's actual
+distribution of short answers and tool calls. It will not match every frontier
+model on long context, difficult coding, multimodal work, every language, and
+peak concurrent traffic. The decision is therefore made against a replayable
+Mu evaluation set, not a public leaderboard or a parameter count.
+
+### What one host is
+
+The serious version is an eight-GPU HGX-class server, not the CPU box running
+the Go binary. Eight H200s provide 1,128 GB of aggregate GPU memory; each H200
+has 141 GB of HBM3e and a 700 W maximum thermal design power. GPU memory is not
+ordinary RAM: weights, the attention cache, and temporary working memory must
+fit there, and crossing GPUs makes the interconnect part of the machine.
+
+That is enough to serve a strong 70B-class dense model without severe
+quantisation, or a much larger quantised or mixture-of-experts model. It is not
+a promise of quality. A model that fits may still be bad at choosing Mu tools,
+and a model that produces a good token in isolation may still have poor
+throughput once several agents are running.
+
+A smaller two- or four-GPU machine is a useful evaluation and low-traffic
+deployment. It is not an honest basis for claiming frontier-comparable service.
+An eight-GPU machine is still one failure domain: maintenance, a driver fault,
+or a failed power supply takes all model calls down.
+
+### Cost basis
+
+These are planning numbers, in USD, before tax, dated September 2026. They are
+deliberately ranges: a physical system is quote-priced, and power, rack, and
+support vary more than a precise-looking estimate suggests.
+
+| Cost | Own one eight-GPU host | Rent one eight-GPU host |
+|---|---:|---:|
+| GPUs, server, NVSwitch, CPUs, RAM, local storage | $250k-$400k once | included |
+| Accelerator power | 5.6 kW maximum for eight H200s | included |
+| Whole-host power and cooling budget | 8-10 kW | included |
+| Electricity at $0.10-$0.25/kWh and PUE 1.2-1.5 | about $700-$2,700/month | included |
+| Rack, network, spares, support | site-specific | included to the provider's terms |
+| Current cloud reference | — | eight H100s at $3.99/GPU-hour: $31.92/hour, about $23.3k per 30-day month |
+
+The cloud line is a reference rather than an H200 equivalence. Lambda publishes
+that on-demand H100 SXM rate, while availability and reserved pricing change.
+At full utilisation, owning can amortise below renting. At low or uncertain
+utilisation, APIs win because idle GPUs cost nothing. Hardware also has an
+opportunity cost: money is committed before the workload and useful life are
+known.
+
+API comparison must use a measured request shape. At Anthropic's published
+Sonnet 5 price of $2 per million input tokens and $10 per million output tokens,
+a run with 10,000 input and 2,000 output tokens costs $0.04 before caching or
+tool-provider costs. $23.3k buys roughly 582,000 such runs in a month. If Mu is
+well below that volume, renting an always-on eight-GPU host does not save model
+cost; if it is above it and can keep the host busy, the calculation can reverse.
+The same calculation must be repeated from Mu's usage log because input/output
+ratio, cache hits, batch traffic, and model tier change the answer.
+
+Sources for the assumptions: [NVIDIA H200 specifications](https://www.nvidia.com/en-us/data-center/h200/),
+[AWS's eight-H200 instance memory and interconnect description](https://aws.amazon.com/ec2/instance-types/p5/),
+[Lambda GPU Cloud pricing](https://lambda.ai/service/gpu-cloud), and
+[Anthropic model pricing](https://docs.anthropic.com/en/docs/about-claude/pricing).
+
+### Benefits
+
+- Prompts, retrieved private records, tool results, and model outputs can remain
+  on the operator's machine. This benefit disappears for any request routed to
+  an upstream fallback.
+- The weights, system prompt, decoding, retention, upgrade date, and availability
+  policy are under one operator's control. A vendor cannot silently move an
+  alias or withdraw a model.
+- A busy, batchable workload turns a fixed machine into a predictable marginal
+  cost, and local retrieval avoids sending large private contexts over the
+  network.
+- Mu can fine-tune or preference-train for its own tool grammar and failure
+  modes rather than optimising for a general chat benchmark.
+
+### Costs and disadvantages
+
+- Quality is no longer bought as a service. Model selection, serving, drivers,
+  quantisation, evaluation, abuse handling, upgrades, and incident response all
+  become our work.
+- Capacity is a ceiling. Interactive latency and background jobs compete for
+  the same GPUs; a traffic spike queues rather than borrowing a vendor's fleet.
+- One host has neither redundancy nor a maintenance window without downtime.
+  A second host is the first real high-availability feature and almost doubles
+  the fixed cost.
+- Open weights provide control, not automatically permission for every use.
+  Each model's licence, acceptable-use terms, and redistribution conditions
+  still need review.
+- Quantisation saves memory and often throughput cost, but can damage exactly
+  the rare tool-choice and structured-output cases that matter. It must be
+  evaluated, not assumed harmless.
+- Privacy shifts rather than becoming automatic: logs, traces, swap, crash
+  dumps, backups, administrators, and the tools called by the model remain data
+  paths to secure.
+
+### How to reach comparable product performance
+
+1. **Define the target from production.** Build a redacted, consented replay set
+   stratified by client, agent, tool, context length, language, and destructive
+   action. Record answer quality, correct tool and arguments, unsupported claims,
+   policy failures, time to first token, total latency, and cost. Keep destructive
+   calls in a simulator.
+2. **Rent before buying.** Run the candidate on one eight-GPU node for 30 days.
+   Shadow traffic first, then opt-in traffic. This discovers memory, concurrency,
+   and tokens-per-second requirements without making the hardware decision the
+   model decision.
+3. **Choose on the Mu set.** Test several current open-weight models at BF16/FP8
+   and conservative quantisations. Reject any candidate that cannot reliably
+   emit the native tool calls and schemas used by `runNative`, regardless of its
+   leaderboard score.
+4. **Optimise the serving path.** Use a production continuous-batching server,
+   prefix/prompt caching, paged attention, bounded contexts, admission control,
+   and separate interactive from batch queues. Quantise only after establishing
+   the unquantised quality baseline. Speculative decoding is useful only when
+   measurements show its draft model repays the extra memory.
+5. **Train the narrow gap.** Curate failed Mu traces, correct them, and use
+   supervised fine-tuning or preference optimisation for tool selection,
+   argument construction, refusal, and house style. Do not try to pre-train a
+   general model. Re-run held-out and destructive-action evaluations after every
+   model, prompt, runtime, or quantisation change.
+6. **Make the limit visible.** Set concurrency and latency objectives, queue
+   background work, shed load cleanly, and return an error when the model is
+   unavailable. An upstream escape hatch is a separate product mode because it
+   changes the privacy claim; it must be explicit per operator and per account,
+   never a silent fallback.
+
+### Decision
+
+Do not buy the host yet. First instrument input tokens, output tokens, cacheable
+prefixes, concurrency, latency, and vendor spend by workload; then conduct the
+rented-node evaluation above. Buy only when the candidate clears the Mu quality
+and latency gates, observed steady demand can keep it usefully occupied, and
+the three-year owned cost including power, support, labour, and a downtime plan
+beats the measured API alternative.
+
+That experiment buys the information the capital decision needs. If the local
+model clears ordinary Mu work but not the hardest tail, the honest outcomes are
+either a local-only product with a stated capability boundary or an explicit
+hybrid mode with a weaker privacy boundary. Calling a silent frontier fallback
+"self-hosted" would obtain the benchmark result by giving up the reason to run
+the model.
+
 ## The order of work
 
 1. **Prove federation against a real server.** The code is written; what is


### PR DESCRIPTION
## Summary

- define what one self-hosted inference machine can and cannot achieve relative to frontier providers
- give a dated cost basis for owning, renting, and continuing to pay per token
- document the privacy, control, capacity, reliability, licensing, and operational tradeoffs
- propose a production-replay evaluation, rented eight-GPU trial, serving optimisations, and narrow post-training plan
- recommend measuring and renting before making the capital purchase

## Checks

- `git diff --check`

## Sources

The note links the primary NVIDIA, AWS, Lambda, and Anthropic pages used for hardware specifications and current reference pricing.
