### PR TITLE
Publish M3O MCP tools to x402 Bazaar

### DIFF
--- a/internal/api/describe.go
+++ b/internal/api/describe.go
@@ -43,3 +43,19 @@ func ToolByName(name string) (Tool, bool) {
 	}
 	return Tool{}, false
 }
+
+// ToolForWalletOp maps the operation known by the payment gate back to the
+// canonical MCP tool that sells it. This lets discovery reuse the MCP registry
+// instead of carrying a second list of tool names, descriptions and schemas.
+func ToolForWalletOp(op string) (Tool, bool) {
+	if op == "" {
+		return Tool{}, false
+	}
+	for i := range tools {
+		if tools[i].RESTOnly || tools[i].Name == "" || tools[i].WalletOp != op {
+			continue
+		}
+		return tools[i], true
+	}
+	return Tool{}, false
+}

--- a/internal/server/bazaar.go
+++ b/internal/server/bazaar.go
@@ -1,0 +1,16 @@
+package server
+
+import (
+	"mu/internal/api"
+	"mu/internal/x402"
+)
+
+func init() {
+	x402.BazaarLookup = func(op string) (string, string, map[string]any, bool) {
+		t, ok := api.ToolForWalletOp(op)
+		if !ok {
+			return "", "", nil, false
+		}
+		return t.Name, t.Description, api.ToolSchema(t), true
+	}
+}

--- a/internal/x402/bazaar.go
+++ b/internal/x402/bazaar.go
@@ -1,25 +1,94 @@
 package x402
 
-// The bazaar, and why there is not one.
-//
-// There was a discovery extension here. The x402 Bazaar is the ecosystem's
-// answer to "a priced endpoint nobody can find is a shop with the lights off":
-// facilitators index resources by reading an extension out of the 402 challenge
-// itself, so you are listed at the moment a facilitator asks what you charge.
-// It suited an MCP server exactly, because every field a listing wants — tool
-// name, description, argument schema — is what tools/list already publishes.
-//
-// It was off by default and stayed off, which is the part worth reading twice.
-// Listing tells a third party that this instance exists, what it sells and what
-// it charges, and buys discovery by an index nobody is searching. There are no
-// other Mu servers. Federation needs something to federate with, and when there
-// is, DNS is how instances will find each other rather than a facilitator's
-// catalogue — a Mu instance is already a domain with services under it, which
-// is the same shape mail has used for forty years.
-//
-// So the setting is gone rather than defaulted off. A switch for something that
-// is not going to happen is a decision left lying around for somebody to make
-// by accident.
-//
-// The word is worth keeping in mind, though. A bazaar is a marketplace, and
-// being one is a better ambition than being listed in somebody else's.
+import (
+	"net/url"
+	"strings"
+
+	"mu/internal/settings"
+)
+
+const mcpTransport = "streamable-http"
+
+// BazaarLookup is wired by the server to the MCP registry. It returns the
+// canonical tool name, description and input schema for a priced operation.
+var BazaarLookup func(op string) (name, description string, inputSchema map[string]any, ok bool)
+
+// BazaarExtensions describes one paid MCP tool for the x402 Bazaar. It is
+// emitted only when the resource is on an alternate public host (for example
+// m3o.com in front of micro.mu), so self-hosted Mu instances remain
+// private-by-default while an explicitly exposed machine surface is findable.
+func BazaarExtensions(op, resource string) map[string]any {
+	if !alternatePublicResource(resource) || BazaarLookup == nil {
+		return nil
+	}
+	name, description, inputSchema, ok := BazaarLookup(op)
+	if !ok || strings.TrimSpace(name) == "" {
+		return nil
+	}
+	if inputSchema == nil {
+		inputSchema = map[string]any{"type": "object", "properties": map[string]any{}}
+	}
+
+	input := map[string]any{
+		"type":        "mcp",
+		"toolName":    name,
+		"inputSchema": inputSchema,
+		"transport":   mcpTransport,
+	}
+	if d := strings.TrimSpace(description); d != "" {
+		input["description"] = d
+	}
+
+	inputProps := map[string]any{
+		"type":        map[string]any{"type": "string", "const": "mcp"},
+		"toolName":    map[string]any{"type": "string"},
+		"inputSchema": map[string]any{"type": "object"},
+		"transport":   map[string]any{"type": "string", "enum": []string{mcpTransport}},
+	}
+	if _, ok := input["description"]; ok {
+		inputProps["description"] = map[string]any{"type": "string"}
+	}
+
+	return map[string]any{
+		"bazaar": map[string]any{
+			"info": map[string]any{"input": input},
+			"schema": map[string]any{
+				"$schema": "https://json-schema.org/draft/2020-12/schema",
+				"type":    "object",
+				"properties": map[string]any{
+					"input": map[string]any{
+						"type":                 "object",
+						"properties":           inputProps,
+						"required":             []string{"type", "toolName", "inputSchema"},
+						"additionalProperties": false,
+					},
+				},
+				"required": []string{"input"},
+			},
+		},
+	}
+}
+
+func alternatePublicResource(resource string) bool {
+	u, err := url.Parse(strings.TrimSpace(resource))
+	if err != nil || u.Hostname() == "" {
+		return false
+	}
+	configured := configuredHost()
+	return configured != "" && strings.ToLower(u.Hostname()) != configured
+}
+
+func configuredHost() string {
+	if v := strings.TrimSpace(settings.Get("MU_DOMAIN")); v != "" {
+		v = strings.TrimPrefix(strings.TrimPrefix(v, "https://"), "http://")
+		if u, err := url.Parse("https://" + v); err == nil {
+			return strings.ToLower(u.Hostname())
+		}
+	}
+	if v := strings.TrimSpace(settings.Get("APP_URL")); v != "" {
+		if u, err := url.Parse(v); err == nil {
+			return strings.ToLower(u.Hostname())
+		}
+	}
+	return ""
+}

