### PR TITLE
Carry the landing conversation into Home

### DIFF
--- a/account/pages.go
+++ b/account/pages.go
@@ -1212,14 +1212,8 @@ type signupBucket struct {
 // safeRedirect is where signing in lands you.
 //
 // Where you were going, when you were going somewhere — signing in should
-// finish the thing you were doing. Otherwise the front door.
-//
-// It was the dashboard, and that was right while the front door was a pitch a
-// signed-in account had no use for. It is the same page for everybody now, and
-// landing on /home instead put a rail and a grid of sixteen cards in front of
-// somebody whose next move is to type a question. The dashboard is a place to
-// go and look at things, reached from the corner when that is what you came
-// for. See home.Index.
+// finish the thing you were doing. Otherwise Home: the public front door has
+// become this person's place, with their assistant and context in it.
 func safeRedirect(r *http.Request) string {
 	return SafeRedirectTo(r.URL.Query().Get("redirect"))
 }
@@ -1246,7 +1240,7 @@ func safeRedirect(r *http.Request) string {
 // somebody straight back to a login page, which is a loop rather than a
 // vulnerability but is still not a destination.
 func SafeRedirectTo(to string) string {
-	const home = "/"
+	const home = "/home"
 	if to == "" || to[0] != '/' {
 		return home
 	}

--- a/account/redirect_test.go
+++ b/account/redirect_test.go
@@ -11,6 +11,9 @@ import "testing"
 // somebody else's site with our domain in the address bar on the way — which
 // is what makes a phishing page convincing.
 func TestWhereYouComeBackToIsAPageHere(t *testing.T) {
+	if got := SafeRedirectTo(""); got != "/home" {
+		t.Errorf("a plain login lands at %q, want /home", got)
+	}
 	for _, elsewhere := range []string{
 		"//evil.example",       // protocol-relative
 		"/\\evil.example",      // a backslash a browser folds into a slash
@@ -18,7 +21,7 @@ func TestWhereYouComeBackToIsAPageHere(t *testing.T) {
 		"https://evil.example", // not even a path
 		"evil.example",
 	} {
-		if got := SafeRedirectTo(elsewhere); got != "/" {
+		if got := SafeRedirectTo(elsewhere); got != "/home" {
 			t.Errorf("SafeRedirectTo(%q) = %q — that leaves this instance", elsewhere, got)
 		}
 	}
@@ -28,7 +31,7 @@ func TestWhereYouComeBackToIsAPageHere(t *testing.T) {
 	}
 	// A login page is not a destination — it is a loop.
 	for _, loop := range []string{"/login", "/logout", "/signup?invite=x"} {
-		if got := SafeRedirectTo(loop); got != "/" {
+		if got := SafeRedirectTo(loop); got != "/home" {
 			t.Errorf("SafeRedirectTo(%q) = %q", loop, got)
 		}
 	}

--- a/home/home.go
+++ b/home/home.go
@@ -486,6 +486,8 @@ function fetchW(la,lo){
 			Ask:             true,
 			HideSuggestions: true,
 			Placeholder:     "What do you need?",
+			StorageNS:       "home",
+			ImportNS:        "landing",
 			// Who answers, for the byline over the reply. The default agent,
 			// which is what an unpicked box reaches — see agent.DefaultName.
 			AgentName: agent.DefaultName(),

--- a/home/home.go
+++ b/home/home.go
@@ -411,6 +411,15 @@ function fetchW(la,lo){
 	if sess, _ := auth.TrySession(r); sess != nil {
 		viewerID = sess.Account
 	}
+	chatStorageNS := ""
+	chatImportNS := ""
+	if viewerID != "" {
+		// Browser-held Home state belongs to the account, just like the server
+		// thread it mirrors. A fixed namespace would let the next account using
+		// this tab restore and submit the previous account's conversation.
+		chatStorageNS = "home:" + viewerID
+		chatImportNS = "landing"
+	}
 
 	// The rail is built before it is placed, because whether there is a second
 	// column at all depends on whether anything goes in it.
@@ -486,8 +495,8 @@ function fetchW(la,lo){
 			Ask:             true,
 			HideSuggestions: true,
 			Placeholder:     "What do you need?",
-			StorageNS:       "home",
-			ImportNS:        "landing",
+			StorageNS:       chatStorageNS,
+			ImportNS:        chatImportNS,
 			// Who answers, for the byline over the reply. The default agent,
 			// which is what an unpicked box reaches — see agent.DefaultName.
 			AgentName: agent.DefaultName(),

--- a/home/index.go
+++ b/home/index.go
@@ -245,6 +245,9 @@ func indexBody() string {
 			Ask:             true,
 			HideSuggestions: true,
 			Placeholder:     "What do you need?",
+			// Kept for the login handoff. Home adopts this tab's public
+			// conversation once, so signing in continues rather than resets.
+			StorageNS: "landing",
 			// Who answers, for the byline over the reply. The default agent,
 			// which is what an unpicked box reaches — see agent.DefaultName.
 			AgentName: agent.DefaultName(),

--- a/home/login_continuity_test.go
+++ b/home/login_continuity_test.go
@@ -1,0 +1,24 @@
+package home
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestLoginTurnsTheLandingChatIntoTheHomeChat(t *testing.T) {
+	landing := indexBody()
+	if !strings.Contains(landing, `var NS="landing"`) {
+		t.Error("the public conversation is not retained for the login handoff")
+	}
+
+	home, err := os.ReadFile("home.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{`StorageNS:       "home"`, `ImportNS:        "landing"`} {
+		if !strings.Contains(string(home), want) {
+			t.Errorf("Home does not adopt the landing conversation: missing %q", want)
+		}
+	}
+}

--- a/home/login_continuity_test.go
+++ b/home/login_continuity_test.go
@@ -16,7 +16,11 @@ func TestLoginTurnsTheLandingChatIntoTheHomeChat(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	for _, want := range []string{`StorageNS:       "home"`, `ImportNS:        "landing"`} {
+	for _, want := range []string{
+		`chatStorageNS = "home:" + viewerID`,
+		`StorageNS:       chatStorageNS`,
+		`ImportNS:        chatImportNS`,
+	} {
 		if !strings.Contains(string(home), want) {
 			t.Errorf("Home does not adopt the landing conversation: missing %q", want)
 		}

--- a/internal/app/chat.go
+++ b/internal/app/chat.go
@@ -119,7 +119,8 @@ type ChatConfig struct {
 	StorageNS string
 	// ImportNS is a one-time handoff from another chat surface. This surface
 	// adopts the other namespace's conversation, history, context and draft,
-	// then removes the source copy.
+	// then removes the source copy. The destination namespace must include the
+	// account identity when the destination is account-owned.
 	// Used when the public landing becomes the signed-in Home after login.
 	ImportNS string
 	// Doors is a row of links rendered directly under the input — the handful
@@ -729,6 +730,26 @@ if(!SESSION && PERSIST){
       if(imported)savedConv=sessionStorage.getItem(CKEY);
     }
     if(savedConv)conv.innerHTML=savedConv;
+    // A guest can leave while its answer is still streaming. That run has no
+    // account-owned thread for Home to recover, so carrying its spinner across
+    // login would make it permanent. Put the unanswered prompt back in the
+    // composer and retain only the completed turns.
+    if(imported){
+      var agents=conv.querySelectorAll('.mu-agent');
+      var pendingAgent=agents.length?agents[agents.length-1]:null;
+      if(pendingAgent&&pendingAgent.querySelector('.mu-think')){
+        var by=pendingAgent.previousElementSibling;
+        var user=by&&by.classList.contains('mu-by')?by.previousElementSibling:by;
+        if(user&&user.classList.contains('mu-user')&&!sessionStorage.getItem(DKEY)){
+          sessionStorage.setItem(DKEY,user.textContent||'');
+        }
+        pendingAgent.remove();
+        if(by&&by.classList.contains('mu-by'))by.remove();
+        if(user&&user.classList.contains('mu-user'))user.remove();
+        sessionStorage.setItem(CKEY,conv.innerHTML);
+        sessionStorage.removeItem(TKEY);
+      }
+    }
     var savedHist=sessionStorage.getItem(HKEY);
     if(savedHist)history=JSON.parse(savedHist)||[];
     var savedCtx=sessionStorage.getItem(TKEY);

--- a/internal/app/chat.go
+++ b/internal/app/chat.go
@@ -115,8 +115,13 @@ type ChatConfig struct {
 	// StorageNS namespaces the component's sessionStorage keys so different
 	// surfaces (Home, /agent) keep separate in-tab conversations and never show
 	// each other's. When empty the component is ephemeral: it neither restores
-	// nor saves, so it always starts clean (used for Home's quick-ask box).
+	// nor saves, so it always starts clean.
 	StorageNS string
+	// ImportNS is a one-time handoff from another chat surface. This surface
+	// adopts the other namespace's conversation, history, context and draft,
+	// then removes the source copy.
+	// Used when the public landing becomes the signed-in Home after login.
+	ImportNS string
 	// Doors is a row of links rendered directly under the input — the handful
 	// of services that are each a search over one set, where the box above is a
 	// search over anything.
@@ -690,6 +695,7 @@ var minConv=220, convGap=28;
 var sugDiv=document.getElementById('mu-chat-suggest');
 if(!form)return;
 var NS=` + JSString(cfg.StorageNS) + `;
+var IMPORT_NS=` + JSString(cfg.ImportNS) + `;
 // Persistence is per-surface and opt-in. With no namespace the component is
 // ephemeral (Home's quick-ask box) so it never restores or leaks a
 // conversation — in particular it must not show the /agent app's thread.
@@ -697,6 +703,7 @@ var PERSIST=!!NS;
 var CKEY='mu_chat_conv:'+NS;
 var HKEY='mu_chat_hist:'+NS;
 var TKEY='mu_chat_ctx:'+NS;
+var DKEY='mu_chat_draft:'+NS;
 var history=[];
 
 // A reopened server session is authoritative; otherwise restore this surface's
@@ -706,11 +713,28 @@ var history=[];
 if(!SESSION && PERSIST){
   try{
     var savedConv=sessionStorage.getItem(CKEY);
+    // A login turns the public entry into Home. Adopt that tab's conversation
+    // once, then remove the public copy so a later signed-out landing does not
+    // echo an exchange that has already moved inside.
+    if(IMPORT_NS){
+      var from=['conv','hist','ctx','draft'];
+      var to=[CKEY,HKEY,TKEY,DKEY];
+      var imported=false;
+      for(var n=0;n<from.length;n++){
+        var source='mu_chat_'+from[n]+':'+IMPORT_NS;
+        var value=sessionStorage.getItem(source);
+        if(value!==null){sessionStorage.setItem(to[n],value);imported=true;}
+        sessionStorage.removeItem(source);
+      }
+      if(imported)savedConv=sessionStorage.getItem(CKEY);
+    }
     if(savedConv)conv.innerHTML=savedConv;
     var savedHist=sessionStorage.getItem(HKEY);
     if(savedHist)history=JSON.parse(savedHist)||[];
     var savedCtx=sessionStorage.getItem(TKEY);
     if(savedCtx)contextId=savedCtx;
+    var savedDraft=sessionStorage.getItem(DKEY);
+    if(savedDraft)input.value=savedDraft;
   }catch(e){}
 }
 
@@ -747,6 +771,10 @@ function save(){
     sessionStorage.setItem(TKEY,contextId||'');
   }catch(e){}
 }
+function saveDraft(){
+  if(!PERSIST)return;
+  try{sessionStorage.setItem(DKEY,input.value||'');}catch(e){}
+}
 
 // agentName is who answers: whatever the picker is showing when there is one,
 // and the page's own answer otherwise. The picker holds ids and displays names,
@@ -778,7 +806,7 @@ function ask(q){
   var byName=agentName();
   if(byName){var by=document.createElement('div');by.className='mu-by';by.textContent=byName;conv.appendChild(by);}
   var a=document.createElement('div');a.className='mu-agent';conv.appendChild(a);
-  input.value='';input.style.height='auto';input.focus();
+  input.value='';saveDraft();input.style.height='auto';input.focus();
 
   var workLabel='Working';
   var t0=Date.now();
@@ -1004,7 +1032,7 @@ showSuggestions();
 // Start a fresh session (clears the log + thread id).
 window.muChatNew=function(){
   conv.innerHTML='';history=[];contextId='';
-  try{sessionStorage.removeItem(CKEY);sessionStorage.removeItem(HKEY);sessionStorage.removeItem(TKEY);}catch(e){}
+  try{sessionStorage.removeItem(CKEY);sessionStorage.removeItem(HKEY);sessionStorage.removeItem(TKEY);sessionStorage.removeItem(DKEY);}catch(e){}
   showBrief();
   showSuggestions();input.focus();
 };
@@ -1303,7 +1331,7 @@ if(window.visualViewport){
   window.visualViewport.addEventListener('resize',onView);
   window.visualViewport.addEventListener('scroll',onView);
 }
-if(input) input.addEventListener('input',fitConv);
+if(input) input.addEventListener('input',function(){fitConv();saveDraft();});
 })();
 </script>`
 

--- a/internal/app/chat_continuity_test.go
+++ b/internal/app/chat_continuity_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestAChatCanHandItsTabStateToAnotherSurface(t *testing.T) {
 	got := ChatComponent(ChatConfig{
-		Ask:       true,
+		Ask:      true,
 		StorageNS: "home",
 		ImportNS:  "landing",
 	})
@@ -19,6 +19,9 @@ func TestAChatCanHandItsTabStateToAnotherSurface(t *testing.T) {
 		`var IMPORT_NS="landing"`,
 		"'mu_chat_'+from[n]+':'+IMPORT_NS",
 		"sessionStorage.removeItem(source)",
+		"pendingAgent.querySelector('.mu-think')",
+		"sessionStorage.setItem(DKEY,user.textContent||'')",
+		"sessionStorage.removeItem(TKEY)",
 	} {
 		if !strings.Contains(got, want) {
 			t.Errorf("the one-time chat handoff is missing %q", want)

--- a/internal/app/chat_continuity_test.go
+++ b/internal/app/chat_continuity_test.go
@@ -1,0 +1,41 @@
+package app
+
+// A public conversation becomes the signed-in Home conversation rather than
+// disappearing at the login boundary.
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestAChatCanHandItsTabStateToAnotherSurface(t *testing.T) {
+	got := ChatComponent(ChatConfig{
+		Ask:       true,
+		StorageNS: "home",
+		ImportNS:  "landing",
+	})
+
+	for _, want := range []string{
+		`var IMPORT_NS="landing"`,
+		"'mu_chat_'+from[n]+':'+IMPORT_NS",
+		"sessionStorage.removeItem(source)",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("the one-time chat handoff is missing %q", want)
+		}
+	}
+}
+
+func TestAStoredChatKeepsAnUnsentDraft(t *testing.T) {
+	got := ChatComponent(ChatConfig{Ask: true, StorageNS: "landing"})
+
+	for _, want := range []string{
+		"mu_chat_draft:",
+		"if(savedDraft)input.value=savedDraft",
+		"saveDraft()",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("the chat draft handoff is missing %q", want)
+		}
+	}
+}

--- a/internal/app/chat_continuity_test.go
+++ b/internal/app/chat_continuity_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestAChatCanHandItsTabStateToAnotherSurface(t *testing.T) {
 	got := ChatComponent(ChatConfig{
-		Ask:      true,
+		Ask:       true,
 		StorageNS: "home",
 		ImportNS:  "landing",
 	})


### PR DESCRIPTION
## Summary
- send a plain login or signup directly to `/home` while preserving explicit safe return destinations
- retain the landing chat's conversation, context and unsent draft in tab-local storage
- let Home adopt that landing state once after authentication, then remove the public copy
- keep Home's own chat state separate thereafter
- add regression coverage for redirects, draft retention and the one-time handoff

## Product shape
This keeps the two-page model intact: `/` remains the clean public front door and `/home` remains the personal dashboard. The transition now feels like the public assistant becomes the user's assistant instead of resetting at the threshold.

## Validation
- confirmed every committed blob after writing
- local diff is whitespace-clean
- GitHub Actions provides Go formatting/build/test validation