### PR TITLE
Restore Home as the signed-in entry point

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -521,7 +521,7 @@ func servePage(w http.ResponseWriter, r *http.Request) {
 	// something the nav already says.
 	chip := `<div class="agent-bar">` +
 		`<a class="btn chat-open-list" href="` + chatPath(accountID, selAgent) + `?new=1">New chat</a>` +
-		`<button type="button" class="chat-open-list" onclick="muPane('chats')">Conversations</button>` +
+		`<button type="button" class="btn chat-open-list" onclick="muPane('chats')">Chats</button>` +
 		`</div>` + paneJS
 
 	// No tabs. There were four — Chat, Threads, Runs, Connect — for one thing:
@@ -748,7 +748,7 @@ func renderSessionsRail(accountID, currentID, agentID string, named bool, extra 
 		// also mean "a chat you had". Chat is what these are, it is what the
 		// button under them starts, and thread.WebClient is the client that
 		// makes them.
-		`<div class="chat-sess-head">Conversations</div><div class="chat-sess-list">`)
+		`<div class="chat-sess-head">Chats</div><div class="chat-sess-list">`)
 	if len(sessions) == 0 {
 		// An empty inbox says how to fill it, and the answer is an address.
 		// "No conversations yet" is a true sentence that leaves somebody looking
@@ -798,7 +798,7 @@ func renderSessionsRail(accountID, currentID, agentID string, named bool, extra 
 			`onclick="muSessionDelete(` + app.JSAttr(s.ID) + `,event)">&times;</button></div>`)
 	}
 	if len(sessions) >= railShown {
-		b.WriteString(`<a class="chat-sess-more" href="/recall">Older conversations →</a>`)
+		b.WriteString(`<a class="chat-sess-more" href="/recall">Older chats →</a>`)
 	}
 	b.WriteString(`</div>` + extra)
 
