### PR TITLE
Fix x402 diagnostic reporting

### DIFF
--- a/internal/cli/x402pay.go
+++ b/internal/cli/x402pay.go
@@ -94,12 +94,14 @@ func runX402Pay(args []string, rc *ResolvedConfig) int {
 	}
 
 	if out.Settlement != nil {
-		fmt.Printf("settled: %s on %s\n", out.Settlement.Transaction, out.Settlement.Network)
-		if out.ExtensionResponses != "" {
-			fmt.Printf("extensions: %s\n", out.ExtensionResponses)
-		} else {
-			fmt.Println("extensions: none returned by server")
-		}
+		fmt.Printf("payment: settled %s on %s\n", out.Settlement.Transaction, out.Settlement.Network)
+	} else if out.PaymentError != "" {
+		fmt.Printf("payment: %s\n", out.PaymentError)
+	}
+	if out.ExtensionResponses != "" {
+		fmt.Printf("extensions: %s\n", out.ExtensionResponses)
+	} else if out.Settlement != nil || out.PaymentError != "" {
+		fmt.Println("extensions: none returned by server")
 	}
 	fmt.Println(out.Text)
 	return 0

--- a/service/wallet/x402client.go
+++ b/service/wallet/x402client.go
@@ -31,10 +31,12 @@ type Server402 struct {
 }
 
 // PaymentCallResult is a tool result plus the payment diagnostics exposed by
-// the server after a paid retry. Settlement is nil for free calls.
+// the server after a paid retry. Settlement is nil for free calls or a failed
+// settlement receipt; PaymentError explains the latter when available.
 type PaymentCallResult struct {
 	Text               string
 	Settlement         *x402.SettleResponse
+	PaymentError       string
 	ExtensionResponses string
 }
 
@@ -149,31 +151,43 @@ func PayAndCallMCPWithReceipt(ctx context.Context, accountID, baseURL, tool stri
 	}
 	out := PaymentCallResult{Text: text}
 	if paid {
-		out.Settlement = settlementFromHeaders(headers)
+		out.Settlement, out.PaymentError = settlementFromHeaders(headers)
 		out.ExtensionResponses = strings.TrimSpace(headers.Get("EXTENSION-RESPONSES"))
 	}
 	return out, nil
 }
 
