### PR TITLE
Unify page controls and simplify document editing

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -527,7 +527,7 @@ func servePage(w http.ResponseWriter, r *http.Request) {
 	// only exists here put a row of chrome above the conversation to say
 	// something the nav already says.
 	chip := `<div class="agent-bar">` +
-		`<a class="btn chat-open-list" href="` + chatPath(accountID, selAgent) + `?new=1">New chat</a>` +
+		`<a class="btn chat-open-list" href="` + chatPath(accountID, selAgent) + `?new=1">New</a>` +
 		`<button type="button" class="btn chat-open-list" onclick="muPane('chats')">Chats</button>` +
 		`</div>` + paneJS
 
@@ -742,7 +742,7 @@ func renderSessionsRail(accountID, currentID, agentID string, named bool, extra 
 	}
 	var b strings.Builder
 	b.WriteString(`<aside class="chat-rail"><button class="btn chat-new" onclick="if(window.muChatNew){muChatNew();history.replaceState(null,''` +
-		`,` + app.JSAttr(newURL) + `);document.querySelectorAll('.chat-sess.active').forEach(function(e){e.classList.remove('active')});}">New chat</button>` +
+		`,` + app.JSAttr(newURL) + `);document.querySelectorAll('.chat-sess.active').forEach(function(e){e.classList.remove('active')});}">New</button>` +
 		`<div class="chat-sess-scroll">` +
 		// Chats, which is what the store has always called them in every way
 		// but this one. The record is threads.json, the package is

--- a/agent/platform_page_test.go
+++ b/agent/platform_page_test.go
@@ -161,7 +161,7 @@ func TestTheRosterIsYourOwnAgents(t *testing.T) {
 		}
 	}
 	// And the way to make one is on it.
-	if !strings.Contains(page, "New agent") {
+	if !strings.Contains(page, `href="/agent/new" class="btn">New</a>`) {
 		t.Error("there is no way to make an agent on the page about agents")
 	}
 	// Fork is gone: it offered to copy an agent as a first-class action, on a

--- a/agent/roster_page.go
+++ b/agent/roster_page.go
@@ -228,7 +228,7 @@ func RosterHandler(w http.ResponseWriter, r *http.Request) {
 func newAgentAction(owner string) string {
 	full, have, max := AtAgentLimit(owner)
 	if !full {
-		return app.ActionLink("/agent/new", "New agent")
+		return app.ActionLink("/agent/new", "New")
 	}
 	return app.ActionLink("/account/topup", "Top up to lift the limit") +
 		fmt.Sprintf(`<p class="text-sm text-secondary mt-2 m-0">Your plan runs %d agent%s and `+

--- a/inbox/search.go
+++ b/inbox/search.go
@@ -60,11 +60,11 @@ func searchBox(box, q, csrf string) string {
 	if action == "" {
 		action = "/inbox"
 	}
-	return `<form class="ib-search" method="POST" action="` + html.EscapeString(action) + `">` +
+	return `<form class="search-bar" method="POST" action="` + html.EscapeString(action) + `">` +
 		app.CSRFField(csrf) +
 		`<input type="search" name="q" placeholder="Search your conversations" ` +
-		`value="` + html.EscapeString(q) + `" autocomplete="off" class="ib-search-in">` +
-		`<button type="submit" class="btn btn-quiet">Search</button>` +
+		`value="` + html.EscapeString(q) + `" autocomplete="off">` +
+		`<button type="submit">Search</button>` +
 		clearSearch(action, q) +
 		`</form>`
 }

--- a/internal/api/service_ref.go
+++ b/internal/api/service_ref.go
@@ -70,7 +70,6 @@ func serveServiceReference(w http.ResponseWriter, r *http.Request, name string) 
 func serviceRef(spec service.Spec, who service.Viewer, base string) string {
 	var b strings.Builder
 	b.WriteString(`<div class="svc-page">`)
-	b.WriteString(`<p class="svc-lead">` + html.EscapeString(spec.Description) + `</p>`)
 
 	// The demonstration, first, and it is the argument the whole instance
 	// makes: a page showing today's actual forecast is the difference between

--- a/internal/api/service_ref_test.go
+++ b/internal/api/service_ref_test.go
@@ -66,7 +66,6 @@ func TestAServiceReferenceIsDerivedFromItsSpec(t *testing.T) {
 		"Read the things",              // the doc off the Endpoint
 		"query",                        // the declared argument
 		`href="/refprobe"`,             // the way out to the service itself
-		"A service to render a reference for",
 	} {
 		if !strings.Contains(out, want) {
 			t.Errorf("the reference does not carry %q", want)

--- a/internal/app/html/mu.css
+++ b/internal/app/html/mu.css
@@ -4675,7 +4675,12 @@ a.card-hover:hover {
    ======================================== */
 
 .page-action {
-  margin-bottom: 16px;
+  display:flex;
+  flex-wrap:wrap;
+  align-items:center;
+  gap:8px;
+  width:100%;
+  margin:0 0 16px;
 }
 
 .page-filters {
@@ -8026,7 +8031,7 @@ a:hover, a:hover * { text-decoration: none !important; }
 .collection-title { font-size:14px; font-weight:600; overflow-wrap:anywhere; }
 .collection-preview { grid-column:1; font-size:13px; color:var(--text-muted,#666); overflow-wrap:anywhere; }
 .collection-when { grid-column:2; grid-row:1; font-size:12px; color:var(--text-muted,#888); }
-.record-card { width:100%; max-width:794px; min-width:0; box-sizing:border-box; }
+.record-card { width:100%; max-width:100%; min-width:0; box-sizing:border-box; }
 .record-editor { display:flex; flex-direction:column; gap:12px; min-width:0; }
 .record-editor > * { min-width:0; max-width:100%; box-sizing:border-box; }
 .record-editor input.record-title { width:100%; font:inherit; font-size:19px; font-weight:600; padding:9px 0; border:0; border-bottom:1px solid var(--border-color,#eee); background:transparent; }
@@ -8037,4 +8042,20 @@ a:hover, a:hover * { text-decoration: none !important; }
  .collection-item { grid-template-columns:minmax(0,1fr); }
  .collection-when { grid-column:1; grid-row:auto; }
  .record-editor input.record-title,.record-editor textarea.record-body { font-size:16px; }
+}
+
+/* Editor actions belong above the sheet and stay available while writing. */
+.record-controls { position:sticky; top:50px; z-index:10; display:flex; flex-direction:column; gap:10px; padding:10px 0; background:var(--card-background,#fff); border-bottom:1px solid var(--border-color,#eee); }
+.record-controls .record-actions { justify-content:space-between; }
+.search-bar { width:100%; min-width:0; align-items:stretch; }
+.search-bar input:not([type=hidden]) { flex:1 1 0; min-width:0; margin:0; }
+.search-bar button { margin:0; }
+.search-bar select { width:auto; max-width:40%; flex:0 1 auto; }
+.collection-head > .search-bar { margin-bottom:0; }
+
+/* New is the first action under a page title; search-led pages keep its edge. */
+.collection-head > .page-action { margin-bottom:0; }
+@media(max-width:900px) {
+ .record-controls { top:44px; }
+ .page-action:first-child, #page-title + .page-action { justify-content:center; }
 }

--- a/service/apps/apps.go
+++ b/service/apps/apps.go
@@ -516,7 +516,6 @@ func handleList(w http.ResponseWriter, r *http.Request) {
 
 	// HTML
 	var sb strings.Builder
-	sb.WriteString(`<p class="card-desc">Small, useful apps that do one thing well. Build apps, set your price, keep every penny of every sale.</p>`)
 
 	// Building one is the point of the page, so it is a button at the top
 	// rather than a line of text under however many apps happen to be listed —
@@ -530,7 +529,7 @@ func handleList(w http.ResponseWriter, r *http.Request) {
 	// stylesheet outrank a plain class and turn a white label on a black button
 	// black on black. There is a comment about it on connect-cta too. Third
 	// time; hence using the shared thing.
-	sb.WriteString(`<p class="m-0 mb-4">` + app.ActionLink("/apps/new", "New app") + `</p>`)
+	sb.WriteString(`<div class="page-action">` + app.ActionLink("/apps/new", "New") + `</div>`)
 
 	// Pricing filter
 	pricing := r.URL.Query().Get("pricing")
@@ -727,7 +726,6 @@ func handleNew(w http.ResponseWriter, r *http.Request) {
 	// Two boxes that both claim to build an app from a sentence is the thing
 	// to avoid here, and the one to delete is the one that cannot iterate. What
 	// stays on this page is the other job entirely: pasting HTML you wrote.
-	sb.WriteString(`<p class="card-desc">Describe what you want and it gets written, checked and run — then you say what to change.</p>`)
 	sb.WriteString(`<p class="col-narrow mb-2">` + app.ActionLink("/agent/micro", "Describe an app to Micro") + `</p>`)
 	sb.WriteString(`<details class="col-narrow mt-5"><summary class="clickable text-secondary text-base">Write the HTML yourself</summary>`)
 	sb.WriteString(`<form method="POST" action="/apps/new" class="mt-4">`)

--- a/service/apps/embed.go
+++ b/service/apps/embed.go
@@ -103,8 +103,6 @@ func handleEmbed(w http.ResponseWriter, r *http.Request, slug string) {
 	b.WriteString(app.Actions(app.TextLink("← Apps", "/apps"),
 		app.TextLink("Open "+a.Name, "/apps/"+a.Slug)))
 	b.WriteString(`<h2 class="embed-title">Embed ` + html.EscapeString(a.Name) + `</h2>`)
-	b.WriteString(`<p class="embed-lead">An app is a page at a URL. Put this on ` +
-		`any site and it runs there, sandboxed, the same way it runs here.</p>`)
 
 	// Paid apps are not offered. ?raw=1 is what the tag points at and it is the
 	// path that does not charge — see handleApp, where the count and the charge

--- a/service/apps/newbutton_test.go
+++ b/service/apps/newbutton_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 func TestTheNewAppButtonIsTheSharedButton(t *testing.T) {
-	want := app.ActionLink("/apps/new", "New app")
+	want := app.ActionLink("/apps/new", "New")
 	if !strings.Contains(want, `class="btn"`) {
 		t.Fatalf("ActionLink no longer renders the shared button class: %s", want)
 	}
@@ -47,7 +47,7 @@ func TestTheAppsPageDoesNotRollItsOwnButton(t *testing.T) {
 	// app happens and not a change to how the button is drawn — the one thing
 	// this test exists to hold. Where it goes is
 	// TestThereIsOneBoxThatBuildsAnAppFromASentence's business.
-	if !strings.Contains(src, `"New app"`) {
+	if !strings.Contains(src, `"New"`) {
 		t.Fatal("there is no new-app button on the apps page at all")
 	}
 	if !strings.Contains(src, `app.ActionLink(`) {

--- a/service/archive/page.go
+++ b/service/archive/page.go
@@ -77,18 +77,14 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 
 	var b strings.Builder
 	b.WriteString(`<div class="ar">`)
-	b.WriteString(`<p class="lens-lead">Everything this server has collected and kept — headlines, ` +
-		`video, market moves, what it has written. It archives as it goes, so this is what it ` +
-		`knew as well as what it knows. One search across all of it. What you have said to an ` +
-		`agent is somewhere else that it can ` + app.TextLink("Recall", "/recall") + `.</p>`)
 
-	b.WriteString(`<form method="GET" action="/archive" class="ar-form">`)
+	b.WriteString(`<form method="GET" action="/archive" class="search-bar">`)
 	if kind != "" {
 		b.WriteString(`<input type="hidden" name="kind" value="` + html.EscapeString(kind) + `">`)
 	}
-	b.WriteString(`<input class="ar-input" type="search" name="q" placeholder="Search the archive" ` +
+	b.WriteString(`<input type="search" name="q" placeholder="Search the archive" ` +
 		`value="` + html.EscapeString(query) + `" autofocus>` +
-		`<button class="ar-go" type="submit">Search</button></form>`)
+		`<button type="submit">Search</button></form>`)
 
 	b.WriteString(kindChips(kinds, query, kind))
 
@@ -203,10 +199,6 @@ func kindChips(kinds []data.Kind, query, active string) string {
 
 const pageCSS = `<style>
 .ar{max-width:var(--measure,760px)}
-.ar-form{display:flex;gap:8px;margin:0 0 14px}
-.ar-input{flex:1;font:inherit;font-size:15px;padding:9px 13px;border:1px solid #e2e2e2;border-radius:8px}
-.ar-input:focus{outline:none;border-color:#bbb}
-.ar-go{font:inherit;font-size:14px;padding:8px 18px;border:1px solid #111;background:#111;color:#fff;border-radius:8px;cursor:pointer}
 .ar-empty{font-size:14px;color:#888;line-height:1.6}
 .ar-row{padding:12px 0;border-bottom:1px solid #f4f4f4}
 /* A kind and a time are two facts, and this had nothing between them — the pill
@@ -219,8 +211,4 @@ const pageCSS = `<style>
 .ar-title{font-size:15px;color:#111;font-weight:500;text-decoration:none;display:block}
 a.ar-title:hover{text-decoration:underline}
 .ar-body{font-size:13px;color:#888;line-height:1.55;margin-top:3px}
-@media (max-width:640px){
-  .ar-form{flex-wrap:wrap}
-  .ar-input{flex-basis:100%}
-}
 </style>`

--- a/service/blog/blog.go
+++ b/service/blog/blog.go
@@ -951,7 +951,7 @@ func handleGetBlog(w http.ResponseWriter, r *http.Request) {
 			// where the rest of the operator's work is. A second door to it on
 			// a reading page put the operator's job in front of everybody
 			// else's page, and made the one place moderation lives two.
-			actions = `<div class="mb-4">
+			actions = `<div class="page-action">
 				<a href="/blog?write=true" class="btn">New</a>
 			</div>`
 		} else {
@@ -960,7 +960,7 @@ func handleGetBlog(w http.ResponseWriter, r *http.Request) {
 				<a href="/login?redirect=/blog" class="text-muted">Login</a> to write a post
 			</div>`
 		}
-		actions += `<form method="GET" action="/blog" class="d-flex gap-2 mb-4"><input type="search" name="q" class="grow" placeholder="Search posts" aria-label="Search posts" value="` + stdhtml.EscapeString(query) + `"><button type="submit">Search</button></form>`
+		actions = `<form method="GET" action="/blog" class="search-bar"><input type="search" name="q" class="grow" placeholder="Search posts" aria-label="Search posts" value="` + stdhtml.EscapeString(query) + `"><button type="submit">Search</button></form>` + actions
 		content = fmt.Sprintf(`<div id="blog">
 			%s
 			<div id="posts-list">

--- a/service/bookmarks/page.go
+++ b/service/bookmarks/page.go
@@ -96,7 +96,7 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	var b strings.Builder
-	b.WriteString(`<div class="bookmarks-page"><p class="lens-lead">Your reading, kept privately. Save something while browsing, then come back to it or ask Micro about it.</p>`)
+	b.WriteString(`<div class="bookmarks-page">`)
 	if ref := r.URL.Query().Get("item"); ref != "" {
 		item, e := store.Source(ref)
 		if e != nil {
@@ -128,7 +128,7 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 			app.RespondJSON(w, map[string]any{"items": items, "total": total})
 			return
 		}
-		b.WriteString(`<form method="POST" action="/bookmarks/search" class="bookmarks-search">` + token(r) + `<input type="search" name="query" value="` + html.EscapeString(query) + `" placeholder="Search your saved items"><select name="kind" aria-label="Content type">`)
+		b.WriteString(`<form method="POST" action="/bookmarks/search" class="search-bar">` + token(r) + `<input type="search" name="query" value="` + html.EscapeString(query) + `" placeholder="Search your saved items"><select name="kind" aria-label="Content type">`)
 		for _, k := range []string{"", "article", "video", "post", "link"} {
 			selected := ""
 			if k == kind {
@@ -163,7 +163,7 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 		}
 		b.WriteString(`</div><details><summary>Add a link</summary><form method="POST" action="/bookmarks" class="bookmarks-add">` + token(r) + hidden("action", "add") + `<input name="url" type="url" required maxlength="4096" placeholder="https://…" aria-label="Link"><input name="title" maxlength="1000" placeholder="Title" aria-label="Title"><button>Save link</button></form></details>`)
 	}
-	b.WriteString(`</div>` + app.ReadingCSS + `<style>.bookmarks-page{max-width:800px}.bookmarks-search,.bookmarks-add{display:flex;gap:8px;flex-wrap:wrap;margin-bottom:20px}.bookmarks-search input{flex:1;min-width:160px}.bookmarks-page textarea{display:block;width:100%;box-sizing:border-box;margin:8px 0}.bookmarks-add{margin-top:12px}</style>`)
+	b.WriteString(`</div>` + app.ReadingCSS + `<style>.bookmarks-page{max-width:800px}.bookmarks-add{display:flex;gap:8px;flex-wrap:wrap;margin-bottom:20px}.bookmarks-page textarea{display:block;width:100%;box-sizing:border-box;margin:8px 0}.bookmarks-add{margin-top:12px}</style>`)
 	app.Respond(w, r, app.Response{Title: "Bookmarks", Description: "Your private saved reading", HTML: b.String()})
 }
 func hidden(name, value string) string {

--- a/service/browser/page.go
+++ b/service/browser/page.go
@@ -66,9 +66,6 @@ func hexID(s string) bool {
 func Handler(w http.ResponseWriter, r *http.Request) {
 	var b strings.Builder
 	b.WriteString(`<div class="browser-page">`)
-	b.WriteString(`<p class="svc-lead">` + Spec.Description + `. Most of the web builds ` +
-		`itself in the browser, so a plain fetch of it comes back with a nav bar and an ` +
-		`empty box — this is what the page actually says once its scripts have run.</p>`)
 
 	if !Configured() {
 		b.WriteString(app.Problem("This instance has no browser and could not find one on " +

--- a/service/contacts/handler.go
+++ b/service/contacts/handler.go
@@ -115,8 +115,6 @@ func listPage(w http.ResponseWriter, r *http.Request) {
 
 	var b strings.Builder
 	b.WriteString(`<div class="card">`)
-	b.WriteString(`<p class="text-sm text-muted">Names your agent can turn into addresses. ` +
-		`Ask it to mail someone and it looks them up here.</p>`)
 
 	if msg := r.URL.Query().Get("error"); msg != "" {
 		b.WriteString(`<p class="text-error">` + html.EscapeString(msg) + `</p>`)
@@ -125,7 +123,7 @@ func listPage(w http.ResponseWriter, r *http.Request) {
 	// POST: an address book is a list of the people somebody knows, and the name
 	// they looked up is not a thing to write into a URL. See AGENTS.md, "What may
 	// travel in a URL".
-	fmt.Fprintf(&b, `<form method="POST" action="/contacts" class="contact-search">
+	fmt.Fprintf(&b, `<form method="POST" action="/contacts" class="search-bar">
   <input type="hidden" name="_csrf" value="%s">
   <input type="search" name="q" value="%s" placeholder="Search by name or address">
   <button type="submit">Search</button>

--- a/service/docs/editor.go
+++ b/service/docs/editor.go
@@ -11,11 +11,7 @@ const editorTools = `<div class="doc-toolbar" role="group" aria-label="Text form
 <button type="button" data-before="&#96;" data-after="&#96;">Code</button>
 </div>`
 
-const importTools = `<label class="btn" tabindex="0" role="button" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();document.getElementById('doc-import').click()}">Choose file<input id="doc-import" type="file" accept=".txt,.md,.markdown,text/plain,text/markdown" hidden></label>
-<p id="doc-import-status" class="text-sm text-muted" role="status">Import a Markdown or plain-text file, then save it as a document.</p>`
-
 const editorScript = `<script>(function(){
-var body=document.getElementById('doc-body'),pick=document.getElementById('doc-import');if(!body||body.dataset.editorWired)return;body.dataset.editorWired='1';
+var body=document.getElementById('doc-body');if(!body||body.dataset.editorWired)return;body.dataset.editorWired='1';
 document.querySelectorAll('.doc-toolbar button').forEach(function(b){b.addEventListener('click',function(){var start=body.selectionStart,end=body.selectionEnd,text=body.value.slice(start,end),before=b.dataset.before||'',after=b.dataset.after||'';if(b.dataset.line){start=body.value.lastIndexOf('\n',start-1)+1;text=body.value.slice(start,end).split('\n').map(function(line){return before+line}).join('\n');before='';}body.setRangeText(before+text+after,start,end,'select');body.focus();body.dispatchEvent(new Event('input',{bubbles:true}));});});
-pick.addEventListener('change',async function(){var file=pick.files[0],status=document.getElementById('doc-import-status');if(!file)return;if(file.size>1048576){status.textContent='Choose a file up to 1 MB.';return;}if(!/\.(txt|md|markdown)$/i.test(file.name)){status.textContent='Choose a Markdown or plain-text file.';return;}if(body.value.trim()&&!confirm('Replace the current draft with this file?'))return;try{var text=new TextDecoder('utf-8',{fatal:true}).decode(await file.arrayBuffer());if(text.includes('\u0000'))throw new Error();body.value=text;var title=document.getElementById('doc-title');if(!title.value)title.value=file.name.replace(/\.[^.]+$/,'');status.textContent='Imported into this draft. Save to keep it.';body.dispatchEvent(new Event('input',{bubbles:true}));}catch(e){status.textContent='Could not import this file. Use UTF-8 plain text or Markdown.';}pick.value='';});
 })();</script>`

--- a/service/docs/handler.go
+++ b/service/docs/handler.go
@@ -30,12 +30,22 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 	}
 	who := sess.Account
 
-	if r.Method == http.MethodPost {
-		handlePost(w, r, who)
+	if r.Method == http.MethodPost && r.URL.Query().Get("import") == "1" {
+		handleImport(w, r)
 		return
 	}
-
 	query := strings.TrimSpace(r.URL.Query().Get("q"))
+	if r.Method == http.MethodPost {
+		if err := r.ParseForm(); err != nil {
+			app.BadRequest(w, r, "could not read the form")
+			return
+		}
+		if r.PostForm.Get("action") != "search" {
+			handlePost(w, r, who)
+			return
+		}
+		query = strings.TrimSpace(r.PostForm.Get("q"))
+	}
 	docs := All(who, query, 0)
 
 	if app.WantsJSON(r) {
@@ -45,23 +55,27 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 
 	// One document open, or the list.
 	var body string
+	title := "Docs"
 	switch {
+	case r.URL.Query().Get("import") == "1":
+		body = importPage(r, "")
+		title = "Import document"
 	case r.URL.Query().Get("new") == "1":
 		body = editor(r, nil)
 	case r.URL.Query().Get("id") != "":
 		d := Get(who, r.URL.Query().Get("id"))
 		if d == nil {
-			body = notice("No such document.") + list(docs, query)
+			body = notice("No such document.") + list(r, docs, query)
 		} else if r.URL.Query().Get("edit") == "1" {
 			body = editor(r, d)
 		} else {
 			body = view(r, d)
 		}
 	default:
-		body = list(docs, query)
+		body = list(r, docs, query)
 	}
 
-	app.Respond(w, r, app.Response{Title: "Docs", Description: "Your own documents", HTML: body + pageCSS})
+	app.Respond(w, r, app.Response{Title: title, Description: "Your own documents", HTML: body + pageCSS})
 }
 
 // handlePost saves or deletes.
@@ -94,14 +108,15 @@ func handlePost(w http.ResponseWriter, r *http.Request, who string) {
 }
 
 // list is every document, newest change first.
-func list(docs []*Doc, query string) string {
+func list(r *http.Request, docs []*Doc, query string) string {
 	var b strings.Builder
 	b.WriteString(`<div class="collection-head">`)
-	b.WriteString(`<form method="GET" action="/docs" class="doc-search">` +
-		`<input type="text" name="q" value="` + html.EscapeString(query) +
+	b.WriteString(`<form method="POST" action="/docs" class="search-bar">` + app.CSRFField(auth.CSRFToken(r)) +
+		`<input type="hidden" name="action" value="search">` +
+		`<input type="search" name="q" value="` + html.EscapeString(query) +
 		`" placeholder="Search your documents" autocomplete="off">` +
 		`<button type="submit">Search</button></form>`)
-	b.WriteString(`<div class="doc-create"><a class="btn" href="/docs?new=1">New</a><a class="btn" href="/docs?new=1&amp;import=1">Import</a></div>`)
+	b.WriteString(`<div class="page-action"><a class="btn" href="/docs?new=1">New</a><a class="btn" href="/docs?import=1">Import</a></div>`)
 	b.WriteString(`</div>`)
 
 	if len(docs) == 0 {
@@ -126,7 +141,7 @@ func view(r *http.Request, d *Doc) string {
 	var b strings.Builder
 	b.WriteString(`<div class="collection-head"><a class="doc-back" href="/docs">← Documents</a>`)
 	b.WriteString(`<a class="doc-new" href="/docs?id=` + html.EscapeString(d.ID) + `&amp;edit=1">Edit</a></div>`)
-	b.WriteString(`<article class="card doc-view">`)
+	b.WriteString(`<article class="card record-card doc-view">`)
 	b.WriteString(`<h2>` + html.EscapeString(d.Title) + `</h2>`)
 	// Untrusted: this is one account's content and may be published to others.
 	b.WriteString(string(app.Render([]byte(d.Content))))
@@ -153,20 +168,17 @@ func editor(r *http.Request, d *Doc) string {
 	if d.ID != "" {
 		back = `<a class="doc-back" href="/docs?id=` + html.EscapeString(d.ID) + `">← Back</a>`
 	}
-	importOpen := ""
-	if r.URL.Query().Get("import") == "1" {
-		importOpen = " open"
-	}
-	return `<div class="collection-head">` + back + `</div>
-<form method="POST" action="/docs" class="card record-card record-editor">
+	return `<form method="POST" action="/docs" class="record-editor">
 <input type="hidden" name="id" value="` + html.EscapeString(d.ID) + `">
-<input type="hidden" name="csrf_token" value="` + html.EscapeString(auth.CSRFToken(r)) + `">
+<input type="hidden" name="_csrf" value="` + html.EscapeString(auth.CSRFToken(r)) + `">
+<div class="record-controls">
+<div class="record-actions">` + back + `<button type="submit">Save</button></div>
+` + editorTools + `</div>
+<div class="card record-card record-editor">
 <input id="doc-title" class="record-title" type="text" name="title" value="` + html.EscapeString(d.Title) + `" placeholder="Title" autocomplete="off" autofocus>
-` + editorTools + `<details class="doc-import-panel"` + importOpen + `><summary>Import</summary>` + importTools + `</details><textarea id="doc-body" class="record-body" name="content" rows="32" placeholder="Write. Markdown works.">` + html.EscapeString(d.Content) + `</textarea>
-<div class="record-actions">
-<label class="doc-public"><input type="checkbox" name="public"` + checked + `> Anyone with the link can read it</label>
-<button type="submit">Save</button>
+<textarea id="doc-body" class="record-body" name="content" rows="24" placeholder="Write. Markdown works.">` + html.EscapeString(d.Content) + `</textarea>
 </div>
+<label class="doc-public"><input type="checkbox" name="public"` + checked + `> Anyone with the link can read it</label>
 </form>` + editorScript
 }
 
@@ -175,16 +187,10 @@ func notice(msg string) string {
 }
 
 const pageCSS = `<style>
-.doc-search{display:flex;gap:8px;width:100%}
-.doc-search input{flex:1;min-width:0}
-.doc-create{display:flex;gap:8px;flex-wrap:wrap}
 .doc-back{font-size:14px;color:#888;text-decoration:none}
 .doc-new{font-size:14px;padding:6px 14px;border:1px solid #ccc;border-radius:6px;color:#111;text-decoration:none}
 .doc-toolbar{display:flex;flex-wrap:wrap;gap:6px}
 .doc-toolbar button{flex:0 0 auto;margin:0}
-.doc-import-panel input[type=file]{display:none}
-.doc-import-panel summary{cursor:pointer;margin-bottom:8px}
-.doc-import-panel p{margin:8px 0 0}
 .doc-view{overflow-wrap:anywhere}
 .doc-view h2{margin:0 0 12px}
 .doc-view img{max-width:100%}
@@ -193,5 +199,5 @@ const pageCSS = `<style>
 .doc-meta{font-size:12px;color:#888;display:flex;flex-wrap:wrap;align-items:center;gap:10px;margin:10px 2px 0}
 .doc-meta form{display:inline;margin:0}
 .doc-delete{background:none;border:none;color:#c00;font-size:12px;padding:0;cursor:pointer}
-.doc-public{min-width:0;flex:1 1 200px;font-size:13px;color:#888;display:flex;align-items:center;gap:6px}
+.doc-public{min-width:0;font-size:13px;color:#888;display:flex;align-items:center;gap:6px}
 </style>`

--- a/service/docs/import.go
+++ b/service/docs/import.go
@@ -1,0 +1,61 @@
+package docs
+
+import (
+	"html"
+	"io"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"unicode/utf8"
+
+	"mu/internal/app"
+	"mu/internal/auth"
+)
+
+// Import is a file-selection page. Reading a file opens an unsaved draft;
+// only the editor's Save action writes a document.
+func importPage(r *http.Request, message string) string {
+	return `<div class="collection-head"><a class="doc-back" href="/docs">← Documents</a></div>` +
+		`<form method="POST" action="/docs?import=1" enctype="multipart/form-data" class="record-editor">` +
+		app.CSRFField(auth.CSRFToken(r)) +
+		`<label for="doc-file">Choose a Markdown or plain-text file</label>` +
+		`<input id="doc-file" type="file" name="file" accept=".txt,.md,.markdown,text/plain,text/markdown" required>` +
+		`<p class="text-sm text-muted">UTF-8 text, up to 200 KB. Review the draft before saving.</p>` +
+		`<p role="status">` + html.EscapeString(message) + `</p>` +
+		`<div class="record-actions"><button type="submit">Open draft</button></div></form>`
+}
+
+func handleImport(w http.ResponseWriter, r *http.Request) {
+	fail := func(message string) {
+		app.Respond(w, r, app.Response{Title: "Import document", HTML: importPage(r, message) + pageCSS})
+	}
+	r.Body = http.MaxBytesReader(w, r.Body, maxBody+64*1024)
+	if err := r.ParseMultipartForm(maxBody + 64*1024); err != nil {
+		fail("Choose a text file up to 200 KB.")
+		return
+	}
+	defer r.MultipartForm.RemoveAll()
+	file, header, err := r.FormFile("file")
+	if err != nil {
+		fail("Choose a file to import.")
+		return
+	}
+	defer file.Close()
+	ext := strings.ToLower(filepath.Ext(header.Filename))
+	if ext != ".txt" && ext != ".md" && ext != ".markdown" {
+		fail("Choose a Markdown or plain-text file.")
+		return
+	}
+	content, err := io.ReadAll(io.LimitReader(file, maxBody+1))
+	if err != nil || len(content) > maxBody {
+		fail("Choose a text file up to 200 KB.")
+		return
+	}
+	if !utf8.Valid(content) || strings.ContainsRune(string(content), '\x00') {
+		fail("Use UTF-8 plain text or Markdown.")
+		return
+	}
+	title := strings.TrimSuffix(header.Filename, filepath.Ext(header.Filename))
+	draft := &Doc{Title: title, Content: strings.TrimPrefix(string(content), "\ufeff")}
+	app.Respond(w, r, app.Response{Title: "Docs", HTML: editor(r, draft) + pageCSS})
+}

--- a/service/docs/import_test.go
+++ b/service/docs/import_test.go
@@ -1,0 +1,65 @@
+package docs
+
+import (
+	"bytes"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestImportOpensDraftWithoutSaving(t *testing.T) {
+	const owner = "import_draft"
+	var body bytes.Buffer
+	form := multipart.NewWriter(&body)
+	file, err := form.CreateFormFile("file", "A plan.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+	file.Write([]byte("# A plan\n\nRead before saving."))
+	form.Close()
+	r := signedIn(t, owner, "POST", "/docs?import=1", nil)
+	r.Body = io.NopCloser(&body)
+	r.Header.Set("Content-Type", form.FormDataContentType())
+	w := httptest.NewRecorder()
+	Handler(w, r)
+	if w.Code != http.StatusOK || !strings.Contains(w.Body.String(), "Read before saving.") || !strings.Contains(w.Body.String(), `value="A plan"`) {
+		t.Fatal("file did not open as an editable draft")
+	}
+	if len(shown(t, owner)) != 0 {
+		t.Fatal("import saved without review")
+	}
+	if strings.Contains(w.Body.String(), `type="file"`) {
+		t.Fatal("file picker leaked into editor")
+	}
+}
+
+func TestImportRejectsInvalidFiles(t *testing.T) {
+	for _, tc := range []struct{ name, content, want string }{
+		{"bad.pdf", "text", "Markdown or plain-text"},
+		{"bad.txt", string([]byte{255}), "UTF-8"},
+		{"bad.md", "text\x00binary", "UTF-8"},
+		{"large.txt", strings.Repeat("a", maxBody+1), "200 KB"},
+	} {
+		t.Run(tc.name+tc.want, func(t *testing.T) {
+			var body bytes.Buffer
+			form := multipart.NewWriter(&body)
+			file, err := form.CreateFormFile("file", tc.name)
+			if err != nil {
+				t.Fatal(err)
+			}
+			file.Write([]byte(tc.content))
+			form.Close()
+			r := signedIn(t, "import_invalid", "POST", "/docs?import=1", nil)
+			r.Body = io.NopCloser(&body)
+			r.Header.Set("Content-Type", form.FormDataContentType())
+			w := httptest.NewRecorder()
+			Handler(w, r)
+			if !strings.Contains(w.Body.String(), tc.want) || strings.Contains(w.Body.String(), `id="doc-body"`) {
+				t.Fatal("invalid file opened as a draft")
+			}
+		})
+	}
+}

--- a/service/docs/page_test.go
+++ b/service/docs/page_test.go
@@ -159,3 +159,16 @@ func TestThePageRefusesAGuest(t *testing.T) {
 		t.Errorf("a guest got %d rather than a redirect to sign in", w.Code)
 	}
 }
+
+func TestSearchDoesNotSaveADocument(t *testing.T) {
+	const owner = "docs_search"
+	post(t, owner, url.Values{"title": {"A plan"}, "content": {"private phrase"}})
+	w := httptest.NewRecorder()
+	Handler(w, signedIn(t, owner, "POST", "/docs", url.Values{"action": {"search"}, "q": {"private phrase"}}))
+	if w.Code != http.StatusOK || !strings.Contains(w.Body.String(), "A plan") {
+		t.Fatal("search did not return the matching document")
+	}
+	if len(shown(t, owner)) != 1 {
+		t.Fatal("search changed the document collection")
+	}
+}

--- a/service/files/handler.go
+++ b/service/files/handler.go
@@ -180,8 +180,8 @@ func listPage(w http.ResponseWriter, r *http.Request) {
 	var b strings.Builder
 	// No heading here: the page is already titled Files by the shell, and a
 	// card that repeats the page title just costs a phone a line of screen.
-	b.WriteString(`<p><a class="btn" href="/files?new=1">New file</a></p><div class="card">`)
-	b.WriteString(`<p class="text-sm text-muted">Anything you or your agent has stored. Using ` +
+	b.WriteString(`<div class="page-action"><a class="btn" href="/files?new=1">New</a></div><div class="card">`)
+	b.WriteString(`<p class="text-sm text-muted">Using ` +
 		human(UsedBytes(sess.Account)) + ` of ` + human(MaxOwnerBytes) + `.</p>`)
 
 	if msg := r.URL.Query().Get("error"); msg != "" {

--- a/service/food/page.go
+++ b/service/food/page.go
@@ -24,9 +24,6 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 	rating := strings.TrimSpace(q.Get("rating"))
 
 	var b strings.Builder
-	b.WriteString(`<p class="card-desc">What is in a packet, and whether the kitchen is clean. ` +
-		`Ingredients and allergens from Open Food Facts; hygiene ratings from the Food ` +
-		`Standards Agency. Both public, neither needs a key.</p>`)
 
 	b.WriteString(`<div class="card"><h3>Products</h3><form class="food-form" method="get" action="/food">`)
 	fmt.Fprintf(&b, `<input class="food-input" type="text" name="q" value="%s" placeholder="Find a product — oat milk" aria-label="Product name">`,

--- a/service/images/images.go
+++ b/service/images/images.go
@@ -520,13 +520,13 @@ func handleHTML(w http.ResponseWriter, r *http.Request) {
 
 	auth.SetCSRFCookie(w, r)
 	if caller != "" {
-		b.WriteString(`<div class="card"><form method="POST" action="/images?web=1" class="d-flex gap-2">` + app.CSRFField(auth.CSRFToken(r)) + `<input name="query" class="grow" placeholder="Search images on the web" required maxlength="400"><button>Search web</button></form></div>`)
+		b.WriteString(`<div class="card"><form method="POST" action="/images?web=1" class="search-bar">` + app.CSRFField(auth.CSRFToken(r)) + `<input name="query" class="grow" placeholder="Search images on the web" required maxlength="400"><button>Search web</button></form></div>`)
 		b.WriteString(uploadForm(r))
 	}
 	// Search box — searches your images plus the public stock pool.
-	b.WriteString(`<div class="card"><form method="GET" action="/images" class="d-flex gap-2 m-0">`)
-	b.WriteString(`<input name="q" value="` + html.EscapeString(q) + `" placeholder="Search your image library…" class="form-input grow text-base">`)
-	b.WriteString(`<button type="submit" class="text-base">Search</button>`)
+	b.WriteString(`<div class="card"><form method="GET" action="/images" class="search-bar">`)
+	b.WriteString(`<input name="q" value="` + html.EscapeString(q) + `" placeholder="Search your image library…">`)
+	b.WriteString(`<button type="submit">Search</button>`)
 	b.WriteString(`</form></div>`)
 
 	// Search results.
@@ -561,7 +561,6 @@ func handleHTML(w http.ResponseWriter, r *http.Request) {
 	if past := pastDailies(d.Date, 60); len(past) > 0 {
 		b.WriteString(`<div class="card">`)
 		b.WriteString(`<h3>Past dailies</h3>`)
-		b.WriteString(`<p class="card-desc">Every daily image Mu has generated, kept on this server.</p>`)
 		b.WriteString(`<div class="thumb-grid">`)
 		for _, e := range past {
 			title := strings.Title(e.Theme) + " · " + e.Date
@@ -575,7 +574,6 @@ func handleHTML(w http.ResponseWriter, r *http.Request) {
 	// Generate panel.
 	b.WriteString(`<div class="card">`)
 	b.WriteString(`<h3>Generate an image</h3>`)
-	b.WriteString(`<p class="card-desc">Describe an image and Mu creates it with nano-banana.</p>`)
 	if acc == nil {
 		b.WriteString(`<p><a href="/login">Sign in</a> to generate images.</p>`)
 	} else {
@@ -619,7 +617,6 @@ func handleHTML(w http.ResponseWriter, r *http.Request) {
 	if len(stock) > 0 {
 		b.WriteString(`<div class="card">`)
 		b.WriteString(`<h3>Community stock</h3>`)
-		b.WriteString(`<p class="card-desc">Public images shared by the community — free to reuse.</p>`)
 		b.WriteString(imageGrid(stock))
 		b.WriteString(`</div>`)
 	}

--- a/service/mail/mail.go
+++ b/service/mail/mail.go
@@ -1169,7 +1169,7 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 		}
 		pageHTML := app.Page(app.PageOpts{
 			Action:  "/mail?compose=true",
-			Label:   "Compose",
+			Label:   "New",
 			Content: mailSearchBar(q, auth.CSRFToken(r)) + content,
 		})
 		app.Respond(w, r, app.Response{Title: "Mail — Search", Description: "", HTML: pageHTML})
@@ -1435,7 +1435,7 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 
 	pageHTML := app.Page(app.PageOpts{
 		Action:  "/mail?compose=true",
-		Label:   "Compose",
+		Label:   "New",
 		Filters: tabs,
 		Content: addressPanel(acc.ID) + tagFilter(userInbox, acc.ID, viewTag) + searchBar +
 			`<div id="mailbox">` + content + `</div>`,
@@ -2384,9 +2384,9 @@ func searching(r *http.Request) bool {
 // had to be changed together — which is how a form gets switched to POST in one
 // place and left as a GET in the other.
 func mailSearchBar(q, csrf string) string {
-	return `<form action="/mail" method="POST" class="mb-3 d-flex gap-2">` +
+	return `<form action="/mail" method="POST" class="search-bar">` +
 		app.CSRFField(csrf) +
 		`<input type="text" name="q" value="` + html.EscapeString(q) + `" ` +
-		`placeholder="Search mail..." class="form-input grow text-base">` +
+		`placeholder="Search mail...">` +
 		`<button type="submit" class="btn">Search</button></form>`
 }

--- a/service/maps/page.go
+++ b/service/maps/page.go
@@ -129,9 +129,6 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 
 	var b strings.Builder
 	b.WriteString(`<div class="maps-page">`)
-	b.WriteString(`<p class="svc-lead">` + Spec.Description + `. Free, and fetched once — a ` +
-		`tile is served from here forever after, so a region costs this instance one look ` +
-		`however many people use it.</p>`)
 
 	if !Configured() {
 		b.WriteString(app.Problem("This instance has no Ordnance Survey key, so it can only " +

--- a/service/notes/page.go
+++ b/service/notes/page.go
@@ -75,7 +75,7 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 // list is every note, newest change first, each one a link into the editor.
 func list(entries []*notes.Entry) string {
 	var b strings.Builder
-	b.WriteString(`<div class="collection-head">` +
+	b.WriteString(`<div class="page-action">` +
 		`<a class="btn" href="/notes?new=1">New</a></div>`)
 
 	if len(entries) == 0 {

--- a/service/places/places.go
+++ b/service/places/places.go
@@ -662,11 +662,10 @@ func renderPlacesPage(r *http.Request) string {
 
 	// No <h4>Places</h4>. The page is already titled Places by app.Respond, and
 	// a card headed with the name of the page it is the only card on says the
-	// same word twice. The line under it is what the card is for.
+	// same word twice.
 	return fmt.Sprintf(`<div class="places-page">
 %s
 <div class="card">
-  <p class="text-muted places-form-desc">Find somewhere by name or category — cafe, pharmacy — or leave it empty and see what is nearby.</p>
   %s
 </div>
 %s

--- a/service/recall/page.go
+++ b/service/recall/page.go
@@ -65,16 +65,13 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 
 	var b strings.Builder
 	b.WriteString(`<div class="w-760">`)
-	b.WriteString(`<p class="lens-lead">Search everything you have said to an agent and been ` +
-		`told, whether you said it in the browser, by email, or from the command line. ` +
-		`To read a conversation and carry it on, go to ` + app.TextLink("your inbox", "/inbox") + `.</p>`)
 
 	csrf := auth.CSRFToken(r)
-	b.WriteString(`<form method="POST" action="/recall" class="rc-form">` +
+	b.WriteString(`<form method="POST" action="/recall" class="search-bar">` +
 		app.CSRFField(csrf) +
-		`<input class="rc-input" type="search" name="q" placeholder="A word or phrase somebody said" ` +
+		`<input type="search" name="q" placeholder="A word or phrase somebody said" ` +
 		`value="` + html.EscapeString(query) + `" autofocus>` +
-		`<button class="rc-go" type="submit">Search</button></form>`)
+		`<button type="submit">Search</button></form>`)
 
 	// The clients this account has actually used, so an instance that has only ever seen
 	// mail does not offer to narrow to anything else.
@@ -227,10 +224,6 @@ func sortStrings(s []string) {
 }
 
 const pageCSS = `<style>
-.lens-lead{color:#666;font-size:14px;margin:0 0 18px;max-width:640px}
-.rc-form{display:flex;gap:8px;margin:0 0 16px}
-.rc-input{flex:1;padding:9px 12px;font-size:14px;font-family:inherit;border:1px solid var(--border-color,#ddd);border-radius:6px;background:var(--card-background,#fff);color:var(--text-primary,#111)}
-.rc-go{padding:9px 16px;background:#111;color:#fff;border:0;border-radius:6px;font-size:14px;font-family:inherit;cursor:pointer}
 .rc-chips{display:flex;flex-wrap:wrap;gap:6px;margin:0 0 16px}
 .rc-chip{border:1px solid #eee;border-radius:6px;padding:3px 11px;font-size:12px;color:#666;text-decoration:none}
 .rc-chip:hover{border-color:#ccc}

--- a/service/shell/page.go
+++ b/service/shell/page.go
@@ -28,9 +28,6 @@ import (
 func Handler(w http.ResponseWriter, r *http.Request) {
 	var b strings.Builder
 	b.WriteString(`<div class="sbx">`)
-	b.WriteString(`<p class="svc-lead">` + Spec.Description + `. A container of your ` +
-		`own with a shell in it: what you put in it stays there between commands, ` +
-		`and nothing you run can reach this machine.</p>`)
 
 	if !Configured() {
 		// The reason rather than a guess at it. This said "an admin installs

--- a/service/tasks/handler.go
+++ b/service/tasks/handler.go
@@ -109,8 +109,6 @@ func listPage(w http.ResponseWriter, r *http.Request) {
 
 	var b strings.Builder
 	b.WriteString(`<div class="card">`)
-	b.WriteString(`<p class="text-sm text-muted">What is to be done. Assign a task to the agent ` +
-		`and it can pick it up — or press Run and it starts now.</p>`)
 
 	if msg := r.URL.Query().Get("error"); msg != "" {
 		b.WriteString(`<p class="text-error">` + html.EscapeString(msg) + `</p>`)

--- a/service/users/page.go
+++ b/service/users/page.go
@@ -53,22 +53,13 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var b strings.Builder
-	b.WriteString(`<p class="svc-lead">Everybody on this instance — the people and ` +
-		`the agents.`)
-	// The address only where there is one. Unconfigured this said
-	// "name@this instance", which is not an address and reads as a bug in the
-	// place a reader is most likely to copy something.
-	if d := mailDomain(); d != "" {
-		b.WriteString(` Write to any of them at <code>name@` + html.EscapeString(d) + `</code>.`)
-	}
-	b.WriteString(`</p>`)
 
 	// Search, because a hundred and eighty rows is a list you scroll and a
 	// thousand is one you cannot.
-	b.WriteString(`<form method="GET" action="/users" class="users-find">` +
+	b.WriteString(`<form method="GET" action="/users" class="search-bar">` +
 		`<input name="q" class="field" placeholder="Find somebody" value="` +
 		html.EscapeString(q) + `">` +
-		`<button class="btn" type="submit">Find</button>`)
+		`<button type="submit">Search</button>`)
 	if q != "" {
 		b.WriteString(` <a class="mini-btn" href="/users">Clear</a>`)
 	}

--- a/service/wallet/page.go
+++ b/service/wallet/page.go
@@ -33,9 +33,6 @@ import (
 // import TestNoServiceImportsTheAccount forbids, wearing a function variable.
 func SignedOut() string {
 	return `<div class="card">` +
-		`<p>What you have here, and a key of your own on Base: an address that holds ` +
-		`USDC, and an agent that can spend it on priced endpoints anywhere — no account ` +
-		`with those servers, no card on file, no key to rotate.</p>` +
 		`<p><a href="/login" class="btn">Sign in</a> <a href="/signup" class="btn btn-secondary">Sign up</a></p></div>`
 }
 

--- a/service/weather/page.go
+++ b/service/weather/page.go
@@ -134,10 +134,10 @@ func PageHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func searchForm(q, csrf string) string {
-	return `<form class="wx-find" method="POST" action="/weather">` + app.CSRFField(csrf) + `
-  <input class="field" type="search" name="q" placeholder="Anywhere — a town, a city" ` +
+	return `<form class="search-bar" method="POST" action="/weather">` + app.CSRFField(csrf) + `
+  <input type="search" name="q" placeholder="Anywhere — a town, a city" ` +
 		`value="` + html.EscapeString(q) + `" maxlength="120">
-  <button class="btn" type="submit">Look up</button>
+  <button type="submit">Search</button>
 </form>`
 }
 


### PR DESCRIPTION
Docs hid Save below a long document, mixed formatting controls into the sheet, and used an expanded editor section as Import. Its fixed editor width also wasted space with the sidebar closed. Service search forms and New actions had drifted into different layouts.

Move Save and formatting into sticky controls above the document, and let the shared record layout fill the available width. Import is now a separate file-selection page that validates UTF-8 Markdown/plain text and opens an unsaved draft for review. Docs search posts its query without saving a document.

Reuse the News/Video search-bar style across Blog, Docs, Archive, Recall, Contacts, Bookmarks, Users, Mail, Inbox, Images and Weather. Blog search precedes New. Use New for creation links and the shared page-action row: centered at the mobile title breakpoint when it is first, left-aligned when search or other content precedes it. Remove introductory descriptions from service pages and service references.

Validation: focused Docs/import/search, service UI, Inbox, agent roster/action and API tests pass; JavaScript syntax, gofmt, diff checks, go vet ./... and go build -buildvcs=false ./... pass. Broad suite execution was blocked by automatic approval review after an unrelated Twilio call; two broader agent runtime tests failed on unavailable network-interface discovery. No browser visual verification was available.