### PR TITLE
Persist agent progress across reconnects

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1254,8 +1254,6 @@ func streamNativeSSE(w http.ResponseWriter, accountID, prompt string, opts Query
 	emitted := false
 	var captured strings.Builder
 	var nativeTools []string
-	// The tool names behind those labels, for the run record.
-	var nativeToolNames []string
 	// Pairing a start with its end, by the provider's call id.
 	//
 	// It was keyed on the label, which is the same string for every command in
@@ -1289,8 +1287,13 @@ func streamNativeSSE(w http.ResponseWriter, accountID, prompt string, opts Query
 			startedTools[key] = true
 			emitted = true
 			nativeTools = append(nativeTools, run.Label)
-			nativeToolNames = append(nativeToolNames, NativeToolName(run.Name))
 			wmu.Unlock()
+			if accountID != "" {
+				updateFlow(flow.ID, func(f *Flow) {
+					f.Steps = append(f.Steps, FlowStep{ID: key, Tool: NativeToolName(run.Name),
+						Label: run.Label, Status: "running", Started: time.Now().UTC()})
+				})
+			}
 			send(map[string]any{"type": "tool_start", "name": run.Label, "message": run.Label})
 		},
 		ToolEnd: func(run ToolRun) {
@@ -1302,6 +1305,19 @@ func streamNativeSSE(w http.ResponseWriter, accountID, prompt string, opts Query
 			}
 			endedTools[key] = true
 			wmu.Unlock()
+			if accountID != "" {
+				updateFlow(flow.ID, func(f *Flow) {
+					name := NativeToolName(run.Name)
+					for i := len(f.Steps) - 1; i >= 0; i-- {
+						if f.Steps[i].ID == key || (run.ID == "" &&
+							f.Steps[i].Status == "running" && f.Steps[i].Tool == name) {
+							f.Steps[i].Status = "done"
+							f.Steps[i].Finished = time.Now().UTC()
+							break
+						}
+					}
+				})
+			}
 			send(map[string]any{"type": "tool_done", "name": run.Label, "message": run.Label + " — done"})
 		},
 		Token: func(tok string) {
@@ -1328,7 +1344,16 @@ func streamNativeSSE(w http.ResponseWriter, accountID, prompt string, opts Query
 		} else {
 			app.Log("agent", "stream failed before output: %v", err)
 		}
-		updateFlow(flow.ID, func(f *Flow) { f.Status = "error"; f.Error = err.Error() })
+		updateFlow(flow.ID, func(f *Flow) {
+			f.Status = "error"
+			f.Error = err.Error()
+			for i := range f.Steps {
+				if f.Steps[i].Status == "running" {
+					f.Steps[i].Status = "error"
+					f.Steps[i].Finished = time.Now().UTC()
+				}
+			}
+		})
 		send(map[string]any{"type": "error", "message": agentErrorMessage(err)})
 		send(map[string]any{"type": "done"})
 		return
@@ -1365,12 +1390,6 @@ func streamNativeSSE(w http.ResponseWriter, accountID, prompt string, opts Query
 			f.Answer = answer
 			f.HTML = html
 			f.Status = "done"
-			// What it ran. The stream emitted tool_start and tool_done to the
-			// browser and then dropped both on the floor, so a finished run
-			// recorded an answer and no account of how it got there.
-			for _, name := range nativeToolNames {
-				f.Steps = append(f.Steps, FlowStep{Tool: name})
-			}
 		})
 	}
 	send(map[string]any{"type": "response", "html": html, "flow_id": flow.ID})
