### PR TITLE
Keep agent chat above the PWA bar and recover dropped streams

### DIFF
--- a/internal/app/chat.go
+++ b/internal/app/chat.go
@@ -672,6 +672,15 @@ function fitConv(){
   var opts=document.getElementById('mu-chat-opts');
   var sug=document.getElementById('mu-chat-suggest');
   [form,opts,sug].forEach(function(el){ if(el) below+=el.offsetHeight; });
+  // A fixed tab bar is not in the document flow, so none of the elements
+  // above account for the screen it covers. The CSS fallback subtracts
+  // --tabbar, but this measured inline max-height replaces that rule as soon
+  // as the script runs. Measure the actual visible bar here; while a keyboard
+  // is open the shell hides it and its height is naturally zero.
+  var tabs=document.getElementById('tabs');
+  if(tabs&&window.getComputedStyle(tabs).display!=='none'){
+    below+=tabs.getBoundingClientRect().height;
+  }
   var h=Math.max(minConv, screenH()-top-below-convGap);
   conv.style.maxHeight=h+'px';
 }
@@ -954,8 +963,38 @@ function ask(q){
   .catch(function(err){
     stopWork();
     if(err==='handled')return;
-    a.innerHTML='<div class="mu-err">Error: '+esc(err&&err.message||err)+'</div>';
-    save();
+    // Losing the stream is not the same as losing the run. The server uses a
+    // run context independent of this request and records the eventual answer
+    // in the conversation. Stay attached to that record instead of replacing
+    // a still-running answer with the browser's unhelpful "network error".
+    if(contextId){
+      var reconnectUntil=Date.now()+600000;
+      a.innerHTML='<div class="mu-think"><span class="mu-spin"></span><span>Connection lost. Reconnecting...</span></div>';
+      save();
+      (function recover(){
+        fetch('/agent/pending?thread='+encodeURIComponent(contextId),
+          {headers:{'Accept':'application/json'},credentials:'same-origin'})
+          .then(function(r){return r.ok?r.json():null})
+          .then(function(d){
+            if(d&&d.html){a.outerHTML=d.html;save();toBottom(false);return;}
+            if(d&&!d.waiting){
+              a.innerHTML='<div class="mu-err">The run stopped without returning an answer.</div>';save();return;
+            }
+            if(Date.now()>reconnectUntil){
+              a.innerHTML='<div class="mu-err">The connection was lost and no answer came back. Please try again.</div>';save();return;
+            }
+            setTimeout(recover,3000);
+          })
+          .catch(function(){
+            if(Date.now()>reconnectUntil){
+              a.innerHTML='<div class="mu-err">The connection was lost and no answer came back. Please try again.</div>';save();return;
+            }
+            setTimeout(recover,3000);
+          });
+      })();
+      return;
+    }
+    a.innerHTML='<div class="mu-err">Error: '+esc(err&&err.message||err)+'</div>';save();
   });
 }
 

--- a/internal/app/chat_viewport_test.go
+++ b/internal/app/chat_viewport_test.go
@@ -38,4 +38,27 @@ func TestTheChatFitsWhatIsActuallyOnScreen(t *testing.T) {
 	if !strings.Contains(js, "|| window.innerHeight") {
 		t.Error("there is no fallback for a browser with no visualViewport")
 	}
+	// The mobile tab bar is fixed, so it occupies no layout space. fitConv sets
+	// an inline max-height and therefore has to include the visible bar itself;
+	// the stylesheet's --tabbar fallback no longer participates once it does.
+	if !strings.Contains(js, "tabs.getBoundingClientRect().height") {
+		t.Error("the measured conversation ignores the fixed tab bar, so the composer lands underneath it")
+	}
+	if !strings.Contains(js, "getComputedStyle(tabs).display!=='none'") {
+		t.Error("the fit reserves room for the tab bar even while the keyboard has hidden it")
+	}
+}
+
+// A browser or proxy may drop the SSE connection while the independently
+// running agent continues. The page must follow the recorded conversation in
+// that case rather than turning a transport failure into the run's outcome.
+func TestAChatRecoversTheAnswerAfterItsStreamDrops(t *testing.T) {
+	js := ChatComponent(ChatConfig{Ask: true, Transcript: true, StorageNS: "probe"})
+
+	if !strings.Contains(js, "Connection lost. Reconnecting...") {
+		t.Error("a dropped stream is still presented as a failed run")
+	}
+	if strings.Count(js, "'/agent/pending?thread='") < 2 {
+		t.Error("the live request does not poll the recorded conversation after its stream drops")
+	}
 }


### PR DESCRIPTION
## Summary
- include the visible fixed PWA tab bar in the agent transcript height calculation so it cannot cover the composer
- treat a dropped SSE connection as a transport interruption, not a failed agent run
- poll the existing recorded conversation after disconnect and show the eventual answer without starting a duplicate run
- add regression coverage for both paths

## Why
The CSS already reserved `--tabbar`, but `fitConv` replaced that rule with an inline height that omitted it. Separately, the server deliberately continues agent work independently of the browser request, while the browser converted a dropped stream directly into `network error` and never looked for the recorded result.

## Validation
- confirmed both committed blobs after writing
- `git diff --check` passes locally
- local Go is unavailable in this runner; GitHub Actions provides build/test validation

This intentionally does not add persisted per-tool progress for a reopened page; that requires extending the saved run state and should be a separate change.