### PR TITLE
Restore balanced news/video overviews and sidebar presets

### DIFF
--- a/home/index.go
+++ b/home/index.go
@@ -281,7 +281,7 @@ func indexBody() string {
 			// furniture in front of somebody who has not asked anything yet.
 			Speak: false,
 		}) +
-		`<p class="landing-browse"><a href="/home">Browse news, markets, prayer and more →</a></p>` + today("") + `
+		today("") + `
 </div>
 
 <style>

--- a/home/index.go
+++ b/home/index.go
@@ -281,7 +281,7 @@ func indexBody() string {
 			// furniture in front of somebody who has not asked anything yet.
 			Speak: false,
 		}) +
-		today("") + `
+		`<p class="landing-browse"><a class="mini-btn" href="/home">Browse news, video, markets and more</a></p>` + today("") + `
 </div>
 
 <style>

--- a/internal/api/pin_test.go
+++ b/internal/api/pin_test.go
@@ -41,7 +41,7 @@ func TestThePinSaysWhichItMeans(t *testing.T) {
 // Pressing pin twice leaves it pinned, which is what makes the request safe to
 // send from two places.
 func TestPinningIsIdempotent(t *testing.T) {
-	acc := &auth.Account{ID: "pinner"}
+	acc := &auth.Account{ID: "pinner", Pinned: []string{}}
 
 	acc.Pin("news")
 	acc.Pin("news")

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -251,7 +251,7 @@ func TestRenderHTMLGuestNavHidesSignedInActions(t *testing.T) {
 // holds better: Log out is an ordinary link, so it needs no disclosure to open
 // and no script to work.
 func TestTheSignedInRailCarriesEveryDestination(t *testing.T) {
-	result := renderWithLang("Test", "A test page", "<p>content</p>", "en", &auth.Account{ID: "alice"})
+	result := renderWithLang("Test", "A test page", "<p>content</p>", "en", &auth.Account{ID: "alice", Pinned: []string{}})
 	for _, want := range []string{
 		`id="nav-home"`, `id="nav-account"`, `id="nav-inbox"`,
 		`id="nav-agents"`, `id="nav-services"`,
@@ -304,7 +304,7 @@ func TestSignedOutSeesNoAccountDestinations(t *testing.T) {
 // there now, under the balance, and /usage is still the page it links to. A
 // sidebar entry per view of a page is how a sidebar becomes a site map.
 func TestTheBottomGroupIsTheAccount(t *testing.T) {
-	result := renderWithLang("Test", "d", "<p>c</p>", "en", &auth.Account{ID: "alice"})
+	result := renderWithLang("Test", "d", "<p>c</p>", "en", &auth.Account{ID: "alice", Pinned: []string{}})
 
 	for _, want := range []string{`id="nav-account"`, `id="nav-logout"`} {
 		if !strings.Contains(result, want) {
@@ -333,7 +333,7 @@ func TestTheBottomGroupIsTheAccount(t *testing.T) {
 // something the rest of the product does not agree with. Anyone who lives in
 // Apps pins it, which is what pinning is for.
 func TestTheSidebarIsTheProductsNouns(t *testing.T) {
-	result := renderWithLang("Test", "d", "<p>c</p>", "en", &auth.Account{ID: "alice"})
+	result := renderWithLang("Test", "d", "<p>c</p>", "en", &auth.Account{ID: "alice", Pinned: []string{}})
 
 	// The order somebody meets them in: what is yours first — Inbox, then
 	// Agents — and the catalogue after.
@@ -408,7 +408,7 @@ func TestAPinnedServiceReturnsToTheSidebar(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	acc := &auth.Account{ID: "alice"}
+	acc := &auth.Account{ID: "alice", Pinned: []string{}}
 	acc.SetPinned([]string{name})
 	result := renderWithLang("Test", "d", "<p>c</p>", "en", acc)
 	if !strings.Contains(result, `href="/`+name+`"`) {
@@ -426,9 +426,9 @@ func (PinProbe) List(ctx context.Context, req *struct{}, rsp *struct {
 }
 
 // Nothing pinned draws no group at all. An empty heading over an empty list is
-// a worse answer than no heading, and it is what every new account would see.
+// a worse answer than no heading when the reader has unpinned everything.
 func TestPinningNothingDrawsNoGroup(t *testing.T) {
-	result := renderWithLang("Test", "d", "<p>c</p>", "en", &auth.Account{ID: "alice"})
+	result := renderWithLang("Test", "d", "<p>c</p>", "en", &auth.Account{ID: "alice", Pinned: []string{}})
 	if strings.Contains(result, "nav-group") || strings.Contains(result, "nav-heading") {
 		t.Error("an account that pinned nothing was given a Services group")
 	}

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -60,7 +60,7 @@ type Account struct {
 	Lat             float64   `json:"lat,omitempty"`
 	Lon             float64   `json:"lon,omitempty"`
 	Zone            string    `json:"zone,omitempty"`
-	Pinned          []string  `json:"pinned,omitempty"`   // Service names pinned to the sidebar, in the order shown
+	Pinned          []string  `json:"pinned"`             // Service names pinned to the sidebar, in the order shown
 	Approved        bool      `json:"approved,omitempty"` // Admin-approved, bypasses new account restrictions
 	Email           string    `json:"email,omitempty"`
 	EmailVerified   bool      `json:"email_verified,omitempty"`
@@ -1113,22 +1113,19 @@ func (t *Token) HasPermission(perm string) bool {
 
 // PinnedServices is the services this account keeps in its sidebar, in order.
 //
-// Empty is the default and the common case. The sidebar teaches three levels —
-// agents, tools, services — and a reader who has pinned nothing sees exactly
-// those, which is what somebody arriving from a landing page that says tools
-// for agents should see.
-//
-// It stops being the right thing the moment you use one of the services. The
-// nav went from nineteen alphabetical entries to none, and reaching for Video
-// meant going to the catalogue and hunting; the answer to both is a list that
-// is yours rather than the instance's opinion.
+// An unset selection gets useful presets. An explicit empty slice means the
+// reader unpinned everything and survives JSON round trips as an empty array.
 func (a *Account) PinnedServices() []string {
 	if a == nil {
 		return nil
 	}
-	out := make([]string, 0, len(a.Pinned))
+	names := a.Pinned
+	if names == nil {
+		names = []string{"web", "news", "video", "bookmarks"}
+	}
+	out := make([]string, 0, len(names))
 	seen := map[string]bool{}
-	for _, name := range a.Pinned {
+	for _, name := range names {
 		name = strings.ToLower(strings.TrimSpace(name))
 		if name == "" || seen[name] {
 			continue

--- a/internal/auth/pinned_test.go
+++ b/internal/auth/pinned_test.go
@@ -1,12 +1,16 @@
 package auth
 
-import "testing"
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
 
 // Pinning is a toggle, because the control is one button on a tile. Two
 // buttons, or a button whose meaning depends on state you cannot see, would
 // both be worse.
 func TestPinningTogglesAndReportsTheResult(t *testing.T) {
-	acc := &Account{ID: "reader"}
+	acc := &Account{ID: "reader", Pinned: []string{}}
 
 	if on := acc.TogglePin("video"); !on {
 		t.Error("pinning a service reported it as not pinned")
@@ -25,7 +29,7 @@ func TestPinningTogglesAndReportsTheResult(t *testing.T) {
 
 // Order is the reader's, and pinning appends rather than sorting.
 func TestPinningAppendsInTheOrderChosen(t *testing.T) {
-	acc := &Account{ID: "reader"}
+	acc := &Account{ID: "reader", Pinned: []string{}}
 	for _, name := range []string{"video", "mail", "news"} {
 		acc.TogglePin(name)
 	}
@@ -46,7 +50,7 @@ func TestPinningAppendsInTheOrderChosen(t *testing.T) {
 // test because the obvious implementation shares the backing array between the
 // slice it reads and the slice it writes, which silently corrupts the tail.
 func TestUnpinningFromTheMiddleKeepsTheRest(t *testing.T) {
-	acc := &Account{ID: "reader"}
+	acc := &Account{ID: "reader", Pinned: []string{}}
 	for _, name := range []string{"video", "mail", "news", "markets"} {
 		acc.TogglePin(name)
 	}
@@ -68,7 +72,7 @@ func TestUnpinningFromTheMiddleKeepsTheRest(t *testing.T) {
 // Duplicates and blanks are the shapes a form can produce, and neither should
 // reach the sidebar.
 func TestPinnedIsCleanedOnTheWayIn(t *testing.T) {
-	acc := &Account{ID: "reader"}
+	acc := &Account{ID: "reader", Pinned: []string{}}
 	acc.SetPinned([]string{"Video", " video ", "", "  ", "mail"})
 
 	got := acc.PinnedServices()
@@ -80,5 +84,28 @@ func TestPinnedIsCleanedOnTheWayIn(t *testing.T) {
 		if got[i] != want[i] {
 			t.Fatalf("got %v, want %v", got, want)
 		}
+	}
+}
+
+func TestDefaultPinsAndExplicitEmptySurviveJSON(t *testing.T) {
+	a := &Account{}
+	want := []string{"web", "news", "video", "bookmarks"}
+	if !reflect.DeepEqual(a.PinnedServices(), want) {
+		t.Fatal(a.PinnedServices())
+	}
+	a.SetPinned(nil)
+	raw, _ := json.Marshal(a)
+	var restored Account
+	if err := json.Unmarshal(raw, &restored); err != nil {
+		t.Fatal(err)
+	}
+	if len(restored.PinnedServices()) != 0 {
+		t.Fatal("empty selection reset to defaults")
+	}
+	a.SetPinned([]string{"mail", "news"})
+	raw, _ = json.Marshal(a)
+	json.Unmarshal(raw, &restored)
+	if !reflect.DeepEqual(restored.PinnedServices(), []string{"mail", "news"}) {
+		t.Fatal("custom pins changed")
 	}
 }

--- a/service/news/browse.go
+++ b/service/news/browse.go
@@ -29,10 +29,24 @@ func browse(r *http.Request, posts []*Post) string {
 		}
 	}
 	sort.SliceStable(items, func(i, j int) bool { return items[i].PostedAt.After(items[j].PostedAt) })
+	if category == "" {
+		latest := make([]*Post, 0, len(categories))
+		covered := map[string]bool{}
+		for _, p := range items {
+			if !covered[p.Category] {
+				latest = append(latest, p)
+				covered[p.Category] = true
+			}
+		}
+		items = latest
+	}
 	page, start, end := app.ReadingPage(r, len(items), 20)
 	var b strings.Builder
 	b.WriteString(`<form id="news-search" class="search-bar" action="/news" method="GET"><input id="news-query" name="query" type="search" placeholder="Search news" aria-label="Search news" maxlength="256"><button type="submit">Search</button></form>`)
 	b.WriteString(app.ReadingFilters("/news", category, categories))
+	if category == "" {
+		b.WriteString(`<h2>Headlines</h2>`)
+	}
 	b.WriteString(`<div class="reading-list">`)
 	if len(items) == 0 {
 		b.WriteString(`<p>No articles in this category yet.</p>`)
@@ -40,9 +54,12 @@ func browse(r *http.Request, posts []*Post) string {
 	for _, p := range items[start:end] {
 		articleURL := "/news?id=" + url.QueryEscape(p.ID)
 		b.WriteString(`<article id="reading-` + htmlpkg.EscapeString(p.ID) + `" class="reading-row news-reading-row">`)
+		b.WriteString(`<a class="news-reading-image" href="` + articleURL + `" aria-label="` + htmlpkg.EscapeString(p.Title) + `">`)
 		if p.Image != "" {
-			b.WriteString(`<a class="news-reading-image" href="` + articleURL + `" aria-label="` + htmlpkg.EscapeString(p.Title) + `"><img src="` + htmlpkg.EscapeString(imageproxy.URL(p.Image)) + `" alt="" loading="lazy" onerror="this.parentElement.hidden=true"></a>`)
+			b.WriteString(`<img src="` + htmlpkg.EscapeString(imageproxy.URL(p.Image)) + `" alt="" loading="lazy" onerror="this.hidden=true">`)
 		}
+		b.WriteString(`</a>`)
+
 		b.WriteString(`<div class="news-reading-content">`)
 		if p.Category != "" {
 			b.WriteString(`<div class="category-header"><a class="news-topic" href="/news?category=` + url.QueryEscape(p.Category) + `">` + htmlpkg.EscapeString(p.Category) + `</a></div>`)
@@ -62,12 +79,12 @@ func browse(r *http.Request, posts []*Post) string {
 	return b.String() + `</div>` + app.ReadingCSS + `<style>
 .news-reading-row{display:flex;gap:20px;align-items:flex-start}
 .news-reading-content{flex:1;min-width:0}
-.news-reading-image{flex:0 0 200px;display:block}
-.news-reading-image[hidden]{display:none}
+.news-reading-image{flex:0 0 200px;display:block;aspect-ratio:4/3;background:var(--hover-background,#eee);border-radius:var(--border-radius,6px)}
+.news-reading-image img[hidden]{display:none}
 .news-reading-image img{display:block;width:100%;aspect-ratio:4/3;object-fit:cover;border-radius:var(--border-radius,6px)}
 .news-reading-row .category-header{margin-bottom:6px}
 .news-topic{display:inline-block;padding:3px 8px;border:1px solid var(--card-border,#ddd);border-radius:var(--border-radius,6px);background:var(--card-background,#fff);color:var(--text-secondary,#555);font-size:12px;font-weight:600;text-decoration:none}
-@media(max-width:600px){.news-reading-row{flex-direction:column;gap:12px}.news-reading-content{width:100%}.news-reading-image{flex-basis:auto;width:100%}.news-reading-image img{aspect-ratio:16/9}}
+@media(max-width:600px){.news-reading-row{flex-direction:column;gap:12px}.news-reading-content{width:100%}.news-reading-image{flex-basis:auto;width:100%;aspect-ratio:16/9}.news-reading-image img{aspect-ratio:16/9}}
 </style>`
 }
 

--- a/service/news/browse_test.go
+++ b/service/news/browse_test.go
@@ -37,3 +37,19 @@ func TestBrowseKeepsLegacyNewsCache(t *testing.T) {
 		t.Fatal("legacy cache lost")
 	}
 }
+
+func TestOverviewKeepsSlowCategoriesAndPlaceholders(t *testing.T) {
+	now := time.Now()
+	posts := []*Post{
+		{ID: "fast1", URL: "https://example.com/1", Title: "Fast newest", Category: "Tech", PostedAt: now},
+		{ID: "fast2", URL: "https://example.com/2", Title: "Fast older", Category: "Tech", PostedAt: now.Add(-time.Hour)},
+		{ID: "slow", URL: "https://example.com/3", Title: "Slow topic", Category: "World", PostedAt: now.Add(-48 * time.Hour)},
+	}
+	body := browse(httptest.NewRequest("GET", "/news", nil), posts)
+	if strings.Count(body, "<article ") != 2 || !strings.Contains(body, "Slow topic") || strings.Contains(body, "Fast older") {
+		t.Fatal("overview crowded out a topic")
+	}
+	if strings.Count(body, `class="news-reading-image"`) != 2 {
+		t.Fatal("missing image placeholders")
+	}
+}

--- a/service/video/browse.go
+++ b/service/video/browse.go
@@ -18,6 +18,7 @@ func browse(r *http.Request, all map[string]Channel) string {
 	seenCat := map[string]bool{}
 	seen := map[string]bool{}
 	items := []*Result{}
+	feed := map[*Result]string{}
 	for cat, ch := range all {
 		if !seenCat[cat] {
 			seenCat[cat] = true
@@ -29,6 +30,7 @@ func browse(r *http.Request, all map[string]Channel) string {
 			}
 			seen[v.ID] = true
 			items = append(items, v)
+			feed[v] = cat
 		}
 	}
 	sort.Slice(items, func(i, j int) bool {
@@ -41,16 +43,8 @@ func browse(r *http.Request, all map[string]Channel) string {
 		latest := make([]*Result, 0)
 		covered := map[string]bool{}
 		for _, v := range items {
-			key := v.ChannelID
-			if key == "" {
-				key = v.Channel
-			}
-			if key == "" {
-				key = v.Category
-			}
-			if key == "" {
-				key = v.ID
-			}
+			// The enclosing feed is present even in legacy caches without metadata.
+			key := feed[v]
 			if !covered[key] {
 				latest = append(latest, v)
 				covered[key] = true

--- a/service/video/browse.go
+++ b/service/video/browse.go
@@ -37,9 +37,33 @@ func browse(r *http.Request, all map[string]Channel) string {
 		}
 		return items[i].Published.After(items[j].Published)
 	})
-	page, start, end := app.ReadingPage(r, len(items), 12)
+	if category == "" {
+		latest := make([]*Result, 0)
+		covered := map[string]bool{}
+		for _, v := range items {
+			key := v.ChannelID
+			if key == "" {
+				key = v.Channel
+			}
+			if key == "" {
+				key = v.Category
+			}
+			if key == "" {
+				key = v.ID
+			}
+			if !covered[key] {
+				latest = append(latest, v)
+				covered[key] = true
+			}
+		}
+		items = latest
+	}
+	page, start, end := app.ReadingPage(r, len(items), 9)
 	var b strings.Builder
 	b.WriteString(app.ReadingFilters("/video", category, categories))
+	if category == "" {
+		b.WriteString(`<h2>Latest</h2>`)
+	}
 	b.WriteString(`<div class="video-grid">`)
 	if len(items) == 0 {
 		b.WriteString(`<p>No videos in this category yet.</p>`)
@@ -47,7 +71,7 @@ func browse(r *http.Request, all map[string]Channel) string {
 	for _, v := range items[start:end] {
 		b.WriteString(`<article id="reading-` + html.EscapeString("video_"+v.ID) + `" class="reading-row"><a href="/video?id=` + url.QueryEscape(v.ID) + `"><img src="` + html.EscapeString(thumbSrc(v.ID, v.Thumbnail)) + `" loading="lazy" alt=""><h3>` + html.EscapeString(v.Title) + `</h3></a><div class="reading-meta">` + html.EscapeString(v.Channel+" · "+app.TimeAgo(v.Published)) + `</div>` + app.ReadingActions(r, "video_"+v.ID) + `</article>`)
 	}
-	return fmt.Sprintf(Template, "", b.String()+`</div>`) + app.ReadingPages("/video", category, page, len(items), 12) + app.ReadingCSS + `<style>.video-grid{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:24px}.video-grid .reading-row{padding:0 0 16px;min-width:0}.video-grid img{width:100%;aspect-ratio:16/9;object-fit:cover;border-radius:8px}.video-grid h3{font-size:16px}.video-grid a{text-decoration:none}@media(max-width:1000px){.video-grid{grid-template-columns:repeat(2,minmax(0,1fr))}}@media(max-width:600px){.video-grid{grid-template-columns:1fr}}</style>`
+	return fmt.Sprintf(Template, "", b.String()+`</div>`) + app.ReadingPages("/video", category, page, len(items), 9) + app.ReadingCSS + `<style>.video-grid{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:24px}.video-grid .reading-row{padding:0 0 16px;min-width:0}.video-grid img{width:100%;aspect-ratio:16/9;object-fit:cover;border-radius:8px}.video-grid h3{font-size:16px}.video-grid a{text-decoration:none}@media(max-width:1000px){.video-grid{grid-template-columns:repeat(2,minmax(0,1fr))}}@media(max-width:600px){.video-grid{grid-template-columns:1fr}}</style>`
 }
 
 func watchTitle(id string) (string, string) {

--- a/service/video/browse_test.go
+++ b/service/video/browse_test.go
@@ -84,8 +84,9 @@ func TestOverviewKeepsSlowChannelsVisible(t *testing.T) {
 	now := time.Now()
 	all := map[string]Channel{"Tech": {Videos: []*Result{
 		{ID: "fast1", ChannelID: "fast", Title: "Fast newest", Published: now},
-		{ID: "fast2", ChannelID: "fast", Title: "Fast older", Published: now.Add(-time.Hour)},
-		{ID: "slow", ChannelID: "slow", Title: "Slow channel", Published: now.Add(-48 * time.Hour)},
+		{ID: "fast2", Title: "Fast older", Published: now.Add(-time.Hour)},
+	}}, "Slow": {Videos: []*Result{
+		{ID: "slow", Title: "Slow channel", Published: now.Add(-48 * time.Hour)},
 	}}}
 	body := browse(httptest.NewRequest("GET", "/video", nil), all)
 	if strings.Count(body, "<article ") != 2 || !strings.Contains(body, "Slow channel") || strings.Contains(body, "Fast older") {

--- a/service/video/browse_test.go
+++ b/service/video/browse_test.go
@@ -21,10 +21,10 @@ func TestBrowseIsBoundedAndHasReadingActions(t *testing.T) {
 	if !strings.Contains(body, `id="video-search"`) || !strings.Contains(body, `id="recent-searches-container"`) {
 		t.Fatal("missing search controls")
 	}
-	if strings.Count(body, `<article `) != 2 || !strings.Contains(body, `video-grid`) {
+	if strings.Count(body, `<article `) != 5 || !strings.Contains(body, `video-grid`) {
 		t.Fatal("wrong video page")
 	}
-	if !strings.Contains(body, `/agent/micro?item=video_v12`) {
+	if !strings.Contains(body, `/agent/micro?item=video_v9`) {
 		t.Fatal("wrong archive reference")
 	}
 }
@@ -77,5 +77,18 @@ func TestListPreservesEmptyFeedDiagnostic(t *testing.T) {
 	}
 	if rsp.Text != LatestText(0) || rsp.Text == "" {
 		t.Fatalf("lost diagnostic: %q", rsp.Text)
+	}
+}
+
+func TestOverviewKeepsSlowChannelsVisible(t *testing.T) {
+	now := time.Now()
+	all := map[string]Channel{"Tech": {Videos: []*Result{
+		{ID: "fast1", ChannelID: "fast", Title: "Fast newest", Published: now},
+		{ID: "fast2", ChannelID: "fast", Title: "Fast older", Published: now.Add(-time.Hour)},
+		{ID: "slow", ChannelID: "slow", Title: "Slow channel", Published: now.Add(-48 * time.Hour)},
+	}}}
+	body := browse(httptest.NewRequest("GET", "/video", nil), all)
+	if strings.Count(body, "<article ") != 2 || !strings.Contains(body, "Slow channel") || strings.Contains(body, "Fast older") {
+		t.Fatal("overview crowded out a channel")
 	}
 }


### PR DESCRIPTION
Restore balanced browsing without letting fast feeds crowd out slower sources.

- [x] Headlines: one latest article per category, with placeholders for missing/failed images.
- [x] Video Latest: one latest item per enclosing feed, including legacy caches; nine per page in the existing three-column grid.
- [x] Category links filter the page and retain the full archive.
- [x] Default pins: Web, News, Video, Bookmarks. Existing custom lists stay intact; explicit empty choices persist after this upgrade.
- [x] Landing browse action uses shared mini-btn styling and exact wording: “Browse news, video, markets and more”.
- [x] Regression tests for selection, placeholders, pagination and pin persistence.
- [x] Codex Cloud review addressed: fixed legacy video grouping; documented legacy pin migration limitation.
- [x] CI checked: build, format and vet pass. Only existing home/TestTheNameIsTheSameOnEverySurface and internal/origin/TestURLPreservesExplicitPublicSurface fail; race step is consequently skipped.

Upgrade limitation: the old omitted-empty pin format erased whether someone never selected pins or deliberately cleared them. Both legacy states receive presets once. No migration can recover the missing distinction. New empty selections serialize explicitly and survive reloads.

Local affected packages pass. Local home additionally reproduces TestTheBriefSaysWhatIsOnToday on untouched baseline code (time formatting); hosted CI passes it.