### PR TITLE
Deduplicate chat participants across devices

### DIFF
--- a/service/chat/chat.go
+++ b/service/chat/chat.go
@@ -37,7 +37,7 @@ var f embed.FS
 // other, /agent is where you talk to something that acts.
 var Template = `
 %s
-<div class="room-layout"><aside class="room-roster"><h3>HERE</h3><div id="chat-users"></div><a href="/chat?view=rooms">All rooms</a></aside><div class="room-main"><div id="messages"></div>
+<div class="room-layout"><aside class="room-roster"><h3>Here</h3><div id="chat-users"></div><a href="/chat?view=rooms">All rooms</a></aside><div class="room-main"><div id="messages"></div>
 <form id="chat-form" onsubmit="return false;">
 <input id="topic" name="topic" type="hidden">
 <textarea id="prompt" name="prompt" rows="1" placeholder="Say something" autocomplete="off" onkeydown="if(event.key==='Enter'&&!event.shiftKey){event.preventDefault();this.form.dispatchEvent(new Event('submit'))}"></textarea>
@@ -830,7 +830,7 @@ func getOrCreateRoom(id string) *Room {
 	return room
 }
 
-// roster is who is in the room: everybody connected.
+// roster lists each connected account once, across tabs and devices.
 //
 // # People, not programs
 //
@@ -862,12 +862,15 @@ func (room *Room) roster() []string {
 	room.mutex.RLock()
 	defer room.mutex.RUnlock()
 	names := make([]string, 0, len(room.Clients))
+	seen := make(map[string]bool, len(room.Clients))
 	for _, client := range room.Clients {
-		if client == nil || client.UserID == agentName {
+		if client == nil || client.UserID == "" || client.UserID == agentName || seen[client.UserID] {
 			continue
 		}
+		seen[client.UserID] = true
 		names = append(names, client.UserID)
 	}
+	sort.Strings(names)
 	return names
 }
 

--- a/service/chat/rooms_test.go
+++ b/service/chat/rooms_test.go
@@ -298,3 +298,21 @@ func TestTheAgentIsNotOnTheRoster(t *testing.T) {
 		t.Fatalf("roster() = %v, want the two people connected", got)
 	}
 }
+
+func TestRosterListsAnAccountOnceAcrossDevices(t *testing.T) {
+	phone, desktop, other := &websocket.Conn{}, &websocket.Conn{}, &websocket.Conn{}
+	room := &Room{Clients: map[*websocket.Conn]*Client{
+		phone: {UserID: "asim"}, desktop: {UserID: "asim"}, other: {UserID: "zara"},
+	}}
+	check := func(want string) {
+		t.Helper()
+		if got := strings.Join(room.roster(), ","); got != want {
+			t.Fatalf("roster = %q, want %q", got, want)
+		}
+	}
+	check("asim,zara")
+	delete(room.Clients, phone)
+	check("asim,zara")
+	delete(room.Clients, desktop)
+	check("zara")
+}


### PR DESCRIPTION
The room roster listed websocket connections, so the same account appeared twice when connected from phone and desktop. Deduplicate by account and sort the names for stable ordering. Change the heading from HERE to Here.

The regression test connects the same account twice, then removes each connection in turn: the name remains until the last device leaves. Chat tests, vet, formatting and diff checks pass.