### PR TITLE
Stream GLM responses live on the shared agent path

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1317,6 +1317,12 @@ func streamNativeSSE(w http.ResponseWriter, accountID, prompt string, opts Query
 	// frames and owns nothing else about the run.
 	sopts := opts
 	sopts.Stream = StreamHooks{
+		Start: func() {
+			wmu.Lock()
+			defer wmu.Unlock()
+			streaming = false
+			captured.Reset()
+		},
 		ToolStart: func(run ToolRun) {
 			wmu.Lock()
 			key := keyOf(run)
@@ -1361,17 +1367,18 @@ func streamNativeSSE(w http.ResponseWriter, accountID, prompt string, opts Query
 			send(map[string]any{"type": "tool_done", "name": run.Label, "message": run.Label + " — done"})
 		},
 		Token: func(tok string) {
+			wmu.Lock()
+			defer wmu.Unlock()
+			captured.WriteString(tok)
 			if shouldHoldNativeNewsStreamTokens(prompt, nativeTools) {
-				captured.WriteString(tok)
 				return
 			}
 			if !streaming {
 				streaming = true
 				emitted = true
-				send(map[string]any{"type": "stream_start"})
+				sse(w, map[string]any{"type": "stream_start"})
 			}
-			captured.WriteString(tok)
-			send(map[string]any{"type": "stream_token", "token": tok})
+			sse(w, map[string]any{"type": "stream_token", "token": tok})
 		},
 	}
 	answer, err := runNative(accountID, prompt, sopts)
@@ -1432,7 +1439,7 @@ func streamNativeSSE(w http.ResponseWriter, accountID, prompt string, opts Query
 			f.Status = "done"
 		})
 	}
-	send(map[string]any{"type": "response", "html": html, "flow_id": flow.ID})
+	send(map[string]any{"type": "response", "html": html, "text": answer, "flow_id": flow.ID})
 	send(map[string]any{"type": "done"})
 }
 

--- a/agent/live_test.go
+++ b/agent/live_test.go
@@ -1,0 +1,31 @@
+package agent
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	gmai "go-micro.dev/v6/ai"
+)
+
+func TestLiveToolHooksIncludeRefusedCalls(t *testing.T) {
+	var events []string
+	call := gmai.ToolCall{ID: "call-1", Name: "news_News_Search", Input: map[string]any{"q": "today"}}
+	hooks := StreamHooks{
+		ToolStart: func(run ToolRun) { events = append(events, "start:"+run.ID) },
+		ToolEnd:   func(run ToolRun) { events = append(events, "end:"+run.ID) },
+	}
+	wrapped := streamToolReporter(hooks)(func(ctx context.Context, c gmai.ToolCall) gmai.ToolResult {
+		events = append(events, "guard")
+		if c.Name != call.Name {
+			t.Error("changed tool call")
+		}
+		return gmai.ToolResult{Refused: "approval"}
+	})
+	if got := wrapped(context.Background(), call); got.Refused != "approval" {
+		t.Fatal("lost refusal")
+	}
+	if want := []string{"start:call-1", "guard", "end:call-1"}; !reflect.DeepEqual(events, want) {
+		t.Fatalf("events=%v", events)
+	}
+}

