### PR TITLE
Restore news images and clear topic labels; use small action buttons

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -1349,7 +1349,7 @@ func headAdmin(acc *auth.Account) string {
 	//
 	// Set like the rest of this corner — it is a link to somewhere, the same as
 	// the name beside it, and it should read as one.
-	return `<a id="head-admin" href="/admin">Admin</a>`
+	return `<a id="head-admin" class="mini-btn" href="/admin">Admin</a>`
 }
 
 // navPinned is the reader's own services, under a heading of their own.

--- a/internal/app/html/mu.css
+++ b/internal/app/html/mu.css
@@ -812,19 +812,13 @@ td {
    colour. The label goes at phone width — #head-right is beside a centred brand
    and the two of them fight for the middle — and the icon stays, which is why
    there is an aria-label on the link. */
-/* Admin, beside the name. It was an icon with a label — the rail's markup,
-   borrowed — and the icon said nothing the word did not; on a phone the label
-   was hidden and what was left was a glyph you had to guess. Set like the rest
-   of the corner, because it is a link to somewhere the same as the name is. */
+/* Admin uses the same small white control as content actions. */
 #head-admin {
-  color: #555;
+  display: inline-flex;
+  align-items: center;
   text-decoration: none;
-  font-size: 14px;
-  font-weight: 600;
-  line-height: 20px;
   white-space: nowrap;
 }
-#head-admin:hover { color: #111; }
 
 #head-wallet {
   display: none;

