### PR TITLE
Print x402 settlement and Bazaar status

### DIFF
--- a/internal/cli/x402pay.go
+++ b/internal/cli/x402pay.go
@@ -14,10 +14,6 @@ package cli
 //
 //	mu x402 call web_search query="x402"
 //	mu x402 call --server https://micro.mu weather_forecast lat=51.5 lon=-0.12
-//
-// It is deliberately not a tool the agent can call. What spends money here is a
-// person at a terminal with a key in a file, which is the one arrangement where
-// "it paid without asking" is not a surprise.
 
 import (
 	"context"
@@ -34,7 +30,6 @@ import (
 
 // runX402Pay handles `mu x402 call ...`.
 func runX402Pay(args []string, rc *ResolvedConfig) int {
-	// See runAgent: --server, then whatever the rest of the binary is using.
 	flagServer := ""
 	seedPath := ""
 	var rest []string
@@ -76,10 +71,6 @@ func runX402Pay(args []string, rc *ResolvedConfig) int {
 		toolArgs[k] = typedArg(v)
 	}
 
-	// The wallet is optional, because most of the catalogue is free and calling
-	// a free tool with no credentials and no key is the clearest demonstration
-	// there is of what this endpoint offers. It is only needed if the server
-	// answers 402, and the error then says so.
 	bw, err := walletFromSeed(seedPath)
 	if err != nil {
 		fmt.Printf("no wallet (%v) — free tools will still answer\n", err)
@@ -90,10 +81,7 @@ func runX402Pay(args []string, rc *ResolvedConfig) int {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
-	// No account id: this is the anonymous path, which is the entire point —
-	// the caller has no login here and the payment is the identity. The daily
-	// cap that argument meters is the instance's own, and there is no instance.
-	out, err := wallet.PayAndCallMCP(ctx, "", server, tool, toolArgs, bw)
+	out, err := wallet.PayAndCallMCPWithReceipt(ctx, "", server, tool, toolArgs, bw)
 	if err != nil {
 		fmt.Println("failed:", err)
 		if bw == nil && strings.Contains(err.Error(), "no wallet") {
@@ -104,16 +92,19 @@ func runX402Pay(args []string, rc *ResolvedConfig) int {
 		}
 		return 1
 	}
-	fmt.Println(out)
+
+	if out.Settlement != nil {
+		fmt.Printf("settled: %s on %s\n", out.Settlement.Transaction, out.Settlement.Network)
+		if out.ExtensionResponses != "" {
+			fmt.Printf("extensions: %s\n", out.ExtensionResponses)
+		} else {
+			fmt.Println("extensions: none returned by server")
+		}
+	}
+	fmt.Println(out.Text)
 	return 0
 }
 
-// walletFromSeed loads a Base wallet from a private key on disk.
-//
-// The same file `mu x402 key` audits, so an operator who has already checked
-// which address they control pays from that one. Read here rather than through
-// EnsureFor, because that keys wallets by account and there is no
-// account in this flow.
 func walletFromSeed(path string) (*wallet.BaseWallet, error) {
 	if path == "" {
 		home, err := os.UserHomeDir()
@@ -134,22 +125,6 @@ func walletFromSeed(path string) (*wallet.BaseWallet, error) {
 	return &wallet.BaseWallet{Address: addr, PrivateKey: key}, nil
 }
 
-// typedArg reads a command-line value as the JSON type it looks like.
-//
-// Everything off a command line is a string, and the tools are not: lat is a
-// float64 and limit is an int, so `mu x402 call weather_forecast lat=51.5`
-// arrived as "51.5" and was refused with "cannot unmarshal string into Go
-// struct field ForecastRequest.lat".
-//
-// Which cost real money. The payment is settled at the door, before the tool
-// runs and therefore before anything looks at the arguments — so a typo in a
-// number was a charge with no answer. The flag path (`mu weather forecast
-// --lat 51.5`) has always coerced properly; only the x402 path did not, and it
-// is the one where being wrong costs a payment.
-//
-// Deliberately narrow. A bare word stays a string, because a tool taking a
-// query of "true" or "42" is ordinary and silently retyping it would be a
-// worse bug than the one being fixed.
 func typedArg(v string) any {
 	switch v {
 	case "true":
@@ -160,10 +135,6 @@ func typedArg(v string) any {
 	if n, err := strconv.ParseInt(v, 10, 64); err == nil {
 		return n
 	}
-	// Only what parses whole and is an actual finite number. ParseFloat accepts
-	// "1e5", "Inf" and "NaN"; the round trip rejects the first, and the last two
-	// round-trip to themselves so they need saying out loud. None of them is a
-	// coordinate anybody typed, and NaN in a request body is not even valid JSON.
 	if f, err := strconv.ParseFloat(v, 64); err == nil &&
 		!math.IsNaN(f) && !math.IsInf(f, 0) &&
 		strconv.FormatFloat(f, 'f', -1, 64) == v {

--- a/service/wallet/x402client.go
+++ b/service/wallet/x402client.go
@@ -8,6 +8,7 @@ package wallet
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -27,6 +28,14 @@ import (
 type Server402 struct {
 	Name string `json:"name" description:"The short name to pass to wallet_pay"`
 	URL  string `json:"url" description:"Its base URL; /mcp is appended"`
+}
+
+// PaymentCallResult is a tool result plus the payment diagnostics exposed by
+// the server after a paid retry. Settlement is nil for free calls.
+type PaymentCallResult struct {
+	Text               string
+	Settlement         *x402.SettleResponse
+	ExtensionResponses string
 }
 
 // Servers returns the configured MCP servers: always "self" (this instance),
@@ -69,12 +78,6 @@ func ServerURL(name string) string {
 }
 
 // selfURL is this instance's own address.
-//
-// It read APP_URL alone, which nothing sets and nothing documents, so "self"
-// resolved to the empty string and wallet_pay refused every call to this
-// instance with "no server called". internal/origin is where the question of
-// what this instance's public address is already has an answer; APP_URL still
-// wins when it is set, because an operator who set it meant it.
 func selfURL() string {
 	if v := strings.TrimSpace(settings.Get("APP_URL")); v != "" {
 		return strings.TrimRight(v, "/")
@@ -84,58 +87,100 @@ func selfURL() string {
 
 var payClient = &http.Client{Timeout: 60 * time.Second}
 
-// PayAndCallMCP calls tool on the MCP server at baseURL with args. If the server
-// answers HTTP 402, it signs a payment from bw for a payable requirement and
-// retries once. Returns the tool's text result. accountID is the authenticated
-// caller, used only to meter spend against the daily cap — never to choose the
-// source wallet (that is always bw).
+// PayAndCallMCP preserves the long-standing text-only API for agents and other
+// callers that do not care about payment diagnostics.
 func PayAndCallMCP(ctx context.Context, accountID, baseURL, tool string, args map[string]any, bw *BaseWallet) (string, error) {
+	res, err := PayAndCallMCPWithReceipt(ctx, accountID, baseURL, tool, args, bw)
+	if err != nil {
+		return "", err
+	}
+	return res.Text, nil
+}
+
+// PayAndCallMCPWithReceipt is PayAndCallMCP plus the settlement receipt and any
+// x402 extension response headers returned after payment. This is primarily for
+// diagnostics: Bazaar indexing acknowledgements are carried in
+// EXTENSION-RESPONSES, while PAYMENT-RESPONSE proves the payment itself settled.
+func PayAndCallMCPWithReceipt(ctx context.Context, accountID, baseURL, tool string, args map[string]any, bw *BaseWallet) (PaymentCallResult, error) {
 	endpoint := strings.TrimRight(baseURL, "/") + "/mcp"
 	rpc := map[string]any{
 		"jsonrpc": "2.0", "id": 1, "method": "tools/call",
 		"params": map[string]any{"name": tool, "arguments": args},
 	}
 
-	status, body, err := postJSON(ctx, endpoint, rpc, "", bw)
+	status, body, headers, err := postJSON(ctx, endpoint, rpc, "", bw)
 	if err != nil {
-		return "", err
+		return PaymentCallResult{}, err
 	}
 
+	paid := false
 	if status == http.StatusPaymentRequired {
 		if bw == nil {
-			return "", fmt.Errorf("payment required but no wallet")
+			return PaymentCallResult{}, fmt.Errorf("payment required but no wallet")
 		}
 		req, perr := choosePayable(body)
 		if perr != nil {
-			return "", perr
+			return PaymentCallResult{}, perr
 		}
-		// Bound the payment: a server's challenge can never authorise more than
-		// the per-call/daily caps, so a misled agent can't drain the wallet.
 		amt, ok := new(big.Int).SetString(req.AmountAtomic(), 10)
 		if !ok {
-			return "", fmt.Errorf("invalid payment amount %q", req.AmountAtomic())
+			return PaymentCallResult{}, fmt.Errorf("invalid payment amount %q", req.AmountAtomic())
 		}
 		if err := checkAndRecordSpend(accountID, amt); err != nil {
-			return "", err
+			return PaymentCallResult{}, err
 		}
 		payHeader, serr := SignX402Payment(bw, req)
 		if serr != nil {
-			return "", fmt.Errorf("sign payment: %w", serr)
+			return PaymentCallResult{}, fmt.Errorf("sign payment: %w", serr)
 		}
-		status, body, err = postJSON(ctx, endpoint, rpc, payHeader, bw)
+		status, body, headers, err = postJSON(ctx, endpoint, rpc, payHeader, bw)
 		if err != nil {
-			return "", err
+			return PaymentCallResult{}, err
 		}
 		if status == http.StatusPaymentRequired {
-			return "", fmt.Errorf("payment rejected: %s", challengeError(body))
+			return PaymentCallResult{}, fmt.Errorf("payment rejected: %s", challengeError(body))
 		}
+		paid = true
 	}
 
-	return parseToolResult(body)
+	text, err := parseToolResult(body)
+	if err != nil {
+		return PaymentCallResult{}, err
+	}
+	out := PaymentCallResult{Text: text}
+	if paid {
+		out.Settlement = settlementFromHeaders(headers)
+		out.ExtensionResponses = strings.TrimSpace(headers.Get("EXTENSION-RESPONSES"))
+	}
+	return out, nil
 }
 
-// choosePayable picks a requirement from a 402 body that this wallet can pay:
-// a known EVM network with an EIP-712 domain in extra.
+func settlementFromHeaders(h http.Header) *x402.SettleResponse {
+	value := firstHeader(h, x402.HeaderPaymentRespV2, x402.HeaderPaymentRespV1)
+	if value == "" {
+		return nil
+	}
+	raw, err := base64.StdEncoding.DecodeString(value)
+	if err != nil {
+		return nil
+	}
+	var settle x402.SettleResponse
+	if err := json.Unmarshal(raw, &settle); err != nil {
+		return nil
+	}
+	return &settle
+}
+
+func firstHeader(h http.Header, names ...string) string {
+	for _, name := range names {
+		if v := strings.TrimSpace(h.Get(name)); v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+// choosePayable picks a requirement from a 402 body that this wallet can pay.
 func choosePayable(body []byte) (x402.PaymentRequirements, error) {
 	var challenge struct {
 		Accepts []x402.PaymentRequirements `json:"accepts"`
@@ -188,35 +233,30 @@ func parseToolResult(body []byte) (string, error) {
 	return sb.String(), nil
 }
 
-func postJSON(ctx context.Context, endpoint string, payload any, xPayment string, bw *BaseWallet) (int, []byte, error) {
+func postJSON(ctx context.Context, endpoint string, payload any, xPayment string, bw *BaseWallet) (int, []byte, http.Header, error) {
 	b, _ := json.Marshal(payload)
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(b))
 	if err != nil {
-		return 0, nil, err
+		return 0, nil, nil, err
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/json")
 
-	// Say who we are on every call, for nothing. Free account-scoped tools —
-	// notes, files, tasks — need an identity and never charge for one, so
-	// without this an agent holding a funded wallet still could not keep a
-	// note. Signing costs no round trip and no money, so there is no reason to
-	// wait until something is refused before doing it.
 	if bw != nil {
 		if u, uerr := url.Parse(endpoint); uerr == nil {
 			if h, herr := SignAuth(bw, u.Host); herr == nil {
 				req.Header.Set("Authorization", h)
 			}
-		}
+	}
 	}
 	if xPayment != "" {
 		req.Header.Set("X-PAYMENT", xPayment)
 	}
 	resp, err := payClient.Do(req)
 	if err != nil {
-		return 0, nil, err
+		return 0, nil, nil, err
 	}
 	defer resp.Body.Close()
 	data, err := io.ReadAll(resp.Body)
-	return resp.StatusCode, data, err
+	return resp.StatusCode, data, resp.Header.Clone(), err
 }

--- a/service/wallet/x402client_test.go
+++ b/service/wallet/x402client_test.go
@@ -49,13 +49,58 @@ func TestPayAndCallMCP(t *testing.T) {
 	if out != "bitcoin is up" {
 		t.Errorf("result = %q", out)
 	}
-	// The retry payment must decode to an exact-scheme payload paying from us.
 	raw, err := base64.StdEncoding.DecodeString(sawPayment)
 	if err != nil {
 		t.Fatalf("payment not base64: %v", err)
 	}
 	if !strings.Contains(string(raw), `"scheme":"exact"`) || !strings.Contains(strings.ToLower(string(raw)), strings.ToLower(addr[2:])) {
 		t.Errorf("payment payload missing scheme/from: %s", raw)
+	}
+}
+
+func TestPayAndCallMCPWithReceipt(t *testing.T) {
+	priv, addr, _ := GenerateKeypair()
+	bw := &BaseWallet{Address: addr, PrivateKey: priv}
+	settle := x402.SettleResponse{
+		Success: true, Transaction: "0xabc123", Network: "eip155:8453", Payer: addr,
+	}
+	settleJSON, _ := json.Marshal(settle)
+	settleHeader := base64.StdEncoding.EncodeToString(settleJSON)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("X-PAYMENT") != "" {
+			w.Header().Set(x402.HeaderPaymentRespV2, settleHeader)
+			w.Header().Set("EXTENSION-RESPONSES", `{"bazaar":{"status":"processing"}}`)
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"jsonrpc": "2.0", "id": 1,
+				"result": map[string]any{"content": []map[string]any{{"type": "text", "text": "paid result"}}},
+			})
+			return
+		}
+		w.WriteHeader(http.StatusPaymentRequired)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"x402Version": 2, "error": "payment required",
+			"accepts": []x402.PaymentRequirements{{
+				Scheme: "exact", Network: "eip155:8453", Amount: "10000",
+				PayTo: "0x9a717EFF039622231C65ADbF7B2A002b544b06A9", Asset: baseUSDC,
+				MaxTimeoutSeconds: 60, Extra: map[string]string{"name": "USD Coin", "version": "2"},
+			}},
+		})
+	}))
+	defer srv.Close()
+
+	out, err := PayAndCallMCPWithReceipt(context.Background(), "acct-test", srv.URL, "web_search", map[string]any{"query": "x402"}, bw)
+	if err != nil {
+		t.Fatalf("PayAndCallMCPWithReceipt: %v", err)
+	}
+	if out.Text != "paid result" {
+		t.Fatalf("text = %q", out.Text)
+	}
+	if out.Settlement == nil || out.Settlement.Transaction != "0xabc123" || out.Settlement.Network != "eip155:8453" {
+		t.Fatalf("settlement = %#v", out.Settlement)
+	}
+	if out.ExtensionResponses != `{"bazaar":{"status":"processing"}}` {
+		t.Fatalf("extension responses = %q", out.ExtensionResponses)
 	}
 }
 


### PR DESCRIPTION
## Why

We need to distinguish three different outcomes when testing M3O Bazaar discovery:

1. the tool call succeeded
2. the x402 payment actually settled
3. the server exposed an `EXTENSION-RESPONSES` acknowledgement for Bazaar

Until now `mu x402 call` printed only the tool result, so a successful paid call gave no visibility into settlement or discovery status.

## What

- add `PayAndCallMCPWithReceipt`, preserving the existing `PayAndCallMCP` text-only API
- capture the paid retry response headers
- decode `PAYMENT-RESPONSE` into the settlement transaction/network
- surface raw `EXTENSION-RESPONSES` when present
- make `mu x402 call` print settlement details and extension status before the tool result
- add a regression test for both payment receipt and Bazaar `processing` response

If the server does not expose `EXTENSION-RESPONSES`, the CLI says `extensions: none returned by server` explicitly rather than silently hiding the missing diagnostic.