--- a/agent/native.go
+++ b/agent/native.go
@@ -267,6 +267,8 @@ func nativeToolCallKey(call gmai.ToolCall) string {
 type nativeRun struct {
 	agent    gmagent.Agent
 	question string
+	provider string
+	baseURL  string
 	// name is the per-request agent name the timeline is filed under.
 	name string
 	// runs is where it is filed: a store that lives as long as the run.
@@ -369,6 +371,9 @@ func buildNativeAgent(accountID, prompt string, opts QueryOpts, wrappers ...gmai
 	// per-agent conversation state keyed by name, so reusing a stable "assistant"
 	// name can leak prior independent prompts into fresh requests.
 	toolWrappers := append([]gmai.ToolWrapper{acceptToolNamesWeAdvertise(), blockDestructiveTools(), injectAccount(accountID), dedupeNativeToolCalls()}, wrappers...)
+	if opts.Stream.wants() {
+		toolWrappers = append([]gmai.ToolWrapper{streamToolReporter(opts.Stream)}, toolWrappers...)
+	}
 	// A store that lasts as long as the run.
 	//
 	// go-micro's agent writes a timeline of the run — every model call with the
@@ -418,7 +423,7 @@ func buildNativeAgent(accountID, prompt string, opts QueryOpts, wrappers ...gmai
 	}
 	name := nativeAgentInstanceName()
 	a := service.NewAgent(name, sys, provider, key, services, agentOpts...)
-	return nativeRun{agent: a, question: question, name: name, runs: runs}, true
+	return nativeRun{agent: a, question: question, name: name, runs: runs, provider: provider, baseURL: baseURL}, true
 }
 
 // nativeLLM picks the go-micro provider the native agent talks to.
@@ -643,7 +648,7 @@ func nativeAgentInstanceName() string {
 // wants reports whether anything is listening. A caller with no hooks is not
 // asking for a stream.
 func (h StreamHooks) wants() bool {
-	return h.Token != nil || h.ToolStart != nil || h.ToolEnd != nil
+	return h.Start != nil || h.Token != nil || h.ToolStart != nil || h.ToolEnd != nil
 }
 
 type StreamHooks struct {
@@ -652,7 +657,9 @@ type StreamHooks struct {
 	// a trace, which is exactly what /runs was showing before this.
 	ToolStart func(ToolRun)
 	ToolEnd   func(ToolRun)
-	Token     func(tok string)
+	// Start resets the visible answer when a provider begins another round.
+	Start func()
+	Token func(tok string)
 }
 
 // runNative answers a question with the go-micro agent: the model does native
@@ -712,9 +719,25 @@ func runNative(accountID, prompt string, opts QueryOpts) (string, error) {
 
 	final := ""
 	if opts.Stream.wants() {
-		var err error
-		if final, err = askStreaming(ctx, a, question, recorder, opts.Stream); err != nil {
-			return "", err
+		liveCtx, live := ai.LiveTokens(ctx, run.provider, run.baseURL, opts.Stream.Start, func(tok string) {
+			if !shouldBufferNativeToken(recorder) && opts.Stream.Token != nil {
+				opts.Stream.Token(tok)
+			}
+		})
+		if live {
+			resp, err := a.Ask(liveCtx, question)
+			if streamErr := ai.LiveError(liveCtx); streamErr != nil {
+				return "", fmt.Errorf("agent stream: %w", streamErr)
+			}
+			if err != nil {
+				return "", fmt.Errorf("agent: %w", err)
+			}
+			final = resp.Reply
+		} else {
+			var err error
+			if final, err = askStreaming(ctx, a, question, recorder, opts.Stream); err != nil {
+				return "", err
+			}
 		}
 	} else {
 		resp, err := a.Ask(ctx, question)
@@ -779,14 +802,33 @@ func stepReporter(onStep func(Step)) gmai.ToolWrapper {
 	}
 }
 
-// askStreaming runs the agent with StreamAsk, reporting tools and tokens as
-// they arrive, and returns the whole answer.
+// streamToolReporter observes the same guarded tool handler for both live and
+// buffered providers. Tool requests cannot inherit the provider HTTP bridge.
+func streamToolReporter(hooks StreamHooks) gmai.ToolWrapper {
+	return func(next gmai.ToolHandler) gmai.ToolHandler {
+		return func(ctx context.Context, call gmai.ToolCall) gmai.ToolResult {
+			run, show := toolRun(call)
+			if show && hooks.ToolStart != nil {
+				hooks.ToolStart(run)
+			}
+			result := next(ai.WithoutLiveTokens(ctx), call)
+			if show && hooks.ToolEnd != nil {
+				hooks.ToolEnd(run)
+			}
+			return result
+		}
+	}
+}
+
+// askStreaming retains the existing StreamAsk behavior for providers whose
+// native wire protocol is not handled by the live completion bridge.
 func askStreaming(ctx context.Context, a gmagent.Agent, question string, recorder *nativeToolRecorder, hooks StreamHooks) (string, error) {
 	stream, err := gmagent.StreamAsk(ctx, a, question)
 	if err != nil {
 		return "", fmt.Errorf("native agent stream: %w", err)
 	}
 
+	defer stream.Close()
 	var reply strings.Builder
 	var final string
 	for {
@@ -801,14 +843,6 @@ func askStreaming(ctx context.Context, a gmagent.Agent, question string, recorde
 			continue
 		}
 		switch ev.Type {
-		case gmagent.StreamEventToolStart:
-			if run, show := toolRun(ev.ToolCall); show && hooks.ToolStart != nil {
-				hooks.ToolStart(run)
-			}
-		case gmagent.StreamEventToolEnd:
-			if run, show := toolRun(ev.ToolCall); show && hooks.ToolEnd != nil {
-				hooks.ToolEnd(run)
-			}
 		case gmagent.StreamEventToken:
 			reply.WriteString(ev.Token)
 			if shouldBufferNativeToken(recorder) {

--- a/internal/ai/live.go
+++ b/internal/ai/live.go
@@ -1,0 +1,280 @@
+package ai
+
+// The pinned agent's StreamAsk replays a completed Generate response. This
+// request-scoped bridge streams the compatible provider's HTTP response while
+// returning the ordinary completion to its existing tool loop. Tool execution,
+// retries, memory and accounting remain owned by that loop.
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+)
+
+type liveKey struct{}
+type liveRequest struct {
+	mu       sync.Mutex
+	err      error
+	endpoint string
+	start    func()
+	token    func(string)
+}
+
+// LiveTokens opts one native run into live OpenAI-compatible completions.
+// Unsupported providers retain their existing streaming implementation.
+func LiveTokens(ctx context.Context, provider, baseURL string, start func(), token func(string)) (context.Context, bool) {
+	switch provider {
+	case "atlascloud":
+		if baseURL == "" {
+			baseURL = "https://api.atlascloud.ai"
+		}
+	case "openrouter":
+		if baseURL == "" {
+			baseURL = openRouterBaseURL
+		}
+	case "openai":
+		if baseURL == "" {
+			baseURL = "https://api.openai.com"
+		}
+	default:
+		return ctx, false
+	}
+	return context.WithValue(ctx, liveKey{}, &liveRequest{endpoint: strings.TrimRight(baseURL, "/") + "/v1/chat/completions", start: start, token: token}), true
+}
+
+// LiveError reports a broken stream even if a provider swallowed its follow-up
+// error. A successful retry clears it, so normal provider retries still work.
+func LiveError(ctx context.Context) error {
+	live, _ := ctx.Value(liveKey{}).(*liveRequest)
+	if live == nil {
+		return nil
+	}
+	live.mu.Lock()
+	defer live.mu.Unlock()
+	return live.err
+}
+
+// WithoutLiveTokens keeps HTTP calls made by tools outside the provider bridge.
+func WithoutLiveTokens(ctx context.Context) context.Context {
+	return context.WithValue(ctx, liveKey{}, (*liveRequest)(nil))
+}
+
+func init() {
+	// These providers use http.DefaultClient and offer no client option. All
+	// traffic without the private context marker passes through untouched.
+	next := http.DefaultClient.Transport
+	if next == nil {
+		next = http.DefaultTransport
+	}
+	http.DefaultClient.Transport = liveTransport{next}
+}
+
+type liveTransport struct{ next http.RoundTripper }
+
+func (t liveTransport) RoundTrip(req *http.Request) (_ *http.Response, roundErr error) {
+	live, _ := req.Context().Value(liveKey{}).(*liveRequest)
+	if live == nil || req.Method != http.MethodPost || req.URL.String() != live.endpoint || req.Body == nil {
+		return t.next.RoundTrip(req)
+	}
+	defer func() {
+		live.mu.Lock()
+		live.err = roundErr
+		live.mu.Unlock()
+	}()
+	body, err := io.ReadAll(req.Body)
+	req.Body.Close()
+	if err != nil {
+		return nil, err
+	}
+	var payload map[string]json.RawMessage
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return nil, err
+	}
+	clone := req.Clone(req.Context())
+	setBody := func(b []byte) {
+		clone.Body = io.NopCloser(bytes.NewReader(b))
+		clone.ContentLength = int64(len(b))
+		clone.GetBody = func() (io.ReadCloser, error) { return io.NopCloser(bytes.NewReader(b)), nil }
+	}
+	// Requests already streaming belong to the provider's own Stream reader.
+	if string(payload["stream"]) == "true" {
+		setBody(body)
+		return t.next.RoundTrip(clone)
+	}
+	payload["stream"] = json.RawMessage(`true`)
+	payload["stream_options"] = json.RawMessage(`{"include_usage":true}`)
+	body, err = json.Marshal(payload)
+	if err != nil {
+		return nil, err
+	}
+	setBody(body)
+	clone.Header.Set("Accept", "text/event-stream")
+	resp, err := t.next.RoundTrip(clone)
+	if err != nil {
+		return nil, err
+	}
+	// Preserve provider status and error bodies (including retry hints).
+	if resp.StatusCode != http.StatusOK {
+		return resp, nil
+	}
+	if !strings.Contains(resp.Header.Get("Content-Type"), "text/event-stream") {
+		// Some compatible endpoints ignore stream:true and return ordinary JSON.
+		return resp, nil
+	}
+	defer resp.Body.Close()
+	if live.start != nil {
+		live.start()
+	}
+	result, err := collectCompletion(resp.Body, live.token)
+	if err != nil {
+		return nil, err
+	}
+	resp.Body = io.NopCloser(bytes.NewReader(result))
+	resp.ContentLength = int64(len(result))
+	resp.Header = resp.Header.Clone()
+	resp.Header.Set("Content-Type", "application/json")
+	resp.Header.Del("Content-Length")
+	resp.Header.Del("Content-Encoding")
+	resp.TransferEncoding = nil
+	return resp, nil
+}
+
+type liveTool struct {
+	Index    int    `json:"index"`
+	ID       string `json:"id"`
+	Type     string `json:"type"`
+	Function struct {
+		Name      string `json:"name"`
+		Arguments string `json:"arguments"`
+	} `json:"function"`
+}
+
+// collectCompletion accepts SSE frames, joining tool argument fragments without
+// executing them. Only visible content is emitted; reasoning stays private.
+func collectCompletion(r io.Reader, token func(string)) ([]byte, error) {
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 4096), 4<<20)
+	var content, refusal, reasoning strings.Builder
+	tools := map[int]*liveTool{}
+	var usage json.RawMessage
+	finish := ""
+	done := false
+	var data []string
+	consume := func() error {
+		if len(data) == 0 {
+			return nil
+		}
+		raw := strings.Join(data, "\n")
+		data = nil
+		if raw == "[DONE]" {
+			done = true
+			return nil
+		}
+		var chunk struct {
+			Error   json.RawMessage `json:"error"`
+			Choices []struct {
+				Index int `json:"index"`
+				Delta struct {
+					Content   string     `json:"content"`
+					Refusal   string     `json:"refusal"`
+					Reasoning string     `json:"reasoning_content"`
+					Tools     []liveTool `json:"tool_calls"`
+				} `json:"delta"`
+				Finish string `json:"finish_reason"`
+			} `json:"choices"`
+			Usage json.RawMessage `json:"usage"`
+		}
+		if err := json.Unmarshal([]byte(raw), &chunk); err != nil {
+			return fmt.Errorf("invalid provider stream: %w", err)
+		}
+		if len(chunk.Error) > 0 && string(chunk.Error) != "null" {
+			return fmt.Errorf("provider stream error: %s", chunk.Error)
+		}
+		if len(chunk.Usage) > 0 && string(chunk.Usage) != "null" {
+			usage = chunk.Usage
+		}
+		for _, c := range chunk.Choices {
+			if c.Index != 0 {
+				continue
+			}
+			if c.Finish != "" {
+				finish = c.Finish
+			}
+			content.WriteString(c.Delta.Content)
+			refusal.WriteString(c.Delta.Refusal)
+			reasoning.WriteString(c.Delta.Reasoning)
+			for _, part := range c.Delta.Tools {
+				if part.Index < 0 || part.Index > 1024 {
+					return fmt.Errorf("invalid streamed tool index")
+				}
+				call := tools[part.Index]
+				if call == nil {
+					call = &liveTool{}
+					tools[part.Index] = call
+				}
+				call.ID += part.ID
+				call.Type += part.Type
+				call.Function.Name += part.Function.Name
+				call.Function.Arguments += part.Function.Arguments
+			}
+			if c.Delta.Content != "" && token != nil {
+				token(c.Delta.Content)
+			}
+		}
+		return nil
+	}
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == "" {
+			if err := consume(); err != nil {
+				return nil, err
+			}
+			if done {
+				break
+			}
+			continue
+		}
+		if strings.HasPrefix(line, "data:") {
+			data = append(data, strings.TrimPrefix(strings.TrimPrefix(line, "data:"), " "))
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	if err := consume(); err != nil {
+		return nil, err
+	}
+	if !done || finish == "" {
+		return nil, fmt.Errorf("provider stream ended before completion")
+	}
+	calls := make([]map[string]any, 0, len(tools))
+	for i := 0; i < len(tools); i++ {
+		call := tools[i]
+		if call == nil || call.ID == "" || call.Function.Name == "" || !json.Valid([]byte(call.Function.Arguments)) {
+			return nil, fmt.Errorf("incomplete streamed tool call")
+		}
+		calls = append(calls, map[string]any{"id": call.ID, "type": "function", "function": call.Function})
+	}
+	message := map[string]any{"role": "assistant", "content": content.String()}
+	if len(calls) > 0 {
+		message["tool_calls"] = calls
+	}
+	if refusal.Len() > 0 {
+		message["refusal"] = refusal.String()
+	}
+	if reasoning.Len() > 0 {
+		message["reasoning_content"] = reasoning.String()
+	}
+	return json.Marshal(map[string]any{"choices": []any{map[string]any{"index": 0, "message": message, "finish_reason": finish}}, "usage": usage})
+}
+
+func (t liveTransport) CloseIdleConnections() {
+	if next, ok := t.next.(interface{ CloseIdleConnections() }); ok {
+		next.CloseIdleConnections()
+	}
+}

--- a/internal/ai/live_test.go
+++ b/internal/ai/live_test.go
@@ -1,0 +1,218 @@
+package ai
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	gmai "go-micro.dev/v6/ai"
+)
+
+func TestLiveTokensBeforeCompletionWithTools(t *testing.T) {
+	for _, provider := range []string{"openai", "atlascloud", "openrouter"} {
+		t.Run(provider, func(t *testing.T) {
+			var calls atomic.Int32
+			release := make(chan struct{})
+			defer close(release)
+			tokens := make(chan string, 8)
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				var request map[string]any
+				if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+					t.Error(err)
+					return
+				}
+				if request["stream"] != true {
+					t.Error("provider did not request streaming")
+				}
+				w.Header().Set("Content-Type", "text/event-stream")
+				if calls.Add(1) == 1 {
+					fmt.Fprint(w, `data: {"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_1","type":"function","function":{"name":"lookup","arguments":"{\"city\":"}}]}}]}`+"\n\n")
+					fmt.Fprint(w, `data: {"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\"London\"}"}}]},"finish_reason":"tool_calls"}],"usage":{"prompt_tokens":10,"completion_tokens":3,"total_tokens":13}}`+"\n\ndata: [DONE]\n\n")
+					return
+				}
+				fmt.Fprint(w, `data: {"choices":[{"index":0,"delta":{"content":"Hello"}}]}`+"\n\n")
+				w.(http.Flusher).Flush()
+				select {
+				case <-release:
+				case <-r.Context().Done():
+					return
+				}
+				fmt.Fprint(w, `data: {"choices":[{"index":0,"delta":{"content":" world"},"finish_reason":"stop"}]}`+"\n\n")
+				fmt.Fprint(w, `data: {"choices":[],"usage":{"prompt_tokens":20,"completion_tokens":2,"total_tokens":22}}`+"\n\ndata: [DONE]\n\n")
+			}))
+			defer srv.Close()
+			var ran atomic.Int32
+			model := gmai.New(provider, gmai.WithAPIKey("test"), gmai.WithBaseURL(srv.URL), gmai.WithToolHandler(func(ctx context.Context, call gmai.ToolCall) gmai.ToolResult {
+				if call.Name != "lookup" || call.Input["city"] != "London" {
+					t.Errorf("bad tool call: %+v", call)
+				}
+				ran.Add(1)
+				return gmai.ToolResult{Content: `{"temperature":20}`}
+			}))
+			var starts atomic.Int32
+			ctx, ok := LiveTokens(ctx, provider, srv.URL, func() { starts.Add(1) }, func(s string) { tokens <- s })
+			if !ok {
+				t.Fatal("provider unsupported")
+			}
+			type result struct {
+				r *gmai.Response
+				e error
+			}
+			finished := make(chan result, 1)
+			go func() {
+				r, e := model.Generate(ctx, &gmai.Request{Prompt: "hello", Tools: []gmai.Tool{{Name: "lookup", Description: "lookup weather", Properties: map[string]any{"type": "object", "properties": map[string]any{"city": map[string]any{"type": "string"}}}}}})
+				finished <- result{r, e}
+			}()
+			select {
+			case tok := <-tokens:
+				if tok != "Hello" {
+					t.Fatalf("first token=%q", tok)
+				}
+			case res := <-finished:
+				t.Fatalf("finished before first token: %+v", res)
+			case <-ctx.Done():
+				t.Fatal("no live token")
+			}
+			select {
+			case <-finished:
+				t.Fatal("completion did not wait for remaining tokens")
+			default:
+			}
+			release <- struct{}{}
+			res := <-finished
+			if res.e != nil {
+				t.Fatal(res.e)
+			}
+			if res.r.Answer != "Hello world" {
+				t.Errorf("reply=%q", res.r.Answer)
+			}
+			if res.r.Usage.TotalTokens != 13 {
+				t.Errorf("usage=%+v", res.r.Usage)
+			}
+			if ran.Load() != 1 || starts.Load() != 2 {
+				t.Errorf("tools=%d starts=%d", ran.Load(), starts.Load())
+			}
+		})
+	}
+}
+
+func TestLiveCompletionRejectsBrokenStreams(t *testing.T) {
+	for _, body := range []string{
+		`data: {broken}` + "\n\n",
+		`data: {"choices":[{"delta":{"content":"partial"}}]}` + "\n\n",
+		`data: {"error":{"message":"provider failed"}}` + "\n\n",
+		`data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"x","function":{"name":"lookup","arguments":"{"}}]},"finish_reason":"tool_calls"}]}` + "\n\ndata: [DONE]\n\n",
+	} {
+		if _, err := collectCompletion(strings.NewReader(body), nil); err == nil {
+			t.Errorf("accepted broken stream %q", body)
+		}
+	}
+}
+
+type liveRoundTripper func(*http.Request) (*http.Response, error)
+
+func (f liveRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+func TestLiveTransportScopeAndProviderErrors(t *testing.T) {
+	for _, mode := range []string{"ordinary", "tool", "other_url", "error", "json"} {
+		t.Run(mode, func(t *testing.T) {
+			ctx := context.Background()
+			if mode != "ordinary" {
+				ctx, _ = LiveTokens(ctx, "openai", "https://provider.test", nil, func(string) { t.Error("unexpected token") })
+			}
+			if mode == "tool" {
+				ctx = WithoutLiveTokens(ctx)
+			}
+			url := "https://provider.test/v1/chat/completions"
+			if mode == "other_url" {
+				url = "https://tool.test/v1/chat/completions"
+			}
+			req, _ := http.NewRequestWithContext(ctx, "POST", url, strings.NewReader(`{"model":"test"}`))
+			status := 200
+			body := `{"choices":[]}`
+			if mode == "error" {
+				status = 429
+				body = `{"error":"rate limited"}`
+			}
+			tr := liveTransport{liveRoundTripper(func(r *http.Request) (*http.Response, error) {
+				b, _ := io.ReadAll(r.Body)
+				streaming := strings.Contains(string(b), `"stream":true`)
+				if streaming != (mode == "error" || mode == "json") {
+					t.Errorf("unexpected request: %s", b)
+				}
+				return &http.Response{StatusCode: status, Header: http.Header{"Content-Type": []string{"application/json"}, "Retry-After": []string{"3"}}, Body: io.NopCloser(strings.NewReader(body))}, nil
+			})}
+			resp, err := tr.RoundTrip(req)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer resp.Body.Close()
+			b, _ := io.ReadAll(resp.Body)
+			if string(b) != body || resp.StatusCode != status || resp.Header.Get("Retry-After") != "3" {
+				t.Fatal("changed provider response")
+			}
+		})
+	}
+}
+
+func TestLiveTransportCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		fmt.Fprint(w, `data: {"choices":[{"delta":{"content":"partial"}}]}`+"\n\n")
+		w.(http.Flusher).Flush()
+		<-r.Context().Done()
+	}))
+	defer srv.Close()
+	ctx, _ = LiveTokens(ctx, "openai", srv.URL, nil, func(string) { cancel() })
+	req, _ := http.NewRequestWithContext(ctx, "POST", srv.URL+"/v1/chat/completions", strings.NewReader(`{}`))
+	finished := make(chan error, 1)
+	go func() {
+		resp, err := http.DefaultClient.Do(req)
+		if resp != nil {
+			resp.Body.Close()
+		}
+		finished <- err
+	}()
+	select {
+	case err := <-finished:
+		if err == nil || LiveError(ctx) == nil {
+			t.Fatal("cancelled stream was treated as successful")
+		}
+	case <-time.After(5 * time.Second):
+		cancel()
+		t.Fatal("cancelled stream did not close")
+	}
+}
+
+func TestLiveCompletionPreservesUsageAndHidesReasoning(t *testing.T) {
+	body := `: keepalive` + "\n\n" + `data: {"choices":[{"delta":{"reasoning_content":"private","content":"answer"},"finish_reason":"stop"}]}` + "\n\n" + `data: {"choices":[],"usage":{"prompt_tokens":20,"completion_tokens":2,"total_tokens":22}}` + "\n\ndata: [DONE]\n\n"
+	visible := ""
+	result, err := collectCompletion(strings.NewReader(body), func(s string) { visible += s })
+	if err != nil {
+		t.Fatal(err)
+	}
+	if visible != "answer" {
+		t.Fatalf("visible output %q", visible)
+	}
+	var decoded struct {
+		Usage struct {
+			Total int `json:"total_tokens"`
+		} `json:"usage"`
+	}
+	if err := json.Unmarshal(result, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if decoded.Usage.Total != 22 {
+		t.Fatalf("lost usage: %s", result)
+	}
+}

--- a/internal/app/chat.go
+++ b/internal/app/chat.go
@@ -1008,6 +1008,7 @@ function ask(q){
             }else if(ev.type==='response'){
               stopWork();
               a.innerHTML=ev.html;
+              if(typeof ev.text==='string')streamText=ev.text;
               history.push({prompt:q,answer:streamText});
               save();
               toBottom(false);


### PR DESCRIPTION
The landing page already flushes SSE and renders incoming tokens, but the pinned native agent's StreamAsk waits for Generate to finish and then replays the reply. This leaves users waiting for the complete answer before seeing any text.

Add a Mu-local, request-scoped HTTP bridge for Atlas, OpenRouter and OpenAI-compatible native runs. It requests upstream SSE, forwards visible content immediately, and reconstructs ordinary completions for the existing provider tool loop. The existing agent still owns tool guards, memory, retries and run accounting. Other providers keep their current behavior.

Only the exact configured completion endpoint with a private context marker enters the bridge; tool contexts explicitly remove the marker. Preserve fragmented tool calls and usage, reject malformed or incomplete streams, and propagate stream failures even when the provider swallows a follow-up error. Reset displayed text between rounds and use the final answer for browser history and speech.

Validation: delayed local HTTP tests prove tokens arrive before completion for all three supported providers, including tool calls. Additional tests cover cancellation, malformed streams, request isolation, provider errors, usage and hidden reasoning. Focused agent tests, race tests for the bridge, go vet for changed packages, and the full binary build passed. No live-provider latency measurement or browser visual test was performed.