### PR TITLE
Align Account preview and payment page spacing

### DIFF
--- a/account/balance.go
+++ b/account/balance.go
@@ -66,22 +66,12 @@ func thousands(n int) string {
 // nav item of its own called Wallet, which put a person's money one click
 // further away than their choice of language.
 func BalanceCard(userID string) string {
-	return app.SectionID("balance", "Balance", BalanceBody(userID)...)
+	return app.SectionID("balance", "Balance", BalanceBody(userID, true)...)
 }
 
-// BalanceBody is what is inside that card, without the card.
-//
-// Split out for Home's rail, which draws the balance under a "Wallet" heading
-// in the same shape as the Inbox and Agents blocks beside it — a card nested
-// under a section heading would be a second frame around one number, and a
-// second "Balance" title under a "Wallet" one.
-//
-// Split rather than reimplemented, because the parts are not decoration: the
-// figure is meaningless without "1 credit = 1¢" next to it, an admin needs
-// telling their own calls are never charged, and Top up and Transfer are the
-// two things anybody comes to a balance to do. Home had a hand-rolled number
-// and a link for one commit and it was already missing all four.
-func BalanceBody(userID string) []string {
+// BalanceBody renders the balance and actions. Conversion is useful on Account,
+// while Home keeps a compact credit balance.
+func BalanceBody(userID string, showConversion bool) []string {
 	c := CreditsOf(userID)
 
 	isAdmin := false
@@ -111,9 +101,13 @@ func BalanceBody(userID string) []string {
 	// balances — this one in credits, and the USDC the key holds — but the
 	// second card names itself "Crypto", so this one does not have to
 	// carry the disambiguation in its own title as well.
+	conversion := ""
+	if showConversion {
+		conversion = app.Note(money(c.Balance) + " · 1 credit = 1¢")
+	}
 	return []string{
 		`<p class="balance-figure"><b>` + thousands(c.Balance) + `</b> <span>credits</span></p>`,
-		app.Note(money(c.Balance) + " · 1 credit = 1¢"),
+		conversion,
 		free,
 		admin,
 		`<p class="balance-links"><a href="/account/topup">Top up &rarr;</a> · ` +
@@ -400,6 +394,8 @@ func renderStripeDeposit(userID, errMsg string) string {
 	if errMsg != "" {
 		sb.WriteString(fmt.Sprintf(`<p class="text-error">%s</p>`, errMsg))
 	}
+	sb.WriteString(`<h4>Current balance</h4>`)
+	sb.WriteString(`<p class="mt-0">` + thousands(Balance(userID)) + ` credits</p>`)
 	sb.WriteString(`<hr class="hr-soft my-4">`)
 
 	sb.WriteString("<h4>One-time top-up</h4>")
@@ -422,10 +418,7 @@ func renderStripeDeposit(userID, errMsg string) string {
 
 	sb.WriteString(`<button type="submit" class="btn mt-4">Continue to Payment</button>`)
 	sb.WriteString(`</form>`)
-	sb.WriteString(`</div>`)
-
-	sb.WriteString(`<div class="card">`)
-	sb.WriteString(`<p class="text-sm text-muted">Secure payment via Stripe. 1 credit = 1¢.</p>`)
+	sb.WriteString(`<p class="text-sm text-muted mt-3 mb-0">Secure payment via Stripe. 1 credit = 1¢.</p>`)
 	sb.WriteString(`</div>`)
 
 	return sb.String()
@@ -497,7 +490,7 @@ func handleTransferPage(w http.ResponseWriter, r *http.Request) {
 	sb.WriteString(`</div>`)
 
 	sb.WriteString(`<div class="card">`)
-	sb.WriteString(fmt.Sprintf(`<p class="text-sm text-muted">1 credit = 1¢. Transfers are instant and non-reversible. Daily transfer limit: %d credits.</p>`, DailyTransferCap))
+	sb.WriteString(fmt.Sprintf(`<p class="text-sm text-muted mt-0 mb-0">1 credit = 1¢. Transfers are instant and non-reversible. Daily transfer limit: %d credits.</p>`, DailyTransferCap))
 	sb.WriteString(`</div>`)
 
 	app.Respond(w, r, app.Response{Title: "Transfer", Description: "Send credits to somebody else", HTML: sb.String()})

--- a/account/topup_routes_test.go
+++ b/account/topup_routes_test.go
@@ -56,3 +56,17 @@ func TestAccountShowsConversionConfirmation(t *testing.T) {
 		t.Fatalf("conversion confirmation missing: status %d", rec.Code)
 	}
 }
+
+func TestTopupShowsBalanceAndPaymentNoteInTheFormCard(t *testing.T) {
+	got := renderStripeDeposit("topup-display-empty", "")
+	balance := strings.Index(got, "Current balance")
+	divider := strings.Index(got, "<hr")
+	button := strings.Index(got, "Continue to Payment")
+	note := strings.Index(got, "Secure payment via Stripe")
+	if balance < 0 || balance > divider || !strings.Contains(got, "0 credits") {
+		t.Fatal("current balance must appear above the top-up divider")
+	}
+	if button < 0 || note < button || strings.Count(got, `class="card"`) != 1 {
+		t.Fatal("payment note must follow the button inside the same card")
+	}
+}

--- a/home/layout_test.go
+++ b/home/layout_test.go
@@ -258,10 +258,10 @@ func TestTheBalanceIsInTheRailOnHome(t *testing.T) {
 	if !strings.Contains(got, "credits") {
 		t.Error("the number has no unit on it")
 	}
-	// The real card's contents, not a hand-rolled number. Those two links are
-	// what somebody looking at a balance has come to do, and a figure with no
-	// rate beside it does not say what a credit is.
-	for _, want := range []string{"/account/topup", "/account/transfer", "1 credit = 1"} {
+	if strings.Contains(got, "1 credit =") {
+		t.Error("Home repeats the account conversion note")
+	}
+	for _, want := range []string{"/account/topup", "/account/transfer"} {
 		if !strings.Contains(got, want) {
 			t.Errorf("the balance block is missing %s — it should be account.BalanceBody, "+
 				"not a number written again here", want)
@@ -306,7 +306,7 @@ func TestTheAccountBlockLooksLikeTheOtherRailBlocks(t *testing.T) {
 	t.Cleanup(func() { quota.Enabled = was })
 
 	got := walletHTML("walletshape")
-	if !strings.Contains(got, ">Balance</h3>") || strings.Contains(got, `href="/wallet"`) {
+	if !strings.Contains(got, ">Balance</h4>") || strings.Contains(got, `href="/wallet"`) {
 		t.Fatal("account card has wrong label or destination")
 	}
 

--- a/home/wallet.go
+++ b/home/wallet.go
@@ -26,15 +26,7 @@ package home
 // the same relationship Inbox has to the Inbox in the rail. A glance and a
 // place are allowed to be about the same thing.
 //
-// # The real card, not a number
-//
-// This drew its own figure and its own link for one commit, and a balance
-// rendered by hand is a balance that drifts from the one on /account. It is
-// account.BalanceBody now — the same figure, the same "1 credit = 1¢", the same
-// note to an admin that their calls are never charged, and the same Top up and
-// Transfer. Those are not trimmings: the number means nothing without the rate
-// beside it, and topping up is the thing somebody looking at a balance has come
-// to do.
+// Home shares the balance and actions with Account, omitting its conversion note.
 //
 // # At the foot
 //
@@ -75,8 +67,8 @@ func walletHTML(accountID string) string {
 	// Home, which is the same job "Go to inbox" does above.
 	var b strings.Builder
 	b.WriteString(sectionRule("Account"))
-	b.WriteString(`<div class="wallet-peek"><h3 class="mt-0">Balance</h3>`)
-	for _, part := range account.BalanceBody(accountID) {
+	b.WriteString(`<div class="wallet-peek"><h4>Balance</h4>`)
+	for _, part := range account.BalanceBody(accountID, false) {
 		b.WriteString(part)
 	}
 	b.WriteString(`<a href="/account" class="link">Go to account &rarr;</a>`)

--- a/internal/app/html/mu.css
+++ b/internal/app/html/mu.css
@@ -1251,8 +1251,8 @@ body.page-home #page-title ~ #customize-link {
    block in a column under two lists, and a 32px figure shouts over them. */
 .wallet-peek .balance-figure {
   margin: 8px 0 2px;
-  font-size: 22px;
-  line-height: 1;
+  font-size: 1em;
+  line-height: var(--line-height);
 }
 .wallet-peek .balance-figure span {
   font-size: 13px;
@@ -1491,7 +1491,8 @@ body.page-home #page-title ~ #customize-link {
   }
 }
 
-.card h4 {
+.card h4,
+.wallet-peek h4 {
   margin-top: 0;
   margin-bottom: var(--spacing-sm);
   font-size: 1em;
@@ -4085,6 +4086,7 @@ button.btn-plain { padding: 6px 12px; font: inherit; cursor: pointer; color: var
 .mt-4 { margin-top: 15px; }
 .mt-5 { margin-top: 20px; }
 .mt-6 { margin-top: 30px; }
+.mb-0 { margin-bottom: 0; }
 .mb-1 { margin-bottom: 5px; }
 .mb-3 { margin-bottom: 10px; }
 .mb-4 { margin-bottom: 15px; }
@@ -8011,3 +8013,7 @@ a.btn-secondary:hover, .btn-secondary:hover {
 .code-box input[type="text"] { flex: 1 1 auto; min-width: 0 }
 .code-box input:disabled, .code-box button:disabled { opacity: 0.55 }
 .code-status { margin: 8px 0 0 }
+
+/* The account preview starts with a heading, not an inset list row. */
+.wallet-peek { padding-top: 16px; }
+.wallet-peek .balance-figure b { font-weight: 400; }


### PR DESCRIPTION
Make the Home Account preview fit the other cards and keep payment pages compact.

- [x] Match the Balance heading to service-card headings and give the preview proper top padding.
- [x] Use a compact credit figure and omit the redundant currency/conversion note on Home; retain it on Account.
- [x] Show current balance above the One-time top-up divider.
- [x] Move the Stripe note below Continue to Payment within the form card.
- [x] Remove extra paragraph margins from the Transfer note card.
- [x] Targeted Account/Home rendering tests pass; gofmt applied.

No changes to Home columns, assistant entry/navigation, payment execution or pricing. Codex Cloud review and CI remain enabled.