### PR TITLE
Identify assigned agents and fix inbox task handoffs

### DIFF
--- a/agent/work/handoff_test.go
+++ b/agent/work/handoff_test.go
@@ -1,0 +1,72 @@
+package work
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"mu/agent"
+	"mu/internal/thread"
+	"mu/service/tasks"
+)
+
+func TestChatHandoffCarriesDestinationAndTask(t *testing.T) {
+	who := t.Name()
+	th := thread.Open(who, thread.ChatClient, "private-room-123")
+	r := request{Account: who, Thread: th.ID, Kind: tasks.Kind, ID: "task-123", Prompt: "reply to this"}
+	prompt := workPrompt(r)
+	for _, want := range []string{"private-room-123", "task-123", "chat Send", "A draft or summary is not a request to send", "reply to this"} {
+		if !strings.Contains(prompt, want) {
+			t.Errorf("missing %q in %s", want, prompt)
+		}
+	}
+	r.Account = "someone-else"
+	if strings.Contains(workPrompt(r), "private-room-123") {
+		t.Fatal("leaked another account's room")
+	}
+}
+
+func TestPanickedWorkClearsWorkingAndReportsFailure(t *testing.T) {
+	who := t.Name()
+	th := thread.Open(who, thread.ChatClient, "test-room")
+	task, err := tasks.CreateOn(who, th.ID, "malten", "reply", "", tasks.Agent, time.Time{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tasks.Update(who, task.ID, "", "", tasks.StatusDoing, "", ""); err != nil {
+		t.Fatal(err)
+	}
+	runWithQuery(request{Account: who, Thread: th.ID, Kind: tasks.Kind, ID: task.ID, Agent: "malten", Prompt: "reply"}, func(string, string, agent.QueryOpts) (string, error) { panic("test panic") })
+	got, err := tasks.Get(who, task.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tasks.Running(got) || !strings.Contains(got.Result, "stopped unexpectedly") {
+		t.Fatalf("task still working: %+v", got)
+	}
+	msgs := thread.Messages(who, th.ID, 10)
+	if len(msgs) != 1 || msgs[0].From != "malten" || !strings.Contains(msgs[0].Text, "stopped unexpectedly") {
+		t.Fatalf("missing named failure: %+v", msgs)
+	}
+}
+
+func TestSuccessfulWorkCompletesAndNamesReply(t *testing.T) {
+	who := t.Name()
+	th := thread.Open(who, thread.ChatClient, "test-room")
+	task, err := tasks.CreateOn(who, th.ID, "malten", "reply", "", tasks.Agent, time.Time{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	runWithQuery(request{Account: who, Thread: th.ID, Kind: tasks.Kind, ID: task.ID, Agent: "malten", Prompt: "reply"}, func(string, string, agent.QueryOpts) (string, error) { return "The reply was sent.", nil })
+	got, err := tasks.Get(who, task.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != tasks.StatusDone || got.Result != "The reply was sent." {
+		t.Fatalf("incomplete: %+v", got)
+	}
+	msgs := thread.Messages(who, th.ID, 10)
+	if len(msgs) != 1 || msgs[0].From != "malten" {
+		t.Fatalf("missing author: %+v", msgs)
+	}
+}

--- a/agent/work/work.go
+++ b/agent/work/work.go
@@ -41,12 +41,15 @@
 package work
 
 import (
+	"fmt"
 	"strings"
+	"sync"
 
 	"mu/agent"
 	"mu/internal/app"
 	"mu/internal/auth"
 	"mu/internal/event"
+	"mu/internal/thread"
 	"mu/service/events"
 	"mu/service/mail"
 	"mu/service/tasks"
@@ -107,7 +110,22 @@ func requestFrom(data map[string]interface{}) (request, bool) {
 
 // run does the work and puts the answer where it belongs.
 func run(r request) {
+	runWithQuery(r, agent.QueryWithOpts)
+}
+
+func runWithQuery(r request, query func(string, string, agent.QueryOpts) (string, error)) {
 	var steps []tasks.Step
+	var stepsMu sync.Mutex
+	defer func() {
+		if rec := recover(); rec != nil {
+			failure := fmt.Errorf("the agent run stopped unexpectedly")
+			app.Log("work", "running %s %s panicked: %v", r.Kind, r.ID, rec)
+			if r.Kind == tasks.Kind {
+				finishTask(r, "", nil, failure)
+			}
+			answered(r, "", failure)
+		}
+	}()
 
 	// Work that came out of a conversation is framed as acting on one.
 	//
@@ -150,18 +168,13 @@ func run(r request) {
 		system = agent.InboxPrompt(opts.System)
 	}
 
-	answer, err := agent.QueryWithOpts(r.Account, r.Prompt, agent.QueryOpts{
-		System: system,
-		Tools:  opts.Tools,
-		OnStep: func(s agent.Step) {
-			steps = append(steps, tasks.Step{
-				Tool:    s.Tool,
-				Detail:  tasks.StepDetail(s.Args),
-				OK:      s.OK,
-				Seconds: s.Took.Seconds(),
-			})
-		},
-	})
+	opts.System = system
+	opts.OnStep = func(s agent.Step) {
+		stepsMu.Lock()
+		defer stepsMu.Unlock()
+		steps = append(steps, tasks.Step{Tool: s.Tool, Detail: tasks.StepDetail(s.Args), OK: s.OK, Seconds: s.Took.Seconds()})
+	}
+	answer, err := query(r.Account, workPrompt(r), opts)
 
 	switch r.Kind {
 	case tasks.Kind:
@@ -182,6 +195,20 @@ func run(r request) {
 	answered(r, answer, err)
 }
 
+// The text of a conversation does not identify its delivery address. Give the
+// worker the owned thread's destination so an explicit request to reply can
+// actually send, while a summary or draft remains a private result.
+func workPrompt(r request) string {
+	var context strings.Builder
+	if r.Kind == tasks.Kind {
+		fmt.Fprintf(&context, "You are already executing task %q. Do the requested work now; do not create or reassign another task for this same work. Return the outcome; the runner saves it and completes this task automatically.\n\n", r.ID)
+	}
+	if th := thread.Get(r.Account, r.Thread); th != nil && th.Client == thread.ChatClient && !strings.HasPrefix(th.Key, "xmpp_") {
+		fmt.Fprintf(&context, "The source conversation is chat room %q. If the owner asks you to send or reply in this conversation, use the chat Send tool with that exact room id. A draft or summary is not a request to send. Never claim a reply was sent unless the tool confirms it; if the tool is unavailable, say so. Your final answer is a private report to the owner.\n\n", th.Key)
+	}
+	return context.String() + r.Prompt
+}
+
 // answered puts the outcome back on the conversation the work came out of.
 //
 // Through agent.Answered, which is what every client uses to write down what an
@@ -198,7 +225,11 @@ func answered(r request, answer string, err error) {
 		// silence is indistinguishable from work nobody picked up.
 		text = "That did not work: " + err.Error()
 	}
-	agent.Answered(r.Account, r.Thread, text, "")
+	from := r.Agent
+	if from == "" {
+		from = agent.DefaultName()
+	}
+	agent.AnsweredAs(r.Account, r.Thread, text, "", from)
 }
 
 // finishTask writes the result back onto the task.
@@ -208,12 +239,14 @@ func answered(r request, answer string, err error) {
 func finishTask(r request, answer string, steps []tasks.Step, err error) {
 	if err != nil {
 		app.Log("work", "task %q failed for %s: %v", r.Title, r.Account, err)
-		tasks.Update(r.Account, r.ID, "", "", tasks.StatusTodo, "", //nolint:errcheck
-			"Last run failed: "+err.Error(), steps)
+		if _, saveErr := tasks.Update(r.Account, r.ID, "", "", tasks.StatusTodo, "", "Last run failed: "+err.Error(), steps); saveErr != nil {
+			app.Log("work", "saving failed task %s: %v", r.ID, saveErr)
+		}
 		return
 	}
-	tasks.Update(r.Account, r.ID, "", "", tasks.StatusDone, "", //nolint:errcheck
-		strings.TrimSpace(answer), steps)
+	if _, saveErr := tasks.Update(r.Account, r.ID, "", "", tasks.StatusDone, "", strings.TrimSpace(answer), steps); saveErr != nil {
+		app.Log("work", "saving completed task %s: %v", r.ID, saveErr)
+	}
 }
 
 // deliver mails what a standing instruction produced.

--- a/inbox/act.go
+++ b/inbox/act.go
@@ -156,7 +156,7 @@ func hand(accountID string, t *thread.Thread, ask, agentID string) error {
 	// knows was made — and because inferring that somebody wanted work rather
 	// than an answer is a claim about what they meant, which they should be
 	// able to see and correct.
-	agentSaid(accountID, t.ID, "Taking that on — I will answer here when it is done.")
+	agentSaid(accountID, t.ID, "Taking that on — I will answer here when it is done.", agentID)
 	return tasks.Run(accountID, task.ID)
 }
 
@@ -174,10 +174,10 @@ const (
 // One line rather than the whole of agent.Answered: what is needed here is
 // "say this on that thread", and the agent owns how anything it says is
 // written down.
-var agentSaid = func(accountID, threadID, text string) {}
+var agentSaid = func(accountID, threadID, text, agentID string) {}
 
 // AgentSaid is how the server hands that over. See agentSaid.
-func AgentSaid(f func(accountID, threadID, text string)) {
+func AgentSaid(f func(accountID, threadID, text, agentID string)) {
 	if f != nil {
 		agentSaid = f
 	}

--- a/inbox/act_test.go
+++ b/inbox/act_test.go
@@ -143,8 +143,8 @@ func TestTheInstructionLandsOnTheConversation(t *testing.T) {
 	thread.Add(thread.Message{Thread: mine.ID, Account: who, Text: "dinner on the 4th at 8"})
 
 	said := ""
-	AgentSaid(func(accountID, threadID, text string) { said = text })
-	t.Cleanup(func() { AgentSaid(func(string, string, string) {}) })
+	AgentSaid(func(accountID, threadID, text, agentID string) { said = text })
+	t.Cleanup(func() { AgentSaid(func(string, string, string, string) {}) })
 
 	form := url.Values{"id": {mine.ID}, "ask": {"add this to my calendar"}}
 	r := httptest.NewRequest("POST", "/inbox", strings.NewReader(form.Encode()))
@@ -176,8 +176,8 @@ func TestHandingOverMakesATaskOnTheConversation(t *testing.T) {
 	reader(t, who)
 
 	said := ""
-	AgentSaid(func(accountID, threadID, text string) { said = text })
-	t.Cleanup(func() { AgentSaid(func(string, string, string) {}) })
+	AgentSaid(func(accountID, threadID, text, agentID string) { said = text })
+	t.Cleanup(func() { AgentSaid(func(string, string, string, string) {}) })
 
 	th := thread.Open(who, "mail", "<hand@example.com>")
 	if th == nil {

--- a/inbox/agent_author_test.go
+++ b/inbox/agent_author_test.go
@@ -1,0 +1,21 @@
+package inbox
+
+import (
+	"mu/internal/thread"
+	"strings"
+	"testing"
+)
+
+func TestMessagesShowTheirOwnAgent(t *testing.T) {
+	old := AgentName
+	AgentName = func(owner, id string) string {
+		return map[string]string{"malten": "Malten", "research": "Research"}[id]
+	}
+	t.Cleanup(func() { AgentName = old })
+	th := thread.Open(t.Name(), thread.ChatClient, "room")
+	th.Agent = "research"
+	got := messageBlock(t.Name(), th, thread.Message{Role: thread.RoleAgent, From: "malten", Text: "Taking that on"}, "")
+	if !strings.Contains(got, "Malten") || strings.Contains(got, ">Agent<") || strings.Contains(got, "Research") {
+		t.Fatalf("wrong agent: %s", got)
+	}
+}

--- a/inbox/conversation.go
+++ b/inbox/conversation.go
@@ -413,6 +413,26 @@ func partyName(p thread.Party) string {
 	return "You"
 }
 
+// Resolve the author on each message: assigning a thread to another agent
+// must not rename earlier replies. Legacy messages fall back to the thread.
+func messageAgentName(accountID string, t *thread.Thread, m thread.Message) string {
+	if m.From != "" {
+		if name := agentLabel(accountID, m.From); name != "" {
+			return name
+		}
+		for _, p := range thread.Parties(accountID, t.ID) {
+			if p.Kind == thread.RoleAgent && p.Key == m.From && p.Name != "" {
+				return p.Name
+			}
+		}
+		return m.From
+	}
+	if name := agentLabel(accountID, t.Agent); name != "" {
+		return name
+	}
+	return defaultAgentName()
+}
+
 // messageBlock is one message. What a person wrote is escaped and shown as
 // typed; what an agent wrote is markdown, rendered the way the chat renders it —
 // through the untrusted renderer, because model output is exactly what that
@@ -424,7 +444,7 @@ func messageBlock(accountID string, t *thread.Thread, m thread.Message, subject 
 		if m.Workflow != "" {
 			ran = runTools(m.Workflow)
 		}
-		return `<div class="ib-msg ib-agent">` + fromLine("Agent", m.At) +
+		return `<div class="ib-msg ib-agent">` + fromLine(messageAgentName(accountID, t, m), m.At) +
 			`<div class="ib-body">` + app.RenderString(m.Text) + `</div>` + ran + `</div>`
 	}
 	// The author, by the name the conversation knows them under rather than the

--- a/inbox/kinds.go
+++ b/inbox/kinds.go
@@ -137,7 +137,11 @@ func noteRow(n *notes.Entry) string {
 func taskRow(t *tasks.Task) string {
 	tags := []string{html.EscapeString(t.Status)}
 	if t.Assignee == tasks.Agent {
-		tags = append(tags, "agent")
+		name := agentLabel(t.Owner, t.Agent)
+		if name == "" {
+			name = defaultAgentName()
+		}
+		tags = append(tags, html.EscapeString(name))
 	}
 	tags = append(tags, html.EscapeString(app.TimeAgo(t.Updated)))
 

--- a/internal/server/hooks.go
+++ b/internal/server/hooks.go
@@ -361,8 +361,11 @@ func wireHooks() {
 	// One line from the agent onto a conversation — the acknowledgement when
 	// work is handed over. The agent owns how anything it says is written
 	// down, so the inbox asks rather than writing to the record itself.
-	inbox.AgentSaid(func(accountID, threadID, text string) {
-		agent.Answered(accountID, threadID, text, "")
+	inbox.AgentSaid(func(accountID, threadID, text, agentID string) {
+		if agentID == "" {
+			agentID = agent.DefaultName()
+		}
+		agent.AnsweredAs(accountID, threadID, text, "", agentID)
 	})
 	inbox.AgentName = agent.NameOf
 	inbox.Address = mail.SharedAgentAddress

--- a/service/tasks/handler.go
+++ b/service/tasks/handler.go
@@ -181,7 +181,7 @@ func taskRow(t *Task, csrf string) string {
 	if !t.Open() {
 		class += " task-done"
 	}
-	fmt.Fprintf(&b, `<div class="%s">`, class)
+	fmt.Fprintf(&b, `<div class="%s" data-task-id="%s" data-task-status="%s">`, class, html.EscapeString(t.ID), html.EscapeString(t.Status))
 
 	fmt.Fprintf(&b, `<div class="task-title">%s</div>`, html.EscapeString(t.Title))
 
@@ -265,13 +265,14 @@ func button(b *strings.Builder, id, action, csrf, label, extra string) {
 const taskPollJS = `<script>
 (function(){
   var tries = 0;
+  var watched = Array.from(document.querySelectorAll('[data-task-status="doing"]')).map(function(el){return el.dataset.taskId;});
   function check(){
     if (++tries > 120) return; // ten minutes, then stop asking
     fetch('/tasks', {headers:{'Accept':'application/json'}, credentials:'same-origin'})
       .then(function(r){ return r.json(); })
       .then(function(d){
-        var busy = (d.tasks||[]).some(function(t){ return t.status === 'doing'; });
-        if (!busy) { location.reload(); return; }
+        var changed = watched.some(function(id){return !(d.tasks||[]).some(function(t){return t.id===id && t.status==='doing';});});
+        if (changed) { location.reload(); return; }
         setTimeout(check, 3000);
       })
       .catch(function(){ setTimeout(check, 5000); });


### PR DESCRIPTION
Inbox assignment acknowledgements and results were labelled only Agent. Chat handoffs carried message text but no room destination, and the worker discarded the selected agent's model settings. The task page also waited for every running task to finish before refreshing, while a panicked run left its task doing indefinitely.

Record the chosen agent on each acknowledgement/result and resolve its display name per message and on inbox task rows. Retain the selected agent's query options. Include the owned chat room id in the work context so an explicit instruction to reply can invoke chat Send; drafts and summaries remain private, and unavailable send tools must be reported. Identify the existing task and tell the runner not to create/reassign duplicate work.

On panic, reopen the task with a visible failure. Log result persistence failures. Refresh when any watched task completes, even if another task is still running.

Validation: inbox, agent/work and service/tasks tests pass, including named authors, successful completion, panic recovery and account-scoped destinations. A JavaScript check verifies refresh with another task still running. Focused go vet and the full binary build pass. No live model call or resend of the existing Malten task was performed.

Web-fetch caching and bookmark full-page indexing were investigated separately; this PR does not add either.