### PR TITLE
Fix mobile chat and document layouts

### DIFF
--- a/internal/app/html/mu.css
+++ b/internal/app/html/mu.css
@@ -3055,7 +3055,7 @@ a.highlight {
     font-size: small;
   }
   #blog > div:first-child {
-    text-align: center;
+    text-align: left;
   }
   
   /* Topic selectors */

--- a/internal/app/html/mu.css
+++ b/internal/app/html/mu.css
@@ -8017,3 +8017,25 @@ a.btn-secondary:hover, .btn-secondary:hover {
 /* Links retain their colour and keyboard focus without hover underlines. */
 a:hover, a:hover * { text-decoration: none !important; }
 .mu-agent .card p, .mu-user { white-space: pre-wrap; }
+
+/* Shared collection and editor contract: Docs and Notes supply fields and
+   actions, never their own width, wrapping or mobile spacing. */
+.collection-head { display:flex; flex-direction:column; align-items:flex-start; gap:12px; margin:0 0 16px; min-width:0; }
+.collection-list { display:flex; flex-direction:column; border:1px solid var(--border-color,#eee); border-radius:8px; overflow:hidden; }
+.collection-item { display:grid; grid-template-columns:minmax(0,1fr) auto; gap:5px 12px; padding:14px; border-bottom:1px solid var(--divider,#eee); min-width:0; }
+.collection-item:last-child { border-bottom:0; }
+.collection-title { font-size:14px; font-weight:600; overflow-wrap:anywhere; }
+.collection-preview { grid-column:1; font-size:13px; color:var(--text-muted,#666); overflow-wrap:anywhere; }
+.collection-when { grid-column:2; grid-row:1; font-size:12px; color:var(--text-muted,#888); }
+.record-card { width:100%; max-width:794px; min-width:0; box-sizing:border-box; }
+.record-editor { display:flex; flex-direction:column; gap:12px; min-width:0; }
+.record-editor > * { min-width:0; max-width:100%; box-sizing:border-box; }
+.record-editor input.record-title { width:100%; font:inherit; font-size:19px; font-weight:600; padding:9px 0; border:0; border-bottom:1px solid var(--border-color,#eee); background:transparent; }
+.record-editor textarea.record-body { width:100%; min-height:50dvh; padding:12px; font:inherit; line-height:1.6; resize:vertical; border:1px solid var(--border-color,#eee); }
+.record-actions { display:flex; flex-wrap:wrap; align-items:center; gap:12px; }
+.record-actions button { flex-shrink:0; margin:0; }
+@media(max-width:760px) {
+ .collection-item { grid-template-columns:minmax(0,1fr); }
+ .collection-when { grid-column:1; grid-row:auto; }
+ .record-editor input.record-title,.record-editor textarea.record-body { font-size:16px; }
+}

--- a/internal/app/ui.go
+++ b/internal/app/ui.go
@@ -156,3 +156,9 @@ func Column() string { return `<div class="page-col">` }
 
 // Close closes what Column opened.
 func Close() string { return `</div>` }
+
+// CollectionItem renders a linked record using the shared collection layout.
+// Services supply content; the app owns wrapping, spacing and mobile layout.
+func CollectionItem(href, title, preview, when string) string {
+	return `<a class="collection-item" href="` + html.EscapeString(href) + `"><span class="collection-title">` + html.EscapeString(title) + `</span><span class="collection-preview">` + html.EscapeString(preview) + `</span><span class="collection-when">` + html.EscapeString(when) + `</span></a>`
+}

--- a/service/blog/blog.go
+++ b/service/blog/blog.go
@@ -952,7 +952,7 @@ func handleGetBlog(w http.ResponseWriter, r *http.Request) {
 			// a reading page put the operator's job in front of everybody
 			// else's page, and made the one place moderation lives two.
 			actions = `<div class="mb-4">
-				<a href="/blog?write=true" class="btn">New Post</a>
+				<a href="/blog?write=true" class="btn">New</a>
 			</div>`
 		} else {
 			// Guest user, show login prompt

--- a/service/chat/chat.go
+++ b/service/chat/chat.go
@@ -44,15 +44,15 @@ var Template = `
 <button>Send</button>
 </form></div></div><style>
 /* Keep the scroll viewport connected to the page's bounded flex column. */
-body:has(.room-layout) #content { height:calc(100dvh - 70px - var(--tabbar)); }
+body:has(#messages):has(.room-layout) #content { height:calc(100dvh - 70px - var(--tabbar)); }
 .room-layout { display:grid; grid-template-columns:160px minmax(0,1fr); grid-template-rows:minmax(0,1fr); gap:20px; flex:1 1 0; min-height:0; min-width:0; }
 .room-roster { padding:12px 0; min-width:0; overflow-y:auto; overflow-wrap:anywhere; }
 .room-roster h3 { font-size:13px; margin:0 0 12px; }
 .room-roster #chat-users a { display:block; margin-bottom:8px; }
 .room-main { display:flex; flex-direction:column; min-width:0; min-height:0; }
 .room-main #messages { min-height:0; max-height:none; overflow-wrap:anywhere; }
-.room-main #messages img, .room-main #messages video { max-width:100%; height:auto; }
-.room-main #messages pre { max-width:100%; overflow-x:auto; }
+.room-main #messages img, .room-main #messages video { max-width:100%%; height:auto; }
+.room-main #messages pre { max-width:100%%; overflow-x:auto; }
 .room-main #chat-form { flex:0 0 auto; min-width:0; }
 .room-main #prompt { width:0; min-width:0; max-width:none; flex:1 1 0; }
 @media(max-width:760px) {

--- a/service/chat/chat.go
+++ b/service/chat/chat.go
@@ -42,7 +42,28 @@ var Template = `
 <input id="topic" name="topic" type="hidden">
 <textarea id="prompt" name="prompt" rows="1" placeholder="Say something" autocomplete="off" onkeydown="if(event.key==='Enter'&&!event.shiftKey){event.preventDefault();this.form.dispatchEvent(new Event('submit'))}"></textarea>
 <button>Send</button>
-</form></div></div><style>.room-layout{display:grid;grid-template-columns:160px minmax(0,1fr);gap:20px}.room-roster{padding:12px 0}.room-roster h3{font-size:13px;margin:0 0 12px}.room-roster #chat-users a{display:block;margin-bottom:8px}.room-main{min-width:0}@media(max-width:760px){.room-layout{grid-template-columns:1fr;gap:8px}.room-roster{padding:0}.room-roster #chat-users a{display:inline-block;margin-right:10px}.room-roster h3{margin-bottom:6px}}</style>`
+</form></div></div><style>
+/* Keep the scroll viewport connected to the page's bounded flex column. */
+body:has(.room-layout) #content { height:calc(100dvh - 70px - var(--tabbar)); }
+.room-layout { display:grid; grid-template-columns:160px minmax(0,1fr); grid-template-rows:minmax(0,1fr); gap:20px; flex:1 1 0; min-height:0; min-width:0; }
+.room-roster { padding:12px 0; min-width:0; overflow-y:auto; overflow-wrap:anywhere; }
+.room-roster h3 { font-size:13px; margin:0 0 12px; }
+.room-roster #chat-users a { display:block; margin-bottom:8px; }
+.room-main { display:flex; flex-direction:column; min-width:0; min-height:0; }
+.room-main #messages { min-height:0; max-height:none; overflow-wrap:anywhere; }
+.room-main #messages img, .room-main #messages video { max-width:100%; height:auto; }
+.room-main #messages pre { max-width:100%; overflow-x:auto; }
+.room-main #chat-form { flex:0 0 auto; min-width:0; }
+.room-main #prompt { width:0; min-width:0; max-width:none; flex:1 1 0; }
+@media(max-width:760px) {
+  .room-layout { grid-template-columns:minmax(0,1fr); grid-template-rows:auto minmax(0,1fr); gap:8px; }
+  .room-roster { display:flex; align-items:baseline; gap:10px; padding:0; overflow:hidden; font-size:13px; }
+  .room-roster h3 { font-size:inherit; margin:0; flex-shrink:0; }
+  .room-roster #chat-users { flex:1; min-width:0; white-space:nowrap; overflow-x:auto; border:0; margin:0; padding:0; }
+  .room-roster #chat-users a { display:inline-block; margin:0 8px 0 0; }
+  .room-roster > a { flex-shrink:0; }
+}
+</style>`
 
 var mutex sync.RWMutex
 

--- a/service/docs/editor.go
+++ b/service/docs/editor.go
@@ -1,6 +1,6 @@
 package docs
 
-const editorTools = `<div class="doc-toolbar d-flex gap-2 mb-3" role="group" aria-label="Text formatting" style="flex-wrap:wrap">
+const editorTools = `<div class="doc-toolbar" role="group" aria-label="Text formatting">
 <button type="button" data-before="**" data-after="**" title="Bold"><strong>B</strong></button>
 <button type="button" data-before="_" data-after="_" title="Italic"><em>I</em></button>
 <button type="button" data-before="## " data-line="1">Heading</button>
@@ -9,8 +9,10 @@ const editorTools = `<div class="doc-toolbar d-flex gap-2 mb-3" role="group" ari
 <button type="button" data-before="&gt; " data-line="1">Quote</button>
 <button type="button" data-before="[" data-after="](https://)">Link</button>
 <button type="button" data-before="&#96;" data-after="&#96;">Code</button>
-<label class="btn">Import text<input id="doc-import" type="file" accept=".txt,.md,.markdown,text/plain,text/markdown" class="sr-only"></label>
-</div><p id="doc-import-status" class="text-sm text-muted" role="status">Import a Markdown or plain-text file, then save it as a document.</p>`
+</div>`
+
+const importTools = `<label class="btn" tabindex="0" role="button" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();document.getElementById('doc-import').click()}">Choose file<input id="doc-import" type="file" accept=".txt,.md,.markdown,text/plain,text/markdown" hidden></label>
+<p id="doc-import-status" class="text-sm text-muted" role="status">Import a Markdown or plain-text file, then save it as a document.</p>`
 
 const editorScript = `<script>(function(){
 var body=document.getElementById('doc-body'),pick=document.getElementById('doc-import');if(!body||body.dataset.editorWired)return;body.dataset.editorWired='1';

--- a/service/docs/handler.go
+++ b/service/docs/handler.go
@@ -96,7 +96,7 @@ func handlePost(w http.ResponseWriter, r *http.Request, who string) {
 // list is every document, newest change first.
 func list(docs []*Doc, query string) string {
 	var b strings.Builder
-	b.WriteString(`<div class="doc-head">`)
+	b.WriteString(`<div class="collection-head">`)
 	b.WriteString(`<form method="GET" action="/docs" class="doc-search">` +
 		`<input type="text" name="q" value="` + html.EscapeString(query) +
 		`" placeholder="Search your documents" autocomplete="off">` +
@@ -113,15 +113,9 @@ func list(docs []*Doc, query string) string {
 			`remember, <a href="/notes">notes</a> is the shorter tool.`)
 	}
 
-	b.WriteString(`<div class="doc-list">`)
+	b.WriteString(`<div class="collection-list">`)
 	for _, d := range docs {
-		b.WriteString(`<a class="doc-row" href="/docs?id=` + html.EscapeString(d.ID) + `">`)
-		b.WriteString(`<span class="doc-title">` + html.EscapeString(d.Title) + `</span>`)
-		if s := snippet(d.Content); s != "" {
-			b.WriteString(`<span class="doc-snip">` + html.EscapeString(s) + `</span>`)
-		}
-		b.WriteString(`<span class="doc-when">` + html.EscapeString(app.TimeAgo(d.Updated)) + `</span>`)
-		b.WriteString(`</a>`)
+		b.WriteString(app.CollectionItem("/docs?id="+d.ID, d.Title, snippet(d.Content), app.TimeAgo(d.Updated)))
 	}
 	b.WriteString(`</div>`)
 	return b.String()
@@ -130,7 +124,7 @@ func list(docs []*Doc, query string) string {
 // view is one document, read.
 func view(r *http.Request, d *Doc) string {
 	var b strings.Builder
-	b.WriteString(`<div class="doc-head"><a class="doc-back" href="/docs">← Documents</a>`)
+	b.WriteString(`<div class="collection-head"><a class="doc-back" href="/docs">← Documents</a>`)
 	b.WriteString(`<a class="doc-new" href="/docs?id=` + html.EscapeString(d.ID) + `&amp;edit=1">Edit</a></div>`)
 	b.WriteString(`<article class="card doc-view">`)
 	b.WriteString(`<h2>` + html.EscapeString(d.Title) + `</h2>`)
@@ -163,13 +157,13 @@ func editor(r *http.Request, d *Doc) string {
 	if r.URL.Query().Get("import") == "1" {
 		importOpen = " open"
 	}
-	return `<div class="doc-head">` + back + `</div>
-<form method="POST" action="/docs" class="card doc-editor">
+	return `<div class="collection-head">` + back + `</div>
+<form method="POST" action="/docs" class="card record-card record-editor">
 <input type="hidden" name="id" value="` + html.EscapeString(d.ID) + `">
 <input type="hidden" name="csrf_token" value="` + html.EscapeString(auth.CSRFToken(r)) + `">
-<input id="doc-title" class="doc-title-input" type="text" name="title" value="` + html.EscapeString(d.Title) + `" placeholder="Title" autocomplete="off" autofocus>
-` + editorTools + `<details class="doc-import-panel"` + importOpen + `><summary>Import</summary>` + importTools + `</details><textarea id="doc-body" class="doc-body" name="content" rows="32" placeholder="Write. Markdown works.">` + html.EscapeString(d.Content) + `</textarea>
-<div class="doc-actions">
+<input id="doc-title" class="record-title" type="text" name="title" value="` + html.EscapeString(d.Title) + `" placeholder="Title" autocomplete="off" autofocus>
+` + editorTools + `<details class="doc-import-panel"` + importOpen + `><summary>Import</summary>` + importTools + `</details><textarea id="doc-body" class="record-body" name="content" rows="32" placeholder="Write. Markdown works.">` + html.EscapeString(d.Content) + `</textarea>
+<div class="record-actions">
 <label class="doc-public"><input type="checkbox" name="public"` + checked + `> Anyone with the link can read it</label>
 <button type="submit">Save</button>
 </div>
@@ -181,47 +175,23 @@ func notice(msg string) string {
 }
 
 const pageCSS = `<style>
-/* A column, so New document sits on its own line under the search rather than
-   at the far end of it. margin-left:auto pushed it to the right edge, which on
-   a wide screen put the one action on the page as far from the reading column
-   as it could be, and on a narrow one wrapped it anyway. */
-.doc-head{display:flex;flex-direction:column;align-items:flex-start;gap:12px;margin:0 0 16px}
 .doc-search{display:flex;gap:8px;width:100%}
 .doc-search input{flex:1;min-width:0}
-.doc-new{font-size:14px;padding:6px 14px;border:1px solid #ccc;border-radius:6px;color:#111;text-decoration:none;white-space:nowrap}
-.doc-back{font-size:14px;color:#888;text-decoration:none}
-.doc-list{border:1px solid #eee;border-radius:8px;overflow:hidden}
-.doc-row{display:flex;align-items:baseline;gap:10px;padding:12px 14px;border-bottom:1px solid #f4f4f4;text-decoration:none;color:inherit}
-.doc-row:last-child{border-bottom:none}
-.doc-row:hover{background:#fafafa}
-.doc-title{font-weight:600;font-size:14px;white-space:nowrap}
-.doc-snip{color:#888;font-size:13px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;flex:1}
-.doc-when{color:#bbb;font-size:12px;margin-left:auto;white-space:nowrap}
-.doc-view h2{margin:0 0 12px}
-.doc-view img{max-width:100%}
-.doc-meta{font-size:12px;color:#888;display:flex;align-items:center;gap:10px;margin:10px 2px 0}
-.doc-meta form{display:inline;margin:0}
-.doc-delete{background:none;border:none;color:#c00;font-size:12px;padding:0;cursor:pointer}
-/* A page, roughly. 794px is 210mm at 96dpi, so the column is A4's width and
-   the text wraps where it would on paper; the height is the viewport rather
-   than A4's 1123px, because a box taller than the screen is scrolled twice —
-   once inside the textarea and once in the page around it. */
-.doc-editor{display:flex;flex-direction:column;gap:10px;width:100%;min-width:0;max-width:794px;box-sizing:border-box}
-.doc-editor > *{min-width:0;max-width:100%;box-sizing:border-box}
 .doc-create{display:flex;gap:8px;flex-wrap:wrap}
+.doc-back{font-size:14px;color:#888;text-decoration:none}
+.doc-new{font-size:14px;padding:6px 14px;border:1px solid #ccc;border-radius:6px;color:#111;text-decoration:none}
 .doc-toolbar{display:flex;flex-wrap:wrap;gap:6px}
 .doc-toolbar button{flex:0 0 auto;margin:0}
 .doc-import-panel input[type=file]{display:none}
 .doc-import-panel summary{cursor:pointer;margin-bottom:8px}
 .doc-import-panel p{margin:8px 0 0}
-.doc-editor .doc-title-input,.doc-editor .doc-body{width:100%}
 .doc-view{overflow-wrap:anywhere}
+.doc-view h2{margin:0 0 12px}
+.doc-view img{max-width:100%}
 .doc-view pre{overflow-x:auto}
 .doc-view table{display:block;max-width:100%;overflow-x:auto}
-.doc-title-input{font-size:1.15rem;font-weight:600;border:none;border-bottom:1px solid #eee;padding:6px 0;outline:none}
-.doc-body{font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:13px;line-height:1.7;border:1px solid #eee;border-radius:6px;padding:24px 28px;resize:vertical;min-height:70vh}
-.doc-actions{display:flex;align-items:center;gap:12px;flex-wrap:wrap}
+.doc-meta{font-size:12px;color:#888;display:flex;flex-wrap:wrap;align-items:center;gap:10px;margin:10px 2px 0}
+.doc-meta form{display:inline;margin:0}
+.doc-delete{background:none;border:none;color:#c00;font-size:12px;padding:0;cursor:pointer}
 .doc-public{min-width:0;flex:1 1 200px;font-size:13px;color:#888;display:flex;align-items:center;gap:6px}
-.doc-actions button{margin-left:auto;flex-shrink:0}
-@media(max-width:760px){.doc-body{padding:12px;min-height:50dvh}.doc-title{white-space:normal;overflow-wrap:anywhere;min-width:0}.doc-row{flex-wrap:wrap}.doc-snip{flex-basis:100%}}
 </style>`

--- a/service/docs/handler.go
+++ b/service/docs/handler.go
@@ -101,7 +101,7 @@ func list(docs []*Doc, query string) string {
 		`<input type="text" name="q" value="` + html.EscapeString(query) +
 		`" placeholder="Search your documents" autocomplete="off">` +
 		`<button type="submit">Search</button></form>`)
-	b.WriteString(`<a class="doc-new" href="/docs?new=1">New document / Import</a>`)
+	b.WriteString(`<div class="doc-create"><a class="btn" href="/docs?new=1">New</a><a class="btn" href="/docs?new=1&amp;import=1">Import</a></div>`)
 	b.WriteString(`</div>`)
 
 	if len(docs) == 0 {
@@ -159,12 +159,16 @@ func editor(r *http.Request, d *Doc) string {
 	if d.ID != "" {
 		back = `<a class="doc-back" href="/docs?id=` + html.EscapeString(d.ID) + `">← Back</a>`
 	}
+	importOpen := ""
+	if r.URL.Query().Get("import") == "1" {
+		importOpen = " open"
+	}
 	return `<div class="doc-head">` + back + `</div>
 <form method="POST" action="/docs" class="card doc-editor">
 <input type="hidden" name="id" value="` + html.EscapeString(d.ID) + `">
 <input type="hidden" name="csrf_token" value="` + html.EscapeString(auth.CSRFToken(r)) + `">
 <input id="doc-title" class="doc-title-input" type="text" name="title" value="` + html.EscapeString(d.Title) + `" placeholder="Title" autocomplete="off" autofocus>
-` + editorTools + `<textarea id="doc-body" class="doc-body" name="content" rows="32" placeholder="Write. Markdown works.">` + html.EscapeString(d.Content) + `</textarea>
+` + editorTools + `<details class="doc-import-panel"` + importOpen + `><summary>Import</summary>` + importTools + `</details><textarea id="doc-body" class="doc-body" name="content" rows="32" placeholder="Write. Markdown works.">` + html.EscapeString(d.Content) + `</textarea>
 <div class="doc-actions">
 <label class="doc-public"><input type="checkbox" name="public"` + checked + `> Anyone with the link can read it</label>
 <button type="submit">Save</button>
@@ -202,10 +206,22 @@ const pageCSS = `<style>
    the text wraps where it would on paper; the height is the viewport rather
    than A4's 1123px, because a box taller than the screen is scrolled twice —
    once inside the textarea and once in the page around it. */
-.doc-editor{display:flex;flex-direction:column;gap:10px;max-width:794px}
+.doc-editor{display:flex;flex-direction:column;gap:10px;width:100%;min-width:0;max-width:794px;box-sizing:border-box}
+.doc-editor > *{min-width:0;max-width:100%;box-sizing:border-box}
+.doc-create{display:flex;gap:8px;flex-wrap:wrap}
+.doc-toolbar{display:flex;flex-wrap:wrap;gap:6px}
+.doc-toolbar button{flex:0 0 auto;margin:0}
+.doc-import-panel input[type=file]{display:none}
+.doc-import-panel summary{cursor:pointer;margin-bottom:8px}
+.doc-import-panel p{margin:8px 0 0}
+.doc-editor .doc-title-input,.doc-editor .doc-body{width:100%}
+.doc-view{overflow-wrap:anywhere}
+.doc-view pre{overflow-x:auto}
+.doc-view table{display:block;max-width:100%;overflow-x:auto}
 .doc-title-input{font-size:1.15rem;font-weight:600;border:none;border-bottom:1px solid #eee;padding:6px 0;outline:none}
 .doc-body{font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:13px;line-height:1.7;border:1px solid #eee;border-radius:6px;padding:24px 28px;resize:vertical;min-height:70vh}
-.doc-actions{display:flex;align-items:center;gap:12px}
-.doc-public{font-size:13px;color:#888;display:flex;align-items:center;gap:6px}
-.doc-actions button{margin-left:auto}
+.doc-actions{display:flex;align-items:center;gap:12px;flex-wrap:wrap}
+.doc-public{min-width:0;flex:1 1 200px;font-size:13px;color:#888;display:flex;align-items:center;gap:6px}
+.doc-actions button{margin-left:auto;flex-shrink:0}
+@media(max-width:760px){.doc-body{padding:12px;min-height:50dvh}.doc-title{white-space:normal;overflow-wrap:anywhere;min-width:0}.doc-row{flex-wrap:wrap}.doc-snip{flex-basis:100%}}
 </style>`

--- a/service/notes/page.go
+++ b/service/notes/page.go
@@ -75,7 +75,7 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 // list is every note, newest change first, each one a link into the editor.
 func list(entries []*notes.Entry) string {
 	var b strings.Builder
-	b.WriteString(`<div class="note-head">` +
+	b.WriteString(`<div class="collection-head">` +
 		`<a class="btn" href="/notes?new=1">New</a></div>`)
 
 	if len(entries) == 0 {
@@ -97,16 +97,13 @@ func list(entries []*notes.Entry) string {
 		ordered[i], ordered[j] = ordered[j], ordered[i]
 	}
 
-	b.WriteString(`<div class="note-grid">`)
+	b.WriteString(`<div class="collection-list">`)
 	for _, e := range ordered {
 		when := e.UpdatedAt
 		if when.IsZero() {
 			when = e.CreatedAt
 		}
-		b.WriteString(`<a class="note-card" href="/notes?note=` + html.EscapeString(urlArg(e.Title)) + `">` +
-			`<span class="note-card-title">` + html.EscapeString(e.Title) + `</span>` +
-			`<span class="note-card-body">` + html.EscapeString(preview(e.Text)) + `</span>` +
-			`<span class="note-card-when">` + html.EscapeString(app.TimeAgo(when)) + `</span></a>`)
+		b.WriteString(app.CollectionItem("/notes?note="+urlArg(e.Title), e.Title, preview(e.Text), app.TimeAgo(when)))
 	}
 	b.WriteString(`</div>` + pageCSS)
 	return b.String()
@@ -116,27 +113,27 @@ func list(entries []*notes.Entry) string {
 func editor(r *http.Request, title, text string) string {
 	csrf := html.EscapeString(auth.CSRFToken(r))
 
-	titleField := `<input name="title" class="note-title-in" required maxlength="40" ` +
+	titleField := `<input name="title" class="record-title" required maxlength="40" ` +
 		`placeholder="Title" autofocus value="` + html.EscapeString(title) + `">`
 	if title != "" {
 		// The title is the note's address — rewriting it would leave the old
 		// note behind and make a second one. Renaming means delete and write,
 		// and it is not worth a control that looks like an edit and is not.
-		titleField = `<input class="note-title-in" value="` + html.EscapeString(title) +
+		titleField = `<input class="record-title" value="` + html.EscapeString(title) +
 			`" readonly aria-label="Title">` +
 			`<input type="hidden" name="title" value="` + html.EscapeString(title) + `">`
 	}
 
 	var b strings.Builder
-	b.WriteString(`<div class="note-head">` +
+	b.WriteString(`<div class="collection-head">` +
 		`<a class="link" href="/notes">← All notes</a></div>`)
-	b.WriteString(`<div class="card"><form method="POST" action="/notes" class="note-editor">` +
+	b.WriteString(`<div class="card record-card"><form method="POST" action="/notes" class="record-editor">` +
 		`<input type="hidden" name="_csrf" value="` + csrf + `">` +
 		`<input type="hidden" name="save" value="1">` +
 		titleField +
-		`<textarea name="text" class="note-body-in" rows="14" required maxlength="` +
+		`<textarea name="text" class="record-body" rows="14" required maxlength="` +
 		strconv.Itoa(maxText) + `" placeholder="Write it down">` + html.EscapeString(text) + `</textarea>` +
-		`<div class="note-actions"><button type="submit">Save</button></div></form>`)
+		`<div class="record-actions"><button type="submit">Save</button></div></form>`)
 
 	if title != "" {
 		b.WriteString(`<form method="POST" action="/notes" class="note-delete" ` +
@@ -195,44 +192,4 @@ func preview(text string) string {
 
 func urlArg(s string) string { return url.QueryEscape(s) }
 
-const pageCSS = `<style>
-.note-head{display:flex;align-items:center;justify-content:flex-start;gap:12px;margin:0 0 14px}
-.note-new,.note-new:visited{display:inline-block;background:#111;color:#fff;text-decoration:none;padding:7px 14px;
-  border-radius:8px;font-size:13px;font-weight:600;white-space:nowrap}
-.note-new:hover,.note-new:visited:hover{background:#333;color:#fff}
-.note-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(220px,1fr));gap:10px}
-/* min-width:0 because a grid track sized 1fr will not shrink below its
-   content, so one long unbroken run — a URL, a token, a hash — widens the
-   column instead of wrapping in it. */
-.note-card{display:flex;flex-direction:column;gap:5px;padding:14px;border:1px solid var(--border-color,#e5e5e5);
-  border-radius:10px;text-decoration:none;min-height:110px;min-width:0}
-.note-card:hover{border-color:#bbb}
-/* anywhere rather than break-word: break-word only breaks a word when the line
-   has nothing else on it, which leaves a long URL sitting beside a short word
-   and still overflowing. Notes are where somebody pastes a link. */
-.note-card-title{font-size:14px;font-weight:600;color:var(--text-color,#111);overflow-wrap:anywhere}
-.note-card-body{font-size:13px;color:var(--text-muted,#666);line-height:1.45;flex:1;overflow-wrap:anywhere}
-.note-card-when{font-size:12px;color:var(--text-muted,#999)}
-.note-editor{display:flex;flex-direction:column;gap:10px}
-/* Both flush left, because they are the two halves of one note and an eye
-   reading down them should not have to step sideways. They were a bordered box
-   at 12px and a borderless one at 0 — the title inset, the body not — which is
-   what "the title is padded more than the content" looks like. No boxes now: a
-   heading with a rule under it while it can be typed into, and the note under
-   that. See the comment on .note-editor in mu.css for why there were two. */
-/* Qualified, and it has to be. mu.css styles controls globally, and its input
-   rule is input:not([type=checkbox]):not([type=radio]) — specificity 0,2,1,
-   which no single class can outrank. Its textarea rule is a bare element
-   selector at 0,0,1, which any class beats. So .note-body-in applied and
-   .note-title-in did not, and the two lines of a note came out 12px apart with
-   nothing in either file saying why. .note-editor input.note-title-in is 0,2,1
-   and comes later, so it wins. */
-.note-editor input.note-title-in{padding:9px 0;border:0;
-  border-bottom:1px solid var(--border-color,#e5e5e5);font-size:19px;font-weight:600;
-  font-family:inherit;width:100%;outline:none;background:transparent;min-height:0}
-.note-editor input.note-title-in[readonly]{border-bottom-color:transparent}
-.note-body-in{padding:11px 0;border:0;font-size:15px;font-family:inherit;line-height:1.55;
-  resize:vertical;width:100%;outline:none;background:transparent}
-.note-actions{display:flex;gap:10px;align-items:center}
-.note-delete{margin:12px 0 0}
-</style>`
+const pageCSS = `<style>.note-delete{margin:12px 0 0}</style>`

--- a/service/notes/page.go
+++ b/service/notes/page.go
@@ -76,7 +76,7 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 func list(entries []*notes.Entry) string {
 	var b strings.Builder
 	b.WriteString(`<div class="note-head">` +
-		`<a class="note-new" href="/notes?new=1">New note</a></div>`)
+		`<a class="btn" href="/notes?new=1">New</a></div>`)
 
 	if len(entries) == 0 {
 		// Most accounts land here, because an agent only writes a note when a

--- a/service/notes/page_test.go
+++ b/service/notes/page_test.go
@@ -48,7 +48,7 @@ func TestTheEditorHasABody(t *testing.T) {
 
 	// A new note needs a title field; an existing one is addressed by its
 	// title, so that field is fixed and posted as it stands.
-	if fresh := editor(r, "", ""); !strings.Contains(fresh, `name="title" class="note-title-in"`) ||
+	if fresh := editor(r, "", ""); !strings.Contains(fresh, `name="title" class="record-title"`) ||
 		strings.Contains(fresh, `readonly aria-label`) {
 		t.Error("a new note should ask for a title")
 	}

--- a/service/notes/page_test.go
+++ b/service/notes/page_test.go
@@ -24,7 +24,7 @@ func TestTheListLinksIntoAnEditor(t *testing.T) {
 	if !strings.Contains(body, `href="/notes?note=shopping"`) {
 		t.Error("a note in the list does not open")
 	}
-	if !strings.Contains(body, "New note") {
+	if !strings.Contains(body, `href="/notes?new=1">New</a>`) {
 		t.Error("no way to write a new note")
 	}
 	if strings.Contains(body, "Remember that my") {


### PR DESCRIPTION
Recent service UI changes broke narrow-screen layouts: the chat roster wrapper disconnected its scroll viewport from the bounded page, and Docs included a visible native file input inside its toolbar.

- [x] Restore bounded chat scrolling and full-width composer; compact mobile roster, wrap long text and contain media.
- [x] Separate Docs New and Import actions using existing primary button styling. Import opens a draft with its file chooser expanded; supports text/Markdown as before.
- [x] Hide the native file input correctly; wrap formatting/save controls and constrain editor widths.
- [x] Left-align Blog creation on mobile and label creation actions New on Blog, Docs and Notes.
- [x] Focused chat/docs/blog/notes/app tests and vet pass; initial full build passed; formatting clean.
- [ ] Final CI and Codex review.

Browser/PWA visual verification is not available in this workspace. No release tag. Codex Cloud remains enabled.