### PR TITLE
Fix x402 challenge regression

### DIFF
--- a/internal/x402/x402.go
+++ b/internal/x402/x402.go
@@ -321,7 +321,9 @@ func WritePaymentRequired(w http.ResponseWriter, operation, resource string, ext
 		return false
 	}
 	if reason == "" {
-		reason = "Payment required. Choose an entry from accepts, submit payment, and retry."
+		reason = "This tool costs credits. Sign in, or send a token from /token as " +
+			"'Authorization: Bearer' — see /tools. Machine callers can pay per call " +
+			"via x402 instead; choose an entry from accepts, submit payment, and retry."
 	}
 	if extensions == nil {
 		extensions = BazaarExtensions(operation, resource)


### PR DESCRIPTION
## Summary

- restore the actionable default x402 challenge for anonymous callers
- tell a stranger to sign in or use a bearer token, while still explaining x402 pay-per-call
- preserve caller-specific refusal reasons unchanged

## Testing

Targets the existing failing `TestAChallengeSaysWhyThisCallerWasRefused` regression on current `main`. No branding or routing changes.