### PR TITLE
Open into Micro and preserve the journey to Home and back

### DIFF
--- a/account/google_oauth.go
+++ b/account/google_oauth.go
@@ -180,7 +180,7 @@ func GoogleCallback(w http.ResponseWriter, r *http.Request) {
 		Name: "session", Value: sess.Token, Path: "/", MaxAge: 2592000,
 		HttpOnly: true, Secure: requestSecure(r), SameSite: http.SameSiteLaxMode,
 	})
-	http.Redirect(w, r, "/home", http.StatusFound)
+	http.Redirect(w, r, "/agent/micro", http.StatusFound)
 }
 
 // googleExchange trades an authorization code for an access token.

--- a/account/pages.go
+++ b/account/pages.go
@@ -433,7 +433,7 @@ func Signup(w http.ResponseWriter, r *http.Request) {
 
 	// Carried through every render so the POST keeps it — see renderSignupTo.
 	redirectParam := ""
-	if to := safeRedirect(r); to != "/home" {
+	if to := safeRedirect(r); to != "/agent/micro" {
 		redirectParam = "?redirect=" + url.QueryEscape(to)
 	}
 
@@ -1232,7 +1232,7 @@ func safeRedirect(r *http.Request) string {
 // somebody straight back to a login page, which is a loop rather than a
 // vulnerability but is still not a destination.
 func SafeRedirectTo(to string) string {
-	const home = "/home"
+	const home = "/agent/micro"
 	if to == "" || to[0] != '/' {
 		return home
 	}

--- a/account/passkey.go
+++ b/account/passkey.go
@@ -288,7 +288,7 @@ func passkeyLoginFinish(w http.ResponseWriter, r *http.Request) {
 
 	app.RespondJSON(w, map[string]interface{}{
 		"success":  true,
-		"redirect": "/home",
+		"redirect": "/agent/micro",
 	})
 }
 

--- a/account/redirect_test.go
+++ b/account/redirect_test.go
@@ -11,8 +11,8 @@ import "testing"
 // somebody else's site with our domain in the address bar on the way — which
 // is what makes a phishing page convincing.
 func TestWhereYouComeBackToIsAPageHere(t *testing.T) {
-	if got := SafeRedirectTo(""); got != "/home" {
-		t.Errorf("a plain login lands at %q, want /home", got)
+	if got := SafeRedirectTo(""); got != "/agent/micro" {
+		t.Errorf("a plain login lands at %q, want /agent/micro", got)
 	}
 	for _, elsewhere := range []string{
 		"//evil.example",       // protocol-relative
@@ -21,7 +21,7 @@ func TestWhereYouComeBackToIsAPageHere(t *testing.T) {
 		"https://evil.example", // not even a path
 		"evil.example",
 	} {
-		if got := SafeRedirectTo(elsewhere); got != "/home" {
+		if got := SafeRedirectTo(elsewhere); got != "/agent/micro" {
 			t.Errorf("SafeRedirectTo(%q) = %q — that leaves this instance", elsewhere, got)
 		}
 	}
@@ -31,7 +31,7 @@ func TestWhereYouComeBackToIsAPageHere(t *testing.T) {
 	}
 	// A login page is not a destination — it is a loop.
 	for _, loop := range []string{"/login", "/logout", "/signup?invite=x"} {
-		if got := SafeRedirectTo(loop); got != "/home" {
+		if got := SafeRedirectTo(loop); got != "/agent/micro" {
 			t.Errorf("SafeRedirectTo(%q) = %q", loop, got)
 		}
 	}

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -453,7 +453,7 @@ func servePage(w http.ResponseWriter, r *http.Request) {
 	if reopened {
 		// A reopened conversation decides its own agent; the rail filters to it.
 		selAgent = reopenAgent
-	} else if selAgent != "" && prefill == "" && cfg.Attachment == "" {
+	} else if (selAgent != "" || named) && prefill == "" && cfg.Attachment == "" && r.URL.Query().Get("new") != "1" {
 		// Land in the last conversation with this agent, if there is one.
 		if last := latestThreadFor(accountID, selAgent, named); last != "" {
 			cfg.ContextID = last
@@ -534,6 +534,10 @@ func servePage(w http.ResponseWriter, r *http.Request) {
 	// This page is for talking to it, so the box asks rather than searches.
 	// See app.ChatConfig.Ask — search is the default everywhere else, because
 	// search works with no model and a page about an agent obviously does not.
+	if cfg.StorageNS == "agent" {
+		cfg.StorageNS = "agent-" + accountID + "-" + selAgent
+	}
+	cfg.ServerOwned = true
 	cfg.Transcript = true
 	cfg.Ask = true
 	main := selected + app.ChatComponent(cfg)
@@ -563,6 +567,7 @@ func servePage(w http.ResponseWriter, r *http.Request) {
 	// non-empty left the tab's remembered selection in charge on a bare /agent:
 	// the rail listed every agent's conversations while the next message went to
 	// whichever agent the tab remembered. The URL is the state.
+	content += resumeMicroJS(accountID, selAgent, cfg.ContextID)
 	content += `<script>window.muSeedAgent(` + app.JSString(selAgent) + `);</script>`
 	if prefill != "" {
 		content += `<script>(function(){var i=document.getElementById('mu-chat-input');if(i&&window.muChatAsk){i.value=` + app.JSString(prefill) + `;window.muChatAsk(i.value);}history.replaceState(null,'',` + app.JSString(Path(accountID, selAgent)) + `);})()</script>`
@@ -720,7 +725,7 @@ func renderSessionsRail(accountID, currentID, agentID string, named bool, extra 
 	// holds what arrived, so a link from one to the other lands somewhere that
 	// does not have the conversation in it.
 	base := Path(accountID, agentID)
-	newURL := base
+	newURL := base + "?new=1"
 	if agentID != "" && base == "/agent/"+DefaultSlug {
 		// An id that resolves to nothing in the roster. Keep it in the URL
 		// rather than silently rewriting to the default, which is what widened

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -534,9 +534,7 @@ func servePage(w http.ResponseWriter, r *http.Request) {
 	// This page is for talking to it, so the box asks rather than searches.
 	// See app.ChatConfig.Ask — search is the default everywhere else, because
 	// search works with no model and a page about an agent obviously does not.
-	if cfg.StorageNS == "agent" {
-		cfg.StorageNS = "agent-" + accountID + "-" + selAgent
-	}
+	cfg.StorageNS = "agent-" + accountID + "-" + selAgent
 	cfg.ServerOwned = true
 	cfg.Transcript = true
 	cfg.Ask = true
@@ -567,6 +565,7 @@ func servePage(w http.ResponseWriter, r *http.Request) {
 	// non-empty left the tab's remembered selection in charge on a bare /agent:
 	// the rail listed every agent's conversations while the next message went to
 	// whichever agent the tab remembered. The URL is the state.
+	content += `<script>window.addEventListener('mu-chat-thread',function(e){history.replaceState(null,'',` + app.JSString(Path(accountID, selAgent)) + `+'?session='+encodeURIComponent(e.detail));});</script>`
 	content += resumeMicroJS(accountID, selAgent, cfg.ContextID)
 	content += `<script>window.muSeedAgent(` + app.JSString(selAgent) + `);</script>`
 	if prefill != "" {

--- a/agent/reading_test.go
+++ b/agent/reading_test.go
@@ -33,7 +33,7 @@ func TestReadingIsPrivateAndAttachedToANewConversation(t *testing.T) {
 		t.Fatalf("page: %d", w.Code)
 	}
 	body := w.Body.String()
-	if strings.Contains(body, "private annotation") || !strings.Contains(body, "bookmark:"+item.ID) || !strings.Contains(body, "reading-"+owner) {
+	if strings.Contains(body, "private annotation") || !strings.Contains(body, "bookmark:"+item.ID) || !strings.Contains(body, "agent-"+owner+"-") {
 		t.Fatal("selected material was not attached to an isolated private chat")
 	}
 	th := thread.Open(owner, thread.WebClient, "reading-test")

--- a/agent/resume.go
+++ b/agent/resume.go
@@ -17,7 +17,8 @@ try{
   location.replace(saved);return;
  }
  function remember(id){sessionStorage.setItem(key,base+(id?'?session='+encodeURIComponent(id):'?new=1'));}
- remember(` + app.JSString(contextID) + `);
+ var query=new URLSearchParams(location.search);
+ if(!['bookmark','saved','item','prompt','q'].some(function(k){return query.has(k);}))remember(` + app.JSString(contextID) + `);
  window.addEventListener('mu-chat-thread',function(e){remember(e.detail);});
  window.addEventListener('mu-chat-new',function(){remember('');});
 }catch(e){}

--- a/agent/resume.go
+++ b/agent/resume.go
@@ -1,0 +1,25 @@
+package agent
+
+import "mu/internal/app"
+
+// Remember only the default assistant's destination, scoped to this account/tab.
+// The server still checks ownership when reopening a thread.
+func resumeMicroJS(accountID, agentID, contextID string) string {
+	if agentID != "" {
+		return ""
+	}
+	return `<script>(function(){
+var key='mu_micro_resume:'+` + app.JSString(accountID) + `;
+var base='/agent/micro';
+try{
+ var saved=sessionStorage.getItem(key);
+ if(location.pathname===base&&!location.search&&saved&&/^\/agent\/micro\?(session=[A-Za-z0-9_-]+|new=1)$/.test(saved)){
+  location.replace(saved);return;
+ }
+ function remember(id){sessionStorage.setItem(key,base+(id?'?session='+encodeURIComponent(id):'?new=1'));}
+ remember(` + app.JSString(contextID) + `);
+ window.addEventListener('mu-chat-thread',function(e){remember(e.detail);});
+ window.addEventListener('mu-chat-new',function(){remember('');});
+}catch(e){}
+})();</script>`
+}

--- a/agent/resume_test.go
+++ b/agent/resume_test.go
@@ -1,0 +1,47 @@
+package agent
+
+import (
+	"mu/internal/auth"
+	"mu/internal/thread"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestMicroEntryReopensHistoryAndNewStartsEmpty(t *testing.T) {
+	const who = "micro-entry-test"
+	if err := auth.Create(&auth.Account{ID: who}); err != nil {
+		t.Fatal(err)
+	}
+	sess, err := auth.CreateSession(who)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer auth.EndSession(sess.Token)
+	id := Opened(who, thread.WebClient, "entry-test", "", "")
+	Said(who, id, "remember this conversation", "", "")
+	Answered(who, id, "a remembered answer", "")
+	for _, tc := range []struct {
+		path string
+		want bool
+	}{
+		{"/agent/micro", true},
+		{"/agent/micro?session=" + id, true},
+		{"/agent/micro?new=1", false},
+	} {
+		r := httptest.NewRequest("GET", tc.path, nil)
+		r.AddCookie(&http.Cookie{Name: "session", Value: sess.Token})
+		w := httptest.NewRecorder()
+		servePage(w, r)
+		if w.Code != 200 {
+			t.Fatalf("%s: %d", tc.path, w.Code)
+		}
+		if got := strings.Contains(w.Body.String(), `var contextId="`+id+`"`); got != tc.want {
+			t.Errorf("%s reopened=%v", tc.path, got)
+		}
+		if !strings.Contains(w.Body.String(), `agent-micro-entry-test-`) {
+			t.Error("storage lacks account scope")
+		}
+	}
+}

--- a/agent/resume_test.go
+++ b/agent/resume_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestMicroEntryReopensHistoryAndNewStartsEmpty(t *testing.T) {
-	const who = "micro-entry-test"
+	const who = "micro_entry_test"
 	if err := auth.Create(&auth.Account{ID: who}); err != nil {
 		t.Fatal(err)
 	}
@@ -40,7 +40,7 @@ func TestMicroEntryReopensHistoryAndNewStartsEmpty(t *testing.T) {
 		if got := strings.Contains(w.Body.String(), `var contextId="`+id+`"`); got != tc.want {
 			t.Errorf("%s reopened=%v", tc.path, got)
 		}
-		if !strings.Contains(w.Body.String(), `agent-micro-entry-test-`) {
+		if !strings.Contains(w.Body.String(), `agent-micro_entry_test-`) {
 			t.Error("storage lacks account scope")
 		}
 	}

--- a/home/entry_test.go
+++ b/home/entry_test.go
@@ -1,0 +1,15 @@
+package home
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestExpiredInstalledSessionOpensLogin(t *testing.T) {
+	w := httptest.NewRecorder()
+	Index(w, httptest.NewRequest("GET", "/?from=app", nil))
+	if w.Code != http.StatusSeeOther || w.Header().Get("Location") != "/login" {
+		t.Fatalf("PWA entry: %d %s", w.Code, w.Header().Get("Location"))
+	}
+}

--- a/home/index.go
+++ b/home/index.go
@@ -67,7 +67,7 @@ func Index(w http.ResponseWriter, r *http.Request) {
 	// So: two pages for two audiences. Out here, a landing. Signed in, /home,
 	// which has the rail, the tabs, your inbox and the same box to type in.
 	if _, acc := auth.TrySession(r); acc != nil {
-		http.Redirect(w, r, "/home", http.StatusSeeOther)
+		http.Redirect(w, r, "/agent/micro", http.StatusSeeOther)
 		return
 	}
 

--- a/home/index.go
+++ b/home/index.go
@@ -70,6 +70,10 @@ func Index(w http.ResponseWriter, r *http.Request) {
 		http.Redirect(w, r, "/agent/micro", http.StatusSeeOther)
 		return
 	}
+	if r.URL.Query().Get("from") == "app" {
+		http.Redirect(w, r, "/login", http.StatusSeeOther)
+		return
+	}
 
 	// Its own shell, and that is the point of it.
 	//

--- a/home/publicbrief_test.go
+++ b/home/publicbrief_test.go
@@ -153,7 +153,7 @@ func TestSigningInLeavesTheLanding(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(string(src), `http.Redirect(w, r, "/home", http.StatusSeeOther)`) {
+	if !strings.Contains(string(src), `http.Redirect(w, r, "/agent/micro", http.StatusSeeOther)`) {
 		t.Error("the landing page is served to people who are signed in, so the\n" +
 			"app's front door is a pitch aimed at somebody who already bought")
 	}

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -729,6 +729,9 @@ var Template = `
           // happened. Let the browser do the whole page: rebuilding the chrome
           // is the point, not a side effect.
           if (u.pathname === '/logout') return;
+          // Agent pages own live streams and per-thread draft/scroll state.
+          // Use document navigation so pagehide saves it and listeners retire.
+          if (/^\/agent(?:\/|$)/.test(u.pathname) || /^\/agent(?:\/|$)/.test(location.pathname)) return;
           e.preventDefault();
           if (u.href === location.href) return;
           go(u.href, true);
@@ -1275,7 +1278,8 @@ func navMain(acc *auth.Account) string {
 			`"><span class="label">` + label + `</span></a>`
 	}
 
-	b := item("nav-home", "/home", "/home.png", "Home")
+	b := item("nav-micro", "/agent/micro", "/agent.svg", "Micro")
+	b += item("nav-home", "/home", "/home.png", "Home")
 	// Account and Profile are not here. They are the two that are about *you*
 	// rather than about the instance, so they sit under your name at the foot
 	// beside Log out — which is where somebody looks when the question is "who
@@ -1320,6 +1324,7 @@ func navTabs(acc *auth.Account) string {
 			`" alt=""><span>` + label + `</span></a>`
 	}
 	return `<nav id="tabs" aria-label="Main">` +
+		tab("/agent/micro", "/agent.svg", "Micro") +
 		tab("/home", "/home.png", "Home") +
 		tab("/inbox", "/mail.png", "Inbox") +
 		tab("/agents", "/agent.svg", "Agents") +

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -358,7 +358,7 @@ func TestTheSidebarIsTheProductsNouns(t *testing.T) {
 		nav = nav[:j]
 	}
 
-	want := []string{`href="/home"`, `href="/inbox"`, `href="/agents"`, `href="/services"`}
+	want := []string{`href="/agent/micro"`, `href="/home"`, `href="/inbox"`, `href="/agents"`, `href="/services"`}
 	at := -1
 	for _, w := range want {
 		i := strings.Index(nav, w)

--- a/internal/app/chat.go
+++ b/internal/app/chat.go
@@ -711,8 +711,8 @@ var CKEY='mu_chat_conv:'+NS;
 var HKEY='mu_chat_hist:'+NS;
 var TKEY='mu_chat_ctx:'+NS;
 var DKEY='mu_chat_draft:'+NS;
-function draftKey(){return DKEY+(SESSION?':'+contextId:'');}
-function scrollKey(){return 'mu_chat_scroll:'+NS+':'+contextId;}
+function draftKey(){return DKEY+(SESSION?':'+(contextId||attachment):'');}
+function scrollKey(){return 'mu_chat_scroll:'+NS+':'+(contextId||attachment);}
 var history=[];
 
 // A reopened server session is authoritative; otherwise restore this surface's

--- a/internal/app/chat.go
+++ b/internal/app/chat.go
@@ -120,6 +120,8 @@ type ChatConfig struct {
 	// each other's. When empty the component is ephemeral: it neither restores
 	// nor saves, so it always starts clean.
 	StorageNS string
+	// ServerOwned keeps persisted transcripts authoritative on agent pages.
+	ServerOwned bool
 	// ImportNS is a one-time handoff from another chat surface. This surface
 	// adopts the other namespace's conversation, history, context and draft,
 	// then removes the source copy. The destination namespace must include the
@@ -611,7 +613,7 @@ func ChatComponent(cfg ChatConfig) string {
 (function(){
 var contextId=` + JSString(cfg.ContextID) + `;
 var attachment=` + JSString(cfg.Attachment) + `;
-var SESSION=` + boolJS(cfg.InitialConvHTML != "") + `;
+var SESSION=` + boolJS(cfg.InitialConvHTML != "" || cfg.ServerOwned) + `;
 var PENDING=` + boolJS(cfg.Pending) + `;
 var HIDE_SUGGEST=` + boolJS(cfg.HideSuggestions) + `;
 var AGENT_NAME=` + JSString(cfg.AgentName) + `;
@@ -709,6 +711,8 @@ var CKEY='mu_chat_conv:'+NS;
 var HKEY='mu_chat_hist:'+NS;
 var TKEY='mu_chat_ctx:'+NS;
 var DKEY='mu_chat_draft:'+NS;
+function draftKey(){return DKEY+(SESSION?':'+contextId:'');}
+function scrollKey(){return 'mu_chat_scroll:'+NS+':'+contextId;}
 var history=[];
 
 // A reopened server session is authoritative; otherwise restore this surface's
@@ -758,10 +762,12 @@ if(!SESSION && PERSIST){
     if(savedHist)history=JSON.parse(savedHist)||[];
     var savedCtx=sessionStorage.getItem(TKEY);
     if(savedCtx)contextId=savedCtx;
-    var savedDraft=sessionStorage.getItem(DKEY);
+    var savedDraft=sessionStorage.getItem(draftKey());
     if(savedDraft)input.value=savedDraft;
   }catch(e){}
 }
+
+if(SESSION&&PERSIST){try{var savedDraft=sessionStorage.getItem(draftKey());if(savedDraft)input.value=savedDraft;}catch(e){}}
 
 // A conversation already on the page means the asking has happened, whether it
 // came back from sessionStorage or was rendered by the server. Without this a
@@ -798,7 +804,7 @@ function save(){
 }
 function saveDraft(){
   if(!PERSIST)return;
-  try{sessionStorage.setItem(DKEY,input.value||'');}catch(e){}
+  try{sessionStorage.setItem(draftKey(),input.value||'');}catch(e){}
 }
 
 // agentName is who answers: whatever the picker is showing when there is one,
@@ -951,6 +957,7 @@ function ask(q){
               if(id){
                 var fresh=!contextId;
                 contextId=id;save();
+                window.dispatchEvent(new CustomEvent('mu-chat-thread',{detail:id}));
                 if(fresh&&window.muSessionStarted)window.muSessionStarted(id,q);
               }
             }else if(ev.type==='working'){
@@ -1061,7 +1068,9 @@ showSuggestions();
 
 // Start a fresh session (clears the log + thread id).
 window.muChatNew=function(){
-  conv.innerHTML='';history=[];contextId='';
+  try{sessionStorage.removeItem(draftKey());sessionStorage.removeItem(scrollKey());}catch(e){}
+  conv.innerHTML='';history=[];contextId='';input.value='';
+  window.dispatchEvent(new CustomEvent('mu-chat-new'));
   try{sessionStorage.removeItem(CKEY);sessionStorage.removeItem(HKEY);sessionStorage.removeItem(TKEY);sessionStorage.removeItem(DKEY);}catch(e){}
   showBrief();
   showSuggestions();input.focus();
@@ -1347,13 +1356,22 @@ if(PENDING&&contextId&&conv){(function(){
 // is also the only signal that says they want to be somewhere else. Anything
 // that changes the height afterwards — late layout, a slow card — keeps it
 // where it was put, and the moment they scroll up it lets go for good.
-var pinned=true;
+var restoredScroll=null;
+try{if(PERSIST)restoredScroll=JSON.parse(sessionStorage.getItem(scrollKey()));}catch(e){}
+var pinned=!restoredScroll||restoredScroll.bottom;
 if(conv){
   conv.addEventListener('scroll',function(){ if(!nearBottom()) pinned=false; });
 }
 function pin(){ if(pinned) toBottom(true); }
 fitConv();
-toBottom(true);
+if(restoredScroll&&!restoredScroll.bottom){
+  requestAnimationFrame(function(){conv.scrollTop=restoredScroll.top;});
+  window.addEventListener("load",function(){conv.scrollTop=restoredScroll.top;});
+}else{toBottom(true);}
+window.addEventListener("pagehide",function(){
+  saveDraft();
+  if(PERSIST&&conv){try{sessionStorage.setItem(scrollKey(),JSON.stringify({top:conv.scrollTop,bottom:nearBottom()}));}catch(e){}}
+});
 window.addEventListener('load',function(){ fitConv(); pin(); });
 if(conv&&window.ResizeObserver){ new ResizeObserver(pin).observe(conv); }
 window.addEventListener('resize',function(){ fitConv(); toBottom(false); });

--- a/internal/app/html/manifest.webmanifest
+++ b/internal/app/html/manifest.webmanifest
@@ -4,7 +4,7 @@
   "description": "A personal assistant. Ask Micro here, or write by mail, text or WhatsApp — with news, web search, your mail, markets, weather, places and storage behind it.",
   "id": "/",
   "scope": "/",
-  "start_url": "/home?from=app",
+  "start_url": "/?from=app",
   "background_color": "#ffffff",
   "theme_color": "#ffffff",
   "display": "standalone", 

--- a/internal/app/html/mu.css
+++ b/internal/app/html/mu.css
@@ -1422,7 +1422,7 @@ body.page-home #page-title ~ #customize-link {
 
   #tabs {
     display: grid;
-    grid-template-columns: repeat(4, 1fr);
+    grid-template-columns: repeat(5, 1fr);
     position: fixed;
     left: 0;
     right: 0;

--- a/test/template_test.go
+++ b/test/template_test.go
@@ -74,19 +74,8 @@ func TestThePageTitleIsNotInTheSidebar(t *testing.T) {
 	}
 }
 
-// The four hubs are in reach of a thumb.
-//
-// This tested an envelope in the header instead, which pointed at /mail for as
-// long as it existed and was corrected to /inbox — and the whole time it was
-// display:none in the stylesheet with nothing anywhere turning it on. The test
-// checked the href and never whether anybody could see it, so it went on
-// passing over an invisible element for as long as that element existed.
-//
-// So it checks the destinations and the count now. On a phone the rail is
-// behind a hamburger and this bar is how anything is reached; four is what a
-// tab bar holds before the labels stop being readable, and it is the reason
-// Tokens and Wallet are not in it.
-func TestThePhoneCarriesTheFourHubs(t *testing.T) {
+// Micro and Home lead the signed-in destinations within reach on a phone.
+func TestThePhoneCarriesMicroAndHome(t *testing.T) {
 	out := app.RenderHTML("A page", "a description", "<p>body</p>",
 		&auth.Account{ID: "someone", Name: "Someone"})
 
@@ -94,14 +83,13 @@ func TestThePhoneCarriesTheFourHubs(t *testing.T) {
 	if tabs == "" {
 		t.Fatal("no tab bar in the rendered shell")
 	}
-	for _, href := range []string{"/home", "/inbox", "/agents", "/services"} {
+	for _, href := range []string{"/agent/micro", "/home", "/inbox", "/agents", "/services"} {
 		if !strings.Contains(tabs, `href="`+href+`"`) {
 			t.Errorf("the tab bar does not reach %s:\n%s", href, tabs)
 		}
 	}
-	if n := strings.Count(tabs, "<a "); n != 4 {
-		t.Errorf("the tab bar holds %d tabs, want 4 — five stops being readable "+
-			"and the rail is still there for the rest:\n%s", n, tabs)
+	if n := strings.Count(tabs, "<a "); n != 5 {
+		t.Errorf("the tab bar holds %d tabs, want Micro, Home, Inbox, Agents and Services:\n%s", n, tabs)
 	}
 	// Not the mail store. That was the bug in the thing this replaced.
 	if strings.Contains(tabs, `href="/mail"`) {


### PR DESCRIPTION
Make Micro the signed-in starting point while keeping Home as the overview one tap away.

- [x] Add Micro before Home in the signed-in sidebar and mobile tabs.
- [x] Open the signed-in root, default login and PWA into Micro; preserve explicit login return destinations.
- [x] Remember the selected Micro conversation per account/tab, including an explicitly new chat.
- [x] Restore drafts on server-rendered conversations and preserve transcript scroll position.
- [x] Scope agent browser state by account, agent and conversation; keep reading-material namespaces.
- [x] Use document navigation at agent-page boundaries so live page listeners retire and draft/scroll state is saved.
- [x] App and Account suites pass; targeted Micro history/New, pending recovery and landing tests pass.

Home layout and pricing are unchanged. Codex Cloud review and CI remain enabled.