### PR TITLE
Show Home headlines in one column with descriptions

### DIFF
--- a/home/collapsed_test.go
+++ b/home/collapsed_test.go
@@ -83,8 +83,15 @@ func TestTheCornerDoesNotRepeatTheRail(t *testing.T) {
 // Headlines form one readable column with their descriptions.
 func TestTheNewsCardIsAGlance(t *testing.T) {
 	css := styles(t)
-	descriptions := regexp.MustCompile(`#home\s+#news\s+\.headline\s+\.description\s*\{[^}]*\}`).FindAllString(css, -1)
+	descriptions := regexp.MustCompile(`[^{}]*\.headline[^{}]*\.description[^{}]*\{[^}]*\}`).FindAllString(css, -1)
 	hidden := regexp.MustCompile(`(?i)\bdisplay\s*:\s*none\s*(!\s*important\s*)?(;|\})`)
+	if len(descriptions) == 0 {
+		t.Fatal("no headline description styles were checked")
+	}
+	visible := regexp.MustCompile(`#home #news \.headline \.description\s*\{\s*display:\s*block;\s*\}`)
+	if !visible.MatchString(css) {
+		t.Error("Home must explicitly display headline descriptions")
+	}
 	for _, rule := range descriptions {
 		if hidden.MatchString(rule) {
 			t.Error("the Home news card hides descriptions")

--- a/home/collapsed_test.go
+++ b/home/collapsed_test.go
@@ -80,22 +80,18 @@ func TestTheCornerDoesNotRepeatTheRail(t *testing.T) {
 	}
 }
 
-// Headlines stay compact and use columns when the card has room.
+// Headlines form one readable column with their descriptions.
 func TestTheNewsCardIsAGlance(t *testing.T) {
 	css := styles(t)
 	descriptions := regexp.MustCompile(`#home\s+#news\s+\.headline\s+\.description\s*\{[^}]*\}`).FindAllString(css, -1)
 	hidden := regexp.MustCompile(`(?i)\bdisplay\s*:\s*none\s*(!\s*important\s*)?(;|\})`)
-	if len(descriptions) != 1 || !hidden.MatchString(descriptions[0]) {
-		t.Error("the Home news card must hide descriptions beneath its headlines")
+	for _, rule := range descriptions {
+		if hidden.MatchString(rule) {
+			t.Error("the Home news card hides descriptions")
+		}
 	}
-	grid := regexp.MustCompile(`#home #news \.section\s*\{[^}]*\}`).FindString(css)
-	if !strings.Contains(grid, "auto-fill") {
-		t.Errorf("the headlines do not lay out in columns: %q", grid)
-	}
-	// auto-fill and not a media query, because what decides the number of
-	// columns is the card's width, and that depends on the rail as much as on
-	// the window.
-	if strings.Contains(grid, "@media") {
-		t.Error("the headline columns are keyed to the window rather than to the card")
+	section := regexp.MustCompile(`#home #news \.section\s*\{[^}]*\}`).FindString(css)
+	if !strings.Contains(section, "display: block") {
+		t.Error("Home headlines must use one column")
 	}
 }

--- a/internal/app/html/mu.css
+++ b/internal/app/html/mu.css
@@ -1327,30 +1327,10 @@ body.page-home #page-title ~ #customize-link {
   padding-top: 0;
 }
 
-/* Home keeps one compact headline per category.
-   Columns follow the card width, including when the sidebar is open. */
+/* Home headlines form one column, with descriptions beneath each title. */
 #home #news .section {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
-  column-gap: 28px;
+  display: block;
 }
-/* In a grid the first and last item are not the first and last of a column, so
-   the rules above that trim their padding would leave one row short of its
-   neighbour. Uniform instead. */
-#home #news .headline,
-#home #news .headline:first-of-type,
-#home #news .headline:last-of-type {
-  padding: 10px 0;
-  border-bottom: 1px solid var(--border-color, #f0f0f0);
-}
-#home #news .headline .description { display: none; }
-#home #news .headline .title {
-  line-height: 1.35;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-#home #news .headline { min-width: 0; }
 
 #home .card .item,
 #home .card .post-item,

--- a/internal/app/html/mu.css
+++ b/internal/app/html/mu.css
@@ -1331,6 +1331,9 @@ body.page-home #page-title ~ #customize-link {
 #home #news .section {
   display: block;
 }
+#home #news .headline .description {
+  display: block;
+}
 
 #home .card .item,
 #home .card .post-item,


### PR DESCRIPTION
Correct my misunderstanding of the requested Home layout: headlines should occupy one column and retain their descriptions. Remove the Home-specific grid, hidden descriptions and title truncation so the normal headline styles apply.

Update the existing news-card layout check to require one column and visible descriptions. Selection remains one headline per category.