### PR TITLE
Focus the landing and correct the Home account card

### DIFF
--- a/home/index.go
+++ b/home/index.go
@@ -281,7 +281,7 @@ func indexBody() string {
 			// furniture in front of somebody who has not asked anything yet.
 			Speak: false,
 		}) +
-		`<p class="landing-browse"><a class="mini-btn" href="/home">Browse news, video, markets and more →</a></p>` + today("") + `
+		today("") + `
 </div>
 
 <style>
@@ -321,10 +321,6 @@ func indexBody() string {
    The 18px that used to be under the wordmark is under this instead, so the
    gap between the name and the box is unchanged and the two lines sit together
    as one block. */
-.landing-browse{margin:16px 0 0}
-.landing-browse a,.landing-browse a:visited{display:inline-flex;align-items:center;justify-content:center;max-width:100%;box-sizing:border-box;padding:5px 10px;border:1px solid #ddd;border-radius:6px;background:#fff;color:#555;font-size:13px;line-height:1.5;text-decoration:none}
-.landing-browse a:hover{background:#f5f5f5;color:#111}
-.landing-browse a:focus-visible{outline:2px solid #555;outline-offset:3px}
 .lwhat{color:#888;font-size:14px;margin:0 0 18px;line-height:1.3}
 /* Today, under the box. */
 .ltoday{margin:30px 0 0}

--- a/home/layout_test.go
+++ b/home/layout_test.go
@@ -252,7 +252,7 @@ func TestTheBalanceIsInTheRailOnHome(t *testing.T) {
 	if got == "" {
 		t.Fatal("no balance block on an instance that charges")
 	}
-	if !strings.Contains(got, `href="/wallet"`) {
+	if !strings.Contains(got, `href="/account"`) {
 		t.Error("nothing on Home leads to /wallet")
 	}
 	if !strings.Contains(got, "credits") {
@@ -300,16 +300,19 @@ func TestTheHeaderBalanceIsNotHiddenOnHome(t *testing.T) {
 // It shipped as a bare heading with a link in it and an unbordered div, beneath
 // two bordered cards with plain headings — the only thing in the rail that did
 // not look like the rail.
-func TestTheWalletBlockLooksLikeTheOtherRailBlocks(t *testing.T) {
+func TestTheAccountBlockLooksLikeTheOtherRailBlocks(t *testing.T) {
 	was := quota.Enabled
 	quota.Enabled = func() bool { return true }
 	t.Cleanup(func() { quota.Enabled = was })
 
 	got := walletHTML("walletshape")
+	if !strings.Contains(got, ">Balance</h3>") || strings.Contains(got, `href="/wallet"`) {
+		t.Fatal("account card has wrong label or destination")
+	}
 
 	// The heading is the same plain one the others use, not a link.
-	if !strings.Contains(got, sectionRule("Wallet")) {
-		t.Error("the Wallet heading is not sectionRule's, so it does not match " +
+	if !strings.Contains(got, sectionRule("Account")) {
+		t.Error("the Account heading is not sectionRule's, so it does not match " +
 			"Inbox and Agents above it")
 	}
 	// A card, sharing the class the other two are styled by.
@@ -317,8 +320,8 @@ func TestTheWalletBlockLooksLikeTheOtherRailBlocks(t *testing.T) {
 		t.Error("the balance is not in a card, and both blocks above it are")
 	}
 	// And the way to the page, where the others put it.
-	if !strings.Contains(got, `href="/wallet" class="link"`) {
-		t.Error("no `Go to wallet` link — every other rail block ends with one, " +
+	if !strings.Contains(got, `href="/account" class="link"`) {
+		t.Error("no `Go to account` link — every other rail block ends with one, " +
 			"and it is the only route to /wallet from Home")
 	}
 }

--- a/home/wallet.go
+++ b/home/wallet.go
@@ -71,15 +71,15 @@ func walletHTML(accountID string) string {
 	// looking at the rendered page, where both neighbours are cards.
 	//
 	// So: a plain heading, a bordered block, and the way to the page at the
-	// foot of it. "Go to wallet" is also what makes /wallet reachable from
+	// foot of it. "Go to account" keeps the credit ledger reachable from
 	// Home, which is the same job "Go to inbox" does above.
 	var b strings.Builder
-	b.WriteString(sectionRule("Wallet"))
-	b.WriteString(`<div class="wallet-peek">`)
+	b.WriteString(sectionRule("Account"))
+	b.WriteString(`<div class="wallet-peek"><h3 class="mt-0">Balance</h3>`)
 	for _, part := range account.BalanceBody(accountID) {
 		b.WriteString(part)
 	}
-	b.WriteString(`<a href="/wallet" class="link">Go to wallet &rarr;</a>`)
+	b.WriteString(`<a href="/account" class="link">Go to account &rarr;</a>`)
 	b.WriteString(`</div>`)
 	return b.String()
 }


### PR DESCRIPTION
Two focused Home corrections requested by the operator:

- Remove the secondary browse action from the landing page and its styles. The primary action remains asking Micro; browsing remains on Home and pinned services.
- Label the Home credit card Account, show Balance inside it, and send its footer link to /account. Top-up and transfer use the existing account.BalanceBody; the crypto Wallet service is a separate domain.

Updated Home card regression tests pass, including the label, account destination and unchanged balance content. Formatted with gofmt. Existing naming/origin baseline CI failures remain unrelated.