### PR TITLE
Restore compact single-line headlines on Home

### DIFF
--- a/home/collapsed_test.go
+++ b/home/collapsed_test.go
@@ -80,15 +80,13 @@ func TestTheCornerDoesNotRepeatTheRail(t *testing.T) {
 	}
 }
 
-// Headlines retain their descriptions and use columns when the card has room.
+// Headlines stay compact and use columns when the card has room.
 func TestTheNewsCardIsAGlance(t *testing.T) {
 	css := styles(t)
 	descriptions := regexp.MustCompile(`#home\s+#news\s+\.headline\s+\.description\s*\{[^}]*\}`).FindAllString(css, -1)
 	hidden := regexp.MustCompile(`(?i)\bdisplay\s*:\s*none\s*(!\s*important\s*)?(;|\})`)
-	for _, rule := range descriptions {
-		if hidden.MatchString(rule) {
-			t.Error("the Home news card hides the descriptions beneath its headlines")
-		}
+	if len(descriptions) != 1 || !hidden.MatchString(descriptions[0]) {
+		t.Error("the Home news card must hide descriptions beneath its headlines")
 	}
 	grid := regexp.MustCompile(`#home #news \.section\s*\{[^}]*\}`).FindString(css)
 	if !strings.Contains(grid, "auto-fill") {

--- a/internal/app/html/mu.css
+++ b/internal/app/html/mu.css
@@ -1327,7 +1327,7 @@ body.page-home #page-title ~ #customize-link {
   padding-top: 0;
 }
 
-/* Home keeps one headline per category with its description below.
+/* Home keeps one compact headline per category.
    Columns follow the card width, including when the sidebar is open. */
 #home #news .section {
   display: grid;
@@ -1343,7 +1343,14 @@ body.page-home #page-title ~ #customize-link {
   padding: 10px 0;
   border-bottom: 1px solid var(--border-color, #f0f0f0);
 }
-#home #news .headline .title { line-height: 1.35; }
+#home #news .headline .description { display: none; }
+#home #news .headline .title {
+  line-height: 1.35;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+#home #news .headline { min-width: 0; }
 
 #home .card .item,
 #home .card .post-item,


### PR DESCRIPTION
Home headlines became crowded after descriptions were restored. Hide descriptions on the Home news card and keep each title to one line with ellipsis. Retain the category, source and one-headline-per-category selection.

The existing Home news-card check is updated and passes locally. The dedicated news page is unaffected. Full CI on the parent has two existing failures: home/TestTheNameIsTheSameOnEverySurface and internal/origin/TestURLPreservesExplicitPublicSurface; build, format and vet pass.