### PR TITLE
Restore x402 onboarding and route the tools-host root

### DIFF
--- a/internal/server/serve.go
+++ b/internal/server/serve.go
@@ -221,6 +221,13 @@ func serve(addr string) {
 						}
 					}
 				} else if r.URL.Path == "/" {
+					// The optional tools hostname has its own machine-first front
+					// door. Resolve it before setup and the normal Micro page so a
+					// fresh instance presents the same tools identity at this host.
+					if r.Method == http.MethodGet && home.IsToolsHost(r) {
+						home.ToolsIndex(w, r)
+						return
+					}
 					// Fresh instance with no admin yet → guide the operator
 					// through the one-time setup wizard.
 					if setup.Needed() {

--- a/internal/x402/x402.go
+++ b/internal/x402/x402.go
@@ -321,7 +321,9 @@ func WritePaymentRequired(w http.ResponseWriter, operation, resource string, ext
 		return false
 	}
 	if reason == "" {
-		reason = "Payment required. Choose an entry from accepts, submit payment, and retry."
+		reason = "This tool costs credits. Sign in, or send a token from /token as " +
+			"'Authorization: Bearer' — see /tools. Machine callers can pay per call " +
+			"via x402 instead; choose an entry from accepts, submit payment, and retry."
 	}
 	if extensions == nil {
 		extensions = BazaarExtensions(operation, resource)


### PR DESCRIPTION
## Summary

- restore actionable default x402 guidance for anonymous callers, including sign-in, bearer-token, and x402 payment paths
- preserve caller-specific challenge reasons unchanged
- route GET / on the configured TOOLS_HOST to the machine-first tools index before setup or the Micro front door
- retain the agreed host-derived branding model and TOOLS_HOST-only configuration

## Testing

- `go test ./internal/x402 -run TestAChallengeSaysWhyThisCallerWasRefused -count=1`
- `go test ./internal/server -run '^TestChargedWriteOp$' -count=1`
- `gofmt -l internal/server/serve.go internal/x402/x402.go`
- `git diff --check`

## Context

This follow-up is based on #1497 and addresses the remaining root-routing review finding and the x402 challenge regression.