### PR TITLE
Simplify chat roster and align room controls

### DIFF
--- a/internal/app/html/mu.css
+++ b/internal/app/html/mu.css
@@ -1876,13 +1876,11 @@ body:has(#messages) #chat-back-link {
   margin: 15px 0 0 0;
   display: flex;
   gap: 10px;
-  align-items: center;
+  align-items: stretch;
 }
 
 #chat-form button {
-  /* Width and flow only. The padding here was 10px 20px, which made the send
-     arrow taller than the field it sits beside — the height comes from the
-     control scale now. */
+  /* Stretch to the textarea height, including when it grows to more rows. */
   margin: 0;
   width: auto;
   flex-shrink: 0;
@@ -7833,8 +7831,9 @@ a.btn-secondary:hover, .btn-secondary:hover {
    are the element's own and there is no display property for .d-none to win an
    argument with. */
 .room-about {
-  margin: 0 0 14px;
-  padding: 0 0 12px;
+  flex-shrink: 0;
+  margin: 0 0 12px;
+  padding: 12px 0;
   border-bottom: 1px solid var(--border-color, #eee);
   font-size: 14px;
   line-height: 1.55;

--- a/internal/app/html/mu.js
+++ b/internal/app/html/mu.js
@@ -1079,26 +1079,14 @@ function updateUserList(users) {
     container.id = 'chat-users';
     messagesDiv.insertBefore(container, messagesDiv.firstChild);
   }
-  if (!users || users.length === 0) {
-    container.innerHTML = '';
-    return;
-  }
-  var parts = users.map(function(u) {
-    return '<a href="/@' + encodeURIComponent(u) + '" title="View profile" style="color:#555;text-decoration:none;font-weight:600;">@' + u + '</a>';
+  container.replaceChildren();
+  (users || []).forEach(function(u) {
+    var link = document.createElement('a');
+    link.href = '/@' + encodeURIComponent(u);
+    link.title = 'View profile';
+    link.textContent = '@' + u;
+    container.appendChild(link);
   });
-  // And that the agent answers, which the list does not say.
-  //
-  // The roster is people — @micro is a program, it is present in every room in
-  // the sense presence means, and listing it put a third party in a
-  // conversation between two. So it came off the list, and then the line said
-  // "In room: @asim" and micro replied to the next message: reported as "I
-  // don't know that micro is in the chat".
-  //
-  // Both halves are true and the list can only carry one of them. Being
-  // reachable by name is not being here, so the reachable half is said in
-  // words next to the people who are.
-  container.innerHTML = '<span style="color:#999;">In room: </span>' + parts.join(' &nbsp;') +
-    '<span style="color:#999;"> &nbsp;· @micro answers when you name it</span>';
 }
 
 function sendRoomMessage(form) {

--- a/service/chat/chat.go
+++ b/service/chat/chat.go
@@ -37,7 +37,7 @@ var f embed.FS
 // other, /agent is where you talk to something that acts.
 var Template = `
 %s
-<div class="room-layout"><aside class="room-roster"><h3>In this room</h3><div id="chat-users"></div><a href="/chat?view=rooms">All rooms</a></aside><div class="room-main"><div id="messages"></div>
+<div class="room-layout"><aside class="room-roster"><h3>HERE</h3><div id="chat-users"></div><a href="/chat?view=rooms">All rooms</a></aside><div class="room-main"><div id="messages"></div>
 <form id="chat-form" onsubmit="return false;">
 <input id="topic" name="topic" type="hidden">
 <textarea id="prompt" name="prompt" rows="1" placeholder="Say something" autocomplete="off" onkeydown="if(event.key==='Enter'&&!event.shiftKey){event.preventDefault();this.form.dispatchEvent(new Event('submit'))}"></textarea>
@@ -46,9 +46,10 @@ var Template = `
 /* Keep the scroll viewport connected to the page's bounded flex column. */
 body:has(#messages):has(.room-layout) #content { height:calc(100dvh - 70px - var(--tabbar)); }
 .room-layout { display:grid; grid-template-columns:160px minmax(0,1fr); grid-template-rows:minmax(0,1fr); gap:20px; flex:1 1 0; min-height:0; min-width:0; }
-.room-roster { padding:12px 0; min-width:0; overflow-y:auto; overflow-wrap:anywhere; }
-.room-roster h3 { font-size:13px; margin:0 0 12px; }
-.room-roster #chat-users a { display:block; margin-bottom:8px; }
+.room-roster { padding:0; min-width:0; overflow-y:auto; overflow-wrap:anywhere; }
+.room-roster h3 { font-size:12px; font-weight:500; letter-spacing:.04em; color:var(--text-secondary,#888); margin:0 0 8px; }
+.room-roster #chat-users { display:flex; flex-direction:column; gap:8px; margin:0 0 12px; padding:0; border:0; }
+.room-roster #chat-users a { color:inherit; font-weight:600; }
 .room-main { display:flex; flex-direction:column; min-width:0; min-height:0; }
 .room-main #messages { min-height:0; max-height:none; overflow-wrap:anywhere; }
 .room-main #messages img, .room-main #messages video { max-width:100%%; height:auto; }
@@ -57,10 +58,10 @@ body:has(#messages):has(.room-layout) #content { height:calc(100dvh - 70px - var
 .room-main #prompt { width:0; min-width:0; max-width:none; flex:1 1 0; }
 @media(max-width:760px) {
   .room-layout { grid-template-columns:minmax(0,1fr); grid-template-rows:auto minmax(0,1fr); gap:8px; }
-  .room-roster { display:flex; align-items:baseline; gap:10px; padding:0; overflow:hidden; font-size:13px; }
+  .room-roster { display:grid; grid-template-columns:auto minmax(0,1fr) auto; align-items:center; gap:10px; padding:8px 0; overflow:hidden; font-size:13px; }
   .room-roster h3 { font-size:inherit; margin:0; flex-shrink:0; }
-  .room-roster #chat-users { flex:1; min-width:0; white-space:nowrap; overflow-x:auto; border:0; margin:0; padding:0; }
-  .room-roster #chat-users a { display:inline-block; margin:0 8px 0 0; }
+  .room-roster #chat-users { flex-direction:row; gap:10px; min-width:0; white-space:nowrap; overflow-x:auto; margin:0; padding:0; }
+  .room-roster #chat-users a { flex-shrink:0; }
   .room-roster > a { flex-shrink:0; }
 }
 </style>`


### PR DESCRIPTION
Chat repeated the roster heading and injected an agent hint that wrapped awkwardly beside profile links. Send also remained shorter than the textarea.

Use HERE with profile links, a compact mobile roster with a scrollable user list and a separate All rooms link, and a vertical desktop list. Remove the duplicated label and agent hint. Stretch Send to the textarea height and give About this room equal vertical padding.

Validation: JavaScript syntax and git diff --check pass. Browser layout verification was blocked by an unavailable Chromium binary and a failed browser download. Go is not installed locally; CI will run the repository checks.