### PR TITLE
Simplify guest navigation

### DIFF
--- a/home/index.go
+++ b/home/index.go
@@ -366,17 +366,9 @@ func indexBody() string {
 </style>`
 }
 
-// topRight is the landing's corner: the public catalogue and the way in.
-//
-// Two links, for the two audiences arriving here. Tools takes an agent builder
-// to the machine-facing catalogue; Log in takes a returning person home. Sign
-// up remains one step behind Log in, on the login page, rather than making
-// three competing actions in this small corner.
-//
-// No redirect on the way in. The landing is the one page where signing in
-// should move you somewhere else, and it already does.
+// topRight offers one way in from the landing; signup is on the login page.
 func topRight() string {
-	return `<a href="/tools">Tools</a><a href="/login">Log in</a>`
+	return `<a href="/login">Log in</a>`
 }
 
 // today is what you are given for arriving, before you ask anything.

--- a/home/landing_test.go
+++ b/home/landing_test.go
@@ -31,27 +31,9 @@ func TestTheWordmarkSaysWhatItIs(t *testing.T) {
 	}
 }
 
-// The corner offers the public tool catalogue and one way into an account.
-//
-// Sign up is available from the login page. Keeping it here as a third link
-// makes the smallest piece of navigation ask a stranger to choose between two
-// account actions before they have decided to use either.
-func TestTheLandingOffersToolsAndOneWayIn(t *testing.T) {
+func TestTheLandingOffersOneWayIn(t *testing.T) {
 	got := topRight()
-	for _, want := range []string{`href="/tools"`, `href="/login"`} {
-		if !strings.Contains(got, want) {
-			t.Errorf("the front door is missing %s: %q", want, got)
-		}
-	}
-	if strings.Contains(got, `href="/signup"`) {
-		t.Errorf("the front door has three corner links instead of Tools and Log in: %q", got)
-	}
-	if strings.Index(got, "/tools") > strings.Index(got, "/login") {
-		t.Errorf("Log in comes before Tools on the front door: %q", got)
-	}
-	// No redirect on the way in. This is the one page where signing in should
-	// move you somewhere else, and it already does.
-	if strings.Contains(got, "redirect=") {
-		t.Errorf("the front door sends you back to itself after signing in: %q", got)
+	if got != `<a href="/login">Log in</a>` {
+		t.Errorf("unexpected landing navigation: %q", got)
 	}
 }

--- a/home/wayin_test.go
+++ b/home/wayin_test.go
@@ -27,11 +27,11 @@ func TestSignedOutHomeDoesNotOfferASecondWayIn(t *testing.T) {
 	if strings.Contains(body, "home-date-actions") {
 		t.Error("the Sign up / Log in pair is back beside the date, under the corner that already says it")
 	}
-	// The corner itself is the shell's and is expected — this is about the
-	// page's own content, so it is the count that matters rather than the
-	// presence. One is the corner's; a second is this page drawing its own.
-	if n := strings.Count(body, `href="/signup"`); n != 1 {
-		t.Errorf("the signed-out home offers Sign up %d times; want once, in the shell's corner", n)
+	if n := strings.Count(body, `href="/signup"`); n != 0 {
+		t.Errorf("the guest Home page offers redundant signup links: %d", n)
+	}
+	if n := strings.Count(body, `href="/login?redirect=%2Fhome"`); n != 1 {
+		t.Errorf("the guest Home page should offer Login once in the sidebar, got %d", n)
 	}
 }
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -1455,9 +1455,16 @@ func headCorner(acc *auth.Account, here string) string {
 		htmlpkg.EscapeString(acc.ID) + `</span></a>`
 }
 
-func navBottom(acc *auth.Account) string {
+func loginBack(here string) string {
+	if here == "" || here == "/" {
+		return ""
+	}
+	return "?redirect=" + url.QueryEscape(here)
+}
+
+func navBottom(acc *auth.Account, here string) string {
 	if acc == nil {
-		return `<a id="nav-login" href="/login"><img src="/account.png?` + Version + `"><span class="label">Login</span></a>`
+		return `<a id="nav-login" href="/login` + loginBack(here) + `"><img src="/account.png?` + Version + `"><span class="label">Login</span></a>`
 	}
 	username := htmlpkg.EscapeString(acc.ID)
 
@@ -1830,6 +1837,6 @@ func renderShell(lang, title, desc, bodyAttr, body string, acc *auth.Account, pa
 		headCorner(acc, here),
 		navMain(acc),
 		navPinned(acc),
-		navBottom(acc),
+		navBottom(acc, here),
 		title, body, footerFor(acc), navTabs(acc))
 }

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -1265,9 +1265,11 @@ func VerifyBanner(r *http.Request) string {
 //
 // A menu is a list of destinations and this is the list. The account's own —
 // Account, Profile, Tokens, Wallet — appear only when there is an account, and
-// Admin only for an admin, so a signed-out visitor sees the four that mean
-// anything to them.
+// Admin only for an admin, and the main destinations require a signed-in account.
 func navMain(acc *auth.Account) string {
+	if acc == nil {
+		return ""
+	}
 	item := func(id, href, icon, label string) string {
 		return `<a id="` + id + `" href="` + href + `"><img src="` + icon + `?` + Version +
 			`"><span class="label">` + label + `</span></a>`
@@ -1428,60 +1430,10 @@ func navPinned(acc *auth.Account) string {
 //
 // nav-username is a label mu.js corrects from the session: a page cached for
 // one viewer and served to another would otherwise greet them by the wrong name.
-// headCorner is the top right of every page: what this account has, or the way
-// to have one.
-//
-// Signed out it was empty, and the only way in was Login at the foot of the
-// sidebar. That was survivable while the sidebar was always open and is not now
-// that it is collapsed by default — a stranger on /contact or /archive would
-// have had to find a hamburger to find a way to sign in.
-//
-// It is also the half of "the signed-out pages do not match the signed-in ones"
-// that is real. The front page had a corner with Sign up and Log in in it and
-// every other page had nothing, so the two states of this product differed by
-// which page you happened to be on rather than by whether you had an account.
-// One corner, on every page, saying which of the two you are.
-// loginBack sends somebody back to the page they were reading.
-//
-// A page that bounced you to /login has always carried this — see
-// RedirectToLogin — but a public page you were reading and chose to sign in
-// from did not, so reading /archive or /contact and pressing Log in landed you
-// on /home with the page you were on gone. The one case where signing in
-// *should* move you is the landing, and that redirects on its own.
-func loginBack(here string) string {
-	if here == "" || here == "/" {
-		return ""
-	}
-	return "?redirect=" + url.QueryEscape(here)
-}
-
+// headCorner shows the signed-in account. Guests sign in through the sidebar.
 func headCorner(acc *auth.Account, here string) string {
 	if acc == nil {
-		// Two links: the decision, then the return.
-		//
-		// This was cut to Log in alone, on the argument that a corner should be
-		// the one thing you can do from here and the login page offers signing
-		// up on it. The argument reads well and the instance stopped taking
-		// signups — which is the measurement the argument did not have. A link
-		// on the login page is only reachable by somebody who already pressed
-		// Log in, and a stranger who has never had an account does not press
-		// Log in; there was nothing on any page of this product telling them
-		// they could have one.
-		//
-		// Sign up first, and it is the darker of the two: it is the decision
-		// being made here. Log in already knows where it is going.
-		//
-		// Not offered where it cannot be taken. On an invite-only instance
-		// /signup is a form asking for a code the person clicking it does not
-		// have, so the corner narrows to one link there — which is the width
-		// difference the cut was partly made to avoid, kept as the exception
-		// rather than made the rule for everybody.
-		signup := ""
-		if !auth.InviteOnly() {
-			signup = `<a id="head-signup" href="/signup">Sign up</a>`
-		}
-		return `<div id="head-out">` + signup +
-			`<a href="/login` + loginBack(here) + `">Log in</a></div>`
+		return ""
 	}
 
 	// And who you are, which is the other half of the same answer.

--- a/internal/app/corner_test.go
+++ b/internal/app/corner_test.go
@@ -1,15 +1,5 @@
 package app
 
-// The corner, which is the only thing in the chrome that says which of the two
-// states you are in.
-//
-// This used to be the front door's, in home/index.go, and only the front door
-// had one — so a stranger on /contact or /archive had no visible way to sign in
-// at all, and the two states of the product differed by which page you were
-// standing on rather than by whether you had an account. It moved into the
-// shell when the sidebar became collapsed by default, because Login at the foot
-// of a hidden rail is not a way in.
-
 import (
 	"strings"
 	"testing"
@@ -17,51 +7,18 @@ import (
 	"mu/internal/auth"
 )
 
-func TestTheCornerIsTheWayInOrWhatYouHave(t *testing.T) {
-	out := headCorner(nil, "")
-	if !strings.Contains(out, `href="/login"`) {
-		t.Errorf("signed out, the corner does not offer a way in: %q", out)
-	}
-	// And the way to have an account, which is the other half.
-	//
-	// This was cut to Log in alone — one control in a corner whose job is to be
-	// the one thing you can do from here, with the login page offering signup
-	// on it. Signups stopped. A link on the login page is reachable only by
-	// somebody who pressed Log in, and a stranger with no account does not
-	// press Log in.
-	if !strings.Contains(out, `href="/signup"`) {
-		t.Errorf("signed out, the corner does not offer a way to have an account: %q", out)
-	}
-	if n := strings.Count(out, "<a "); n != 2 {
-		t.Errorf("the signed-out corner has %d links, want Sign up and Log in: %q", n, out)
-	}
-	// Sign up first: it is the decision being made here, and Log in already
-	// knows where it is going.
-	if strings.Index(out, "/signup") > strings.Index(out, "/login") {
-		t.Errorf("Log in comes before Sign up in the corner: %q", out)
-	}
-	// Install app stood here once and appeared on only some browsers, saying
-	// nothing about what state you are in or what to do about it — which is the
-	// corner's entire purpose.
-	if strings.Contains(out, "install-app") {
-		t.Errorf("Install is back in the corner: %q", out)
-	}
-}
-
-// An invite-only instance does not offer a door that is shut.
-//
-// /signup on one of those is a form asking for a code the person clicking it
-// does not have. The corner narrows to Log in there, which is also the width
-// difference that was once an argument for cutting Sign up everywhere — kept
-// as the exception rather than made the rule.
-func TestInviteOnlyDoesNotOfferSignup(t *testing.T) {
-	t.Setenv("INVITE_ONLY", "true")
-	out := headCorner(nil, "")
-	if strings.Contains(out, "/signup") {
-		t.Errorf("an invite-only instance offers a signup form nobody can complete: %q", out)
-	}
-	if !strings.Contains(out, `href="/login"`) {
-		t.Errorf("and now there is no way in at all: %q", out)
+func TestGuestsSignInThroughTheSidebar(t *testing.T) {
+	for _, inviteOnly := range []string{"false", "true"} {
+		t.Setenv("INVITE_ONLY", inviteOnly)
+		if got := headCorner(nil, "/news"); got != "" {
+			t.Errorf("guest header duplicates account links: %q", got)
+		}
+		if got := navMain(nil); got != "" {
+			t.Errorf("guest sidebar exposes signed-in destinations: %q", got)
+		}
+		if got := navBottom(nil); !strings.Contains(got, `href="/login"`) {
+			t.Errorf("guest sidebar has no way to log in: %q", got)
+		}
 	}
 }
 
@@ -91,23 +48,5 @@ func TestTheNameInTheCornerIsEscaped(t *testing.T) {
 	got := headCorner(&auth.Account{ID: `<script>x</script>`}, "")
 	if strings.Contains(got, "<script>") {
 		t.Errorf("an account id went into the corner as markup: %q", got)
-	}
-}
-
-// Signing in from a page you were reading brings you back to it.
-//
-// A page that bounced you to /login has always carried a redirect — see
-// RedirectToLogin — but a public page you chose to sign in from did not, so
-// reading /archive and pressing Log in landed you on /home with the page you
-// were on gone.
-func TestTheCornerComesBackToThePageYouWereOn(t *testing.T) {
-	got := headCorner(nil, "/archive?q=go+micro")
-	if !strings.Contains(got, "redirect=%2Farchive%3Fq%3Dgo%2Bmicro") {
-		t.Errorf("Log in does not carry the page you were on: %q", got)
-	}
-	// The landing is the one page where signing in should move you, and it
-	// redirects on its own. Carrying it would be a round trip to nowhere.
-	if got := headCorner(nil, "/"); strings.Contains(got, "redirect=") {
-		t.Errorf("the corner sends you back to the landing: %q", got)
 	}
 }

--- a/internal/app/corner_test.go
+++ b/internal/app/corner_test.go
@@ -16,7 +16,7 @@ func TestGuestsSignInThroughTheSidebar(t *testing.T) {
 		if got := navMain(nil); got != "" {
 			t.Errorf("guest sidebar exposes signed-in destinations: %q", got)
 		}
-		if got := navBottom(nil); !strings.Contains(got, `href="/login"`) {
+		if got := navBottom(nil, ""); !strings.Contains(got, `href="/login"`) {
 			t.Errorf("guest sidebar has no way to log in: %q", got)
 		}
 	}
@@ -48,5 +48,15 @@ func TestTheNameInTheCornerIsEscaped(t *testing.T) {
 	got := headCorner(&auth.Account{ID: `<script>x</script>`}, "")
 	if strings.Contains(got, "<script>") {
 		t.Errorf("an account id went into the corner as markup: %q", got)
+	}
+}
+
+func TestSidebarLoginReturnsToTheCurrentPage(t *testing.T) {
+	got := navBottom(nil, "/archive?q=go+micro")
+	if !strings.Contains(got, "redirect=%2Farchive%3Fq%3Dgo%2Bmicro") {
+		t.Errorf("sidebar login loses the current page: %q", got)
+	}
+	if strings.Contains(navBottom(nil, "/"), "redirect=") {
+		t.Error("landing login should proceed to Home")
 	}
 }

--- a/internal/app/nav_admin_test.go
+++ b/internal/app/nav_admin_test.go
@@ -74,7 +74,7 @@ func TestAnAdminGetsTheLinkInTheNav(t *testing.T) {
 // its mailbox were removed — both survived here as links to nothing, which is
 // what this half of the test exists to catch.
 func TestTheBottomIsWhoYouAreAndTheWayOut(t *testing.T) {
-	bottom := navBottom(&auth.Account{ID: "someone"})
+	bottom := navBottom(&auth.Account{ID: "someone"}, "")
 
 	if !strings.Contains(bottom, "Signed in as") || !strings.Contains(bottom, "@someone") {
 		t.Errorf("the rail does not say which account this is: %q", bottom)
@@ -120,13 +120,13 @@ func TestAnOrdinaryAccountIsNotShownTheDoor(t *testing.T) {
 	if nav := headAdmin(&auth.Account{ID: "reader"}); nav != "" {
 		t.Errorf("a non-admin is offered the admin dashboard: %s", nav)
 	}
-	if strings.Contains(navBottom(&auth.Account{ID: "reader"}), "/admin") {
+	if strings.Contains(navBottom(&auth.Account{ID: "reader"}, ""), "/admin") {
 		t.Error("the bottom group still carries an admin link")
 	}
 }
 
 func TestSignedOutGetsNoAdminLink(t *testing.T) {
-	if headAdmin(nil) != "" || strings.Contains(navBottom(nil), "/admin") {
+	if headAdmin(nil) != "" || strings.Contains(navBottom(nil, ""), "/admin") {
 		t.Error("a signed-out visitor is offered the admin dashboard")
 	}
 }

--- a/internal/app/nav_icons_test.go
+++ b/internal/app/nav_icons_test.go
@@ -57,7 +57,7 @@ func TestEveryNavIconExists(t *testing.T) {
 // row collapses to its label rather than showing a broken image, so it reads
 // as a deliberately plain entry rather than a mistake.
 func TestEveryAccountMenuEntryHasAnIcon(t *testing.T) {
-	menu := navBottom(&auth.Account{ID: "someone", Admin: true})
+	menu := navBottom(&auth.Account{ID: "someone", Admin: true}, "")
 	for _, row := range strings.Split(menu, "<a ")[1:] {
 		id := ""
 		if i := strings.Index(row, `id="`); i >= 0 {


### PR DESCRIPTION
Keep public pages focused on their utility, with one route into an account.

- [x] Show sidebar Home, Inbox, Agents and Services only to signed-in accounts.
- [x] Remove Tools from the landing corner; retain Log in.
- [x] Remove duplicate signup/login links from templated-page headers; retain sidebar Login.
- [x] Update navigation tests; targeted app and Home tests pass.

This changes navigation visibility, not public service endpoints or access rules. Pricing and licence terms are unchanged pending a concrete decision.

Codex Cloud review and CI remain enabled.