### PR TITLE
Style the landing browse button and restore its arrow

### DIFF
--- a/home/index.go
+++ b/home/index.go
@@ -281,7 +281,7 @@ func indexBody() string {
 			// furniture in front of somebody who has not asked anything yet.
 			Speak: false,
 		}) +
-		`<p class="landing-browse"><a class="mini-btn" href="/home">Browse news, video, markets and more</a></p>` + today("") + `
+		`<p class="landing-browse"><a class="mini-btn" href="/home">Browse news, video, markets and more →</a></p>` + today("") + `
 </div>
 
 <style>
@@ -321,6 +321,10 @@ func indexBody() string {
    The 18px that used to be under the wordmark is under this instead, so the
    gap between the name and the box is unchanged and the two lines sit together
    as one block. */
+.landing-browse{margin:16px 0 0}
+.landing-browse a,.landing-browse a:visited{display:inline-flex;align-items:center;justify-content:center;max-width:100%;box-sizing:border-box;padding:5px 10px;border:1px solid #ddd;border-radius:6px;background:#fff;color:#555;font-size:13px;line-height:1.5;text-decoration:none}
+.landing-browse a:hover{background:#f5f5f5;color:#111}
+.landing-browse a:focus-visible{outline:2px solid #555;outline-offset:3px}
 .lwhat{color:#888;font-size:14px;margin:0 0 18px;line-height:1.3}
 /* Today, under the box. */
 .ltoday{margin:30px 0 0}


### PR DESCRIPTION
The signed-out landing uses RenderIndex with its own minimal CSS, so the app-shell mini-btn class did nothing: the browse action remained a default blue/purple underlined link. This was reproduced in a live screenshot after #1523.

Add scoped landing styles for normal, visited, hover and keyboard-focus states. Restore the requested text and arrow: “Browse news, video, markets and more →”. Keep the existing layout and destination.

Formatted with gofmt. Will verify the rendered page after deployment. Baseline naming/origin CI failures are tracked separately.