### PR TITLE
Forward x402 extension responses to MCP callers

### DIFF
--- a/internal/x402/x402.go
+++ b/internal/x402/x402.go
@@ -31,25 +31,23 @@ import (
 	"os"
 	"strconv"
 	"strings"
-
-	"mu/internal/quota"
-
 	"time"
-
-	"mu/internal/settings"
 
 	"mu/internal/app"
 	_ "mu/internal/env" // load ~/.env before x402 config is read at init
+	"mu/internal/quota"
+	"mu/internal/settings"
 )
 
 // x402 payment headers. Version 1 uses X-PAYMENT / X-PAYMENT-RESPONSE; version 2
 // renamed them to PAYMENT-SIGNATURE / PAYMENT-RESPONSE. We accept either on the
 // way in and emit both on the way out so any conformant client interoperates.
 const (
-	HeaderPaymentV1     = "X-PAYMENT"
-	HeaderPaymentV2     = "PAYMENT-SIGNATURE"
-	HeaderPaymentRespV1 = "X-PAYMENT-RESPONSE"
-	HeaderPaymentRespV2 = "PAYMENT-RESPONSE"
+	HeaderPaymentV1          = "X-PAYMENT"
+	HeaderPaymentV2          = "PAYMENT-SIGNATURE"
+	HeaderPaymentRespV1      = "X-PAYMENT-RESPONSE"
+	HeaderPaymentRespV2      = "PAYMENT-RESPONSE"
+	HeaderExtensionResponses = "EXTENSION-RESPONSES"
 )
 
 // x402 configuration from the environment. Defaults target Base mainnet via