--- a/internal/x402/bazaar_test.go
+++ b/internal/x402/bazaar_test.go
@@ -1,0 +1,50 @@
+package x402
+
+import "testing"
+
+func TestBazaarExtensionsOnlyOnAlternatePublicSurface(t *testing.T) {
+	t.Setenv("MU_DOMAIN", "micro.mu")
+	old := BazaarLookup
+	t.Cleanup(func() { BazaarLookup = old })
+	BazaarLookup = func(op string) (string, string, map[string]any, bool) {
+		if op != "web_search" {
+			t.Fatalf("lookup op = %q", op)
+		}
+		return "web_search", "Search the web", map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"query": map[string]any{"type": "string"},
+			},
+			"required": []string{"query"},
+		}, true
+	}
+
+	if got := BazaarExtensions("web_search", "https://micro.mu/mcp"); got != nil {
+		t.Fatalf("primary surface unexpectedly advertised Bazaar metadata: %#v", got)
+	}
+
+	ext := BazaarExtensions("web_search", "https://m3o.com/mcp")
+	if ext == nil {
+		t.Fatal("alternate public surface did not advertise Bazaar metadata")
+	}
+	bazaar, ok := ext["bazaar"].(map[string]any)
+	if !ok {
+		t.Fatalf("bazaar extension missing: %#v", ext)
+	}
+	info := bazaar["info"].(map[string]any)
+	input := info["input"].(map[string]any)
+	if got := input["type"]; got != "mcp" {
+		t.Fatalf("input.type = %#v", got)
+	}
+	if got := input["toolName"]; got != "web_search" {
+		t.Fatalf("toolName = %#v", got)
+	}
+	if got := input["transport"]; got != "streamable-http" {
+		t.Fatalf("transport = %#v", got)
+	}
+	schema := input["inputSchema"].(map[string]any)
+	required := schema["required"].([]string)
+	if len(required) != 1 || required[0] != "query" {
+		t.Fatalf("input schema required = %#v", required)
+	}
+}

--- a/internal/x402/x402.go
+++ b/internal/x402/x402.go
@@ -324,6 +324,9 @@ func WritePaymentRequired(w http.ResponseWriter, operation, resource string, ext
 	if reason == "" {
 		reason = "Payment required. Choose an entry from accepts, submit payment, and retry."
 	}
+	if extensions == nil {
+		extensions = BazaarExtensions(operation, resource)
+	}
 	body := map[string]any{
 		"x402Version": x402Ver(),
 		"error":       reason,


### PR DESCRIPTION
## Why

M3O is now an explicit machine-facing public surface for the Mu MCP endpoint. Its paid tools should be discoverable by agents through x402 Bazaar without turning Bazaar publication back on for every self-hosted Mu instance.

## What

- restore x402 v2 Bazaar discovery metadata for alternate public resource hosts such as `m3o.com`
- keep the primary configured Mu host private-by-default
- derive tool name, description and JSON input schema from the existing MCP registry rather than maintaining a second catalogue
- advertise the MCP transport as `streamable-http`
- auto-attach the discovery extension when a 402 challenge has no explicit extensions
- add a regression test proving `micro.mu` stays unadvertised while `m3o.com` gets the Bazaar MCP metadata

The x402 challenge writer itself changes by only three lines; the rest is isolated discovery wiring.