### PR TITLE
Preserve M3O as a public MCP surface

### DIFF
--- a/internal/origin/origin.go
+++ b/internal/origin/origin.go
@@ -24,29 +24,44 @@ import (
 	"mu/internal/settings"
 )
 
-// URL returns the public origin — "https://micro.mu" — for anything a caller
-// outside this process will read back: an OAuth issuer, an x402 resource
-// identifier, a payment return URL, a link in an email.
+// URL returns the public origin for anything a caller outside this process will
+// read back: an OAuth issuer, an x402 resource identifier, a payment return URL,
+// a link in an email.
 //
-// r.Host cannot be used on its own. Mu runs behind a reverse proxy that
-// forwards to a loopback port, so r.Host is "localhost:8081" and any URL built
-// from it names an address no client can reach.
+// An operator may expose one Mu process through a second, machine-facing public
+// surface (for example m3o.com in front of micro.mu). That surface is selected
+// by the trusted reverse proxy with X-Mu-Surface. In that case the forwarded
+// host is the public identity of this request and must win over MU_DOMAIN;
+// otherwise an agent calling m3o.com/mcp receives an x402 or OAuth URL naming
+// micro.mu and the public boundary leaks.
 //
-// Order: MU_DOMAIN when configured, then the proxy's X-Forwarded-Host, then
-// r.Host. X-Forwarded-Host is only trustworthy because the proxy sets it; a
-// directly exposed instance would be taking it from the client, which is the
-// same assumption ClientIP already makes.
+// X-Mu-Surface deliberately does not contain a hostname. The proxy selects the
+// surface; X-Forwarded-Host says which public host the request used. This keeps
+// the mechanism domain-agnostic and gives self-hosters the same capability.
+//
+// Without an explicit surface, MU_DOMAIN remains authoritative. r.Host cannot
+// be used on its own behind a reverse proxy because it may be localhost:8081.
 func URL(r *http.Request) string {
+	if strings.TrimSpace(r.Header.Get("X-Mu-Surface")) != "" {
+		if h := forwardedHost(r); h != "" {
+			return scheme(r) + "://" + trimScheme(h)
+		}
+	}
 	if u := Self(); u != "" {
 		return u
 	}
-	if h := strings.TrimSpace(r.Header.Get("X-Forwarded-Host")); h != "" {
-		if i := strings.Index(h, ","); i > 0 {
-			h = strings.TrimSpace(h[:i])
-		}
+	if h := forwardedHost(r); h != "" {
 		return scheme(r) + "://" + trimScheme(h)
 	}
 	return scheme(r) + "://" + r.Host
+}
+
+func forwardedHost(r *http.Request) string {
+	h := strings.TrimSpace(r.Header.Get("X-Forwarded-Host"))
+	if i := strings.Index(h, ","); i > 0 {
+		h = strings.TrimSpace(h[:i])
+	}
+	return h
 }
 
 // Self is the public origin when there is no request to derive it from.

--- a/internal/origin/origin_test.go
+++ b/internal/origin/origin_test.go
@@ -20,6 +20,29 @@ func TestURLIgnoresTheLoopbackHostBehindAProxy(t *testing.T) {
 	}
 }
 
+// A second public surface is a request identity, not a second deployment. The
+// configured instance domain still names background work, while a request that
+// entered through m3o.com must advertise m3o.com in OAuth and x402 responses.
+func TestURLPreservesExplicitPublicSurface(t *testing.T) {
+	t.Setenv("MU_DOMAIN", "micro.mu")
+
+	r := httptest.NewRequest("POST", "/mcp", nil)
+	r.Host = "localhost:8081"
+	r.Header.Set("X-Mu-Surface", "m3o")
+	r.Header.Set("X-Forwarded-Host", "m3o.com")
+	r.Header.Set("X-Forwarded-Proto", "https")
+	if got := URL(r); got != "https://m3o.com" {
+		t.Fatalf("URL = %q, want https://m3o.com", got)
+	}
+
+	// Merely forwarding a different host does not override the configured
+	// canonical instance. The proxy has to opt into a second public surface.
+	r.Header.Del("X-Mu-Surface")
+	if got := URL(r); got != "https://micro.mu" {
+		t.Fatalf("URL without surface = %q, want https://micro.mu", got)
+	}
+}
+
 func TestURLFallsBackThroughTheProxyThenTheHost(t *testing.T) {
 	t.Setenv("MU_DOMAIN", "")
 


### PR DESCRIPTION
## Why

M3O is again a public machine-facing entry point to the same Mu instance. Today `MU_DOMAIN=micro.mu` wins inside `origin.URL`, so a request proxied through `m3o.com/mcp` can receive OAuth/x402 resource URLs naming `micro.mu`. That makes the vanity surface leak its origin and can break clients that validate the resource they are paying for.

## What

- add a small, domain-agnostic `X-Mu-Surface` proxy contract
- when that header is present, use trusted `X-Forwarded-Host` as the request's public origin
- keep `MU_DOMAIN` authoritative for normal requests and background work
- add regression coverage for `m3o.com -> micro.mu` and for the non-surface case

This deliberately does **not** restore the old developer portal, host-derived branding, or M3O-specific code paths. It only restores the public-origin boundary needed for a second machine-facing domain.

Expected proxy shape:

```nginx
proxy_set_header Host $host;
proxy_set_header X-Forwarded-Host $host;
proxy_set_header X-Forwarded-Proto $scheme;
proxy_set_header X-Mu-Surface m3o;
```

Then a call to `https://m3o.com/mcp` advertises `https://m3o.com/...`, while ordinary `micro.mu` requests and background jobs continue to use the configured `MU_DOMAIN`.