### PR TITLE
Open service tiles into their UI and separate API references

### DIFF
--- a/internal/api/rest_page.go
+++ b/internal/api/rest_page.go
@@ -35,6 +35,10 @@ import (
 
 // RESTPageHandler serves /api.
 func RESTPageHandler(w http.ResponseWriter, r *http.Request) {
+	if name := r.URL.Query().Get("service"); name != "" {
+		serveServiceReference(w, r, name)
+		return
+	}
 	base := app.BaseURL(r)
 
 	var b strings.Builder
@@ -193,7 +197,7 @@ func restReference(base string) string {
 	last := ""
 	for _, m := range methods {
 		if m.Service != last {
-			nav.WriteString(`<div class="ep-nav-title">` + html.EscapeString(m.Service) + `</div>`)
+			nav.WriteString(`<div class="ep-nav-title"><a href="/api?service=` + html.EscapeString(m.Service) + `">` + html.EscapeString(m.Service) + `</a></div>`)
 			last = m.Service
 		}
 		price := ""

--- a/internal/api/service_ref.go
+++ b/internal/api/service_ref.go
@@ -45,6 +45,10 @@ func ServiceRefHandler(w http.ResponseWriter, r *http.Request) {
 		app.NotFound(w, r, "No such service")
 		return
 	}
+	serveServiceReference(w, r, name)
+}
+
+func serveServiceReference(w http.ResponseWriter, r *http.Request, name string) {
 	spec, ok := service.SpecFor(strings.ToLower(name))
 	if !ok {
 		app.NotFound(w, r, "No such service")

--- a/internal/api/service_ref_test.go
+++ b/internal/api/service_ref_test.go
@@ -136,3 +136,17 @@ func TestADeeperPathIsNotTheService(t *testing.T) {
 		t.Errorf("/services/refprobe/extra answered %d, want 404", w.Code)
 	}
 }
+
+func TestAPIServiceReferenceUsesTheExistingAPIDoor(t *testing.T) {
+	refFixture(t)
+	w := httptest.NewRecorder()
+	RESTPageHandler(w, httptest.NewRequest("GET", "/api?service=refprobe", nil))
+	if w.Code != 200 || !strings.Contains(w.Body.String(), "GET /api/v1/refprobe/list") {
+		t.Fatal("API service reference is missing")
+	}
+	w = httptest.NewRecorder()
+	RESTPageHandler(w, httptest.NewRequest("GET", "/api?service=not_a_service", nil))
+	if w.Code != 404 {
+		t.Errorf("unknown reference returned %d", w.Code)
+	}
+}

--- a/internal/api/tools_page.go
+++ b/internal/api/tools_page.go
@@ -181,15 +181,13 @@ func serviceGrid(r *http.Request) string {
 	b.WriteString(`<div class="tool-grid service-grid">`)
 	for _, s := range service.Nav() {
 		b.WriteString(`<div class="service-tile-wrap">`)
-		// Every tile leads to /services/<name> — what the service is, what it
-		// knows right now, and every method with its arguments and its price.
-		// It used to lead straight to the service's own page, which meant a
-		// headless service was a tile you could not click and every other one
-		// skipped the question a reader on this page is asking: not "show me
-		// the weather" but "what is this and how do I call it". The page itself
-		// is one button away at the top of it.
-		open := `<a class="tool-tile service-tile card-hover" href="/services/` +
-			html.EscapeString(s.Name) + `">`
+		// Open the service experience directly. A reference remains the fallback
+		// for services without a dedicated page.
+		destination := s.Page
+		if destination == "" {
+			destination = "/api?service=" + s.Name
+		}
+		open := `<a class="tool-tile service-tile card-hover" href="` + html.EscapeString(destination) + `">`
 		close := `</a>`
 		b.WriteString(open)
 		b.WriteString(`<span class="service-tile-head">` +
@@ -212,18 +210,8 @@ func serviceGrid(r *http.Request) string {
 			b.WriteString(`<a class="service-tile-tools" href="/tools#svc-` +
 				html.EscapeString(groupAnchor(s.NavLabel())) + `">` + label + `</a>`)
 		}
-		// And the way to the thing itself, because the tile answers "what is
-		// this" and a reader who already knows should not have to read it
-		// again to get there. Same move as the count above: a second target on
-		// the tile rather than a second grid on the page.
-		//
-		// Skipped when the service's page *is* its reference — weather and
-		// hazards, whose pages were derived — since that is where the tile
-		// already goes.
-		if s.Page != "" && s.Page != "/services/"+s.Name {
-			b.WriteString(`<a class="service-tile-open" href="` +
-				html.EscapeString(s.Page) + `">Open &rarr;</a>`)
-		}
+		b.WriteString(`<a class="service-tile-open" href="/api?service=` +
+			html.EscapeString(s.Name) + `">API &rarr;</a>`)
 		// Nothing to pin without a page — the sidebar is a list of places.
 		if s.Page != "" {
 			b.WriteString(pinControl(r, s.Name, isPinned[s.Name]))

--- a/internal/api/tools_page_test.go
+++ b/internal/api/tools_page_test.go
@@ -36,10 +36,8 @@ func TestTheCatalogueHasBothLenses(t *testing.T) {
 
 	svc := serviceGrid(httptest.NewRequest("GET", "/services", nil))
 
-	// Every tile leads to the service's reference, not to the service's own
-	// page. A reader on this page is asking what a thing is and how to call it;
-	// the thing itself is one button away at the top of the reference.
-	if !strings.Contains(svc, `href="/services/catpaged"`) {
+	// The main tile opens the service UI; API documentation is secondary.
+	if !strings.Contains(svc, `class="tool-tile service-tile card-hover" href="/catpaged"`) {
 		t.Errorf("the services lens is missing a paged service:\n%s", svc)
 	}
 	if !strings.Contains(svc, ">Cat Paged<") || !strings.Contains(svc, "A service with a page") {
@@ -54,7 +52,7 @@ func TestTheCatalogueHasBothLenses(t *testing.T) {
 	//
 	// Every service has a reference page, so there is no such thing as a
 	// service with nowhere to go any more.
-	if !strings.Contains(svc, `href="/services/cathidden"`) {
+	if !strings.Contains(svc, `href="/api?service=cathidden"`) {
 		t.Errorf("a headless service is not reachable from the services lens:\n%s", svc)
 	}
 	if !strings.Contains(svc, ">Cat Hidden<") {
@@ -64,12 +62,8 @@ func TestTheCatalogueHasBothLenses(t *testing.T) {
 		t.Error("a service was rendered as a link to nowhere")
 	}
 
-	// A tile has three targets: what it is, the thing itself, and its tools.
-	// The reference answers "what is this and how do I call it", which is what
-	// a reader on this page is asking — and somebody who already knows should
-	// not have to read it again to reach the service. A second target on the
-	// tile rather than a second grid on the page.
-	if !strings.Contains(svc, `class="service-tile-open" href="/catpaged"`) {
+	// The API link opens a reference under the existing API door.
+	if !strings.Contains(svc, `class="service-tile-open" href="/api?service=catpaged"`) {
 		t.Errorf("a paged service has no way from its tile to its own page:\n%s", svc)
 	}
 	// A headless service has nothing to open, so it offers nothing.


### PR DESCRIPTION
Services should lead to something a person can use. Clicking Video currently opens its API reference rather than the video experience.

- [x] Make each service tile open its declared UI page.
- [x] Replace the secondary Open link with API, linking to `/api?service=<name>`.
- [x] Reuse the existing per-service reference renderer and make service headings in `/api` link to it.
- [x] Keep existing `/services/<name>` references working and preserve fallback pages for services without a dedicated UI.
- [x] Full `internal/api` test suite passes.

No new `/apis` hierarchy or changes to RPC/API endpoints. Codex Cloud review and CI remain enabled.