@@ -235,12 +233,13 @@ func (r PaymentRequirements) AmountAtomic() string {
 
 // SettleResponse is the facilitator's settlement result.
 type SettleResponse struct {
-	Success     bool   `json:"success"`
-	Transaction string `json:"transaction,omitempty"`
-	Network     string `json:"network,omitempty"`
-	Payer       string `json:"payer,omitempty"`
-	ErrorReason string `json:"errorReason,omitempty"`
-	Message     string `json:"message,omitempty"`
+	Success            bool   `json:"success"`
+	Transaction        string `json:"transaction,omitempty"`
+	Network            string `json:"network,omitempty"`
+	Payer              string `json:"payer,omitempty"`
+	ErrorReason        string `json:"errorReason,omitempty"`
+	Message            string `json:"message,omitempty"`
+	ExtensionResponses string `json:"-"`
 }
 
 // creditsToAtomic converts a credit cost (Mu treats 1 credit ≈ 1 US cent) into
@@ -472,7 +471,7 @@ func settlePayload(payload map[string]any, operation, resource string) (*SettleR
 func verifyRequirement(payload map[string]any, req *PaymentRequirements) error {
 	body := map[string]any{"x402Version": x402Ver(), "paymentPayload": payload, "paymentRequirements": req}
 
-	vres, err := facilitatorPost("/verify", body)
+	vres, _, err := facilitatorPost("/verify", body)
 	if err != nil {
 		return fmt.Errorf("verify: %w", err)
 	}
@@ -493,7 +492,7 @@ func verifyRequirement(payload map[string]any, req *PaymentRequirements) error {
 func settleVerified(payload map[string]any, req *PaymentRequirements) (*SettleResponse, error) {
 	body := map[string]any{"x402Version": x402Ver(), "paymentPayload": payload, "paymentRequirements": req}
 
-	sres, err := facilitatorPost("/settle", body)
+	sres, headers, err := facilitatorPost("/settle", body)
 	if err != nil {
 		return nil, fmt.Errorf("settle: %w", err)
 	}
@@ -502,6 +501,7 @@ func settleVerified(payload map[string]any, req *PaymentRequirements) (*SettleRe
 	if !settle.Success {
 		return nil, fmt.Errorf("settlement failed: %s", firstNonEmpty(settle.Message, settle.ErrorReason, "unknown"))
 	}
+	settle.ExtensionResponses = strings.TrimSpace(headers.Get(HeaderExtensionResponses))
 	app.Log("x402", "settled %s: tx=%s payer=%s", req.Resource, settle.Transaction, settle.Payer)
 	return &settle, nil
 }
@@ -555,39 +555,39 @@ func payloadAsset(payload map[string]any) string {
 // facilitatorPost POSTs JSON to a facilitator endpoint, attaching a CDP Bearer
 // JWT when CDP credentials are configured (required by the Coinbase-hosted
 // facilitator; ignored by the open one).
-func facilitatorPost(path string, body map[string]any) ([]byte, error) {
+func facilitatorPost(path string, body map[string]any) ([]byte, http.Header, error) {
 	endpoint := strings.TrimRight(x402FacilitatorURL, "/") + path
 	b, _ := json.Marshal(body)
 	req, err := http.NewRequest(http.MethodPost, endpoint, bytes.NewReader(b))
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	req.Header.Set("Content-Type", "application/json")
 	if cdpConfigured() {
 		u, err := url.Parse(endpoint)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		bearer, err := cdpBearer(http.MethodPost, u.Host, u.Path)
 		if err != nil {
-			return nil, fmt.Errorf("cdp auth: %w", err)
+			return nil, nil, fmt.Errorf("cdp auth: %w", err)
 		}
 		req.Header.Set("Authorization", "Bearer "+bearer)
 	}
 
 	resp, err := (&http.Client{Timeout: 30 * time.Second}).Do(req)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	defer resp.Body.Close()
 	data, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	if resp.StatusCode != http.StatusOK {
-		return nil, &facilitatorError{Path: path, Status: resp.StatusCode, Body: data}
+		return nil, nil, &facilitatorError{Path: path, Status: resp.StatusCode, Body: data}
 	}
-	return data, nil
+	return data, resp.Header.Clone(), nil
 }
 
 // facilitatorError is a non-200 from the facilitator, carrying the body so it
@@ -786,6 +786,9 @@ func (s *settleWriter) finish() {
 			enc := base64.StdEncoding.EncodeToString(b)
 			s.Header().Set(HeaderPaymentRespV1, enc)
 			s.Header().Set(HeaderPaymentRespV2, enc)
+			if resp.ExtensionResponses != "" {
+				s.Header().Set(HeaderExtensionResponses, resp.ExtensionResponses)
+			}
 		}
 	}
 

--- a/internal/x402/x402_extension_response_test.go
+++ b/internal/x402/x402_extension_response_test.go
@@ -1,0 +1,45 @@
+package x402
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestSettleWriterForwardsExtensionResponses(t *testing.T) {
+	oldFacilitator := x402FacilitatorURL
+	defer func() { x402FacilitatorURL = oldFacilitator }()
+
+	facilitator := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/settle" {
+			t.Fatalf("unexpected facilitator path: %s", r.URL.Path)
+		}
+		w.Header().Set(HeaderExtensionResponses, `{"bazaar":{"status":"processing"}}`)
+		_ = json.NewEncoder(w).Encode(SettleResponse{
+			Success:     true,
+			Transaction: "0xabc123",
+			Network:     "eip155:8453",
+			Payer:       "0x1234",
+		})
+	}))
+	defer facilitator.Close()
+	x402FacilitatorURL = facilitator.URL
+
+	holder := &SettleHolder{Verified: &Verified{
+		payload: map[string]any{},
+		req:     &PaymentRequirements{Resource: "https://m3o.com/mcp"},
+	}}
+	rec := httptest.NewRecorder()
+	w := NewSettleWriter(rec, holder)
+
+	_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":{"content":[{"type":"text","text":"ok"}]}}`))
+	Finish(w)
+
+	if got := rec.Header().Get(HeaderExtensionResponses); got != `{"bazaar":{"status":"processing"}}` {
+		t.Fatalf("%s = %q", HeaderExtensionResponses, got)
+	}
+	if rec.Header().Get(HeaderPaymentRespV2) == "" {
+		t.Fatal("missing payment response header")
+	}
+}


### PR DESCRIPTION
## Why

`mu x402 call --server https://m3o.com ...` now proves payment settlement, but reports `extensions: none returned by server` even when CDP may have returned an x402 `EXTENSION-RESPONSES` acknowledgement for Bazaar.

The server-side x402 path was dropping facilitator response headers in `facilitatorPost`, then synthesizing only `PAYMENT-RESPONSE` on the final MCP response.

## What

- preserve facilitator response headers from `/settle`
- capture `EXTENSION-RESPONSES` on a successful settlement without changing the settlement JSON shape
- forward that header through `settleWriter` to the MCP caller
- add a regression test that simulates a facilitator returning `{"bazaar":{"status":"processing"}}` and verifies the final MCP response exposes it

After deployment, the existing diagnostic command should distinguish whether Bazaar acknowledged the settlement:

```bash
~/go/bin/mu x402 call --server https://m3o.com web_search query=x402
```

Expected on acknowledgement:

```text
payment: settled <tx> on eip155:8453
extensions: {"bazaar":{"status":"processing"}}
```