-func settlementFromHeaders(h http.Header) *x402.SettleResponse {
+func settlementFromHeaders(h http.Header) (*x402.SettleResponse, string) {
 	value := firstHeader(h, x402.HeaderPaymentRespV2, x402.HeaderPaymentRespV1)
 	if value == "" {
-		return nil
+		return nil, "no PAYMENT-RESPONSE returned by server"
 	}
 	raw, err := base64.StdEncoding.DecodeString(value)
 	if err != nil {
-		return nil
+		return nil, "invalid PAYMENT-RESPONSE encoding"
 	}
 	var settle x402.SettleResponse
 	if err := json.Unmarshal(raw, &settle); err != nil {
-		return nil
+		return nil, "invalid PAYMENT-RESPONSE JSON"
 	}
-	return &settle
+	if !settle.Success {
+		return nil, firstNonEmpty(settle.Message, settle.ErrorReason, "settlement reported failure")
+	}
+	return &settle, ""
 }
 
 func firstHeader(h http.Header, names ...string) string {
 	for _, name := range names {
 		if v := strings.TrimSpace(h.Get(name)); v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+func firstNonEmpty(vals ...string) string {
+	for _, v := range vals {
+		if strings.TrimSpace(v) != "" {
 			return v
 		}
 	}
@@ -247,7 +261,7 @@ func postJSON(ctx context.Context, endpoint string, payload any, xPayment string
 			if h, herr := SignAuth(bw, u.Host); herr == nil {
 				req.Header.Set("Authorization", h)
 			}
-	}
+		}
 	}
 	if xPayment != "" {
 		req.Header.Set("X-PAYMENT", xPayment)

--- a/service/wallet/x402client.go
+++ b/service/wallet/x402client.go
@@ -173,6 +173,9 @@ func settlementFromHeaders(h http.Header) (*x402.SettleResponse, string) {
 	if !settle.Success {
 		return nil, firstNonEmpty(settle.Message, settle.ErrorReason, "settlement reported failure")
 	}
+	if strings.TrimSpace(settle.Transaction) == "" || strings.TrimSpace(settle.Network) == "" {
+		return nil, "incomplete PAYMENT-RESPONSE: missing transaction or network"
+	}
 	return &settle, ""
 }
 

--- a/service/wallet/x402client_test.go
+++ b/service/wallet/x402client_test.go
@@ -99,6 +99,53 @@ func TestPayAndCallMCPWithReceipt(t *testing.T) {
 	if out.Settlement == nil || out.Settlement.Transaction != "0xabc123" || out.Settlement.Network != "eip155:8453" {
 		t.Fatalf("settlement = %#v", out.Settlement)
 	}
+	if out.PaymentError != "" {
+		t.Fatalf("payment error = %q", out.PaymentError)
+	}
+	if out.ExtensionResponses != `{"bazaar":{"status":"processing"}}` {
+		t.Fatalf("extension responses = %q", out.ExtensionResponses)
+	}
+}
+
+func TestPayAndCallMCPWithFailedReceiptStillReportsExtensions(t *testing.T) {
+	priv, addr, _ := GenerateKeypair()
+	bw := &BaseWallet{Address: addr, PrivateKey: priv}
+	settle := x402.SettleResponse{Success: false, ErrorReason: "insufficient funds"}
+	settleJSON, _ := json.Marshal(settle)
+	settleHeader := base64.StdEncoding.EncodeToString(settleJSON)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("X-PAYMENT") != "" {
+			w.Header().Set(x402.HeaderPaymentRespV2, settleHeader)
+			w.Header().Set("EXTENSION-RESPONSES", `{"bazaar":{"status":"processing"}}`)
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"jsonrpc": "2.0", "id": 1,
+				"result": map[string]any{"content": []map[string]any{{"type": "text", "text": "tool result"}}},
+			})
+			return
+		}
+		w.WriteHeader(http.StatusPaymentRequired)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"x402Version": 2, "error": "payment required",
+			"accepts": []x402.PaymentRequirements{{
+				Scheme: "exact", Network: "eip155:8453", Amount: "10000",
+				PayTo: "0x9a717EFF039622231C65ADbF7B2A002b544b06A9", Asset: baseUSDC,
+				MaxTimeoutSeconds: 60, Extra: map[string]string{"name": "USD Coin", "version": "2"},
+			}},
+		})
+	}))
+	defer srv.Close()
+
+	out, err := PayAndCallMCPWithReceipt(context.Background(), "acct-test", srv.URL, "web_search", map[string]any{"query": "x402"}, bw)
+	if err != nil {
+		t.Fatalf("PayAndCallMCPWithReceipt: %v", err)
+	}
+	if out.Settlement != nil {
+		t.Fatalf("failed settlement reported as success: %#v", out.Settlement)
+	}
+	if out.PaymentError != "insufficient funds" {
+		t.Fatalf("payment error = %q", out.PaymentError)
+	}
 	if out.ExtensionResponses != `{"bazaar":{"status":"processing"}}` {
 		t.Fatalf("extension responses = %q", out.ExtensionResponses)
 	}

--- a/service/wallet/x402client_test.go
+++ b/service/wallet/x402client_test.go
@@ -151,6 +151,20 @@ func TestPayAndCallMCPWithFailedReceiptStillReportsExtensions(t *testing.T) {
 	}
 }
 
+func TestSettlementFromHeadersRejectsIncompleteSuccess(t *testing.T) {
+	settleJSON, _ := json.Marshal(x402.SettleResponse{Success: true})
+	h := http.Header{}
+	h.Set(x402.HeaderPaymentRespV2, base64.StdEncoding.EncodeToString(settleJSON))
+
+	settle, paymentErr := settlementFromHeaders(h)
+	if settle != nil {
+		t.Fatalf("incomplete receipt reported as success: %#v", settle)
+	}
+	if paymentErr != "incomplete PAYMENT-RESPONSE: missing transaction or network" {
+		t.Fatalf("payment error = %q", paymentErr)
+	}
+}
+
 func TestPayAndCallMCPNoWallet(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusPaymentRequired)


### PR DESCRIPTION
## Why

PR #1493 added payment/Bazaar diagnostics to `mu x402 call`, but Codex review found three issues after merge:

- `service/wallet/x402client.go` was not gofmt-clean
- `EXTENSION-RESPONSES` was only printed when settlement decoding also succeeded, hiding Bazaar status when payment diagnostics were malformed or missing
- a decoded `PAYMENT-RESPONSE` with `success:false` was still treated as a successful settlement

## What

- keep extension reporting independent from settlement reporting
- add `PaymentError` so failed/malformed/missing payment receipts are surfaced explicitly
- only populate `Settlement` when `success:true`
- print `payment: settled ...` or `payment: <reason>` independently from `extensions: ...`
- add regression coverage proving Bazaar status is preserved even when settlement reports failure
- fix the formatting issue in the client file

This is a focused follow-up to #1493.