### PR TITLE
Give Micro and Home a consistent signed-in navigation flow

### DIFF
--- a/account/google_oauth.go
+++ b/account/google_oauth.go
@@ -180,7 +180,7 @@ func GoogleCallback(w http.ResponseWriter, r *http.Request) {
 		Name: "session", Value: sess.Token, Path: "/", MaxAge: 2592000,
 		HttpOnly: true, Secure: requestSecure(r), SameSite: http.SameSiteLaxMode,
 	})
-	http.Redirect(w, r, "/agent/micro", http.StatusFound)
+	http.Redirect(w, r, "/home", http.StatusFound)
 }
 
 // googleExchange trades an authorization code for an access token.

--- a/account/pages.go
+++ b/account/pages.go
@@ -433,7 +433,7 @@ func Signup(w http.ResponseWriter, r *http.Request) {
 
 	// Carried through every render so the POST keeps it — see renderSignupTo.
 	redirectParam := ""
-	if to := safeRedirect(r); to != "/agent/micro" {
+	if to := safeRedirect(r); to != "/home" {
 		redirectParam = "?redirect=" + url.QueryEscape(to)
 	}
 
@@ -1232,7 +1232,7 @@ func safeRedirect(r *http.Request) string {
 // somebody straight back to a login page, which is a loop rather than a
 // vulnerability but is still not a destination.
 func SafeRedirectTo(to string) string {
-	const home = "/agent/micro"
+	const home = "/home"
 	if to == "" || to[0] != '/' {
 		return home
 	}

--- a/account/passkey.go
+++ b/account/passkey.go
@@ -288,7 +288,7 @@ func passkeyLoginFinish(w http.ResponseWriter, r *http.Request) {
 
 	app.RespondJSON(w, map[string]interface{}{
 		"success":  true,
-		"redirect": "/agent/micro",
+		"redirect": "/home",
 	})
 }
 

--- a/account/redirect_test.go
+++ b/account/redirect_test.go
@@ -11,8 +11,8 @@ import "testing"
 // somebody else's site with our domain in the address bar on the way — which
 // is what makes a phishing page convincing.
 func TestWhereYouComeBackToIsAPageHere(t *testing.T) {
-	if got := SafeRedirectTo(""); got != "/agent/micro" {
-		t.Errorf("a plain login lands at %q, want /agent/micro", got)
+	if got := SafeRedirectTo(""); got != "/home" {
+		t.Errorf("a plain login lands at %q, want /home", got)
 	}
 	for _, elsewhere := range []string{
 		"//evil.example",       // protocol-relative
@@ -21,7 +21,7 @@ func TestWhereYouComeBackToIsAPageHere(t *testing.T) {
 		"https://evil.example", // not even a path
 		"evil.example",
 	} {
-		if got := SafeRedirectTo(elsewhere); got != "/agent/micro" {
+		if got := SafeRedirectTo(elsewhere); got != "/home" {
 			t.Errorf("SafeRedirectTo(%q) = %q — that leaves this instance", elsewhere, got)
 		}
 	}
@@ -31,7 +31,7 @@ func TestWhereYouComeBackToIsAPageHere(t *testing.T) {
 	}
 	// A login page is not a destination — it is a loop.
 	for _, loop := range []string{"/login", "/logout", "/signup?invite=x"} {
-		if got := SafeRedirectTo(loop); got != "/agent/micro" {
+		if got := SafeRedirectTo(loop); got != "/home" {
 			t.Errorf("SafeRedirectTo(%q) = %q", loop, got)
 		}
 	}

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -438,7 +438,7 @@ func servePage(w http.ResponseWriter, r *http.Request) {
 	// named is what removes the roster from the room: on a page about one agent
 	// the list of the others is the same furniture as a services list down the
 	// side of /mail.
-	named := false
+	named := r.URL.Path == "/"
 	if slug := strings.TrimPrefix(r.URL.Path, "/agent/"); r.URL.Path != "/agent" &&
 		slug != "" && !strings.Contains(slug, "/") {
 		id, ok := agentSlugTarget(accountID, slug)
@@ -520,7 +520,8 @@ func servePage(w http.ResponseWriter, r *http.Request) {
 	// only exists here put a row of chrome above the conversation to say
 	// something the nav already says.
 	chip := `<div class="agent-bar">` +
-		`<button type="button" class="chat-open-list" onclick="muPane('chats')">Chats</button>` +
+		`<a class="btn chat-open-list" href="` + chatPath(accountID, selAgent) + `?new=1">New chat</a>` +
+		`<button type="button" class="chat-open-list" onclick="muPane('chats')">Conversations</button>` +
 		`</div>` + paneJS
 
 	// No tabs. There were four — Chat, Threads, Runs, Connect — for one thing:
@@ -563,11 +564,14 @@ func servePage(w http.ResponseWriter, r *http.Request) {
 	// non-empty left the tab's remembered selection in charge on a bare /agent:
 	// the rail listed every agent's conversations while the next message went to
 	// whichever agent the tab remembered. The URL is the state.
-	content += `<script>window.addEventListener('mu-chat-thread',function(e){history.replaceState(null,'',` + app.JSString(Path(accountID, selAgent)) + `+'?session='+encodeURIComponent(e.detail));});</script>`
+	content += `<script>window.addEventListener('mu-chat-thread',function(e){history.replaceState(null,'',` + app.JSString(chatPath(accountID, selAgent)) + `+'?session='+encodeURIComponent(e.detail));});</script>`
 	content += resumeMicroJS(accountID, selAgent, cfg.ContextID)
+	if r.URL.Path == "/" {
+		content += HandoffHTML(r)
+	}
 	content += `<script>window.muSeedAgent(` + app.JSString(selAgent) + `);</script>`
 	if prefill != "" {
-		content += `<script>(function(){var i=document.getElementById('mu-chat-input');if(i&&window.muChatAsk){i.value=` + app.JSString(prefill) + `;window.muChatAsk(i.value);}history.replaceState(null,'',` + app.JSString(Path(accountID, selAgent)) + `);})()</script>`
+		content += `<script>(function(){var i=document.getElementById('mu-chat-input');if(i&&window.muChatAsk){i.value=` + app.JSString(prefill) + `;window.muChatAsk(i.value);}history.replaceState(null,'',` + app.JSString(chatPath(accountID, selAgent)) + `);})()</script>`
 	}
 
 	// The agent's own name, because this page is about one agent.
@@ -721,7 +725,7 @@ func renderSessionsRail(accountID, currentID, agentID string, named bool, extra 
 	// page now — the rail holds the conversations you started here and /inbox
 	// holds what arrived, so a link from one to the other lands somewhere that
 	// does not have the conversation in it.
-	base := Path(accountID, agentID)
+	base := chatPath(accountID, agentID)
 	newURL := base + "?new=1"
 	if agentID != "" && base == "/agent/"+DefaultSlug {
 		// An id that resolves to nothing in the roster. Keep it in the URL
@@ -731,7 +735,7 @@ func renderSessionsRail(accountID, currentID, agentID string, named bool, extra 
 	}
 	var b strings.Builder
 	b.WriteString(`<aside class="chat-rail"><button class="btn chat-new" onclick="if(window.muChatNew){muChatNew();history.replaceState(null,''` +
-		`,` + app.JSAttr(newURL) + `);document.querySelectorAll('.chat-sess.active').forEach(function(e){e.classList.remove('active')});}">New</button>` +
+		`,` + app.JSAttr(newURL) + `);document.querySelectorAll('.chat-sess.active').forEach(function(e){e.classList.remove('active')});}">New chat</button>` +
 		`<div class="chat-sess-scroll">` +
 		// Chats, which is what the store has always called them in every way
 		// but this one. The record is threads.json, the package is
@@ -744,7 +748,7 @@ func renderSessionsRail(accountID, currentID, agentID string, named bool, extra 
 		// also mean "a chat you had". Chat is what these are, it is what the
 		// button under them starts, and thread.WebClient is the client that
 		// makes them.
-		`<div class="chat-sess-head">Chats</div><div class="chat-sess-list">`)
+		`<div class="chat-sess-head">Conversations</div><div class="chat-sess-list">`)
 	if len(sessions) == 0 {
 		// An empty inbox says how to fill it, and the answer is an address.
 		// "No conversations yet" is a true sentence that leaves somebody looking
@@ -788,7 +792,7 @@ func renderSessionsRail(accountID, currentID, agentID string, named bool, extra 
 		// Deletable. A conversation you can start and never be rid of is a list
 		// that only grows, and the rail is the one place somebody looks at it.
 		b.WriteString(`<div class="chat-sess-row has-row-del"><a href="` + base + `?session=` + url.QueryEscape(s.ID) +
-			`" class="` + cls + `">` + htmlEsc(title) + where + `</a>` +
+			`" class="` + cls + `">` + htmlEsc(title) + where + `<small class="chat-sess-date">` + s.Updated.Format("2 Jan 2006") + `</small></a>` +
 			`<button type="button" class="row-del" title="Delete conversation" ` +
 			`aria-label="Delete this conversation" ` +
 			`onclick="muSessionDelete(` + app.JSAttr(s.ID) + `,event)">&times;</button></div>`)
@@ -1019,6 +1023,7 @@ const chatLayoutCSS = `<style>
    Hidden here and shown in the phone query below, rather than left to lay
    out around a child that is not there. */
 .agent-bar{display:none;align-items:center;gap:12px;flex-wrap:wrap;margin:0 0 14px;font-size:13px}
+.chat-sess-date{display:block;font-size:11px;font-weight:normal;color:var(--text-muted,#999);margin-top:3px}
 .chat-sess-head{font-size:11px;font-weight:600;letter-spacing:.04em;text-transform:uppercase;
   color:var(--text-muted,#999);padding:0 10px 6px}
 /* Tokens, not hex.

--- a/agent/handoff.go
+++ b/agent/handoff.go
@@ -1,0 +1,98 @@
+package agent
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"sync"
+
+	"mu/internal/app"
+	"mu/internal/auth"
+	"mu/internal/thread"
+)
+
+var handoffMu sync.Mutex
+
+// HandoffHandler adopts completed guest turns as account-owned conversation
+// history. It never executes their contents or imports browser-rendered HTML.
+func HandoffHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		app.MethodNotAllowed(w, r)
+		return
+	}
+	_, acc := auth.TrySession(r)
+	if acc == nil {
+		app.RespondError(w, 401, "Sign in to keep this conversation")
+		return
+	}
+	if r.Header.Get("X-CSRF-Token") == "" || !auth.ValidCSRF(r) {
+		app.RespondError(w, 403, "Invalid CSRF token")
+		return
+	}
+	var req struct {
+		Turns []struct {
+			Prompt string `json:"prompt"`
+			Answer string `json:"answer"`
+		} `json:"turns"`
+	}
+	r.Body = http.MaxBytesReader(w, r.Body, 512*1024)
+	if json.NewDecoder(r.Body).Decode(&req) != nil || len(req.Turns) == 0 || len(req.Turns) > 100 {
+		app.RespondError(w, 400, "Invalid conversation")
+		return
+	}
+	for _, t := range req.Turns {
+		if strings.TrimSpace(t.Prompt) == "" || strings.TrimSpace(t.Answer) == "" {
+			app.RespondError(w, 400, "Only completed turns can be saved")
+			return
+		}
+	}
+	// Stable within the account, so retrying a interrupted handoff does not
+	// create another copy. No guest run/context ID is trusted as a private ID.
+	raw, _ := json.Marshal(req.Turns)
+	sum := sha256.Sum256(raw)
+	handoffMu.Lock()
+	defer handoffMu.Unlock()
+	id := Opened(acc.ID, thread.WebClient, "guest:"+hex.EncodeToString(sum[:]), "", "")
+	if len(thread.Messages(acc.ID, id, 1)) == 0 {
+		for _, t := range req.Turns {
+			Said(acc.ID, id, t.Prompt, "", "")
+			Answered(acc.ID, id, t.Answer, "")
+		}
+	}
+	app.RespondJSON(w, map[string]string{"id": id})
+}
+
+// HandoffHTML carries a guest conversation through any login method, including
+// providers that return to Home. Remove browser copies only after saving succeeds.
+func HandoffHTML(r *http.Request) string {
+	_, acc := auth.TrySession(r)
+	if acc == nil {
+		return ""
+	}
+	return `<script>(function(){
+var turns,draft,raw;
+try{
+ raw=sessionStorage.getItem('mu_chat_hist:landing');
+ turns=JSON.parse(raw||'[]');
+ draft=sessionStorage.getItem('mu_chat_draft:landing')||'';
+ var markup=sessionStorage.getItem('mu_chat_conv:landing');
+ if(markup){var t=document.createElement('template');t.innerHTML=markup;
+ if(t.content.querySelector('.mu-think')){var users=t.content.querySelectorAll('.mu-user');if(users.length&&!draft)draft=users[users.length-1].textContent;}}
+}catch(e){return;}
+if(!turns.length&&!draft)return;
+var ns=` + app.JSString("agent-"+acc.ID+"-") + `;
+function finish(id){
+ try{
+ if(draft)sessionStorage.setItem('mu_chat_draft:'+ns+':'+id,draft);
+ ['hist','conv','ctx','draft'].forEach(function(k){sessionStorage.removeItem('mu_chat_'+k+':landing');});
+ }catch(e){return;}
+ location.replace(id?'/?session='+encodeURIComponent(id):'/?new=1');
+}
+if(!turns.length){finish('');return;}
+fetch('/agent/handoff',{method:'POST',credentials:'same-origin',headers:{'Content-Type':'application/json','X-CSRF-Token':` + app.JSString(auth.CSRFToken(r)) + `},body:JSON.stringify({turns:turns})})
+.then(function(r){if(!r.ok)throw Error();return r.json();}).then(function(r){finish(r.id);})
+.catch(function(){var note=document.createElement('p');note.textContent='Your earlier conversation is still saved in this tab. Reload to try bringing it into your account again.';document.getElementById('content').prepend(note);});
+})();</script>`
+}

--- a/agent/handoff_test.go
+++ b/agent/handoff_test.go
@@ -1,0 +1,64 @@
+package agent
+
+import (
+	"encoding/json"
+	"mu/internal/auth"
+	"mu/internal/thread"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestGuestHandoffIsPrivateAndRetryable(t *testing.T) {
+	const who = "handoff_owner"
+	if err := auth.Create(&auth.Account{ID: who}); err != nil {
+		t.Fatal(err)
+	}
+	sess, err := auth.CreateSession(who)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer auth.EndSession(sess.Token)
+	body := `{"turns":[{"prompt":"keep this question","answer":"and this answer"}]}`
+	request := func(token bool) *http.Request {
+		r := httptest.NewRequest("POST", "/agent/handoff", strings.NewReader(body))
+		r.AddCookie(&http.Cookie{Name: "session", Value: sess.Token})
+		if token {
+			r.Header.Set("X-CSRF-Token", auth.CSRFToken(r))
+		}
+		return r
+	}
+	bad := httptest.NewRecorder()
+	HandoffHandler(bad, request(false))
+	if bad.Code != 403 {
+		t.Fatalf("missing CSRF: %d", bad.Code)
+	}
+	id := ""
+	for i := 0; i < 2; i++ {
+		w := httptest.NewRecorder()
+		HandoffHandler(w, request(true))
+		if w.Code != 200 {
+			t.Fatal(w.Body.String())
+		}
+		var result map[string]string
+		json.Unmarshal(w.Body.Bytes(), &result)
+		if id != "" && id != result["id"] {
+			t.Fatal("retry created a second thread")
+		}
+		id = result["id"]
+	}
+	if n := len(thread.Messages(who, id, 10)); n != 2 {
+		t.Fatalf("saved %d messages", n)
+	}
+	if thread.Get("someone_else", id) != nil {
+		t.Fatal("handoff crossed accounts")
+	}
+	r := httptest.NewRequest("GET", "/?session="+id, nil)
+	r.AddCookie(&http.Cookie{Name: "session", Value: sess.Token})
+	w := httptest.NewRecorder()
+	MicroHandler(w, r)
+	if w.Code != 200 || !strings.Contains(w.Body.String(), "keep this question") {
+		t.Fatal("root did not reopen imported conversation")
+	}
+}

--- a/agent/resume.go
+++ b/agent/resume.go
@@ -1,6 +1,10 @@
 package agent
 
-import "mu/internal/app"
+import (
+	"mu/internal/app"
+	"mu/internal/auth"
+	"net/http"
+)
 
 // Remember only the default assistant's destination, scoped to this account/tab.
 // The server still checks ownership when reopening a thread.
@@ -10,10 +14,12 @@ func resumeMicroJS(accountID, agentID, contextID string) string {
 	}
 	return `<script>(function(){
 var key='mu_micro_resume:'+` + app.JSString(accountID) + `;
-var base='/agent/micro';
+var base='/';
 try{
+ if(sessionStorage.getItem('mu_chat_hist:landing')||sessionStorage.getItem('mu_chat_draft:landing'))return;
  var saved=sessionStorage.getItem(key);
- if(location.pathname===base&&!location.search&&saved&&/^\/agent\/micro\?(session=[A-Za-z0-9_-]+|new=1)$/.test(saved)){
+ if(saved)saved=saved.replace(/^\/agent\/micro\?/, '/?');
+ if(location.pathname===base&&!location.search&&saved&&/^\/\?(session=[A-Za-z0-9_-]+|new=1)$/.test(saved)){
   location.replace(saved);return;
  }
  function remember(id){sessionStorage.setItem(key,base+(id?'?session='+encodeURIComponent(id):'?new=1'));}
@@ -23,4 +29,21 @@ try{
  window.addEventListener('mu-chat-new',function(){remember('');});
 }catch(e){}
 })();</script>`
+}
+
+// MicroHandler renders the signed-in assistant at the front door.
+func MicroHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet && r.Method != http.MethodHead {
+		app.MethodNotAllowed(w, r)
+		return
+	}
+	auth.SetCSRFCookie(w, r)
+	servePage(w, r)
+}
+
+func chatPath(owner, id string) string {
+	if id == "" {
+		return "/"
+	}
+	return Path(owner, id)
 }

--- a/agent/resume_test.go
+++ b/agent/resume_test.go
@@ -26,6 +26,9 @@ func TestMicroEntryReopensHistoryAndNewStartsEmpty(t *testing.T) {
 		path string
 		want bool
 	}{
+		{"/", true},
+		{"/?session=" + id, true},
+		{"/?new=1", false},
 		{"/agent/micro", true},
 		{"/agent/micro?session=" + id, true},
 		{"/agent/micro?new=1", false},

--- a/home/home.go
+++ b/home/home.go
@@ -418,7 +418,7 @@ function fetchW(la,lo){
 		// thread it mirrors. A fixed namespace would let the next account using
 		// this tab restore and submit the previous account's conversation.
 		chatStorageNS = "home:" + viewerID
-		chatImportNS = "landing"
+		// Guest conversations move into Micro through HandoffHTML.
 	}
 
 	// The rail is built before it is placed, because whether there is a second
@@ -764,7 +764,7 @@ function fetchW(la,lo){
 	// when the call site it left behind is not removed. See app.renderForRequest,
 	// which is the only place any of the three banners is added.
 	app.Respond(w, r, app.Response{Title: "Home", Description: "The home screen",
-		HTML: b.String(), BodyClass: bodyClass})
+		HTML: agent.HandoffHTML(r) + b.String(), BodyClass: bodyClass})
 }
 
 // htmlEsc escapes text for HTML.

--- a/home/index.go
+++ b/home/index.go
@@ -47,27 +47,9 @@ import (
 //
 // The description still follows. It reads better as a caption than as a pitch.
 func Index(w http.ResponseWriter, r *http.Request) {
-	// Signed in, this is not your page.
-	//
-	// It went back and forth twice and the second answer is the right one. The
-	// argument for keeping one page in two states was that signing in should
-	// not move you somewhere else, and a question half-typed in the box should
-	// survive it. Both true, and both smaller than what it cost: a landing page
-	// is written for somebody deciding whether they want this, and showing it
-	// to somebody who already has an account means the app's front door is an
-	// argument aimed at a stranger.
-	//
-	// On a phone it was plainer than that. The app has a tab bar with Home in
-	// it — you press Home and you know where you are — and landing on a
-	// wordmark with a marketing tagline over a search box, no rail, no tabs,
-	// is a different product opening under you. Folding this page into the app
-	// shell instead was the other thing tried, and that made every app page
-	// carry a landing page's furniture.
-	//
-	// So: two pages for two audiences. Out here, a landing. Signed in, /home,
-	// which has the rail, the tabs, your inbox and the same box to type in.
+	// The front door is the assistant workspace once signed in.
 	if _, acc := auth.TrySession(r); acc != nil {
-		http.Redirect(w, r, "/agent/micro", http.StatusSeeOther)
+		agent.MicroHandler(w, r)
 		return
 	}
 	if r.URL.Query().Get("from") == "app" {

--- a/home/login_continuity_test.go
+++ b/home/login_continuity_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 )
 
-func TestLoginTurnsTheLandingChatIntoTheHomeChat(t *testing.T) {
+func TestLoginKeepsTheLandingConversation(t *testing.T) {
 	landing := indexBody()
 	if !strings.Contains(landing, `var NS="landing"`) {
 		t.Error("the public conversation is not retained for the login handoff")
@@ -19,7 +19,7 @@ func TestLoginTurnsTheLandingChatIntoTheHomeChat(t *testing.T) {
 	for _, want := range []string{
 		`chatStorageNS = "home:" + viewerID`,
 		`StorageNS:       chatStorageNS`,
-		`ImportNS:        chatImportNS`,
+		`agent.HandoffHTML(r)`,
 	} {
 		if !strings.Contains(string(home), want) {
 			t.Errorf("Home does not adopt the landing conversation: missing %q", want)

--- a/home/publicbrief_test.go
+++ b/home/publicbrief_test.go
@@ -153,7 +153,7 @@ func TestSigningInLeavesTheLanding(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(string(src), `http.Redirect(w, r, "/agent/micro", http.StatusSeeOther)`) {
+	if !strings.Contains(string(src), `agent.MicroHandler(w, r)`) {
 		t.Error("the landing page is served to people who are signed in, so the\n" +
 			"app's front door is a pitch aimed at somebody who already bought")
 	}

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -731,7 +731,7 @@ var Template = `
           if (u.pathname === '/logout') return;
           // Agent pages own live streams and per-thread draft/scroll state.
           // Use document navigation so pagehide saves it and listeners retire.
-          if (/^\/agent(?:\/|$)/.test(u.pathname) || /^\/agent(?:\/|$)/.test(location.pathname)) return;
+          if (u.pathname === '/' || location.pathname === '/' || /^\/agent(?:\/|$)/.test(u.pathname) || /^\/agent(?:\/|$)/.test(location.pathname)) return;
           e.preventDefault();
           if (u.href === location.href) return;
           go(u.href, true);
@@ -864,6 +864,7 @@ var Template = `
       // in the document — so the tab bar was never marked.
       function markNav() {
         var here = location.pathname.replace(/\/+$/, '') || '/';
+        if(here === '/agent/micro') here = '/';
         var groups = ['#nav a, .nav-bottom a', '#tabs a'];
         for (var g = 0; g < groups.length; g++) {
           var links = document.querySelectorAll(groups[g]);
@@ -1278,7 +1279,7 @@ func navMain(acc *auth.Account) string {
 			`"><span class="label">` + label + `</span></a>`
 	}
 
-	b := item("nav-micro", "/agent/micro", "/agent.svg", "Micro")
+	b := `<a id="nav-micro" href="/">` + microMark + `<span class="label">Micro</span></a>`
 	b += item("nav-home", "/home", "/home.png", "Home")
 	// Account and Profile are not here. They are the two that are about *you*
 	// rather than about the instance, so they sit under your name at the foot
@@ -1324,7 +1325,7 @@ func navTabs(acc *auth.Account) string {
 			`" alt=""><span>` + label + `</span></a>`
 	}
 	return `<nav id="tabs" aria-label="Main">` +
-		tab("/agent/micro", "/agent.svg", "Micro") +
+		`<a href="/">` + microMark + `<span>Micro</span></a>` +
 		tab("/home", "/home.png", "Home") +
 		tab("/inbox", "/mail.png", "Inbox") +
 		tab("/agents", "/agent.svg", "Agents") +
@@ -1845,3 +1846,5 @@ func renderShell(lang, title, desc, bodyAttr, body string, acc *auth.Account, pa
 		navBottom(acc, here),
 		title, body, footerFor(acc), navTabs(acc))
 }
+
+const microMark = `<span class="micro-mark" aria-hidden="true">Mu</span>`

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -358,7 +358,7 @@ func TestTheSidebarIsTheProductsNouns(t *testing.T) {
 		nav = nav[:j]
 	}
 
-	want := []string{`href="/agent/micro"`, `href="/home"`, `href="/inbox"`, `href="/agents"`, `href="/services"`}
+	want := []string{`href="/"`, `href="/home"`, `href="/inbox"`, `href="/agents"`, `href="/services"`}
 	at := -1
 	for _, w := range want {
 		i := strings.Index(nav, w)

--- a/internal/app/chat.go
+++ b/internal/app/chat.go
@@ -798,7 +798,7 @@ function save(){
   if(SESSION||!PERSIST)return; // server owns reopened sessions; ephemeral surfaces don't save
   try{
     sessionStorage.setItem(CKEY,conv.innerHTML);
-    sessionStorage.setItem(HKEY,JSON.stringify(history.slice(-6)));
+    sessionStorage.setItem(HKEY,JSON.stringify(NS==='landing'?history:history.slice(-6)));
     sessionStorage.setItem(TKEY,contextId||'');
   }catch(e){}
 }

--- a/internal/app/html/mu.css
+++ b/internal/app/html/mu.css
@@ -8007,3 +8007,6 @@ a.btn-secondary:hover, .btn-secondary:hover {
 /* The account preview starts with a heading, not an inset list row. */
 .wallet-peek { padding-top: 16px; }
 .wallet-peek .balance-figure b { font-weight: 400; }
+
+.micro-mark { display:inline-flex; align-items:center; justify-content:center; flex:none; width:24px; height:24px; border:1.5px solid currentColor; border-radius:50%; font-family:inherit; font-weight:bold; font-size:11px; line-height:1; }
+#tabs .micro-mark { width:22px; height:22px; font-size:10px; }

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -452,6 +452,7 @@ func registerRoutes() {
 		}
 		http.Redirect(w, r, to, http.StatusFound)
 	})
+	http.HandleFunc("/agent/handoff", agent.HandoffHandler)
 	http.HandleFunc("/agent/", agent.Handler)
 	http.HandleFunc("/agents/data", agent.AgentsHandler)
 	// The old path, so a page cached with the previous script keeps working.

--- a/test/template_test.go
+++ b/test/template_test.go
@@ -83,7 +83,7 @@ func TestThePhoneCarriesMicroAndHome(t *testing.T) {
 	if tabs == "" {
 		t.Fatal("no tab bar in the rendered shell")
 	}
-	for _, href := range []string{"/agent/micro", "/home", "/inbox", "/agents", "/services"} {
+	for _, href := range []string{"/", "/home", "/inbox", "/agents", "/services"} {
 		if !strings.Contains(tabs, `href="`+href+`"`) {
 			t.Errorf("the tab bar does not reach %s:\n%s", href, tabs)
 		}


### PR DESCRIPTION
Login defaults to Home; visiting / while signed in renders Micro in the normal app shell and resumes the selected conversation. Micro's menu/tab icon uses the heading's Mu lettering inside a circle. Existing /agent/micro and API addresses remain valid.

New chat and Conversations are available on mobile, with dated conversation history. Returning from Home preserves the selected conversation and its draft. Guest conversations are adopted into account-owned history through a bounded, authenticated, CSRF-checked handoff; browser copies are cleared only after saving succeeds.

Validation: account and shared app suites pass; targeted root entry, new chat, saved reading, mobile tabs, login and private/idempotent guest handoff tests pass. Existing main CI failures are home/TestTheNameIsTheSameOnEverySurface and internal/origin/TestURLPreservesExplicitPublicSurface.