### PR TITLE
Expose the home card headlines as a news endpoint

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 **A personal server: one Go binary you can self-host that carries a web app, an
 HTTP API, a CLI, an MCP server and an installable PWA over the same 35 services
-and 119 tools.** `go build ./...` produces it; nothing else has to be running.
+and 120 tools.** `go build ./...` produces it; nothing else has to be running.
 
 It is not a framework or a set of libraries. It is a thing that runs, that you
 sign into, and that other programs can call.

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -2043,9 +2043,9 @@ func placesMapURL(args map[string]any, items []placeItem) string {
 // summary suitable for inclusion in the AI synthesis RAG context.
 func formatToolResult(toolName, result string, args map[string]any) string {
 	switch toolName {
-	case "news", "news_search":
+	case "news", "news_search", "news_headlines":
 		return withCurrentDateContext(formatNewsResult(result))
-	case "news_headlines", "news_list", "news_read":
+	case "news_list", "news_read":
 		return withCurrentDateContext(result)
 	case "video_search":
 		return formatVideoResult(result)
@@ -2211,7 +2211,8 @@ func formatNewsResult(result string) string {
 	}
 
 	var data struct {
-		Feed []struct {
+		Items []formattedNewsItem `json:"items"`
+		Feed  []struct {
 			Title       string `json:"title"`
 			Description string `json:"description"`
 			Category    string `json:"category"`
@@ -2237,7 +2238,7 @@ func formatNewsResult(result string) string {
 	if err := json.Unmarshal([]byte(result), &data); err != nil {
 		return result
 	}
-	var items []formattedNewsItem
+	items := data.Items
 	for _, a := range data.Results {
 		items = append(items, formattedNewsItem{a.Title, a.Description, a.Category, a.URL, a.PostedAt, ""})
 	}

--- a/agent/tool_text_test.go
+++ b/agent/tool_text_test.go
@@ -8,7 +8,10 @@ package agent
 // envelope — which is how an instruction to turn a sender down politely came
 // back as `{"text":"Your inbox (5 messages):\n- ..."}`.
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestTheResponseEnvelopeIsNotAnAnswer(t *testing.T) {
 	unwrapped := map[string]string{
@@ -44,5 +47,20 @@ func TestAToolWithNoFormatterStillReadsAsText(t *testing.T) {
 		t.Errorf("a tool nobody wrote a formatter for rendered as %q — the switch in "+
 			"formatToolResult names the tools somebody got to, and everything after "+
 			"it has to read as prose without being added to that list", got)
+	}
+}
+
+func TestHeadlineItemsRemainReadableInTheAnswerFallback(t *testing.T) {
+	const payload = `{"items":[{"title":"A new discovery","category":"science","url":"https://example.test/story","description":"Researchers report their findings"}]}`
+	got := formatToolResult("news_headlines", payload, nil)
+	if !strings.Contains(got, "A new discovery") || strings.Contains(got, `{"items"`) {
+		t.Fatalf("headlines were not rendered: %q", got)
+	}
+	lines := strings.Join(meaningfulLines(got, 10), "\n")
+	if !strings.Contains(lines, "A new discovery") {
+		t.Fatalf("answer fallback lost headlines: %q", lines)
+	}
+	if got := formatToolResult("news_headlines", `{"items":[]}`, nil); !strings.Contains(got, "No news available") {
+		t.Fatalf("empty headlines: %q", got)
 	}
 }

--- a/server.json
+++ b/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "mu.micro/mu",
-  "description": "A personal agent: it has an email address and it answers. News, web search, mail, markets, weather, places, transit, files, calendar, contacts and notes behind it. 119 tools, one endpoint.",
+  "description": "A personal agent: it has an email address and it answers. News, web search, mail, markets, weather, places, transit, files, calendar, contacts and notes behind it. 120 tools, one endpoint.",
   "repository": {
     "url": "https://github.com/micro/mu",
     "source": "github"

--- a/service/news/headlines_test.go
+++ b/service/news/headlines_test.go
@@ -30,6 +30,9 @@ func TestHeadlinesReturnsOneStoryPerTopic(t *testing.T) {
 		t.Fatalf("got %d headlines, want 10", len(rsp.Items))
 	}
 	for i, h := range rsp.Items {
+		if !strings.Contains(rsp.Text, "["+h.Category+"] "+h.Title) || !strings.Contains(rsp.Text, h.URL) {
+			t.Errorf("readable output is missing headline %d: %q", i, rsp.Text)
+		}
 		if h.Title != fmt.Sprintf("story %d-0", i) || h.Category != fmt.Sprintf("topic %02d", i) || h.URL != fmt.Sprintf("https://example.test/%d/0", i) || h.Description != "summary" {
 			t.Errorf("headline %d: %+v", i, h)
 		}
@@ -54,7 +57,7 @@ func TestHeadlinesReturnsOneStoryPerTopic(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if string(b) != `{"items":[]}` {
+	if string(b) != `{"text":"No news headlines available right now.","items":[]}` {
 		t.Fatalf("empty feed: %s", b)
 	}
 }

--- a/service/news/headlines_test.go
+++ b/service/news/headlines_test.go
@@ -30,9 +30,6 @@ func TestHeadlinesReturnsOneStoryPerTopic(t *testing.T) {
 		t.Fatalf("got %d headlines, want 10", len(rsp.Items))
 	}
 	for i, h := range rsp.Items {
-		if !strings.Contains(rsp.Text, "["+h.Category+"] "+h.Title) || !strings.Contains(rsp.Text, h.URL) {
-			t.Errorf("readable output is missing headline %d: %q", i, rsp.Text)
-		}
 		if h.Title != fmt.Sprintf("story %d-0", i) || h.Category != fmt.Sprintf("topic %02d", i) || h.URL != fmt.Sprintf("https://example.test/%d/0", i) || h.Description != "summary" {
 			t.Errorf("headline %d: %+v", i, h)
 		}
@@ -57,7 +54,7 @@ func TestHeadlinesReturnsOneStoryPerTopic(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if string(b) != `{"text":"No news headlines available right now.","items":[]}` {
+	if string(b) != `{"items":[]}` {
 		t.Fatalf("empty feed: %s", b)
 	}
 }

--- a/service/news/headlines_test.go
+++ b/service/news/headlines_test.go
@@ -1,0 +1,60 @@
+package news
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestHeadlinesReturnsOneStoryPerTopic(t *testing.T) {
+	at := time.Date(2026, 9, 6, 12, 0, 0, 0, time.UTC)
+	var posts []*Post
+	for i := 11; i >= 0; i-- {
+		for j := 1; j >= 0; j-- {
+			posts = append(posts, &Post{ID: fmt.Sprintf("%d-%d", i, j), Title: fmt.Sprintf("story %d-%d", i, j), URL: fmt.Sprintf("https://example.test/%d/%d", i, j), Category: fmt.Sprintf("topic %02d", i), Description: "summary", PostedAt: at.Add(-time.Duration(i+j*24) * time.Hour)})
+		}
+	}
+	mutex.Lock()
+	was := feed
+	feed = posts
+	mutex.Unlock()
+	t.Cleanup(func() { mutex.Lock(); feed = was; mutex.Unlock() })
+	var rsp HeadlinesResponse
+	if err := (Server{}).Headlines(context.Background(), &HeadlinesRequest{}, &rsp); err != nil {
+		t.Fatal(err)
+	}
+	if len(rsp.Items) != 10 {
+		t.Fatalf("got %d headlines, want 10", len(rsp.Items))
+	}
+	for i, h := range rsp.Items {
+		if h.Title != fmt.Sprintf("story %d-0", i) || h.Category != fmt.Sprintf("topic %02d", i) || h.URL != fmt.Sprintf("https://example.test/%d/0", i) || h.Description != "summary" {
+			t.Errorf("headline %d: %+v", i, h)
+		}
+	}
+	// The response and rendered card select the same stories, in the same order.
+	html := generateHeadlinesHTML(cardPosts(GetFeed()))
+	last := -1
+	for _, h := range rsp.Items {
+		pos := strings.Index(html, h.Title)
+		if pos <= last {
+			t.Fatalf("card differs at %q", h.Title)
+		}
+		last = pos
+	}
+	mutex.Lock()
+	feed = nil
+	mutex.Unlock()
+	if err := (Server{}).Headlines(context.Background(), &HeadlinesRequest{}, &rsp); err != nil {
+		t.Fatal(err)
+	}
+	b, err := json.Marshal(rsp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(b) != `{"items":[]}` {
+		t.Fatalf("empty feed: %s", b)
+	}
+}

--- a/service/news/service.go
+++ b/service/news/service.go
@@ -12,6 +12,27 @@ import (
 // RPC endpoints and, through the agent and gateways, as AI tools.
 type Server struct{}
 
+// HeadlinesRequest selects the current home card without filters.
+type HeadlinesRequest struct{}
+
+// HeadlinesResponse is the same headline selection shown on the home card.
+type HeadlinesResponse struct {
+	Items []Headline `json:"items" description:"Latest story per topic, freshest first, at most ten, as on the home card"`
+}
+
+// Headlines returns the home card's current stories as data.
+// @example {}
+func (Server) Headlines(_ context.Context, _ *HeadlinesRequest, rsp *HeadlinesResponse) error {
+	posts := cardPosts(GetFeed())
+	rsp.Items = make([]Headline, 0, len(posts))
+	for _, p := range posts {
+		rsp.Items = append(rsp.Items, Headline{
+			Title: p.Title, URL: p.URL, Category: p.Category, Description: p.Description,
+		})
+	}
+	return nil
+}
+
 // ListRequest filters the headline list.
 type ListRequest struct {
 	Topic string `json:"topic" description:"Optional topic/category filter (e.g. tech, world, business)"`
@@ -100,8 +121,9 @@ var Spec = service.Spec{
 	// behind it — see service.Spec.Now and Now, above.
 	Now: Now,
 	Endpoints: map[string]service.Endpoint{
-		"List":   {Aliases: []string{"news", "news_headlines"}, Doc: "Read recent news headlines with short summaries, balanced across topics"},
-		"Read":   {Doc: "Read one news article in full by its id or URL"},
-		"Search": {Doc: "Search indexed and live news for a topic", Cost: quota.OpNewsSearch},
+		"Headlines": {Doc: "Read the home card headlines: latest story per topic, freshest first, at most ten"},
+		"List":      {Aliases: []string{"news"}, Doc: "Read recent news headlines with short summaries, balanced across topics"},
+		"Read":      {Doc: "Read one news article in full by its id or URL"},
+		"Search":    {Doc: "Search indexed and live news for a topic", Cost: quota.OpNewsSearch},
 	},
 }

--- a/service/news/service.go
+++ b/service/news/service.go
@@ -2,8 +2,6 @@ package news
 
 import (
 	"context"
-	"fmt"
-	"strings"
 	"time"
 
 	"mu/internal/quota"
@@ -19,7 +17,6 @@ type HeadlinesRequest struct{}
 
 // HeadlinesResponse is the same headline selection shown on the home card.
 type HeadlinesResponse struct {
-	Text  string     `json:"text" description:"The home card headlines with topics and article URLs"`
 	Items []Headline `json:"items" description:"Latest story per topic, freshest first, at most ten, as on the home card"`
 }
 
@@ -27,24 +24,11 @@ type HeadlinesResponse struct {
 // @example {}
 func (Server) Headlines(_ context.Context, _ *HeadlinesRequest, rsp *HeadlinesResponse) error {
 	posts := cardPosts(GetFeed())
-	var text strings.Builder
 	rsp.Items = make([]Headline, 0, len(posts))
 	for _, p := range posts {
 		rsp.Items = append(rsp.Items, Headline{
 			Title: p.Title, URL: p.URL, Category: p.Category, Description: p.Description,
 		})
-		fmt.Fprintf(&text, "[%s] %s\n", p.Category, p.Title)
-		if p.Description != "" {
-			fmt.Fprintln(&text, p.Description)
-		}
-		if p.URL != "" {
-			fmt.Fprintln(&text, p.URL)
-		}
-		fmt.Fprintln(&text)
-	}
-	rsp.Text = strings.TrimSpace(text.String())
-	if len(posts) == 0 {
-		rsp.Text = "No news headlines available right now."
 	}
 	return nil
 }

--- a/service/news/service.go
+++ b/service/news/service.go
@@ -2,6 +2,8 @@ package news
 
 import (
 	"context"
+	"fmt"
+	"strings"
 	"time"
 
 	"mu/internal/quota"
@@ -17,6 +19,7 @@ type HeadlinesRequest struct{}
 
 // HeadlinesResponse is the same headline selection shown on the home card.
 type HeadlinesResponse struct {
+	Text  string     `json:"text" description:"The home card headlines with topics and article URLs"`
 	Items []Headline `json:"items" description:"Latest story per topic, freshest first, at most ten, as on the home card"`
 }
 
@@ -24,11 +27,24 @@ type HeadlinesResponse struct {
 // @example {}
 func (Server) Headlines(_ context.Context, _ *HeadlinesRequest, rsp *HeadlinesResponse) error {
 	posts := cardPosts(GetFeed())
+	var text strings.Builder
 	rsp.Items = make([]Headline, 0, len(posts))
 	for _, p := range posts {
 		rsp.Items = append(rsp.Items, Headline{
 			Title: p.Title, URL: p.URL, Category: p.Category, Description: p.Description,
 		})
+		fmt.Fprintf(&text, "[%s] %s\n", p.Category, p.Title)
+		if p.Description != "" {
+			fmt.Fprintln(&text, p.Description)
+		}
+		if p.URL != "" {
+			fmt.Fprintln(&text, p.URL)
+		}
+		fmt.Fprintln(&text)
+	}
+	rsp.Text = strings.TrimSpace(text.String())
+	if len(posts) == 0 {
+		rsp.Text = "No news headlines available right now."
 	}
 	return nil
 }

--- a/test/alias_test.go
+++ b/test/alias_test.go
@@ -26,11 +26,13 @@ import (
 // legacy is every retired name that must keep resolving, and what it resolves
 // to. Add to it when a tool is renamed; never remove from it, because removing
 // an entry is exactly the breakage this is here to catch.
+// news_headlines was deliberately promoted to its own no-argument endpoint
+// for the home card selection. Callers wanting topic/limit or ListResponse.Text
+// must use news_list; it is no longer a compatibility alias.
 var legacy = map[string]string{
 	"search_web":     "web_search",
 	"search_fetch":   "web_fetch",
 	"news":           "news_list",
-	"news_headlines": "news_list",
 	"markets":        "markets_list",
 	"image_generate": "images_generate",
 	"image_search":   "images_search",

--- a/test/permissions.golden
+++ b/test/permissions.golden
@@ -54,6 +54,7 @@ maps_area                    needsAccount=false destructive=false open accountOn
 maps_tile                    needsAccount=false destructive=false open accountOnly=false optionalAuth=false
 markets_convert              needsAccount=false destructive=false open accountOnly=false optionalAuth=false
 markets_list                 needsAccount=false destructive=false open accountOnly=false optionalAuth=false
+news_headlines               needsAccount=false destructive=false open accountOnly=false optionalAuth=false
 news_list                    needsAccount=false destructive=false open accountOnly=false optionalAuth=false
 news_read                    needsAccount=false destructive=false open accountOnly=false optionalAuth=false
 news_search                  needsAccount=false destructive=false bound accountOnly=false optionalAuth=true


### PR DESCRIPTION
The home card shows the latest story per topic, while news_list returns a broader, configurable list. Callers need to request the card's concise selection directly.

Add news.Headlines, exposed automatically as /api/v1/news/headlines and news_headlines. It takes no parameters and returns structured items with titles, URLs, categories and descriptions using the existing cardPosts selection: one story per topic, freshest first, at most ten. Empty feeds return an empty items array. The agent's existing news formatter accepts these items for readable synthesis and answer fallback, without dropping structured fields from the public response. Update the tool count to 120 and record the public, read-only permission policy.

Compatibility: as explicitly approved by the owner, news_headlines changes from an alias of List to this endpoint. Existing callers needing topic, limit or ListResponse.Text should use news_list; news_list and the news alias retain their behavior. The legacy-name test documents this deliberate exception.

Validation: news, internal/service, internal/api, internal/tool, the complete ./test suite, and focused agent news/answer-fallback tests pass. News, service/API and focused agent tests were checked with the race detector. Formatting and vet pass; all four release targets passed prior CI runs, and final CI is in progress. The only failures on the last full CI run were home/TestTheNameIsTheSameOnEverySurface and internal/origin/TestURLPreservesExplicitPublicSurface; both reproduce on untouched main 72d7f451. CI skips its full race step after those failures. See validation comments for local environment limitations.

Codex findings addressed: documented the approved alias replacement; retained structured items in the public response; formatted those items in the agent so the answer fallback does not discard them. Regression coverage exercises the formatter and meaningfulLines together. All review threads resolved. Codex Cloud remains enabled.