### PR TITLE
Select nearby places by distance before limiting results

### DIFF
--- a/service/places/google.go
+++ b/service/places/google.go
@@ -59,6 +59,8 @@ func googleNearby(lat, lon float64, radiusM int) ([]*Place, error) {
 	}
 	body := map[string]interface{}{
 		"maxResultCount": googleMaxResults,
+		// Rank before the provider truncates the response, not just afterwards.
+		"rankPreference": "DISTANCE",
 		"locationRestriction": map[string]interface{}{
 			"circle": map[string]interface{}{
 				"center": map[string]interface{}{
@@ -82,6 +84,8 @@ func googleSearch(query string, lat, lon float64, radiusM int) ([]*Place, error)
 	body := map[string]interface{}{
 		"textQuery":      query,
 		"maxResultCount": googleMaxResults,
+		// Rank before the provider truncates the response, not just afterwards.
+		"rankPreference": "DISTANCE",
 		"locationBias": map[string]interface{}{
 			"circle": map[string]interface{}{
 				"center": map[string]interface{}{

--- a/service/places/google_test.go
+++ b/service/places/google_test.go
@@ -1,0 +1,61 @@
+package places
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+type placesTransport func(*http.Request) (*http.Response, error)
+
+func (f placesTransport) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+// The provider must select nearby matches before limiting the response.
+// Sorting a relevance-ranked shortlist locally cannot recover omitted cafes.
+func TestGoogleSelectsByDistanceBeforeLimiting(t *testing.T) {
+	t.Setenv("GOOGLE_API_KEY", "test-key")
+	old := httpClient
+	t.Cleanup(func() { httpClient = old })
+	calls := 0
+	httpClient = &http.Client{Transport: placesTransport(func(r *http.Request) (*http.Response, error) {
+		calls++
+		var body map[string]interface{}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatal(err)
+		}
+		if body["rankPreference"] != "DISTANCE" {
+			t.Errorf("%s ranking = %v", r.URL.Path, body["rankPreference"])
+		}
+		if body["maxResultCount"] != float64(20) {
+			t.Errorf("unexpected result limit: %v", body["maxResultCount"])
+		}
+		return &http.Response{StatusCode: 200, Header: make(http.Header), Body: io.NopCloser(strings.NewReader(`{"places":[]}`))}, nil
+	})}
+	if _, err := googleSearch("cafe", 51.5, -0.1, 1000); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := googleNearby(51.5, -0.1, 1000); err != nil {
+		t.Fatal(err)
+	}
+	if calls != 2 {
+		t.Fatalf("made %d requests, want 2", calls)
+	}
+}
+
+func TestChangingSortKeepsTheNearestCafe(t *testing.T) {
+	places := []*Place{{Name: "A cafe", Distance: 600}, {Name: "Z cafe", Distance: 40}, {Name: "B cafe", Distance: 650}}
+	sortPlaces(places, "distance")
+	if places[0].Distance != 40 {
+		t.Fatal("nearest cafe missing from first position")
+	}
+	sortPlaces(places, "name")
+	if len(places) != 3 || places[2].Distance != 40 {
+		t.Fatal("name sort changed the result set")
+	}
+	sortPlaces(places, "distance")
+	if places[0].Distance != 40 {
+		t.Fatal("distance sort did not restore nearest cafe")
+	}
+}


### PR DESCRIPTION
Nearby cafe searches could omit the closest matches because Google selected up to 20 results using default relevance/popularity ranking. Sorting that shortlist by distance afterwards cannot recover omitted places. Resubmitting the form to change the sort can return a different shortlist.

Request DISTANCE ranking for both Google Text Search near a location and Nearby Search. Keep the existing radius filter, result cap and display sorting. Name sorting still uses the nearby shortlist.

Validation: service/places tests pass with mocked Google requests verifying distance ranking before the result cap, plus a 40m-vs-600m sort regression. No live paid provider requests were made. This fixes a confirmed retrieval defect; the exact reported cafe has not been reproduced.

API reference: https://developers.google.com/maps/documentation/places/web-service/text-search#rankpreference