--- a/internal/app/reading.go
+++ b/internal/app/reading.go
@@ -16,12 +16,12 @@ import (
 // enter the shared feed HTML cache.
 func SaveControl(r *http.Request, ref string) string {
 	if r.URL.Query().Get("saved") == ref {
-		return `<a href="/bookmarks">Saved ✓</a>`
+		return `<a class="mini-btn" href="/bookmarks">Saved ✓</a>`
 	}
 	if _, acc := auth.TrySession(r); acc == nil {
-		return `<a href="/bookmarks?item=` + url.QueryEscape(ref) + `">Save</a>`
+		return `<a class="mini-btn" href="/bookmarks?item=` + url.QueryEscape(ref) + `">Save</a>`
 	}
-	return `<form method="POST" action="/bookmarks" class="reading-save"><input type="hidden" name="action" value="add"><input type="hidden" name="ref" value="` + html.EscapeString(ref) + `"><input type="hidden" name="back" value="` + html.EscapeString(r.URL.RequestURI()) + `">` + CSRFField(auth.CSRFToken(r)) + `<button type="submit">Save</button></form>`
+	return `<form method="POST" action="/bookmarks" class="reading-save"><input type="hidden" name="action" value="add"><input type="hidden" name="ref" value="` + html.EscapeString(ref) + `"><input type="hidden" name="back" value="` + html.EscapeString(r.URL.RequestURI()) + `">` + CSRFField(auth.CSRFToken(r)) + `<button class="mini-btn" type="submit">Save</button></form>`
 }
 func ReadingActions(r *http.Request, ref string) string {
 	return `<div class="reading-actions">` + ReadingActionItems(r, ref) + `</div>`
@@ -36,7 +36,7 @@ func ReadingActionItems(r *http.Request, ref string) string {
 	} else if strings.HasPrefix(r.URL.Path, "/blog") {
 		path = "/blog/post?id=" + url.QueryEscape(ref)
 	}
-	return SaveControl(r, ref) + `<a href="` + html.EscapeString(path) + `" onclick="event.preventDefault();const u=this.href;if(navigator.share){navigator.share({url:u}).catch(()=>{})}else{navigator.clipboard.writeText(u).catch(()=>{})}">Share</a>` + `<a href="/agent/micro?item=` + url.QueryEscape(ref) + `">Discuss</a>`
+	return SaveControl(r, ref) + `<button class="mini-btn" type="button" data-url="` + html.EscapeString(path) + `" onclick="const u=new URL(this.dataset.url,location.href).href;if(navigator.share){navigator.share({url:u}).catch(()=>{})}else{navigator.clipboard.writeText(u).catch(()=>{})}">Share</button>` + `<a class="mini-btn" href="/agent/micro?item=` + url.QueryEscape(ref) + `">Discuss</a>`
 }
 func ReadingFilters(path, active string, categories []string) string {
 	sort.Strings(categories)
@@ -78,5 +78,5 @@ func ReadingPages(path, category string, page, total, size int) string {
 }
 
 const ReadingCSS = `<style>
-.reading-row{padding:18px 0;border-bottom:1px solid var(--border,#eee)}.reading-row h3{font-size:18px;line-height:1.4;margin:5px 0}.reading-row p{font-size:14px;line-height:1.6;color:var(--text-muted,#666);margin:6px 0}.reading-meta{font-size:12px;color:var(--text-muted,#777)}.reading-actions{display:flex;align-items:center;gap:16px;flex-wrap:wrap;margin:12px 0;font-size:14px}.reading-actions form,.reading-save{display:inline-flex;flex:0 0 auto;width:auto;margin:0;padding:0}.reading-actions>a,.reading-save button{white-space:nowrap}.reading-save button{font:inherit;background:none;border:0;padding:0;color:inherit;cursor:pointer;text-decoration:underline}.reading-list{max-width:840px}.reading-row h3 a{text-decoration:none}.reading-row h3 a:hover{text-decoration:underline}
+.reading-row{padding:18px 0;border-bottom:1px solid var(--border,#eee)}.reading-row h3{font-size:18px;line-height:1.4;margin:5px 0}.reading-row p{font-size:14px;line-height:1.6;color:var(--text-muted,#666);margin:6px 0}.reading-meta{font-size:12px;color:var(--text-muted,#777)}.reading-actions{display:flex;align-items:center;gap:8px;flex-wrap:wrap;margin:12px 0;font-size:14px}.reading-actions form,.reading-save{display:inline-flex;flex:0 0 auto;width:auto;margin:0;padding:0}.reading-actions>a,.reading-save button{white-space:nowrap}.reading-actions .mini-btn{display:inline-flex;align-items:center;justify-content:center;text-decoration:none}.reading-list{max-width:840px}.reading-row h3 a{text-decoration:none}.reading-row h3 a:hover{text-decoration:underline}
 </style>`

--- a/service/news/browse.go
+++ b/service/news/browse.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"mu/internal/app"
+	"mu/internal/imageproxy"
 )
 
 func browse(r *http.Request, posts []*Post) string {
@@ -37,7 +38,17 @@ func browse(r *http.Request, posts []*Post) string {
 		b.WriteString(`<p>No articles in this category yet.</p>`)
 	}
 	for _, p := range items[start:end] {
-		b.WriteString(`<article id="reading-` + htmlpkg.EscapeString(p.ID) + `" class="reading-row"><div class="reading-meta">` + htmlpkg.EscapeString(getDomain(p.URL)+" · "+p.Category+" · "+app.TimeAgo(p.PostedAt)) + `</div><h3><a href="/news?id=` + url.QueryEscape(p.ID) + `">` + htmlpkg.EscapeString(p.Title) + `</a></h3>`)
+		articleURL := "/news?id=" + url.QueryEscape(p.ID)
+		b.WriteString(`<article id="reading-` + htmlpkg.EscapeString(p.ID) + `" class="reading-row news-reading-row">`)
+		if p.Image != "" {
+			b.WriteString(`<a class="news-reading-image" href="` + articleURL + `" aria-label="` + htmlpkg.EscapeString(p.Title) + `"><img src="` + htmlpkg.EscapeString(imageproxy.URL(p.Image)) + `" alt="" loading="lazy" onerror="this.parentElement.hidden=true"></a>`)
+		}
+		b.WriteString(`<div class="news-reading-content">`)
+		if p.Category != "" {
+			b.WriteString(`<div class="category-header"><a class="news-topic" href="/news?category=` + url.QueryEscape(p.Category) + `">` + htmlpkg.EscapeString(p.Category) + `</a></div>`)
+		}
+		b.WriteString(`<h3><a href="` + articleURL + `">` + htmlpkg.EscapeString(p.Title) + `</a></h3><div class="reading-meta">` + htmlpkg.EscapeString(getDomain(p.URL)+" · "+app.TimeAgo(p.PostedAt)) + `</div>`)
+
 		description := []rune(htmlToText(p.Description))
 		if len(description) > 240 {
 			description = append(description[:240], '…')
@@ -45,10 +56,19 @@ func browse(r *http.Request, posts []*Post) string {
 		if len(description) > 0 {
 			b.WriteString(`<p>` + htmlpkg.EscapeString(string(description)) + `</p>`)
 		}
-		b.WriteString(app.ReadingActions(r, p.ID) + `</article>`)
+		b.WriteString(app.ReadingActions(r, p.ID) + `</div></article>`)
 	}
 	b.WriteString(app.ReadingPages("/news", category, page, len(items), 20))
-	return b.String() + `</div>` + app.ReadingCSS
+	return b.String() + `</div>` + app.ReadingCSS + `<style>
+.news-reading-row{display:flex;gap:20px;align-items:flex-start}
+.news-reading-content{flex:1;min-width:0}
+.news-reading-image{flex:0 0 200px;display:block}
+.news-reading-image[hidden]{display:none}
+.news-reading-image img{display:block;width:100%;aspect-ratio:4/3;object-fit:cover;border-radius:var(--border-radius,6px)}
+.news-reading-row .category-header{margin-bottom:6px}
+.news-topic{display:inline-block;padding:3px 8px;border:1px solid var(--card-border,#ddd);border-radius:var(--border-radius,6px);background:var(--card-background,#fff);color:var(--text-secondary,#555);font-size:12px;font-weight:600;text-decoration:none}
+@media(max-width:600px){.news-reading-row{flex-direction:column;gap:12px}.news-reading-content{width:100%}.news-reading-image{flex-basis:auto;width:100%}.news-reading-image img{aspect-ratio:16/9}}
+</style>`
 }
 
 func feedBody(r *http.Request, posts []*Post) string {


### PR DESCRIPTION
The new /news reading list omitted article images and buried topics in muted metadata. This restores proxied, lazy-loaded images and distinct linked topic badges. Desktop rows show thumbnails beside the text; mobile rows put the image above it.

Save, Share and Discuss reuse the existing white mini-btn styling across News, Blog and Video. Share is a button; navigation remains accessible links styled as buttons. The top-right Admin link uses the same control. Save remains a POST with CSRF protection.

Validation: News, Blog, Video, internal/app and architecture tests pass; formatting and diff checks pass. No new dependencies. Live desktop screenshots of /news and /news?category=World confirm restored article images, distinct topic badges and white action buttons after deployment. Current main has the previously reproduced Home naming and explicit-origin test failures; CI will be checked for additional failures before merge.

- [x] Read current AGENTS.md and inspect main
- [x] Restore images and clear article topics
- [x] Reuse small white buttons for reading actions and Admin
- [x] Run affected-package and architecture tests
- [x] Address Codex review and check CI
- [x] Merge and check automatic deployment (Deploy run 34087825015 succeeded)