### PR TITLE
Keep Micro as the installed app identity

### DIFF
--- a/home/pricing.go
+++ b/home/pricing.go
@@ -66,7 +66,7 @@ func PricingHandler(w http.ResponseWriter, r *http.Request) {
 	// changes it, and this file is served by every instance.
 	b.WriteString(`<div class="card"><h3>What this costs</h3>` +
 		`<p>A question to the agent is ` + strconv.Itoa(quota.OperationCost(quota.OpAgentRun)) +
-		`¢. Mu charges for what it has to buy from somebody else: a question is a ` +
+		`¢. This instance charges for what it has to buy from somebody else: a question is a ` +
 		`model call, a search is a search company's, a text message is a carrier's. ` +
 		`Anything that only touches this server — reading the news, your mail, your ` +
 		`notes, the archive — is free, because serving it costs nothing.</p>` +
@@ -104,7 +104,7 @@ func PricingHandler(w http.ResponseWriter, r *http.Request) {
 
 	app.Respond(w, r, app.Response{
 		Title:       "Pricing",
-		Description: "What Mu costs: a dollar of credit to start, then a credit is a cent.",
+		Description: "What this instance costs: a dollar of credit to start, then a credit is a cent.",
 		HTML:        b.String(),
 	})
 }

--- a/internal/app/manifest_test.go
+++ b/internal/app/manifest_test.go
@@ -23,13 +23,18 @@ func TestTheManifestSaysWhichAppThisIs(t *testing.T) {
 		t.Fatal(err)
 	}
 	var m struct {
-		ID       string `json:"id"`
-		Scope    string `json:"scope"`
-		StartURL string `json:"start_url"`
-		Display  string `json:"display"`
+		Name      string `json:"name"`
+		ShortName string `json:"short_name"`
+		ID        string `json:"id"`
+		Scope     string `json:"scope"`
+		StartURL  string `json:"start_url"`
+		Display   string `json:"display"`
 	}
 	if err := json.Unmarshal(raw, &m); err != nil {
 		t.Fatalf("the manifest is not valid JSON, so nothing can install: %v", err)
+	}
+	if m.Name != "Micro" || m.ShortName != "Micro" {
+		t.Errorf("installed app is %q/%q, want Micro/Micro", m.Name, m.ShortName)
 	}
 	if m.ID != "/" {
 		t.Errorf(`id = %q, want "/" — without a stable id the app's identity is`+"\n"+
@@ -38,6 +43,15 @@ func TestTheManifestSaysWhichAppThisIs(t *testing.T) {
 	}
 	if m.StartURL == "" || !strings.HasPrefix(m.StartURL, m.Scope) {
 		t.Errorf("start_url %q is not inside scope %q, so it will not launch", m.StartURL, m.Scope)
+	}
+
+	for _, tag := range []string{
+		`<meta name="apple-mobile-web-app-title" content="Micro">`,
+		`<meta name="application-name" content="Micro">`,
+	} {
+		if !strings.Contains(Template, tag) {
+			t.Errorf("install metadata is missing %s", tag)
+		}
 	}
 }
 

--- a/internal/app/pwa_brand.go
+++ b/internal/app/pwa_brand.go
@@ -1,0 +1,16 @@
+package app
+
+import "strings"
+
+// The browser shell is Mu because Mu is the runtime, but the installable app is
+// Micro: the personal assistant a person adds to their home screen. The web app
+// manifest already says Micro; keep the HTML fallbacks in the same identity so
+// Safari/iOS and browsers that consult application-name do not install it as Mu.
+func init() {
+	Template = strings.Replace(Template,
+		`<meta name="apple-mobile-web-app-title" content="Mu">`,
+		`<meta name="apple-mobile-web-app-title" content="Micro">`, 1)
+	Template = strings.Replace(Template,
+		`<meta name="application-name" content="Mu">`,
+		`<meta name="application-name" content="Micro">`, 1)
+}


### PR DESCRIPTION
## Summary

- make the HTML install-name fallbacks agree with the existing Micro web manifest
- pin `name`, `short_name`, Apple mobile app title and `application-name` to **Micro** in regression coverage
- keep the normal Mu runtime/browser shell untouched
- make public pricing copy instance-aware instead of saying the Mu runtime itself charges

## Branding model

- **Mu** remains the open-source runtime/project: “Tools for agents”
- **Micro** is the human-facing personal assistant and the installable PWA
- `X402_HOST` remains a separately-derived machine/payment identity (for our deployment, M3O)

The install mismatch was concrete: `manifest.webmanifest` already said Micro, while the HTML still emitted `apple-mobile-web-app-title=Mu` and `application-name=Mu`. Browsers that consult those fallbacks could therefore offer to install the app as Mu.

## Scope

This does not rename the `mu` binary, source/runtime references, app-shell runtime branding, or M3O/x402 surfaces.