### PR TITLE
Restore descriptions beneath Home headlines

### DIFF
--- a/home/collapsed_test.go
+++ b/home/collapsed_test.go
@@ -83,8 +83,12 @@ func TestTheCornerDoesNotRepeatTheRail(t *testing.T) {
 // Headlines retain their descriptions and use columns when the card has room.
 func TestTheNewsCardIsAGlance(t *testing.T) {
 	css := styles(t)
-	if strings.Contains(css, "#home #news .headline .description { display: none; }") {
-		t.Error("the Home news card hides the descriptions beneath its headlines")
+	descriptions := regexp.MustCompile(`#home\s+#news\s+\.headline\s+\.description\s*\{[^}]*\}`).FindAllString(css, -1)
+	hidden := regexp.MustCompile(`(?i)\bdisplay\s*:\s*none\s*(!\s*important\s*)?(;|\})`)
+	for _, rule := range descriptions {
+		if hidden.MatchString(rule) {
+			t.Error("the Home news card hides the descriptions beneath its headlines")
+		}
 	}
 	grid := regexp.MustCompile(`#home #news \.section\s*\{[^}]*\}`).FindString(css)
 	if !strings.Contains(grid, "auto-fill") {

--- a/home/collapsed_test.go
+++ b/home/collapsed_test.go
@@ -80,22 +80,11 @@ func TestTheCornerDoesNotRepeatTheRail(t *testing.T) {
 	}
 }
 
-// News on Home is headlines rather than articles.
-//
-// Eight items with a category, a title, the feed's description and a source
-// line came to 882px, against 469 for the next biggest card and 164 for the
-// smallest: one card was half the page on a screen of glances. The description
-// is a third telling of the same thing — the brief above it is the synthesis
-// and /news is the article — so it goes, and the items lay out in columns when
-// the card is wide enough for them.
-//
-// Not a time window. Cutting to the last few hours empties the card overnight,
-// which is exactly when there is most to catch up on.
+// Headlines retain their descriptions and use columns when the card has room.
 func TestTheNewsCardIsAGlance(t *testing.T) {
 	css := styles(t)
-	if !strings.Contains(css, "#home #news .headline .description { display: none; }") {
-		t.Error("the news card is showing article descriptions again, which is what " +
-			"made it twice the height of every other card")
+	if strings.Contains(css, "#home #news .headline .description { display: none; }") {
+		t.Error("the Home news card hides the descriptions beneath its headlines")
 	}
 	grid := regexp.MustCompile(`#home #news \.section\s*\{[^}]*\}`).FindString(css)
 	if !strings.Contains(grid, "auto-fill") {

--- a/internal/app/html/mu.css
+++ b/internal/app/html/mu.css
@@ -1327,38 +1327,13 @@ body.page-home #page-title ~ #customize-link {
   padding-top: 0;
 }
 
-/* News on Home is headlines, and the card was showing articles.
- *
- * Eight items, each a category, a title, the feed's description sentence and a
- * source line: 882px measured at 1728, against 469 for the next biggest card
- * and 164 for the smallest. One card was half the page while everything around
- * it was a glance.
- *
- * The description is the part that goes. It is a third telling of the same
- * thing on one screen — the brief at the top of the page is the synthesis, this
- * is the headlines, and /news is the articles — and a headline that needs its
- * description to be worth reading is one click away from it either way.
- *
- * Nothing is dropped from the list. A time window was the other way to shorten
- * this and it is the wrong one: somebody who slept through the night would
- * arrive to an empty card, which is exactly when there is most to catch up on.
- * Eight headlines that fit are eight headlines.
- *
- * auto-fill rather than a breakpoint, because what decides how many columns fit
- * is the width of this card and not of the window — the same card is 472px wide
- * with the rail open at 1440 and 892 with it closed at 1728. The grid answers
- * for both without either being written down.
- *
- * 280 and not 300, because the card's own padding is inside the measurement: at
- * 1280 with the rail open the card is 652 wide and the grid had about 610 of
- * it, which is two 300px tracks and a gap short by eighteen pixels — so that
- * width, which is an ordinary laptop, fell back to one column. */
+/* Home keeps one headline per category with its description below.
+   Columns follow the card width, including when the sidebar is open. */
 #home #news .section {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
   column-gap: 28px;
 }
-#home #news .headline .description { display: none; }
 /* In a grid the first and last item are not the first and last of a column, so
    the rules above that trim their padding would leave one row short of its
    neighbour. Uniform instead. */


### PR DESCRIPTION
Home hides the feed descriptions even though they provide useful context beneath each headline.

- [x] Remove the Home-only hiding rule so descriptions use the existing small, muted styling.
- [x] Keep category coverage and responsive columns.
- [x] Update the existing Home regression assertion; targeted test passes.

Validation: `go test -buildvcs=false ./home -run TestTheNewsCardIsAGlance -count=1` passes. Codex Cloud review and CI remain enabled.