### PR TITLE
Moderate imported social content and close visibility bypasses

### DIFF
--- a/admin/flag.go
+++ b/admin/flag.go
@@ -2,6 +2,7 @@ package admin
 
 import (
 	"fmt"
+	"html"
 	"net/http"
 	"strings"
 
@@ -88,8 +89,15 @@ func FlagHandler(w http.ResponseWriter, r *http.Request) {
 		flagger = acc.Name
 	}
 
-	// Add flag
-	count, alreadyFlagged, err := flag.Add(contentType, contentID, flagger)
+	// An authenticated operator can hide content directly, including an
+	// item they previously approved. Ordinary reports retain the vote threshold.
+	count, alreadyFlagged, err := 0, false, error(nil)
+	if acc != nil && acc.Admin {
+		err = flag.AdminFlag(contentType, contentID, acc.ID)
+		count = 3
+	} else {
+		count, alreadyFlagged, err = flag.Add(contentType, contentID, flagger)
+	}
 	if err != nil {
 		http.Error(w, "Failed to flag content", http.StatusInternalServerError)
 		return
@@ -153,6 +161,13 @@ func ModerateHandler(w http.ResponseWriter, r *http.Request) {
 					}
 					contentHTML = fmt.Sprintf(`<p class="whitespace-pre-wrap">%s</p>`, text)
 					author = post.Author
+					createdAt = app.TimeAgo(post.CreatedAt)
+				}
+			case "social":
+				if post, ok := content.(PostContent); ok {
+					title = "Social thread"
+					contentHTML = "<p class=\"whitespace-pre-wrap\">" + html.EscapeString(post.Content) + "</p>"
+					author = html.EscapeString(post.Author)
 					createdAt = app.TimeAgo(post.CreatedAt)
 				}
 			case "news":

--- a/admin/social_moderation_test.go
+++ b/admin/social_moderation_test.go
@@ -1,0 +1,32 @@
+package admin
+
+import (
+	"mu/internal/flag"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestOperatorCanRehideApprovedSocialThroughFlagHandler(t *testing.T) {
+	for _, admin := range []bool{false, true} {
+		id, account := "ordinary-report", "ordinary-reporter"
+		if admin {
+			id, account = "operator-report", "operator-reporter"
+		}
+		cookie := adminSession(t, account, admin)
+		if err := flag.Approve("social", id); err != nil {
+			t.Fatal(err)
+		}
+		r := httptest.NewRequest("POST", "/flag", strings.NewReader("type=social&id="+id))
+		r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		r.AddCookie(cookie)
+		w := httptest.NewRecorder()
+		FlagHandler(w, r)
+		if w.Code != 200 {
+			t.Fatalf("status %d: %s", w.Code, w.Body.String())
+		}
+		if flag.IsHidden("social", id) != admin {
+			t.Fatalf("admin=%v hidden=%v", admin, flag.IsHidden("social", id))
+		}
+	}
+}

--- a/agent/moderate/approval_test.go
+++ b/agent/moderate/approval_test.go
@@ -1,0 +1,22 @@
+package moderate
+
+import "testing"
+
+func TestProfanityIsRejectedWithoutAModel(t *testing.T) {
+	v, err := classify("", "Bring it on you little fuckers")
+	if err != nil || v != "HARMFUL" {
+		t.Fatalf("verdict=%q err=%v", v, err)
+	}
+	if Approved("", "Bring it on you little fuckers") {
+		t.Fatal("approved explicit abuse")
+	}
+}
+
+func TestNoModelCannotApproveImportedContent(t *testing.T) {
+	if Configured() {
+		t.Skip("test requires no configured provider")
+	}
+	if Approved("", "An ordinary news update.") {
+		t.Fatal("approved without moderation")
+	}
+}

--- a/agent/moderate/moderate.go
+++ b/agent/moderate/moderate.go
@@ -77,6 +77,11 @@ func Load() {
 // not do is pretend — see Configured below, which is what /admin/moderate
 // reads to say so on the page.
 func judge(kind, id, title, text string) {
+	// Missing AI is a supported local-only setup, not an operational failure.
+	// Explicit profanity still receives the deterministic verdict below.
+	if !Configured() && !flag.Profane(title+"\n"+text) {
+		return
+	}
 	verdict, err := classify(title, text)
 	if err != nil {
 		app.Log("moderate", "could not classify %s %s: %v", kind, id, err)

--- a/agent/moderate/moderate.go
+++ b/agent/moderate/moderate.go
@@ -77,6 +77,9 @@ func Load() {
 // not do is pretend — see Configured below, which is what /admin/moderate
 // reads to say so on the page.
 func judge(kind, id, title, text string) {
+	if kind == "social" && flag.IsApproved(kind, id) {
+		return
+	}
 	// Missing AI is a supported local-only setup, not an operational failure.
 	// Explicit profanity still receives the deterministic verdict below.
 	if !Configured() && !flag.Profane(title+"\n"+text) {
@@ -153,3 +156,6 @@ Classify the content with ONLY ONE WORD:
 IMPORTANT: Short personal status updates like "Working on X", "Good morning", "Just shipped Y", "Having lunch" are ALWAYS OK. They are normal status messages, not spam or low quality. Only flag content that is clearly abusive, vulgar, or spam. When in doubt, say OK.
 
 Respond with just the single word.`
+
+// Check evaluates an existing publication using the same policy as new ones.
+func Check(kind, id, title, text string) { judge(kind, id, title, text) }

--- a/agent/moderate/moderate.go
+++ b/agent/moderate/moderate.go
@@ -40,6 +40,7 @@
 package moderate
 
 import (
+	"fmt"
 	"strings"
 
 	"mu/internal/ai"
@@ -76,18 +77,8 @@ func Load() {
 // not do is pretend — see Configured below, which is what /admin/moderate
 // reads to say so on the page.
 func judge(kind, id, title, text string) {
-	if !Configured() {
-		return
-	}
-
-	verdict, err := ai.Ask(&ai.Prompt{
-		System:   prompt,
-		Question: "Title: " + title + "\n\nContent: " + text,
-		Model:    ai.BackgroundModel(),
-	})
+	verdict, err := classify(title, text)
 	if err != nil {
-		// Worth a line, because a moderator that has stopped working looks
-		// exactly like a well-behaved community.
 		app.Log("moderate", "could not classify %s %s: %v", kind, id, err)
 		return
 	}
@@ -111,6 +102,26 @@ func judge(kind, id, title, text string) {
 	app.Log("moderate", "hid %s %s: %s", kind, id, verdict)
 }
 
+// Approved is the publication gate for externally selected content.
+// Failure or an unrecognised verdict never grants approval.
+func Approved(title, text string) bool {
+	verdict, err := classify(title, text)
+	return err == nil && strings.EqualFold(strings.TrimSpace(verdict), "OK")
+}
+
+func classify(title, text string) (string, error) {
+	if flag.Profane(title + "\n" + text) {
+		return "HARMFUL", nil
+	}
+	if !Configured() {
+		return "", fmt.Errorf("no moderation model configured")
+	}
+	return ai.Ask(&ai.Prompt{
+		System: prompt, Question: "Title: " + title + "\n\nContent: " + text,
+		Model: ai.BackgroundModel(), Priority: ai.PriorityLow, Caller: "moderate",
+	})
+}
+
 // Configured reports whether this instance can moderate at all.
 //
 // An adjective rather than a verb, and a question rather than an instruction —
@@ -131,7 +142,7 @@ const prompt = `You are a strict content moderator for a family-friendly communi
 Classify the content with ONLY ONE WORD:
 - SPAM (promotional spam, advertising, repetitive junk, SEO content)
 - LOW_QUALITY (gibberish, random characters, meaningless typing like "asdf", single letters)
-- HARMFUL (vulgar, crude, sexual, obscene, gossip, slander, personal attacks, mocking, trolling, shock content, swear words)
+- HARMFUL (vulgar, crude, sexual, obscene, gossip, slander, personal attacks, mocking, trolling, shock content, swear words, threats, dehumanisation, incitement or celebration of violence)
 - OK (everything else — status updates, opinions, questions, short messages, work updates, casual conversation)
 
 IMPORTANT: Short personal status updates like "Working on X", "Good morning", "Just shipped Y", "Having lunch" are ALWAYS OK. They are normal status messages, not spam or low quality. Only flag content that is clearly abusive, vulgar, or spam. When in doubt, say OK.

--- a/agent/social/breaking.go
+++ b/agent/social/breaking.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 	"time"
 
+	"mu/agent/moderate"
 	"mu/internal/app"
 	"mu/service/news"
 	socialsvc "mu/service/social"
@@ -32,7 +33,9 @@ func Start() {
 	// than imported inside the watcher so the filtering and the scoring can be
 	// tested without standing up social.
 	Surface = func(c *candidate) {
-		socialsvc.SurfaceBreaking(c.Category, c.display(), c.Link)
+		if moderate.Approved(c.Category, c.Text) {
+			socialsvc.SurfaceBreaking(c.Category, c.display(), c.Link)
+		}
 	}
 	go Watch()
 }
@@ -103,7 +106,7 @@ func surfaceBreakingFromNews() {
 				// Surface the first one (use URL as dedup key)
 				if !surfaced[a.url] {
 					surfaced[a.url] = true
-					socialsvc.SurfaceBreaking(a.category, a.title, a.url)
+					surfaceApproved(a.category, a.title, a.url)
 					app.Log("social", "Breaking: %q matched across %s and %s", a.title, a.category, b.category)
 				}
 			}
@@ -138,4 +141,12 @@ func extractKeywords(title string) map[string]bool {
 		}
 	}
 	return words
+}
+
+// Both network imports and news-derived threads pass the same content policy.
+func surfaceApproved(category, text, link string) {
+	if !moderate.Approved(category, text) {
+		return
+	}
+	socialsvc.SurfaceBreaking(category, text, link)
 }

--- a/agent/social/breaking.go
+++ b/agent/social/breaking.go
@@ -20,6 +20,7 @@ import (
 
 	"mu/agent/moderate"
 	"mu/internal/app"
+	"mu/internal/flag"
 	"mu/service/news"
 	socialsvc "mu/service/social"
 )
@@ -27,6 +28,13 @@ import (
 // Start begins watching for stories worth surfacing: this instance's own news,
 // and — where an operator has turned it on — the open social network.
 func Start() {
+	// Migrate explicit abuse in cached social posts into moderation state.
+	// Only the deterministic rule is applied here; no model calls at boot.
+	for _, m := range socialsvc.Threads() {
+		if flag.Profane(m.Content) {
+			moderate.Check("social", m.ID, "", m.Content)
+		}
+	}
 	go detectBreakingStories()
 
 	// What the agent decides, handed to the service to store. Wired here rather

--- a/agent/social/jetstream.go
+++ b/agent/social/jetstream.go
@@ -650,12 +650,13 @@ func review() {
 	}
 	short := shortlist(batch)
 	chosen := judge(short)
-	if len(chosen) == 0 {
-		// No model, or it had nothing to say. The arithmetic order is what this
-		// did before there was a judge, and it is a reasonable answer.
-		chosen = short
+	posted := publishChosen(chosen)
+	if posted > 0 {
+		app.Log("social", "atproto: surfaced %d of %d candidates", posted, len(batch))
 	}
+}
 
+func publishChosen(chosen []*candidate) int {
 	posted := 0
 	for _, c := range chosen {
 		if posted >= surfacePerReview {
@@ -667,9 +668,7 @@ func review() {
 		posted++
 		Surface(c)
 	}
-	if posted > 0 {
-		app.Log("social", "atproto: surfaced %d of %d candidates", posted, len(batch))
-	}
+	return posted
 }
 
 // shortlist is the arithmetic pass: the best-scoring candidates, one per

--- a/agent/social/jetstream_test.go
+++ b/agent/social/jetstream_test.go
@@ -279,7 +279,7 @@ func TestReviewTakesTheBestNotTheFirst(t *testing.T) {
 		_ = i
 		candidates = append(candidates, c)
 	}
-	review()
+	publishChosen(shortlist(candidates))
 
 	if len(got) != surfacePerReview {
 		t.Fatalf("surfaced %d, want %d", len(got), surfacePerReview)
@@ -313,7 +313,7 @@ func TestOneVoiceCannotTakeTheBatch(t *testing.T) {
 	} {
 		candidates = append(candidates, c)
 	}
-	review()
+	publishChosen(shortlist(candidates))
 
 	if len(got) != 2 {
 		t.Fatalf("surfaced %d, want one from the bot and one from the person", len(got))
@@ -331,9 +331,9 @@ func TestTheSameLinkIsNotSurfacedTwice(t *testing.T) {
 
 	candidates, surfaced = nil, map[string]bool{}
 	candidates = append(candidates, &candidate{Category: "Tech", Link: "https://same", Score: 10})
-	review()
+	publishChosen(shortlist(candidates))
 	candidates = append(candidates, &candidate{Category: "Tech", Link: "https://same", Score: 90})
-	review()
+	publishChosen(shortlist(candidates))
 
 	if len(got) != 1 {
 		t.Errorf("the same link was surfaced %d times", len(got))

--- a/agent/social/judge.go
+++ b/agent/social/judge.go
@@ -15,8 +15,7 @@ package social
 // which is the cheapest thing in this repo that a model does — and it is the
 // step the arithmetic was only ever approximating.
 //
-// The instance is not required to have a model. Without one the shortlist is
-// published in score order, which is what this did before there was a judge.
+// Without a working model no external shortlist is published.
 
 import (
 	"fmt"
@@ -38,17 +37,13 @@ const judgeChars = 300
 
 // judge asks the model which of the shortlist are worth publishing, and returns
 // them in its order. An empty result means no model, no answer, or nothing it
-// thought was worth it — the caller falls back to the arithmetic order.
+// thought was worth it. None of those states authorises publication.
 func judge(short []*candidate) []*candidate {
 	if len(short) == 0 || !ai.Configured() {
 		return nil
 	}
 	if len(short) > shortlistMax {
 		short = short[:shortlistMax]
-	}
-	// One is not a choice.
-	if len(short) < 2 {
-		return short
 	}
 
 	answer, err := ai.Ask(&ai.Prompt{
@@ -68,7 +63,7 @@ func judge(short []*candidate) []*candidate {
 		Caller:    "social-judge",
 	})
 	if err != nil {
-		app.Log("social", "atproto: judge unavailable (%v), publishing by score", err)
+		app.Log("social", "atproto: judge unavailable (%v), publishing nothing", err)
 		return nil
 	}
 	picked := picks(answer, len(short))
@@ -98,6 +93,7 @@ Pick at most 3 that a thoughtful reader would be glad to have seen. Prefer:
 Reject, however well it scores:
 - advertising, recruitment, self-promotion, or anything asking the reader to buy, apply, book or subscribe
 - a press release, a conference programme, or an announcement of an announcement
+- profanity, targeted abuse, dehumanisation, threats, or celebration of violence
 - engagement bait, a thread opener, or a post whose whole content is a reaction
 - anything you cannot tell the subject of from the text given
 

--- a/agent/social/judge_test.go
+++ b/agent/social/judge_test.go
@@ -47,9 +47,9 @@ func TestTheModelsOrderIsKept(t *testing.T) {
 	}
 }
 
-// TestWithoutAModelTheShortlistIsStillPublished — an instance with no LLM
-// configured is a supported instance, and social should still work on it.
-func TestWithoutAModelTheShortlistIsStillPublished(t *testing.T) {
+// TestWithoutAModelTheShortlistIsNotPublished — an instance with no LLM
+// configured can still host local threads, but must not auto-publish imports.
+func TestWithoutAModelTheShortlistIsNotPublished(t *testing.T) {
 	var got []*candidate
 	Surface = func(c *candidate) { got = append(got, c) }
 	defer func() { Surface = func(*candidate) {} }()
@@ -64,11 +64,8 @@ func TestWithoutAModelTheShortlistIsStillPublished(t *testing.T) {
 	}
 	review() // no AI configured in a test, so judge returns nothing
 
-	if len(got) != 3 {
-		t.Fatalf("surfaced %d with no model configured, want 3", len(got))
-	}
-	if got[0].Link != "https://b" {
-		t.Errorf("fell back to arrival order rather than score: %s first", got[0].Link)
+	if len(got) != 0 {
+		t.Fatalf("surfaced %d without moderation, want none", len(got))
 	}
 }
 

--- a/internal/flag/flag.go
+++ b/internal/flag/flag.go
@@ -5,6 +5,7 @@ package flag
 
 import (
 	"encoding/json"
+	"strings"
 	"sync"
 	"time"
 
@@ -13,6 +14,7 @@ import (
 
 // FlaggedItem represents a piece of content that has been flagged.
 type FlaggedItem struct {
+	Approved    bool      `json:"approved,omitempty"`
 	ContentType string    `json:"content_type"` // "post", "thread", etc.
 	ContentID   string    `json:"content_id"`
 	FlagCount   int       `json:"flag_count"`
@@ -163,7 +165,7 @@ func Approve(contentType, contentID string) error {
 	key := contentType + ":" + contentID
 
 	mutex.Lock()
-	delete(flags, key)
+	flags[key] = &FlaggedItem{ContentType: contentType, ContentID: contentID, Approved: true}
 	err := saveUnlocked()
 	mutex.Unlock()
 
@@ -189,8 +191,15 @@ func AdminFlag(contentType, contentID, username string) error {
 	key := contentType + ":" + contentID
 
 	mutex.Lock()
+	// Social messages are immutable. An operator's approval must also win
+	// against a classifier that was already in flight when Approve ran.
+	if item := flags[key]; contentType == "social" && strings.HasPrefix(username, "system:") && item != nil && item.Approved && !item.Flagged {
+		mutex.Unlock()
+		return nil
+	}
 	adminFlagger := username + " (admin)"
 	if item, exists := flags[key]; exists {
+		item.Approved = false
 		item.FlagCount = 3
 		item.Flagged = true
 		if !contains(item.FlaggedBy, adminFlagger) {
@@ -260,4 +269,12 @@ type PostContent struct {
 	Author    string
 	AuthorID  string
 	CreatedAt time.Time
+}
+
+// IsApproved reports an explicit operator approval, retained across restarts.
+func IsApproved(contentType, contentID string) bool {
+	mutex.RLock()
+	defer mutex.RUnlock()
+	item := flags[contentType+":"+contentID]
+	return item != nil && item.Approved && !item.Flagged
 }

--- a/internal/flag/text.go
+++ b/internal/flag/text.go
@@ -1,0 +1,9 @@
+package flag
+
+import "regexp"
+
+// Explicit profanity is rejected consistently without depending on a model.
+// Word boundaries avoid rejecting names and ordinary words containing a fragment.
+var profanity = regexp.MustCompile(`(?i)\b(?:fuck(?:s|er|ers|ing|ed|head|heads|wit|wits)?|motherfuck(?:er|ers|ing)?|shit(?:s|ty|ting|ted|head|heads)?|bullshit|cunt(?:s)?|asshole(?:s)?)\b`)
+
+func Profane(text string) bool { return profanity.MatchString(text) }

--- a/internal/flag/text_test.go
+++ b/internal/flag/text_test.go
@@ -1,0 +1,16 @@
+package flag
+
+import "testing"
+
+func TestProfanityIncludesInflectionsWithoutSubstringFalsePositives(t *testing.T) {
+	for _, text := range []string{"Bring it on you little fuckers", "FUCKING", "bullshit", "assholes"} {
+		if !Profane(text) {
+			t.Errorf("missed %q", text)
+		}
+	}
+	for _, text := range []string{"Scunthorpe", "Shitake mushrooms", "A difficult political debate", "Classical music"} {
+		if Profane(text) {
+			t.Errorf("false positive: %q", text)
+		}
+	}
+}

--- a/internal/flag/text_test.go
+++ b/internal/flag/text_test.go
@@ -14,3 +14,32 @@ func TestProfanityIncludesInflectionsWithoutSubstringFalsePositives(t *testing.T
 		}
 	}
 }
+
+func TestSocialApprovalSurvivesReloadAndLateAutomaticVerdict(t *testing.T) {
+	resetFlags(t)
+	if err := AdminFlag("social", "quoted", "system:harmful"); err != nil {
+		t.Fatal(err)
+	}
+	if err := Approve("social", "quoted"); err != nil {
+		t.Fatal(err)
+	}
+	mutex.Lock()
+	flags = make(map[string]*FlaggedItem)
+	mutex.Unlock()
+	Load()
+	if !IsApproved("social", "quoted") {
+		t.Fatal("approval did not survive reload")
+	}
+	if err := AdminFlag("social", "quoted", "system:harmful"); err != nil {
+		t.Fatal(err)
+	}
+	if IsHidden("social", "quoted") {
+		t.Fatal("late automatic verdict overruled approval")
+	}
+	if err := AdminFlag("social", "quoted", "operator"); err != nil {
+		t.Fatal(err)
+	}
+	if !IsHidden("social", "quoted") {
+		t.Fatal("operator could not reverse approval")
+	}
+}

--- a/service/social/moderation.go
+++ b/service/social/moderation.go
@@ -1,0 +1,49 @@
+package social
+
+import (
+	"mu/internal/data"
+	"mu/internal/flag"
+)
+
+type moderationStore struct{}
+
+func (moderationStore) RefreshCache() {
+	mutex.Lock()
+	updateCacheLocked()
+	mutex.Unlock()
+}
+
+func (moderationStore) Get(id string) interface{} {
+	mutex.RLock()
+	defer mutex.RUnlock()
+	m := getMessage(id)
+	if m == nil {
+		return nil
+	}
+	return flag.PostContent{ID: m.ID, Title: "Social thread", Content: m.Content, Author: m.Author, AuthorID: m.AuthorID, CreatedAt: m.PostedAt}
+}
+
+func (moderationStore) Delete(id string) error {
+	mutex.Lock()
+	kept := make([]*Message, 0, len(messages))
+	var removed []string
+	for _, m := range messages {
+		if m.ID == id || m.ReplyTo == id {
+			removed = append(removed, m.ID)
+			continue
+		}
+		kept = append(kept, m)
+	}
+	messages = kept
+	updateCacheLocked()
+	mutex.Unlock()
+	if err := save(); err != nil {
+		return err
+	}
+	for _, id := range removed {
+		if err := data.Unindex("social_" + id); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/service/social/moderation_test.go
+++ b/service/social/moderation_test.go
@@ -1,6 +1,7 @@
 package social
 
 import (
+	"mu/internal/flag"
 	"net/http/httptest"
 	"strings"
 	"testing"
@@ -8,6 +9,10 @@ import (
 )
 
 func TestAbusiveCachedThreadIsHiddenAcrossReaders(t *testing.T) {
+	mine(t)
+	if err := flag.AdminFlag("social", "unsafe-cached", "system:harmful"); err != nil {
+		t.Fatal(err)
+	}
 	mutex.Lock()
 	old := messages
 	messages = []*Message{
@@ -32,5 +37,11 @@ func TestAbusiveCachedThreadIsHiddenAcrossReaders(t *testing.T) {
 		if w.Code != 404 || strings.Contains(w.Body.String(), "fuckers") {
 			t.Fatalf("direct thread leaked for %s", accept)
 		}
+	}
+	if err := flag.Approve("social", "unsafe-cached"); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(FeedText(20), "fuckers") {
+		t.Fatal("operator approval did not restore the post")
 	}
 }

--- a/service/social/moderation_test.go
+++ b/service/social/moderation_test.go
@@ -2,6 +2,7 @@ package social
 
 import (
 	"mu/internal/flag"
+	"mu/internal/snapshot"
 	"net/http/httptest"
 	"strings"
 	"testing"
@@ -47,6 +48,9 @@ func TestAbusiveCachedThreadIsHiddenAcrossReaders(t *testing.T) {
 }
 
 func TestModerationRefreshesTheHomeCard(t *testing.T) {
+	oldSnap := cardSnap
+	cardSnap = snapshot.New("social-moderation-test")
+	t.Cleanup(func() { cardSnap = oldSnap })
 	id, _ := mine(t)
 	flag.RegisterDeleter("social", moderationStore{})
 	moderationStore{}.RefreshCache()

--- a/service/social/moderation_test.go
+++ b/service/social/moderation_test.go
@@ -45,3 +45,28 @@ func TestAbusiveCachedThreadIsHiddenAcrossReaders(t *testing.T) {
 		t.Fatal("operator approval did not restore the post")
 	}
 }
+
+func TestModerationRefreshesTheHomeCard(t *testing.T) {
+	id, _ := mine(t)
+	flag.RegisterDeleter("social", moderationStore{})
+	moderationStore{}.RefreshCache()
+	if !strings.Contains(CardHTML(), "A message that exists") {
+		t.Fatal("initial card missing message")
+	}
+	if err := flag.AdminFlag("social", id, "operator"); err != nil {
+		t.Fatal(err)
+	}
+	deadline := time.Now().Add(time.Second)
+	for strings.Contains(CardHTML(), "A message that exists") && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	if strings.Contains(CardHTML(), "A message that exists") {
+		t.Fatal("hidden message remained in cached card")
+	}
+	if err := flag.Approve("social", id); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(CardHTML(), "A message that exists") {
+		t.Fatal("approval did not restore cached card")
+	}
+}

--- a/service/social/moderation_test.go
+++ b/service/social/moderation_test.go
@@ -1,0 +1,36 @@
+package social
+
+import (
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestAbusiveCachedThreadIsHiddenAcrossReaders(t *testing.T) {
+	mutex.Lock()
+	old := messages
+	messages = []*Message{
+		{ID: "unsafe-cached", Author: "Imported", AuthorID: "_system", Content: "Bring it on you little fuckers", PostedAt: time.Now()},
+		{ID: "ordinary-cached", Author: "Reader", AuthorID: "reader", Content: "An ordinary update", PostedAt: time.Now()},
+	}
+	mutex.Unlock()
+	t.Cleanup(func() { mutex.Lock(); messages = old; mutex.Unlock() })
+	if got := FeedText(20); strings.Contains(got, "fuckers") || !strings.Contains(got, "ordinary") {
+		t.Fatal(got)
+	}
+	w := httptest.NewRecorder()
+	Handler(w, httptest.NewRequest("GET", "/social", nil))
+	if strings.Contains(w.Body.String(), "fuckers") {
+		t.Fatal("feed rendered abuse")
+	}
+	for _, accept := range []string{"text/html", "application/json"} {
+		r := httptest.NewRequest("GET", "/social/thread?id=unsafe-cached", nil)
+		r.Header.Set("Accept", accept)
+		w := httptest.NewRecorder()
+		ThreadHandler(w, r)
+		if w.Code != 404 || strings.Contains(w.Body.String(), "fuckers") {
+			t.Fatalf("direct thread leaked for %s", accept)
+		}
+	}
+}

--- a/service/social/service.go
+++ b/service/social/service.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"mu/internal/data"
+	"mu/internal/flag"
 	"mu/internal/quota"
 	"mu/internal/service"
 )
@@ -86,7 +87,7 @@ func (Server) Search(ctx context.Context, req *SearchRequest, rsp *SearchRespons
 	var b strings.Builder
 	n := 0
 	for _, entry := range data.Search(q, 50) {
-		if entry.Type != "social" {
+		if entry.Type != "social" || flag.IsHidden("social", strings.TrimPrefix(entry.ID, "social_")) || flag.Profane(entry.Content) {
 			continue
 		}
 		if n >= limit {

--- a/service/social/service.go
+++ b/service/social/service.go
@@ -87,7 +87,7 @@ func (Server) Search(ctx context.Context, req *SearchRequest, rsp *SearchRespons
 	var b strings.Builder
 	n := 0
 	for _, entry := range data.Search(q, 50) {
-		if entry.Type != "social" || flag.IsHidden("social", strings.TrimPrefix(entry.ID, "social_")) || flag.Profane(entry.Content) {
+		if entry.Type != "social" || flag.IsHidden("social", strings.TrimPrefix(entry.ID, "social_")) {
 			continue
 		}
 		if n >= limit {

--- a/service/social/social.go
+++ b/service/social/social.go
@@ -864,6 +864,10 @@ func generateCardHTML(allMessages []*Message) string {
 		}
 	}
 
+	if len(selected) == 0 {
+		return `<p class="text-muted">No threads yet. Be the first to start one.</p>`
+	}
+
 	var sb strings.Builder
 	for _, p := range selected {
 		content := htmlpkg.EscapeString(p.Content)

--- a/service/social/social.go
+++ b/service/social/social.go
@@ -79,6 +79,7 @@ func addMessage(p *Message) {
 }
 
 func Load() {
+	flag.RegisterDeleter("social", moderationStore{})
 	if err := service.Register(Spec); err != nil {
 		app.Log("social", "service register failed: %v", err)
 	}

--- a/service/social/social.go
+++ b/service/social/social.go
@@ -751,7 +751,7 @@ func handleAPISearch(w http.ResponseWriter, r *http.Request, query string) {
 	results := data.Search(query, 50)
 	var socialResults []map[string]interface{}
 	for _, entry := range results {
-		if entry.Type == "social" && !flag.IsHidden("social", strings.TrimPrefix(entry.ID, "social_")) && !flag.Profane(entry.Content) {
+		if entry.Type == "social" && !flag.IsHidden("social", strings.TrimPrefix(entry.ID, "social_")) {
 			socialResults = append(socialResults, map[string]interface{}{
 				"title":    entry.Title,
 				"content":  entry.Content,
@@ -791,7 +791,7 @@ func handleSearch(w http.ResponseWriter, r *http.Request, query string) {
 
 	count := 0
 	for _, entry := range results {
-		if entry.Type != "social" || flag.IsHidden("social", strings.TrimPrefix(entry.ID, "social_")) || flag.Profane(entry.Content) {
+		if entry.Type != "social" || flag.IsHidden("social", strings.TrimPrefix(entry.ID, "social_")) {
 			continue
 		}
 		count++
@@ -1211,5 +1211,5 @@ func DeleteByAuthor(authorID string) {
 }
 
 func visibleMessage(m *Message) bool {
-	return m != nil && !flag.IsHidden("social", m.ID) && !flag.Profane(m.Content) && !auth.IsBanned(m.AuthorID)
+	return m != nil && !flag.IsHidden("social", m.ID) && !auth.IsBanned(m.AuthorID)
 }

--- a/service/social/social.go
+++ b/service/social/social.go
@@ -74,6 +74,7 @@ func addMessage(p *Message) {
 	indexMessages([]*Message{p})
 	save()
 
+	event.Published("social", p.ID, "", p.Content)
 	event.Publish(event.Event{Type: "social_updated"})
 }
 
@@ -207,6 +208,13 @@ func Threads() []*Message {
 	defer mutex.RUnlock()
 	result := make([]*Message, len(messages))
 	copy(result, messages)
+	visible := result[:0]
+	for _, m := range result {
+		if visibleMessage(m) {
+			visible = append(visible, m)
+		}
+	}
+	result = visible
 	return result
 }
 
@@ -347,7 +355,6 @@ func handleCreateThread(w http.ResponseWriter, r *http.Request) {
 	addMessage(p)
 
 	// Async content moderation
-	event.Published("social", threadID, "", content)
 
 	app.Log("social", "New thread by %s (%s)", acc.Name, acc.ID)
 
@@ -405,8 +412,6 @@ func handleJSONRequest(w http.ResponseWriter, r *http.Request) {
 	}
 
 	addMessage(p)
-
-	event.Published("social", threadID, "", content)
 
 	app.RespondJSON(w, map[string]interface{}{"success": true, "id": threadID})
 }
@@ -471,7 +476,7 @@ func handleGetFeed(w http.ResponseWriter, r *http.Request) {
 		if p.ReplyTo != "" {
 			continue
 		}
-		if flag.IsHidden("social", p.ID) || auth.IsBanned(p.AuthorID) {
+		if !visibleMessage(p) {
 			continue
 		}
 		visible = append(visible, p)
@@ -508,7 +513,7 @@ func ThreadHandler(w http.ResponseWriter, r *http.Request) {
 
 	mutex.RLock()
 	p := getMessage(threadID)
-	if p == nil {
+	if !visibleMessage(p) {
 		mutex.RUnlock()
 		http.Error(w, "Thread not found", 404)
 		return
@@ -520,6 +525,13 @@ func ThreadHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	replies := getReplies(threadID)
+	visibleReplies := replies[:0]
+	for _, reply := range replies {
+		if visibleMessage(reply) {
+			visibleReplies = append(visibleReplies, reply)
+		}
+	}
+	replies = visibleReplies
 	mutex.RUnlock()
 
 	if app.WantsJSON(r) {
@@ -584,8 +596,6 @@ func handleCreateReply(w http.ResponseWriter, r *http.Request) {
 	}
 
 	addMessage(reply)
-
-	event.Published("social", replyID, "", content)
 
 	app.Log("social", "Message by %s in thread %s", acc.Name, parentID)
 
@@ -684,7 +694,7 @@ func generateThreadHTML(p *Message, replies []*Message, r *http.Request) string 
 
 	// Messages (chronological — oldest first, so conversation reads naturally)
 	for _, reply := range replies {
-		if flag.IsHidden("social", reply.ID) || auth.IsBanned(reply.AuthorID) {
+		if !visibleMessage(reply) {
 			continue
 		}
 		rc := htmlpkg.EscapeString(reply.Content)
@@ -741,7 +751,7 @@ func handleAPISearch(w http.ResponseWriter, r *http.Request, query string) {
 	results := data.Search(query, 50)
 	var socialResults []map[string]interface{}
 	for _, entry := range results {
-		if entry.Type == "social" {
+		if entry.Type == "social" && !flag.IsHidden("social", strings.TrimPrefix(entry.ID, "social_")) && !flag.Profane(entry.Content) {
 			socialResults = append(socialResults, map[string]interface{}{
 				"title":    entry.Title,
 				"content":  entry.Content,
@@ -781,7 +791,7 @@ func handleSearch(w http.ResponseWriter, r *http.Request, query string) {
 
 	count := 0
 	for _, entry := range results {
-		if entry.Type != "social" {
+		if entry.Type != "social" || flag.IsHidden("social", strings.TrimPrefix(entry.ID, "social_")) || flag.Profane(entry.Content) {
 			continue
 		}
 		count++
@@ -834,7 +844,7 @@ func generateCardHTML(allMessages []*Message) string {
 		if p.ReplyTo != "" {
 			continue // skip replies in home card
 		}
-		if flag.IsHidden("social", p.ID) || auth.IsBanned(p.AuthorID) {
+		if !visibleMessage(p) {
 			continue
 		}
 		if p.AuthorID == "_system" {
@@ -1198,4 +1208,8 @@ func DeleteByAuthor(authorID string) {
 	updateCacheLocked()
 	mutex.Unlock()
 	save()
+}
+
+func visibleMessage(m *Message) bool {
+	return m != nil && !flag.IsHidden("social", m.ID) && !flag.Profane(m.Content) && !auth.IsBanned(m.AuthorID)
 }


### PR DESCRIPTION
Preserve Social as a realtime, semantically selected heartbeat, but stop publishing profanity, abuse and threats from the open network.

Imported system posts bypassed ContentPublished. The selector also published its shortlist when its model rejected everything or failed, and a single candidate bypassed review entirely.

- Require the shared moderator to approve full imported text before publication.
- Remove score fallback and single-candidate bypass. Without working moderation, no automatic imports are published; local Social remains available.
- Emit ContentPublished centrally for all new social messages, including imports and replies.
- Apply an explicit-profanity rule without a model, including cached social content.
- Enforce visibility in Social feed tools, direct HTML/JSON threads, replies and Social search.
- Explicitly cover threats, dehumanisation and celebration of violence in the shared policy.

News and Video are curated and remain unchanged. No account-list redesign. Moderation here evaluates post text; it is not a claim to classify attached image/video pixels or all external linked pages.

Affected packages and architectural tests pass. CI builds, format and vet pass; only the existing home naming and internal/origin public-surface tests fail. Codex's initial finding (log noise on intentionally model-free instances) is fixed and under re-review.