### PR TITLE
Brand the logged-out front door as Micro

### DIFF
--- a/home/landing_brand_test.go
+++ b/home/landing_brand_test.go
@@ -1,0 +1,22 @@
+package home
+
+import (
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestLoggedOutRootIsMicro(t *testing.T) {
+	r := httptest.NewRequest("GET", "http://example.com/", nil)
+	w := httptest.NewRecorder()
+
+	Index(w, r)
+	body := w.Body.String()
+
+	if !strings.Contains(body, "<title>Micro</title>") {
+		t.Fatalf("logged-out root title is not Micro: %q", body)
+	}
+	if !strings.Contains(body, `<div class="lbrand">Micro</div>`) {
+		t.Fatalf("logged-out root wordmark is not Micro: %q", body)
+	}
+}


### PR DESCRIPTION
## Summary

- make the logged-out `/` front door identify as **Micro**
- keep the caption **A personal assistant**
- leave Mu as the runtime/project/system identity
- add a focused regression test for both the browser title and visible wordmark

## Scope

Landing only. The x402 routing and `tools_*` → `x402_*` cleanup already landed in #1501 and are intentionally not part of this PR.