@@ -1065,14 +1065,14 @@ const chatLayoutCSS = `<style>
    children size to their content rather than the screen and a wide answer pushes
    the input off the side. Hence the stretch. */
 @media(max-width:760px){
-  .agent-bar{display:flex}
+  .agent-bar{display:flex;padding-top:12px;gap:8px;margin-bottom:16px}
   .chat-layout{flex-direction:column;gap:12px;align-items:stretch}
   .chat-main{width:100%;min-width:0;max-width:100%}
   .chat-open-list{display:inline-block;border:1px solid var(--border-color,#e5e5e5);
     background:var(--card-background,#fff);color:var(--text-primary,#111);
     border-radius:6px;padding:3px 12px;font-size:12px;font-weight:600;
     font-family:inherit;cursor:pointer}
-  .chat-open-list::after{content:" ▾";color:#999}
+  button.chat-open-list::after{content:" ▾";color:#999}
   /* The sheet. Off-screen rather than display:none, so opening it animates and
      so the panels inside keep their state. */
   /* The sheet ends above the tab bar. It is fixed to bottom:0 with a lower

--- a/agent/handoff.go
+++ b/agent/handoff.go
@@ -88,7 +88,7 @@ function finish(id){
  if(draft)sessionStorage.setItem('mu_chat_draft:'+ns+':'+id,draft);
  ['hist','conv','ctx','draft'].forEach(function(k){sessionStorage.removeItem('mu_chat_'+k+':landing');});
  }catch(e){return;}
- location.replace(id?'/?session='+encodeURIComponent(id):'/?new=1');
+ location.replace(id?'/agent/micro?session='+encodeURIComponent(id):'/agent/micro?new=1');
 }
 if(!turns.length){finish('');return;}
 fetch('/agent/handoff',{method:'POST',credentials:'same-origin',headers:{'Content-Type':'application/json','X-CSRF-Token':` + app.JSString(auth.CSRFToken(r)) + `},body:JSON.stringify({turns:turns})})

--- a/agent/resume.go
+++ b/agent/resume.go
@@ -14,14 +14,9 @@ func resumeMicroJS(accountID, agentID, contextID string) string {
 	}
 	return `<script>(function(){
 var key='mu_micro_resume:'+` + app.JSString(accountID) + `;
-var base='/';
+var base='/agent/micro';
 try{
  if(sessionStorage.getItem('mu_chat_hist:landing')||sessionStorage.getItem('mu_chat_draft:landing'))return;
- var saved=sessionStorage.getItem(key);
- if(saved)saved=saved.replace(/^\/agent\/micro\?/, '/?');
- if(location.pathname===base&&!location.search&&saved&&/^\/\?(session=[A-Za-z0-9_-]+|new=1)$/.test(saved)){
-  location.replace(saved);return;
- }
  function remember(id){sessionStorage.setItem(key,base+(id?'?session='+encodeURIComponent(id):'?new=1'));}
  var query=new URLSearchParams(location.search);
  if(!['bookmark','saved','item','prompt','q'].some(function(k){return query.has(k);}))remember(` + app.JSString(contextID) + `);
@@ -43,7 +38,7 @@ func MicroHandler(w http.ResponseWriter, r *http.Request) {
 
 func chatPath(owner, id string) string {
 	if id == "" {
-		return "/"
+		return "/agent/micro"
 	}
 	return Path(owner, id)
 }

--- a/home/entry_test.go
+++ b/home/entry_test.go
@@ -1,6 +1,7 @@
 package home
 
 import (
+	"mu/internal/auth"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -11,5 +12,28 @@ func TestExpiredInstalledSessionOpensLogin(t *testing.T) {
 	Index(w, httptest.NewRequest("GET", "/?from=app", nil))
 	if w.Code != http.StatusSeeOther || w.Header().Get("Location") != "/login" {
 		t.Fatalf("PWA entry: %d %s", w.Code, w.Header().Get("Location"))
+	}
+}
+
+func TestSignedInEntryUsesHomeAndPreservesOldChatLinks(t *testing.T) {
+	const who = "home_entry_redirect"
+	if e := auth.Create(&auth.Account{ID: who}); e != nil {
+		t.Fatal(e)
+	}
+	sess, e := auth.CreateSession(who)
+	if e != nil {
+		t.Fatal(e)
+	}
+	defer auth.EndSession(sess.Token)
+	for _, tc := range []struct{ path, want string }{
+		{"/", "/home"}, {"/?from=app", "/home"}, {"/?session=old-thread", "/agent/micro?session=old-thread"}, {"/?new=1", "/agent/micro?new=1"},
+	} {
+		r := httptest.NewRequest("GET", tc.path, nil)
+		r.AddCookie(&http.Cookie{Name: "session", Value: sess.Token})
+		w := httptest.NewRecorder()
+		Index(w, r)
+		if w.Code != http.StatusSeeOther || w.Header().Get("Location") != tc.want {
+			t.Errorf("%s: %d %s", tc.path, w.Code, w.Header().Get("Location"))
+		}
 	}
 }

--- a/home/index.go
+++ b/home/index.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"html"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 	"time"
@@ -49,6 +50,17 @@ import (
 func Index(w http.ResponseWriter, r *http.Request) {
 	// Signed-in users enter Home, which already contains the assistant prompt.
 	if _, acc := auth.TrySession(r); acc != nil {
+		// Preserve links created while the assistant lived at the root.
+		q := url.Values{}
+		for _, key := range []string{"session", "continue", "new"} {
+			if value := r.URL.Query().Get(key); value != "" {
+				q.Set(key, value)
+			}
+		}
+		if len(q) > 0 {
+			http.Redirect(w, r, "/agent/micro?"+q.Encode(), http.StatusSeeOther)
+			return
+		}
 		http.Redirect(w, r, "/home", http.StatusSeeOther)
 		return
 	}

--- a/home/index.go
+++ b/home/index.go
@@ -47,9 +47,9 @@ import (
 //
 // The description still follows. It reads better as a caption than as a pitch.
 func Index(w http.ResponseWriter, r *http.Request) {
-	// The front door is the assistant workspace once signed in.
+	// Signed-in users enter Home, which already contains the assistant prompt.
 	if _, acc := auth.TrySession(r); acc != nil {
-		agent.MicroHandler(w, r)
+		http.Redirect(w, r, "/home", http.StatusSeeOther)
 		return
 	}
 	if r.URL.Query().Get("from") == "app" {

--- a/home/publicbrief_test.go
+++ b/home/publicbrief_test.go
@@ -153,7 +153,7 @@ func TestSigningInLeavesTheLanding(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(string(src), `agent.MicroHandler(w, r)`) {
+	if !strings.Contains(string(src), `http.Redirect(w, r, "/home", http.StatusSeeOther)`) {
 		t.Error("the landing page is served to people who are signed in, so the\n" +
 			"app's front door is a pitch aimed at somebody who already bought")
 	}

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -1279,8 +1279,7 @@ func navMain(acc *auth.Account) string {
 			`"><span class="label">` + label + `</span></a>`
 	}
 
-	b := `<a id="nav-micro" href="/">` + microMark + `<span class="label">Micro</span></a>`
-	b += item("nav-home", "/home", "/home.png", "Home")
+	b := item("nav-home", "/home", "/home.png", "Home")
 	// Account and Profile are not here. They are the two that are about *you*
 	// rather than about the instance, so they sit under your name at the foot
 	// beside Log out — which is where somebody looks when the question is "who
@@ -1325,7 +1324,6 @@ func navTabs(acc *auth.Account) string {
 			`" alt=""><span>` + label + `</span></a>`
 	}
 	return `<nav id="tabs" aria-label="Main">` +
-		`<a href="/">` + microMark + `<span>Micro</span></a>` +
 		tab("/home", "/home.png", "Home") +
 		tab("/inbox", "/mail.png", "Inbox") +
 		tab("/agents", "/agent.svg", "Agents") +
@@ -1846,5 +1844,3 @@ func renderShell(lang, title, desc, bodyAttr, body string, acc *auth.Account, pa
 		navBottom(acc, here),
 		title, body, footerFor(acc), navTabs(acc))
 }
-
-const microMark = `<span class="micro-mark" aria-hidden="true">Mu</span>`

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -864,7 +864,7 @@ var Template = `
       // in the document — so the tab bar was never marked.
       function markNav() {
         var here = location.pathname.replace(/\/+$/, '') || '/';
-        if(here === '/agent/micro') here = '/';
+        if(here === '/agent' || here.indexOf('/agent/') === 0) here = '/agents';
         var groups = ['#nav a, .nav-bottom a', '#tabs a'];
         for (var g = 0; g < groups.length; g++) {
           var links = document.querySelectorAll(groups[g]);

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -358,7 +358,7 @@ func TestTheSidebarIsTheProductsNouns(t *testing.T) {
 		nav = nav[:j]
 	}
 
-	want := []string{`href="/"`, `href="/home"`, `href="/inbox"`, `href="/agents"`, `href="/services"`}
+	want := []string{`href="/home"`, `href="/inbox"`, `href="/agents"`, `href="/services"`}
 	at := -1
 	for _, w := range want {
 		i := strings.Index(nav, w)

--- a/internal/app/html/mu.css
+++ b/internal/app/html/mu.css
@@ -1412,7 +1412,7 @@ body.page-home #page-title ~ #customize-link {
 
   #tabs {
     display: grid;
-    grid-template-columns: repeat(5, 1fr);
+    grid-template-columns: repeat(4, 1fr);
     position: fixed;
     left: 0;
     right: 0;
@@ -8008,5 +8008,3 @@ a.btn-secondary:hover, .btn-secondary:hover {
 .wallet-peek { padding-top: 16px; }
 .wallet-peek .balance-figure b { font-weight: 400; }
 
-.micro-mark { display:inline-flex; align-items:center; justify-content:center; flex:none; width:24px; height:24px; border:1.5px solid currentColor; border-radius:50%; font-family:inherit; font-weight:bold; font-size:11px; line-height:1; }
-#tabs .micro-mark { width:22px; height:22px; font-size:10px; }

--- a/test/template_test.go
+++ b/test/template_test.go
@@ -83,13 +83,13 @@ func TestThePhoneCarriesMicroAndHome(t *testing.T) {
 	if tabs == "" {
 		t.Fatal("no tab bar in the rendered shell")
 	}
-	for _, href := range []string{"/", "/home", "/inbox", "/agents", "/services"} {
+	for _, href := range []string{"/home", "/inbox", "/agents", "/services"} {
 		if !strings.Contains(tabs, `href="`+href+`"`) {
 			t.Errorf("the tab bar does not reach %s:\n%s", href, tabs)
 		}
 	}
-	if n := strings.Count(tabs, "<a "); n != 5 {
-		t.Errorf("the tab bar holds %d tabs, want Micro, Home, Inbox, Agents and Services:\n%s", n, tabs)
+	if n := strings.Count(tabs, "<a "); n != 4 {
+		t.Errorf("the tab bar holds %d tabs, want Home, Inbox, Agents and Services:\n%s", n, tabs)
 	}
 	// Not the mail store. That was the bug in the thing this replaced.
 	if strings.Contains(tabs, `href="/mail"`) {


### PR DESCRIPTION
The assistant-at-root change created redundant navigation and a visible second page load when restoring a remembered conversation. Home already has an assistant prompt.

- Signed-in / redirects directly to /home.
- Remove Micro from sidebar and bottom navigation; use four equal tabs: Home, Inbox, Agents, Services.
- Keep chat links and guest-history handoff under /agent/micro.
- Remove the browser resume redirect that caused a second navigation.
- Use Chats consistently, give mobile controls top spacing, and show a dropdown arrow only on the Chats button.

No UI-kit migration or new voice feature is included. Targeted sidebar, tabs, entry, handoff and login tests pass. Full CI has two known baseline branding/origin failures; recheck this head before merging. Codex Cloud review remains enabled.