@@ -1511,13 +1530,14 @@ func handleQuery(w http.ResponseWriter, r *http.Request) {
 	// turn to Ask and wait — but it must not write its own version of the record
 	// either, which is why it goes through the same three calls Ask uses.
 	if !guest {
-		if err := saveFlow(flow); err != nil {
-			app.Log("agent", "Failed to create flow: %v", err)
-		}
 		if threadID == "" {
 			// A conversation that starts here. Keyed on this first run, which is
 			// unique and is what the record was already keyed on.
 			threadID = Opened(accountID, thread.WebClient, flow.ID, "", req.Agent)
+		}
+		flow.ThreadID = threadID
+		if err := saveFlow(flow); err != nil {
+			app.Log("agent", "Failed to create flow: %v", err)
 		}
 		Said(accountID, threadID, req.Prompt, "", "")
 

--- a/agent/flows.go
+++ b/agent/flows.go
@@ -35,7 +35,8 @@ type Flow struct {
 	ParentID string `json:"parent_id"` // prior flow ID for multi-turn chains
 	// Via is which client the turn arrived through and which conversation on
 	// it, and is what lets the next message find this one. See thread.go.
-	Via       Via       `json:"via,omitzero"`
+	Via Via `json:"via,omitzero"`
+
 	// ThreadID is the conversation this run is answering. Unlike Via.Thread,
 	// which is the remote client's own key, this is the id in internal/thread.
 	// It lets any newly attached client find the active flow and its progress.

--- a/agent/flows.go
+++ b/agent/flows.go
@@ -36,14 +36,44 @@ type Flow struct {
 	// Via is which client the turn arrived through and which conversation on
 	// it, and is what lets the next message find this one. See thread.go.
 	Via       Via       `json:"via,omitzero"`
+	// ThreadID is the conversation this run is answering. Unlike Via.Thread,
+	// which is the remote client's own key, this is the id in internal/thread.
+	// It lets any newly attached client find the active flow and its progress.
+	ThreadID  string    `json:"thread_id,omitempty"`
 	CreatedAt time.Time `json:"created_at"`
 }
 
 // FlowStep records one tool call and its result within a flow.
 type FlowStep struct {
-	Tool   string         `json:"tool"`
-	Args   map[string]any `json:"args"`
-	Result string         `json:"result"`
+	ID       string         `json:"id,omitempty"`
+	Tool     string         `json:"tool"`
+	Label    string         `json:"label,omitempty"`
+	Args     map[string]any `json:"args"`
+	Result   string         `json:"result"`
+	Status   string         `json:"status,omitempty"`
+	Started  time.Time      `json:"started,omitzero"`
+	Finished time.Time      `json:"finished,omitzero"`
+}
+
+// flowProgress returns the live steps for the newest running flow on a thread.
+// It returns copies: callers must not observe a step being mutated after the
+// flow lock is released.
+func flowProgress(accountID, threadID string) []FlowStep {
+	flowMu.RLock()
+	defer flowMu.RUnlock()
+	var latest *Flow
+	for _, f := range flowStore {
+		if f.AccountID != accountID || f.ThreadID != threadID || f.Status != "running" {
+			continue
+		}
+		if latest == nil || f.CreatedAt.After(latest.CreatedAt) {
+			latest = f
+		}
+	}
+	if latest == nil {
+		return nil
+	}
+	return append([]FlowStep(nil), latest.Steps...)
 }
 
 var (

--- a/agent/pending.go
+++ b/agent/pending.go
@@ -107,10 +107,26 @@ func PendingHandler(w http.ResponseWriter, r *http.Request) {
 	for _, m := range msgs[cut+1:] {
 		b.WriteString(renderTurn(m, who))
 	}
+	steps := flowProgress(acc.ID, id)
+	type progressStep struct {
+		Label  string `json:"label"`
+		Status string `json:"status"`
+	}
+	progress := make([]progressStep, 0, len(steps))
+	for _, step := range steps {
+		label := step.Label
+		if label == "" {
+			label = step.Tool
+		}
+		if label != "" {
+			progress = append(progress, progressStep{Label: label, Status: step.Status})
+		}
+	}
 
 	app.RespondJSON(w, map[string]any{
 		"waiting": msgs[len(msgs)-1].Role != thread.RoleAgent,
 		"html":    b.String(),
+		"steps":   progress,
 	})
 }
 

--- a/agent/progress_test.go
+++ b/agent/progress_test.go
@@ -1,0 +1,50 @@
+package agent
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestRunningFlowProgressIsFoundByConversation(t *testing.T) {
+	const account = "progress_account"
+	const threadID = "progress_thread"
+	flow := &Flow{
+		ID: "progress_flow", AccountID: account, ThreadID: threadID,
+		Status: "running", CreatedAt: time.Now(),
+		Steps: []FlowStep{{
+			ID: "call_1", Tool: "web_search", Label: "Searching the web", Status: "running",
+		}},
+	}
+	flowMu.Lock()
+	flowStore[flow.ID] = flow
+	flowMu.Unlock()
+	t.Cleanup(func() {
+		flowMu.Lock()
+		delete(flowStore, flow.ID)
+		flowMu.Unlock()
+	})
+
+	got := flowProgress(account, threadID)
+	if len(got) != 1 || got[0].Label != "Searching the web" {
+		t.Fatalf("progress = %+v", got)
+	}
+	got[0].Label = "changed"
+	if flow.Steps[0].Label == "changed" {
+		t.Error("flowProgress returned the store's mutable slice")
+	}
+}
+
+func TestWebToolProgressIsPersistedWhileRunning(t *testing.T) {
+	src := webSource(t)
+	for _, want := range []string{
+		`Status: "running"`,
+		`Status: "done"`,
+		"updateFlow(flow.ID",
+		"flow.ThreadID = threadID",
+	} {
+		if !strings.Contains(src, want) {
+			t.Errorf("live flow progress is missing %q", want)
+		}
+	}
+}

--- a/agent/progress_test.go
+++ b/agent/progress_test.go
@@ -39,7 +39,7 @@ func TestWebToolProgressIsPersistedWhileRunning(t *testing.T) {
 	src := webSource(t)
 	for _, want := range []string{
 		`Status: "running"`,
-		`Status: "done"`,
+		`f.Steps[i].Status = "done"`,
 		"updateFlow(flow.ID",
 		"flow.ThreadID = threadID",
 	} {

--- a/docs/SERVICE_OS.md
+++ b/docs/SERVICE_OS.md
@@ -1,0 +1,189 @@
+# Mu as a service operating system
+
+## Thesis
+
+The next computer is ambient: it is reached through text, voice, messages,
+programs and events rather than through one screen. Mu is the open-source
+runtime for that computer. Micro is the personal assistant people use to reach
+it.
+
+The model is not the product. It interprets intent and chooses actions. The
+durable value is the system around it: identity, memory, conversations, runs,
+permissions and a dependable set of services that act on the digital and
+physical world.
+
+In this model:
+
+- a service is the unit of capability;
+- a tool is an operation a service exposes to an agent;
+- a flow is the durable record of one piece of work;
+- the agent loop is the shell that composes tools;
+- a saved composition is the equivalent of a script or executable; and
+- web, CLI, MCP, mail, SMS, WhatsApp and voice are clients of the same runtime.
+
+Unix made small programs useful by giving them a common process and stream
+model. Plan 9 made remote resources feel local by giving them a common
+interface. Mu should do the corresponding thing for services: make a capability
+discoverable, callable, observable and composable in the same way wherever it
+runs.
+
+## Existing foundation
+
+Mu already has more of this system than the chat interface makes visible:
+
+- `internal/service` is the service and tool registry used by the web, API,
+  CLI, MCP and agents.
+- `agent.Flow` and `agent.FlowStep` record runs and tool use.
+- `internal/thread` is the durable conversation record across clients.
+- `agent.QueryWithOpts` is the shared agent loop.
+- Native model calls have an idle timeout, retry budget, loop guard, step bound
+  and whole-turn deadline.
+- Web runs are created as `running` before execution, continue independently of
+  the HTTP request and can be recovered after the browser disconnects.
+- Tool annotations already distinguish operations that are safe to retry from
+  writes requiring care or idempotency.
+
+The work is therefore not to introduce another workflow abstraction. It is to
+finish making flows the reliable lifecycle already implied by the code.
+
+## Reliability contract
+
+Every accepted piece of work should have a durable identity and one explicit
+state:
+
+- `running`: work is progressing;
+- `waiting`: the system needs input, permission or payment;
+- `done`: the requested outcome and its record are complete;
+- `error`: work stopped, with a useful reason and the completed steps retained;
+- `cancelled`: somebody deliberately stopped it.
+
+A client connection is only a view onto a flow. Disconnecting must not cancel
+eligible work, erase progress or create a second execution when the client
+returns.
+
+Each tool call should be recorded before it starts and updated when it ends,
+including its stable call ID, tool name, safe display label, status, duration
+and error. Reads may be retried within a bounded policy. Writes require an
+idempotency key, a service guarantee, or explicit confirmation before a retry.
+The whole flow has a deadline, but individual services own shorter deadlines
+appropriate to their operations.
+
+Progress and terminal state must be readable through the same record from every
+client. SSE can make the live view pleasant, but correctness cannot depend on an
+open SSE connection.
+
+## Composition
+
+The first pipe is structured data, not punctuation. Tool results should carry a
+schema and provenance so the agent can pass one result to the next without
+flattening it into prose:
+
+```text
+web_fetch -> text_extract -> notes_add -> tasks_create
+```
+
+The flow records that graph and the values that crossed each edge. A useful
+flow can later be named, parameterised and run again as a new tool. This is the
+service equivalent of turning a shell pipeline into a script.
+
+Composition must not weaken the security of the components. The effective
+permissions of a flow are the intersection of the caller, agent and service;
+credentials are resolved only at the operation that needs them.
+
+## Services and the outside world
+
+Mu should not be limited to productivity-software connectors. Services can
+terminate protocols and participate directly in the world: HTTP, SMTP, XMPP,
+SSH, SFTP, telephony, SMS and messaging networks. That creates three broad
+families:
+
+1. digital primitives such as files, search, computation and storage;
+2. live infrastructure such as communications, devices and places; and
+3. third-party applications such as GitHub, Linear or Slack.
+
+They should share one service contract even though their credentials differ.
+A deployed service may use instance credentials to provide a capability to
+everyone, account credentials to act as one person, or a delegated grant for a
+narrow resource. Those modes must be declared per operation. A service must
+never infer that an instance credential authorises it to impersonate a user.
+
+Self-hosted installations can run a service per owner with local credentials.
+Multi-tenant installations need account-scoped encrypted credentials or OAuth
+grants, isolation at invocation, and revocation. This is a deployment choice,
+not a reason for services to expose different tool shapes.
+
+## Dynamic services
+
+Adding a service should eventually require no edit to Mu's central source. A
+service package needs a manifest containing:
+
+- identity, version and health endpoint;
+- operations with input and output schemas;
+- retry, idempotency and side-effect annotations;
+- required credential modes and scopes;
+- invocation transports such as local process, HTTP or MCP; and
+- optional human pages and protocol listeners.
+
+Mu can then install or register the package, validate its declaration, expose
+its operations through the common catalogue and make them immediately usable
+by agents. A public directory may distribute declarations and packages, while
+each instance decides what to install and which credentials to grant.
+
+## Roadmap
+
+### 1. Make flows dependable
+
+- Persist flow creation before execution on every client, not only the web.
+- Persist tool starts and completions while the run is active.
+- Reconcile `running` flows after restart instead of leaving them ambiguous.
+- Expose progress and terminal state consistently to web, CLI, MCP and inbound
+  protocol clients.
+- Classify errors and implement bounded, safety-aware retries.
+- Add cancellation and `waiting` states.
+
+### 2. Make flows inspectable
+
+- Give conversations a clear link to their active and completed flows.
+- Show current step, completed steps, elapsed time and actionable failures.
+- Add structured operational metrics for model and tool latency, retries and
+  failure rates.
+
+### 3. Make services composable
+
+- Define structured outputs and provenance.
+- Represent dependencies between steps as a flow graph.
+- Support parameters, conditions and approval boundaries.
+- Promote a completed flow into a reusable named tool.
+
+### 4. Make services installable
+
+- Specify the service manifest and lifecycle.
+- Support local-process, HTTP and MCP transports behind one registry contract.
+- Add package verification, health checks, upgrades and removal.
+- Build an optional directory without making a central directory a runtime
+  dependency.
+
+### 5. Broaden the ambient interface
+
+- Treat voice, calls, messages and events as first-class clients.
+- Preserve one identity, permission model, thread and flow record across them.
+- Let proactive work enter the same durable lifecycle as an interactive ask.
+
+## Market comparison to investigate
+
+The relevant comparison is architectural, not a feature checklist. Research
+should examine how OpenAI, Anthropic, Google, Microsoft, open-source assistants
+and agent runtimes handle:
+
+- first-party capabilities versus third-party connectors;
+- dynamic tool discovery and installation;
+- per-user OAuth grants versus operator credentials;
+- durable execution, retries, resumability and background work;
+- protocols beyond SaaS APIs;
+- structured composition and reusable workflows; and
+- self-hosted versus multi-tenant isolation.
+
+The strategic question is where Mu should interoperate and where it should own
+the abstraction. The likely boundary is: interoperate with external ecosystems
+through services, but own the common service contract, flow lifecycle and
+cross-protocol runtime.

--- a/internal/app/chat.go
+++ b/internal/app/chat.go
@@ -1026,6 +1026,11 @@ function ask(q){
           .then(function(r){return r.ok?r.json():null})
           .then(function(d){
             if(d&&d.html){a.outerHTML=d.html;save();toBottom(false);return;}
+            if(d&&Array.isArray(d.steps)&&d.steps.length){
+              done=[];workLabel='Working';
+              d.steps.forEach(function(s){if(s.status==='running')workLabel=s.label;else done.push(s.label);});
+              renderWork();save();
+            }
             if(d&&!d.waiting){
               a.innerHTML='<div class="mu-err">The run stopped without returning an answer.</div>';save();return;
             }
@@ -1273,11 +1278,12 @@ window.muChatAsk=ask;
 // broken". That was the whole report.
 if(PENDING&&contextId&&conv){(function(){
   var a=document.createElement('div');a.className='mu-agent';conv.appendChild(a);
-  var t0=Date.now(),timer=null;
+	var t0=Date.now(),timer=null,progress=[],current='Working';
   function draw(){
     var dots=['.','..','...'][Math.floor((Date.now()-t0)/450)%3];
     var secs=Math.round((Date.now()-t0)/1000);
-    a.innerHTML='<div class="mu-think"><span class="mu-spin"></span><span>Working'+dots+
+		var past='';for(var i=Math.max(0,progress.length-5);i<progress.length;i++)past+='<div class="mu-step">'+esc(progress[i])+'</div>';
+		a.innerHTML=past+'<div class="mu-think"><span class="mu-spin"></span><span>'+esc(current)+dots+
       '</span>'+(secs>=1?'<span class="mu-think-t">'+secs+'s</span>':'')+'</div>';
   }
   draw();timer=setInterval(draw,450);
@@ -1303,6 +1309,11 @@ if(PENDING&&contextId&&conv){(function(){
       .then(function(d){
         if(!d){done('');return;}
         if(d.html){done(d.html);return;}
+        if(Array.isArray(d.steps)){
+          progress=[];current='Working';
+          d.steps.forEach(function(s){if(s.status==='running')current=s.label;else progress.push(s.label);});
+          draw();
+        }
         if(!d.waiting){done('');return;}
         if(Date.now()>giveUp){
           done('<div class="mu-agent"><div class="card">No answer came back. '+


### PR DESCRIPTION
## What changes

- documents the thesis for Mu as a service operating system and the staged reliability/composition roadmap
- links each web flow to its durable conversation
- records tool starts and completions while a flow is running, rather than only after it finishes
- returns active steps from `/agent/pending`
- restores those steps in the chat after a refresh or dropped SSE connection
- adds regression coverage for account/thread-scoped progress and defensive copies

## Why

The agent run already outlives the browser, but its tool progress lived only in the SSE handler. A disconnect therefore reduced a live multi-tool run to a generic reconnecting spinner even though the server knew the work was continuing. Flow is the existing run abstraction; this completes that abstraction rather than adding another one.

## Scope

This first increment covers durable progress for the web flow. The design note records the follow-on work: early flow creation for every client, restart reconciliation, safety-aware retries, explicit waiting/cancelled states, structured composition, and dynamic services.