### PR TITLE
Reconcile interrupted agent flows on startup

### DIFF
--- a/agent/flows.go
+++ b/agent/flows.go
@@ -77,6 +77,27 @@ func flowProgress(accountID, threadID string) []FlowStep {
 	return append([]FlowStep(nil), latest.Steps...)
 }
 
+// flowError returns the terminal error for the newest flow on a thread. The
+// conversation may still end with the person's unanswered message, so pending
+// clients need the flow outcome to distinguish stopped work from live work.
+func flowError(accountID, threadID string) string {
+	flowMu.RLock()
+	defer flowMu.RUnlock()
+	var latest *Flow
+	for _, f := range flowStore {
+		if f.AccountID != accountID || f.ThreadID != threadID {
+			continue
+		}
+		if latest == nil || f.CreatedAt.After(latest.CreatedAt) {
+			latest = f
+		}
+	}
+	if latest == nil || latest.Status != "error" {
+		return ""
+	}
+	return latest.Error
+}
+
 var (
 	flowMu    sync.RWMutex
 	flowStore = map[string]*Flow{} // id → flow

--- a/agent/flows.go
+++ b/agent/flows.go
@@ -85,6 +85,7 @@ var (
 func init() {
 	var flows []*Flow
 	if err := data.LoadJSON("agent_flows.json", &flows); err == nil {
+		changed := reconcileInterruptedFlows(flows)
 		for _, f := range flows {
 			// Backfill status for pre-existing flows
 			if f.Status == "" && f.Answer != "" {
@@ -92,7 +93,33 @@ func init() {
 			}
 			flowStore[f.ID] = f
 		}
+		if changed {
+			persistFlows() //nolint:errcheck
+		}
 	}
+}
+
+const interruptedFlowError = "Run interrupted when the service restarted."
+
+// reconcileInterruptedFlows closes work restored from disk as running. The
+// goroutine that owned it belonged to the previous process, so presenting it
+// as live would leave every client waiting forever.
+func reconcileInterruptedFlows(flows []*Flow) bool {
+	changed := false
+	for _, f := range flows {
+		if f.Status != "running" {
+			continue
+		}
+		f.Status = "error"
+		f.Error = interruptedFlowError
+		for i := range f.Steps {
+			if f.Steps[i].Status == "running" {
+				f.Steps[i].Status = "error"
+			}
+		}
+		changed = true
+	}
+	return changed
 }
 
 // maxFlowsPerUser is the maximum number of flows kept per user.

--- a/agent/pending.go
+++ b/agent/pending.go
@@ -122,11 +122,18 @@ func PendingHandler(w http.ResponseWriter, r *http.Request) {
 			progress = append(progress, progressStep{Label: label, Status: step.Status})
 		}
 	}
+	waiting := msgs[len(msgs)-1].Role != thread.RoleAgent
+	runError := ""
+	if waiting {
+		runError = flowError(acc.ID, id)
+		waiting = runError == ""
+	}
 
 	app.RespondJSON(w, map[string]any{
-		"waiting": msgs[len(msgs)-1].Role != thread.RoleAgent,
+		"waiting": waiting,
 		"html":    b.String(),
 		"steps":   progress,
+		"error":   runError,
 	})
 }
 

--- a/agent/progress_test.go
+++ b/agent/progress_test.go
@@ -48,3 +48,26 @@ func TestWebToolProgressIsPersistedWhileRunning(t *testing.T) {
 		}
 	}
 }
+
+func TestInterruptedFlowsAreClosedOnStartup(t *testing.T) {
+	flows := []*Flow{
+		{Status: "running", Steps: []FlowStep{{Status: "done"}, {Status: "running"}}},
+		{Status: "done", Error: "keep me"},
+	}
+
+	if !reconcileInterruptedFlows(flows) {
+		t.Fatal("running flow was not reconciled")
+	}
+	if flows[0].Status != "error" || flows[0].Error != interruptedFlowError {
+		t.Errorf("interrupted flow = %+v", flows[0])
+	}
+	if flows[0].Steps[0].Status != "done" || flows[0].Steps[1].Status != "error" {
+		t.Errorf("interrupted steps = %+v", flows[0].Steps)
+	}
+	if flows[1].Status != "done" || flows[1].Error != "keep me" {
+		t.Errorf("completed flow changed = %+v", flows[1])
+	}
+	if reconcileInterruptedFlows(flows) {
+		t.Error("reconciliation was not idempotent")
+	}
+}

--- a/agent/progress_test.go
+++ b/agent/progress_test.go
@@ -71,3 +71,21 @@ func TestInterruptedFlowsAreClosedOnStartup(t *testing.T) {
 		t.Error("reconciliation was not idempotent")
 	}
 }
+
+func TestInterruptedFlowErrorIsVisibleToPendingClient(t *testing.T) {
+	flow := &Flow{ID: "interrupted_pending_flow", AccountID: "interrupted_pending_account",
+		ThreadID: "interrupted_pending_thread", Status: "error", Error: interruptedFlowError,
+		CreatedAt: time.Now()}
+	flowMu.Lock()
+	flowStore[flow.ID] = flow
+	flowMu.Unlock()
+	t.Cleanup(func() {
+		flowMu.Lock()
+		delete(flowStore, flow.ID)
+		flowMu.Unlock()
+	})
+
+	if got := flowError(flow.AccountID, flow.ThreadID); got != interruptedFlowError {
+		t.Errorf("flowError = %q", got)
+	}
+}

--- a/internal/app/chat.go
+++ b/internal/app/chat.go
@@ -1032,7 +1032,7 @@ function ask(q){
               renderWork();save();
             }
             if(d&&!d.waiting){
-              a.innerHTML='<div class="mu-err">The run stopped without returning an answer.</div>';save();return;
+              a.innerHTML='<div class="mu-err">'+esc(d.error||'The run stopped without returning an answer.')+'</div>';save();return;
             }
             if(Date.now()>reconnectUntil){
               a.innerHTML='<div class="mu-err">The connection was lost and no answer came back. Please try again.</div>';save();return;
@@ -1314,7 +1314,9 @@ if(PENDING&&contextId&&conv){(function(){
           d.steps.forEach(function(s){if(s.status==='running')current=s.label;else progress.push(s.label);});
           draw();
         }
-        if(!d.waiting){done('');return;}
+        if(!d.waiting){
+          done(d.error?'<div class="mu-agent"><div class="card mu-err">'+esc(d.error)+'</div></div>':'');return;
+        }
         if(Date.now()>giveUp){
           done('<div class="mu-agent"><div class="card">No answer came back. '+
             'The run may have stopped when the server restarted — ask again.</div></div>');


### PR DESCRIPTION
Closes the phantom-progress gap left after #1512.

When Mu starts, a flow restored as `running` cannot still have an owning goroutine: that work belonged to the previous process. Mark those flows as `error` with a clear restart reason, and mark only their still-running steps as errored. Completed flows and completed steps remain unchanged.

The reconciliation is persisted immediately and is idempotent, so Micro and other clients no longer wait forever on stale work.

Includes focused coverage for interrupted, completed, and repeat reconciliation cases.

Part of #1513.