### PR TITLE
Style remaining Discuss and Share actions consistently

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1187,10 +1187,10 @@ func serveFlowPage(w http.ResponseWriter, r *http.Request, id string) {
 		b.WriteString(`</div>`)
 	}
 
-	// Actions — no card wrapper, just links
+	// Actions below the saved run.
 	b.WriteString(`<div class="d-flex gap-3 items-center mt-3 text-sm">`)
 	b.WriteString(`<a href="/agent?continue=` + f.ID + `">Continue →</a>`)
-	b.WriteString(`<a href="#" onclick="var u=location.href;if(navigator.share){navigator.share({url:u})}else if(navigator.clipboard){navigator.clipboard.writeText(u).then(function(){this.textContent='Copied!'}.bind(this))}else{prompt('Copy:',u)};return false;">Share</a>`)
+	b.WriteString(`<a class="mini-btn" href="#" onclick="var u=location.href;if(navigator.share){navigator.share({url:u})}else if(navigator.clipboard){navigator.clipboard.writeText(u).then(function(){this.textContent='Copied!'}.bind(this))}else{prompt('Copy:',u)};return false;">Share</a>`)
 	b.WriteString(`</div>`)
 
 	app.Respond(w, r, app.Response{Title: "Agent", Description: "Saved agent query: " + htmlEsc(f.Prompt), HTML: b.String()})

--- a/internal/app/html/mu.css
+++ b/internal/app/html/mu.css
@@ -3530,6 +3530,10 @@ a.highlight {
 }
 
 .mini-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  text-decoration: none;
   background: var(--card-background, #fff);
   color: var(--text-secondary, #555);
   cursor: pointer;

--- a/service/bookmarks/page.go
+++ b/service/bookmarks/page.go
@@ -115,7 +115,7 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		b.WriteString(`<p><a href="/bookmarks">← Bookmarks</a></p><h2>` + html.EscapeString(item.Title) + `</h2><p>` + html.EscapeString(item.Excerpt) + `</p>`)
-		b.WriteString(`<div class="reading-actions"><a href="` + html.EscapeString(item.URL) + `" rel="noopener noreferrer">Original ↗</a><a href="/agent/micro?bookmark=` + url.QueryEscape(item.ID) + `">Discuss</a></div>`)
+		b.WriteString(`<div class="reading-actions"><a href="` + html.EscapeString(item.URL) + `" rel="noopener noreferrer">Original ↗</a><a class="mini-btn" href="/agent/micro?bookmark=` + url.QueryEscape(item.ID) + `">Discuss</a></div>`)
 		b.WriteString(`<form method="POST" action="/bookmarks">` + token(r) + hidden("action", "note") + hidden("id", item.ID) + `<label for="saved-note">Private note</label><textarea id="saved-note" name="note" rows="4" maxlength="4000">` + html.EscapeString(item.Note) + `</textarea><button>Save note</button></form>`)
 		b.WriteString(`<form method="POST" action="/bookmarks" class="reading-actions">` + token(r) + hidden("action", "delete") + hidden("id", item.ID) + `<button>Remove bookmark</button></form>`)
 	} else {
@@ -149,7 +149,7 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 		for _, i := range items {
-			b.WriteString(`<article class="reading-row"><div class="reading-meta">` + html.EscapeString(i.Kind+" · "+i.Source+" · "+app.TimeAgo(i.Created)) + `</div><h3><a href="/bookmarks?id=` + url.QueryEscape(i.ID) + `">` + html.EscapeString(i.Title) + `</a></h3><p>` + html.EscapeString(i.Note) + `</p><div class="reading-actions"><a href="` + html.EscapeString(i.URL) + `" rel="noopener noreferrer">Original ↗</a><a href="/agent/micro?bookmark=` + url.QueryEscape(i.ID) + `">Discuss</a></div></article>`)
+			b.WriteString(`<article class="reading-row"><div class="reading-meta">` + html.EscapeString(i.Kind+" · "+i.Source+" · "+app.TimeAgo(i.Created)) + `</div><h3><a href="/bookmarks?id=` + url.QueryEscape(i.ID) + `">` + html.EscapeString(i.Title) + `</a></h3><p>` + html.EscapeString(i.Note) + `</p><div class="reading-actions"><a href="` + html.EscapeString(i.URL) + `" rel="noopener noreferrer">Original ↗</a><a class="mini-btn" href="/agent/micro?bookmark=` + url.QueryEscape(i.ID) + `">Discuss</a></div></article>`)
 		}
 		b.WriteString(`<div class="reading-actions">`)
 		for _, p := range []struct {

--- a/service/images/images.go
+++ b/service/images/images.go
@@ -631,7 +631,7 @@ function imgGenerate(){
   var r=document.getElementById('img-result');
   r.innerHTML='<a href="'+res.j.url+'" target="_blank"><img src="'+res.j.url+'" alt="" class="img-full"></a>'+
               '<p class="text-sm text-muted mt-half m-0">'+
-              '<button data-id="'+res.j.id+'" data-next="true" onclick="imgShare(this)" class="text-xs mr-2">Share</button>'+
+              '<button data-id="'+res.j.id+'" data-next="true" onclick="imgShare(this)" class="mini-btn mr-2">Share</button>'+
               'Saved to your images.</p>';
   r.scrollIntoView({block:'nearest'});
   // Add it to the gallery too, so the page matches what a reload would show.


### PR DESCRIPTION
Follow-up to #1521: the shared Save/Share/Discuss row now uses white mini buttons, but standalone Discuss links in Bookmarks and Share controls in saved agent runs and generated Images bypassed that helper.

Apply mini-btn to those controls and give the shared class inline-flex alignment so standalone links render consistently too. Existing handlers, destinations and permissions are unchanged.

Validation: Bookmarks, Images, internal/app and architecture tests pass. Local agent tests encounter a workspace network-interface discovery restriction (netlinkrib: operation not permitted) in TestARunIsPricedFromItsOwnTimeline and TestARunsShapeIsRecorded; hosted CI will verify the agent package. Main also has the documented Home naming/origin test failures.

- [x] Audit remaining standalone content actions
- [x] Apply the existing shared button style
- [x] Check CI and Codex review (Codex approved; hosted agent tests pass; only the two documented baseline failures remain)
- [x] Merge and check deployment (Deploy run 34088468874 succeeded)