### PR TITLE
Run familiar service prompts without a model round trip

### DIFF
--- a/agent/ask.go
+++ b/agent/ask.go
@@ -329,7 +329,8 @@ func Ask(r AskRequest) (Answer, error) {
 	// lands in the conversation like any other reply — somebody who asked a
 	// question on their phone should read why nothing happened in the place
 	// they asked, not find out by opening a wallet page.
-	if reason, ok := affordable(r.Account); !ok {
+	_, directCommand := promptCommand(r.Text, opts)
+	if reason, ok := affordable(r.Account); !ok && !directCommand {
 		Answered(r.Account, threadID(th), reason, "")
 		return Answer{Text: reason, Thread: threadID(th)}, nil
 	}
@@ -342,7 +343,7 @@ func Ask(r AskRequest) (Answer, error) {
 	// a provider timing out is our problem, and billing for it teaches people
 	// to distrust the number. The same reasoning as service/web, which charges
 	// only when the fetch came back.
-	if err == nil && strings.TrimSpace(answer) != "" {
+	if err == nil && strings.TrimSpace(answer) != "" && !directCommand {
 		quota.Charge(r.Account, quota.OpAgentRun, map[string]interface{}{
 			"agent": r.Agent, "client": r.Client,
 		}) //nolint:errcheck

--- a/agent/commands.go
+++ b/agent/commands.go
@@ -1,0 +1,82 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strings"
+	"time"
+
+	"mu/internal/service"
+)
+
+func promptCommand(prompt string, opts QueryOpts) (service.CommandCall, bool) {
+	// A specialist or attached source can change what even a short prompt means.
+	if opts.System != "" || strings.TrimSpace(opts.Extra) != "" {
+		return service.CommandCall{}, false
+	}
+	return service.MatchCommand(prompt, filterServices(nativeServices(opts.Public), opts.Tools))
+}
+
+func executeCommand(ctx context.Context, account string, call service.CommandCall, opts QueryOpts) (string, error) {
+	name := call.Service + "_" + strings.ToLower(call.Method)
+	run := ToolRun{ID: "command", Name: name, Label: toolLabel(name)}
+	if opts.Stream.ToolStart != nil {
+		opts.Stream.ToolStart(run)
+	}
+	start := time.Now()
+	result, err := service.CallDynamic(service.WithAccount(ctx, account), call.Service, call.Method, call.Args)
+	text := ""
+	if err == nil {
+		text = commandText(result)
+		if strings.TrimSpace(text) == "" {
+			err = fmt.Errorf("returned no result")
+		}
+	}
+	if opts.Stream.ToolEnd != nil {
+		opts.Stream.ToolEnd(run)
+	}
+	if opts.OnStep != nil {
+		opts.OnStep(Step{Tool: name, Args: call.Args, OK: err == nil, Took: time.Since(start)})
+	}
+	if err != nil {
+		return "", fmt.Errorf("%s: %w", call.Service, err)
+	}
+	if opts.Stream.Token != nil {
+		opts.Stream.Token(text)
+	}
+	return text, nil
+}
+
+// Prefer structured links to the instruction-bearing prose supplied to models.
+func commandText(result map[string]any) string {
+	if items, ok := result["items"].([]any); ok && len(items) > 0 {
+		var b strings.Builder
+		escape := strings.NewReplacer("\\", "\\\\", "[", "\\[", "]", "\\]", "*", "\\*", "_", "\\_", "<", "&lt;", ">", "&gt;", "\n", " ")
+		for _, raw := range items {
+			item, ok := raw.(map[string]any)
+			if !ok {
+				continue
+			}
+			title, _ := item["title"].(string)
+			link, _ := item["url"].(string)
+			if title == "" {
+				continue
+			}
+			u, err := url.Parse(link)
+			if err != nil || (u.Scheme != "https" && u.Scheme != "http") || u.Host == "" {
+				continue
+			}
+			fmt.Fprintf(&b, "- %s — <%s>\n", escape.Replace(title), strings.NewReplacer("<", "%3C", ">", "%3E", "\n", "%0A", "\r", "%0D").Replace(u.String()))
+		}
+		if b.Len() > 0 {
+			return b.String()
+		}
+	}
+	for _, key := range []string{"summary", "text"} {
+		if s, ok := result[key].(string); ok && s != "" {
+			return s
+		}
+	}
+	return ""
+}

--- a/agent/commands_execution_test.go
+++ b/agent/commands_execution_test.go
@@ -1,0 +1,159 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"mu/internal/app"
+	"mu/internal/service"
+)
+
+func TestCommandExecutionLifecycle(t *testing.T) {
+	for _, mode := range []string{"success", "fail", "empty", "wait"} {
+		t.Run(mode, func(t *testing.T) {
+			name := "command" + mode
+			if err := service.Register(service.Spec{Name: name, Handler: CommandProbe{}, Endpoints: map[string]service.Endpoint{"Read": {}}}); err != nil {
+				t.Fatal(err)
+			}
+			var events []string
+			var step Step
+			var output string
+			opts := QueryOpts{Stream: StreamHooks{
+				ToolStart: func(r ToolRun) {
+					events = append(events, "start")
+					if r.Name != name+"_read" {
+						t.Error(r)
+					}
+				},
+				ToolEnd: func(ToolRun) { events = append(events, "end") },
+				Token:   func(s string) { output += s },
+			}, OnStep: func(s Step) { step = s; events = append(events, "step") }}
+			ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+			defer cancel()
+			text, err := executeCommand(ctx, "owner", service.CommandCall{Service: name, Method: "Read", Args: map[string]any{"mode": mode, "account_id": "victim"}}, opts)
+			if mode == "success" {
+				if err != nil || text != "Ready for owner" || output != text || !step.OK {
+					t.Fatalf("%q %q %+v %v", text, output, step, err)
+				}
+			} else {
+				if err == nil || output != "" {
+					t.Fatalf("failure leaked output: %q %v", output, err)
+				}
+				if step.OK {
+					t.Fatal("failed call marked successful")
+				}
+			}
+			if strings.Join(events, ",") != "start,end,step" {
+				t.Fatalf("events=%v", events)
+			}
+		})
+	}
+}
+
+func TestCommandGatewayEnforcesChargesAndRefusals(t *testing.T) {
+	old := service.Gate
+	t.Cleanup(func() { service.Gate = old })
+	for _, refuse := range []bool{false, true} {
+		t.Run(fmt.Sprint(refuse), func(t *testing.T) {
+			name := "commandpaid"
+			if refuse {
+				name = "commandrefused"
+			}
+			allowed, charged := 0, 0
+			service.Gate.Allow = func(who, op string) (bool, error) {
+				allowed++
+				if who != "owner" || op != "command.test" {
+					t.Errorf("wrong billing %s %s", who, op)
+				}
+				if refuse {
+					return false, fmt.Errorf("insufficient credits")
+				}
+				return true, nil
+			}
+			service.Gate.Charge = func(who, op string) { charged++ }
+			if err := service.Register(service.Spec{Name: name, Handler: CommandProbe{}, Endpoints: map[string]service.Endpoint{"Read": {Cost: "command.test"}}}); err != nil {
+				t.Fatal(err)
+			}
+			_, err := executeCommand(context.Background(), "owner", service.CommandCall{Service: name, Method: "Read", Args: map[string]any{}}, QueryOpts{})
+			if allowed != 1 {
+				t.Errorf("allow checks=%d", allowed)
+			}
+			if refuse {
+				if err == nil || charged != 0 {
+					t.Fatalf("refused request charged or succeeded: %d %v", charged, err)
+				}
+			} else if err != nil || charged != 1 {
+				t.Fatalf("paid request: %d %v", charged, err)
+			}
+		})
+	}
+}
+
+func TestCommandRenderingBoundaries(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		result map[string]any
+		want   string
+	}{
+		{"summary", map[string]any{"summary": "Cloudy", "text": "model prose"}, "Cloudy"},
+		{"text", map[string]any{"text": "No results found."}, "No results found."},
+		{"empty", map[string]any{}, ""},
+		{"empty items", map[string]any{"items": []any{}, "text": "No results."}, "No results."},
+		{"bad shapes", map[string]any{"items": []any{nil, 5, "bad"}, "text": "Fallback"}, "Fallback"},
+		{"missing fields", map[string]any{"items": []any{map[string]any{"title": "No URL"}}, "text": "Fallback"}, "Fallback"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := commandText(tc.result); got != tc.want {
+				t.Fatalf("%q", got)
+			}
+		})
+	}
+	for _, url := range []string{"javascript:alert(1)", "data:text/html,bad", "file:///tmp/private", "//example.com", "https:///missing-host"} {
+		text := commandText(map[string]any{"items": []any{map[string]any{"title": "Link", "url": url}}})
+		if text != "" {
+			t.Errorf("unsafe URL rendered: %s", text)
+		}
+	}
+	text := commandText(map[string]any{"items": []any{map[string]any{"title": "[click](javascript:alert(1)) <script>alert(1)</script>", "url": "https://example.com/"}}})
+	rendered := app.RenderString(text)
+	if strings.Contains(rendered, "<script>") || strings.Contains(rendered, `href="javascript:`) {
+		t.Fatalf("unsafe markup: %s", rendered)
+	}
+	if !strings.Contains(rendered, "https://example.com/") {
+		t.Fatal("lost safe source link")
+	}
+}
+
+func TestCommandClearsInheritedIdentityForGuests(t *testing.T) {
+	if err := service.Register(service.Spec{Name: "commandguest", Handler: CommandProbe{}, Endpoints: map[string]service.Endpoint{"Read": {}}}); err != nil {
+		t.Fatal(err)
+	}
+	ctx := service.WithAccount(context.Background(), "victim")
+	text, err := executeCommand(ctx, "", service.CommandCall{Service: "commandguest", Method: "Read", Args: map[string]any{"account_id": "victim"}}, QueryOpts{})
+	if err != nil || text != "Ready for " {
+		t.Fatalf("guest inherited identity: %q %v", text, err)
+	}
+}
+
+func TestCommandMissingEndpointReturnsFailure(t *testing.T) {
+	for _, call := range []service.CommandCall{{Service: "missing-command-service", Method: "Read"}, {Service: "commandprobe", Method: "Missing"}} {
+		var visible string
+		_, err := executeCommand(context.Background(), "", call, QueryOpts{Stream: StreamHooks{Token: func(s string) { visible += s }}})
+		if err == nil || visible != "" {
+			t.Fatalf("missing endpoint succeeded: %+v %q %v", call, visible, err)
+		}
+	}
+}
+
+func TestCommandFailedServiceDoesNotFallThroughToModel(t *testing.T) {
+	if err := service.Register(service.Spec{Name: "commandfailure", Handler: CommandProbe{}, Endpoints: map[string]service.Endpoint{"Read": {Commands: []service.Command{{Pattern: "command failure", Defaults: map[string]any{"mode": "fail"}}}}}}); err != nil {
+		t.Fatal(err)
+	}
+	_, err := runNative("", "command failure", QueryOpts{})
+	if err == nil || !strings.Contains(err.Error(), "provider unavailable") || strings.Contains(err.Error(), "no AI provider") {
+		t.Fatalf("lost direct service error: %v", err)
+	}
+}

--- a/agent/commands_test.go
+++ b/agent/commands_test.go
@@ -1,0 +1,114 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"mu/internal/service"
+	"mu/service/news"
+	"mu/service/weather"
+	"mu/service/web"
+)
+
+func TestCommandLinksExcludeToolInstructions(t *testing.T) {
+	text := commandText(map[string]any{"text": "instructions for the model", "items": []any{map[string]any{"title": "A story", "url": "https://example.com/story"}}})
+	if !strings.Contains(text, "A story") || !strings.Contains(text, "https://example.com/story") || strings.Contains(text, "instructions") {
+		t.Fatal(text)
+	}
+}
+func TestCommandsRespectAgentAndAttachment(t *testing.T) {
+	for _, opts := range []QueryOpts{{System: "You are a specialist"}, {Extra: "Selected article"}} {
+		if _, ok := promptCommand("headlines", opts); ok {
+			t.Fatal("bypassed explicit context")
+		}
+	}
+}
+
+// A command reaches the same service gateway without configuring any model.
+func TestCommandExecutesWithoutModel(t *testing.T) {
+	if err := service.Register(service.Spec{Name: "commandprobe", Handler: CommandProbe{}, Endpoints: map[string]service.Endpoint{"Read": {}}}); err != nil {
+		t.Fatal(err)
+	}
+	var visible string
+	text, err := executeCommand(context.Background(), "reader", service.CommandCall{Service: "commandprobe", Method: "Read", Args: map[string]any{}}, QueryOpts{Stream: StreamHooks{Token: func(s string) { visible += s }}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if text != "Ready for reader" || visible != text {
+		t.Fatalf("text=%q visible=%q", text, visible)
+	}
+}
+
+type CommandProbe struct{}
+type CommandProbeRequest struct {
+	Mode string `json:"mode"`
+}
+type CommandProbeResponse struct {
+	Text string `json:"text"`
+}
+
+func (CommandProbe) Read(ctx context.Context, req *CommandProbeRequest, rsp *CommandProbeResponse) error {
+	switch req.Mode {
+	case "fail":
+		return fmt.Errorf("provider unavailable")
+	case "empty":
+		return nil
+	case "wait":
+		<-ctx.Done()
+		return ctx.Err()
+	}
+	rsp.Text = "Ready for " + service.AccountFrom(ctx)
+	return nil
+}
+
+func TestCommandCatalogueAndNativeFastPath(t *testing.T) {
+	for _, spec := range []service.Spec{news.Spec, weather.Spec, web.Spec} {
+		if err := service.Register(spec); err != nil {
+			t.Fatal(err)
+		}
+	}
+	cases := []struct{ input, service, method string }{
+		{"headlines", "news", "List"}, {"news", "news", "List"},
+		{"weather in London", "weather", "Lookup"}, {"what's the weather today?", "weather", "Lookup"},
+		{"is it going to rain?", "weather", "Lookup"},
+		{"search the web for Sam Altman", "web", "Search"},
+	}
+	for _, tc := range cases {
+		call, ok := promptCommand(tc.input, QueryOpts{Public: true})
+		if !ok || call.Service != tc.service || call.Method != tc.method {
+			t.Errorf("%q: %+v %v", tc.input, call, ok)
+		}
+	}
+	for _, input := range []string{"don't show headlines", "compare the weather in London and Paris", "weather in London tomorrow"} {
+		if _, ok := promptCommand(input, QueryOpts{Public: true}); ok {
+			t.Errorf("overmatched %q", input)
+		}
+	}
+	for _, opts := range []QueryOpts{{System: "Specialist"}, {Extra: "Selected source"}, {Tools: []string{"weather"}}} {
+		if _, ok := promptCommand("headlines", opts); ok {
+			t.Errorf("escaped options: %+v", opts)
+		}
+	}
+	for _, spec := range []service.Spec{news.Spec, weather.Spec, web.Spec} {
+		for method, ep := range spec.Endpoints {
+			for _, command := range ep.Commands {
+				input := strings.ReplaceAll(strings.ReplaceAll(command.Pattern, "{place}", "São Paulo"), "{query}", "Sam Altman and OpenAI")
+				call, ok := promptCommand(input, QueryOpts{Public: true})
+				if !ok || call.Service != spec.Name || call.Method != method {
+					t.Errorf("declared command %q failed: %+v %v", input, call, ok)
+				}
+				for k, v := range command.Defaults {
+					if call.Args[k] != v {
+						t.Errorf("%q lost default %s: %v", input, k, call.Args)
+					}
+				}
+			}
+		}
+	}
+	text, err := runNative("", "what's the weather today?", QueryOpts{Public: true})
+	if err != nil || !strings.Contains(text, "Which town or city") {
+		t.Fatalf("fast path failed: %q %v", text, err)
+	}
+}

--- a/agent/native.go
+++ b/agent/native.go
@@ -668,6 +668,12 @@ type StreamHooks struct {
 // This is the agent. There is no second one — see the note on ErrNoProvider,
 // and AGENTS.md for the rule that says so.
 func runNative(accountID, prompt string, opts QueryOpts) (string, error) {
+	if command, ok := promptCommand(prompt, opts); ok {
+		ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+		defer cancel()
+		return executeCommand(ctx, accountID, command, opts)
+	}
+
 	recorder := newNativeToolRecorder()
 	wrappers := []gmai.ToolWrapper{recorder.wrap}
 	if opts.OnStep != nil {

--- a/internal/service/commands.go
+++ b/internal/service/commands.go
@@ -1,0 +1,152 @@
+package service
+
+import (
+	"strings"
+	"unicode"
+	"unicode/utf8"
+)
+
+// Command is a deliberately small prompt grammar: an exact phrase, or a phrase
+// ending in one {argument}. Endpoints opt in; writes cannot be prompt commands.
+type Command struct {
+	Pattern  string
+	Defaults map[string]any
+}
+
+type CommandCall struct {
+	Service string
+	Method  string
+	Args    map[string]any
+}
+
+// MatchCommand resolves only declared, read-only commands in the caller's scope.
+// Conflicting declarations fail closed rather than depending on map order.
+func MatchCommand(input string, allowed []string) (CommandCall, bool) {
+	var found CommandCall
+	matched := false
+	best := -1
+	ambiguous := false
+	for _, spec := range Specs() {
+		inScope := false
+		for _, name := range allowed {
+			if name == spec.Name {
+				inScope = true
+				break
+			}
+		}
+		if !inScope || spec.Scoped {
+			continue
+		}
+		for method, ep := range spec.Endpoints {
+			if ep.Writes || ep.Destructive || ep.Needs != 0 {
+				continue
+			}
+			for _, command := range ep.Commands {
+				args, ok := command.match(input)
+				if !ok {
+					continue
+				}
+				score := len(command.Pattern)
+				if i := strings.Index(command.Pattern, "{"); i >= 0 {
+					score = i
+				} else {
+					score += 10000
+				}
+				if score < best {
+					continue
+				}
+				if score == best {
+					ambiguous = true
+					continue
+				}
+				found = CommandCall{spec.Name, method, args}
+				matched = true
+				best = score
+				ambiguous = false
+			}
+		}
+	}
+	if !matched || ambiguous {
+		return CommandCall{}, false
+	}
+	return found, true
+}
+
+func (c Command) match(input string) (map[string]any, bool) {
+	input = strings.TrimSpace(input)
+	if input == "" || len(input) > 8000 || !utf8.ValidString(input) {
+		return nil, false
+	}
+	for _, r := range input {
+		if unicode.IsControl(r) && r != '\t' {
+			return nil, false
+		}
+	}
+	words := strings.Fields(c.Pattern)
+	if len(words) == 0 {
+		return nil, false
+	}
+	args := map[string]any{}
+	for k, v := range c.Defaults {
+		args[k] = v
+	}
+	last := words[len(words)-1]
+	if !strings.HasPrefix(last, "{") {
+		if strings.ContainsAny(c.Pattern, "{}") {
+			return nil, false
+		}
+		return args, strings.EqualFold(strings.Join(strings.Fields(strings.TrimRight(input, "?!.")), " "), strings.Join(words, " "))
+	}
+	if !strings.HasSuffix(last, "}") || len(words) < 2 {
+		return nil, false
+	}
+	key := strings.TrimSuffix(strings.TrimPrefix(last, "{"), "}")
+	if key == "" {
+		return nil, false
+	}
+	for _, r := range key {
+		if !unicode.IsLetter(r) && r != '_' {
+			return nil, false
+		}
+	}
+	rest := input
+	for _, word := range words[:len(words)-1] {
+		if strings.ContainsAny(word, "{}") {
+			return nil, false
+		}
+		end := strings.IndexFunc(rest, unicode.IsSpace)
+		if end < 0 || !strings.EqualFold(rest[:end], word) {
+			return nil, false
+		}
+		rest = strings.TrimLeftFunc(rest[end:], unicode.IsSpace)
+	}
+	value := strings.TrimSpace(rest)
+	if value == "" {
+		return nil, false
+	}
+	for _, join := range []string{" then ", " and send ", " and email ", " and summarise ", " and summarize ", " and compare ", " and weather ", " and news "} {
+		if strings.Contains(strings.ToLower(strings.Join(strings.Fields(value), " ")), join) {
+			return nil, false
+		}
+	}
+	if key == "place" {
+		value = strings.TrimRight(value, "?!. ")
+		if value == "" || strings.EqualFold(value, "in") || strings.EqualFold(value, "at") || strings.EqualFold(value, "for") {
+			return nil, false
+		}
+		for _, word := range strings.Fields(strings.ToLower(value)) {
+			word = strings.Trim(word, ",;:?!.")
+			switch word {
+			case "and", "then", "tomorrow", "today", "next", "yesterday", "not", "don't", "don’t", "like", "here", "there", "me", "my", "this", "week", "tonight":
+				return nil, false
+			}
+		}
+		for _, r := range value {
+			if !unicode.IsLetter(r) && !unicode.IsSpace(r) && !strings.ContainsRune("-'’.,", r) {
+				return nil, false
+			}
+		}
+	}
+	args[key] = value
+	return args, true
+}

--- a/internal/service/commands_exhaustive_test.go
+++ b/internal/service/commands_exhaustive_test.go
@@ -1,0 +1,137 @@
+package service
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestCommandPhrasingMatrix(t *testing.T) {
+	for _, phrase := range []string{"headlines", "show me the news", "what's the weather today", "is it going to rain"} {
+		for _, caseFn := range []func(string) string{strings.ToLower, strings.ToUpper, func(s string) string { return s }} {
+			for _, separator := range []string{" ", "  ", "\t", "\u00a0"} {
+				for _, suffix := range []string{"", "?", "!", "."} {
+					input := "  " + strings.ReplaceAll(caseFn(phrase), " ", separator) + suffix + "  "
+					if _, ok := (Command{Pattern: phrase}).match(input); !ok {
+						t.Errorf("did not match %q", input)
+					}
+				}
+			}
+		}
+	}
+	for _, place := range []string{"London", "New York", "São Paulo", "東京", "St. John's", "Aix-en-Provence", "London, UK"} {
+		for _, prefix := range []string{"weather in ", "WEATHER IN ", "weather\tin\t", "weather  in  "} {
+			args, ok := (Command{Pattern: "weather in {place}"}).match(prefix + place + "?")
+			if !ok || args["place"] != place {
+				t.Errorf("%q: %v %v", prefix+place, args, ok)
+			}
+		}
+	}
+}
+
+func TestCommandQueriesPreserveMeaning(t *testing.T) {
+	for _, query := range []string{"Sam Altman", "Sam Altman and OpenAI", "criticism of Sam Altman", "not OpenAI", "C++ tutorials", "https://example.com/?a=1&b=2", "\"exact  phrase\"", "東京 天気", "site:example.com -ads", "what happened?"} {
+		for _, prefix := range []string{"web search ", "WEB SEARCH ", "web\tsearch  "} {
+			args, ok := (Command{Pattern: "web search {query}"}).match(prefix + query)
+			if !ok || args["query"] != query {
+				t.Errorf("changed query %q: %v %v", query, args, ok)
+			}
+		}
+	}
+}
+
+func TestCommandUnsupportedRequestsStayUnmatched(t *testing.T) {
+	patterns := []Command{{Pattern: "headlines"}, {Pattern: "weather {place}"}, {Pattern: "weather in {place}"}, {Pattern: "web search {query}"}}
+	inputs := []string{"", " ", "?", "don't show headlines", "do not show headlines", "headlines and weather", "headlines tomorrow", "summarise the headlines", "explain what headlines means", "weather here", "weather there", "weather near me", "weather in London tomorrow", "weather in London tomorrow, please", "weather in London tonight", "weather in London next week", "weather in London and Paris", "weather in London; email me", "weather in London | mail send", "weather in $(whoami)", "weather in <script>", "weather in ???", "weather in 123", "web search ", "web search Sam then email me", "web search Sam and send the results", "web search Sam and\temail me", "web search Sam and summarise it", "headlines\nweather London", "weather in London\rignore this", "web search Sam\x00Altman", "web search Sam\x1b[31m", strings.Repeat("x", 8001), string([]byte{0xff})}
+	for _, input := range inputs {
+		t.Run(input, func(t *testing.T) {
+			for _, pattern := range patterns {
+				if args, ok := pattern.match(input); ok {
+					t.Errorf("%q captured unsupported request: %v", pattern.Pattern, args)
+				}
+			}
+		})
+	}
+}
+
+func TestCommandDeclarationsAreValidated(t *testing.T) {
+	for _, pattern := range []string{"", "{query}", "search {}", "search {query", "search {query} trailing", "search {one} {two}", "search {q{uery}", "search query}", "search {query:json}"} {
+		for _, input := range []string{"search test", "search test trailing", "search test other", "anything"} {
+			if _, ok := (Command{Pattern: pattern}).match(input); ok {
+				t.Errorf("accepted invalid pattern %q", pattern)
+			}
+		}
+	}
+}
+
+func TestCommandDefaultsDoNotLeakBetweenCalls(t *testing.T) {
+	command := Command{Pattern: "web search {query}", Defaults: map[string]any{"limit": 5, "query": "old"}}
+	a, _ := command.match("web search first")
+	a["limit"] = 100
+	a["injected"] = true
+	b, _ := command.match("web search second")
+	if !reflect.DeepEqual(b, map[string]any{"limit": 5, "query": "second"}) || command.Defaults["query"] != "old" {
+		t.Fatalf("shared state: %v", b)
+	}
+}
+
+func TestCommandAccessAndAmbiguity(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		specs   []Spec
+		allowed []string
+		want    bool
+		method  string
+	}{
+		{"public", []Spec{{Name: "s", Endpoints: map[string]Endpoint{"Read": {Commands: []Command{{Pattern: "read"}}}}}}, []string{"s"}, true, "Read"},
+		{"outside scope", []Spec{{Name: "s", Endpoints: map[string]Endpoint{"Read": {Commands: []Command{{Pattern: "read"}}}}}}, []string{"other"}, false, ""},
+		{"private service", []Spec{{Name: "s", Scoped: true, Endpoints: map[string]Endpoint{"Read": {Commands: []Command{{Pattern: "read"}}}}}}, []string{"s"}, false, ""},
+		{"write", []Spec{{Name: "s", Endpoints: map[string]Endpoint{"Read": {Writes: true, Commands: []Command{{Pattern: "read"}}}}}}, []string{"s"}, false, ""},
+		{"destructive", []Spec{{Name: "s", Endpoints: map[string]Endpoint{"Read": {Destructive: true, Commands: []Command{{Pattern: "read"}}}}}}, []string{"s"}, false, ""},
+		{"caller", []Spec{{Name: "s", Endpoints: map[string]Endpoint{"Read": {Needs: Caller, Commands: []Command{{Pattern: "read"}}}}}}, []string{"s"}, false, ""},
+		{"account", []Spec{{Name: "s", Endpoints: map[string]Endpoint{"Read": {Needs: Account, Commands: []Command{{Pattern: "read"}}}}}}, []string{"s"}, false, ""},
+		{"operator", []Spec{{Name: "s", Endpoints: map[string]Endpoint{"Read": {Needs: Operator, Commands: []Command{{Pattern: "read"}}}}}}, []string{"s"}, false, ""},
+		{"two methods", []Spec{{Name: "s", Endpoints: map[string]Endpoint{"A": {Commands: []Command{{Pattern: "read"}}}, "B": {Commands: []Command{{Pattern: "read"}}}}}}, []string{"s"}, false, ""},
+		{"two services", []Spec{{Name: "a", Endpoints: map[string]Endpoint{"Read": {Commands: []Command{{Pattern: "read"}}}}}, {Name: "b", Endpoints: map[string]Endpoint{"Read": {Commands: []Command{{Pattern: "read"}}}}}}, []string{"a", "b"}, false, ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			specMu.Lock()
+			old := specs
+			specs = map[string]Spec{}
+			for _, s := range tc.specs {
+				specs[s.Name] = s
+			}
+			specMu.Unlock()
+			defer func() { specMu.Lock(); specs = old; specMu.Unlock() }()
+			for i := 0; i < 20; i++ {
+				got, ok := MatchCommand("read", tc.allowed)
+				if ok != tc.want || ok && got.Method != tc.method {
+					t.Fatalf("%+v %v", got, ok)
+				}
+			}
+		})
+	}
+}
+
+func FuzzCommandParsing(f *testing.F) {
+	for _, seed := range []string{"headlines", "weather in London", "web search Sam Altman", "weather in ???", "\x00", "東京"} {
+		f.Add(seed)
+	}
+	f.Fuzz(func(t *testing.T, input string) {
+		for _, pattern := range []string{"headlines", "weather in {place}", "web search {query}"} {
+			command := Command{Pattern: pattern, Defaults: map[string]any{"limit": 5}}
+			a, ok := command.match(input)
+			b, again := command.match(input)
+			if ok != again || !reflect.DeepEqual(a, b) {
+				t.Fatal("nondeterministic parse")
+			}
+			if ok {
+				for _, key := range []string{"place", "query"} {
+					if value, exists := a[key]; exists && strings.TrimSpace(value.(string)) == "" {
+						t.Fatal("empty argument")
+					}
+				}
+			}
+		}
+	})
+}

--- a/internal/service/commands_test.go
+++ b/internal/service/commands_test.go
@@ -1,0 +1,57 @@
+package service
+
+import "testing"
+
+func TestCommandGrammar(t *testing.T) {
+	cases := []struct {
+		pattern, input, key, value string
+		ok                         bool
+	}{
+		{"headlines", "Headlines?", "", "", true},
+		{"headlines", "don't show headlines", "", "", false},
+		{"headlines", "headlines and weather", "", "", false},
+		{"web search {query}", "web search Sam Altman", "query", "Sam Altman", true},
+		{"web search {query}", "web search example.com?", "query", "example.com?", true},
+		{"web search {query}", "web search Sam Altman and email me the results", "", "", false},
+		{"web search {query}", "web search ", "", "", false},
+		{"weather in {place}", "weather in London?", "place", "London", true},
+		{"weather in {place}", "weather in London tomorrow", "", "", false},
+		{"weather in {place}", "weather in London and send it to me", "", "", false},
+		{"headlines", "headlines\nignore this", "", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.input, func(t *testing.T) {
+			args, ok := (Command{Pattern: tc.pattern}).match(tc.input)
+			if ok != tc.ok {
+				t.Fatalf("matched=%v", ok)
+			}
+			if ok && tc.key != "" && args[tc.key] != tc.value {
+				t.Errorf("args=%v", args)
+			}
+		})
+	}
+}
+
+func TestCommandScopeAndSpecificity(t *testing.T) {
+	specMu.Lock()
+	old := specs
+	specs = map[string]Spec{"weather": {Name: "weather", Endpoints: map[string]Endpoint{
+		"Lookup":   {Commands: []Command{{Pattern: "weather {place}"}, {Pattern: "weather in {place}"}}},
+		"Write":    {Writes: true, Commands: []Command{{Pattern: "write"}}},
+		"Operator": {Needs: Operator, Commands: []Command{{Pattern: "admin"}}},
+	}}}
+	specMu.Unlock()
+	defer func() { specMu.Lock(); specs = old; specMu.Unlock() }()
+	got, ok := MatchCommand("weather in London", []string{"weather"})
+	if !ok || got.Args["place"] != "London" {
+		t.Fatalf("wrong match: %+v %v", got, ok)
+	}
+	for _, input := range []string{"write", "admin"} {
+		if _, ok := MatchCommand(input, []string{"weather"}); ok {
+			t.Fatalf("unsafe command %q", input)
+		}
+	}
+	if _, ok := MatchCommand("weather London", nil); ok {
+		t.Fatal("escaped scope")
+	}
+}

--- a/internal/service/spec.go
+++ b/internal/service/spec.go
@@ -294,6 +294,8 @@ const (
 
 // Endpoint is one method of a service.
 type Endpoint struct {
+	Commands []Command
+
 	// Doc is what the method does, written for a model rather than a
 	// developer: it is what the agent reads when choosing a tool.
 	Doc string

--- a/service/news/service.go
+++ b/service/news/service.go
@@ -122,7 +122,7 @@ var Spec = service.Spec{
 	Now: Now,
 	Endpoints: map[string]service.Endpoint{
 		"Headlines": {Doc: "Read the home card headlines: latest story per topic, freshest first, at most ten"},
-		"List":      {Aliases: []string{"news"}, Doc: "Read recent news headlines with short summaries, balanced across topics"},
+		"List":      {Commands: []service.Command{{Pattern: "news", Defaults: map[string]any{"limit": 5}}, {Pattern: "headlines", Defaults: map[string]any{"limit": 5}}, {Pattern: "latest headlines", Defaults: map[string]any{"limit": 5}}, {Pattern: "show me the news", Defaults: map[string]any{"limit": 5}}}, Aliases: []string{"news"}, Doc: "Read recent news headlines with short summaries, balanced across topics"},
 		"Read":      {Doc: "Read one news article in full by its id or URL"},
 		"Search":    {Doc: "Search indexed and live news for a topic", Cost: quota.OpNewsSearch},
 	},

--- a/service/weather/lookup.go
+++ b/service/weather/lookup.go
@@ -1,0 +1,107 @@
+package weather
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"mu/internal/service"
+)
+
+// LookupRequest names a place rather than requiring coordinates.
+type LookupRequest struct {
+	Place string `json:"place" description:"Town or city to look up"`
+	Focus string `json:"focus,omitempty" description:"rain for a rain-focused answer, otherwise a general forecast"`
+}
+
+func (Server) Lookup(ctx context.Context, req *LookupRequest, rsp *ForecastResponse) error {
+	if len(req.Place) > 200 {
+		return fmt.Errorf("place name is too long")
+	}
+	if req.Focus != "" && req.Focus != "rain" {
+		return fmt.Errorf("focus must be rain or empty")
+	}
+	if strings.TrimSpace(req.Place) == "" {
+		service.ServedFromCache(ctx)
+		rsp.Summary = "Which town or city? Try ‘weather in London’."
+		return nil
+	}
+	places, err := geocode(ctx, req.Place)
+	if err != nil {
+		return err
+	}
+	if len(places) == 0 {
+		service.ServedFromCache(ctx)
+		rsp.Summary = "I couldn't find that place. Please include the town or city and country."
+		return nil
+	}
+	place := places[0]
+	if !validCoordinates(place.Lat, place.Lon) {
+		return fmt.Errorf("place lookup returned invalid coordinates")
+	}
+	forecast, err := FetchWeather(ctx, place.Lat, place.Lon)
+	if err != nil {
+		return err
+	}
+	if forecast == nil {
+		return fmt.Errorf("forecast unavailable")
+	}
+	rsp.Summary = lookupForecastText(forecast, place.Label(), req.Focus, time.Now().UTC())
+	return nil
+}
+
+// A direct answer is for a person, without the calendar instructions carried
+// by the model-facing Forecast response. Dates remain explicit.
+func lookupForecastText(f *WeatherForecast, place, focus string, at time.Time) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s\n\n", place)
+	today, haveToday := dailyItemForDate(f.DailyItems, at)
+	if focus == "rain" {
+		lead := "Today’s rain forecast is unavailable."
+		if haveToday {
+			if today.WillRain || today.RainMM > 0 || today.RainChance > 0 {
+				lead = "Rain is possible today."
+				if today.RainMM > 0 {
+					lead = fmt.Sprintf("Rain is forecast today: %.1f mm.", today.RainMM)
+				}
+				if today.RainChance > 0 {
+					lead += fmt.Sprintf(" Chance of rain: %d%%.", today.RainChance)
+				}
+			} else {
+				lead = "No rain is indicated in today’s forecast."
+			}
+		}
+		b.WriteString(lead + "\n\n")
+	}
+	if f.Current != nil && !f.ObservedAt.IsZero() {
+		fmt.Fprintf(&b, "Now: %.0f°C, %s.\n", f.Current.TempC, f.Current.Description)
+	} else {
+		b.WriteString("Current conditions are unavailable.\n")
+	}
+	if !haveToday {
+		b.WriteString("Today’s forecast is unavailable.\n")
+	}
+	shown := 0
+	for _, day := range f.DailyItems {
+		if day.Date.Format("2006-01-02") < at.Format("2006-01-02") {
+			continue
+		}
+		fmt.Fprintf(&b, "\n%s: %.0f–%.0f°C, %s", day.Date.Format("Mon 2 Jan"), day.MinTempC, day.MaxTempC, day.Description)
+		if day.RainChance > 0 {
+			fmt.Fprintf(&b, ", %d%% chance of rain", day.RainChance)
+		}
+		if day.RainMM > 0 {
+			fmt.Fprintf(&b, ", %.1f mm rain", day.RainMM)
+		}
+		b.WriteString(".\n")
+		shown++
+		if shown == 5 {
+			break
+		}
+	}
+	if !f.GeneratedAt.IsZero() {
+		fmt.Fprintf(&b, "\nForecast updated %s UTC.", f.GeneratedAt.UTC().Format("2 Jan 15:04"))
+	}
+	return b.String()
+}

--- a/service/weather/lookup_test.go
+++ b/service/weather/lookup_test.go
@@ -1,0 +1,144 @@
+package weather
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestLookupAsksForMissingPlace(t *testing.T) {
+	var rsp ForecastResponse
+	if err := (Server{}).Lookup(context.Background(), &LookupRequest{Focus: "rain"}, &rsp); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(rsp.Summary, "Which town or city") {
+		t.Fatal(rsp.Summary)
+	}
+}
+func TestLookupReportsUnknownPlace(t *testing.T) {
+	stubGeocoder(t, nil)
+	var rsp ForecastResponse
+	if err := (Server{}).Lookup(context.Background(), &LookupRequest{Place: "Missing"}, &rsp); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(rsp.Summary, "couldn't find") {
+		t.Fatal(rsp.Summary)
+	}
+}
+
+func TestLookupWeatherAndRainMatrix(t *testing.T) {
+	cases := []struct {
+		name, focus  string
+		day          *DailyItem
+		want, absent string
+	}{
+		{"general", "", &DailyItem{MaxTempC: 20, MinTempC: 12, Description: "Cloudy"}, "Cloudy", "Chance of rain"},
+		{"rain amount", "rain", &DailyItem{RainMM: 3.5, WillRain: true, RainChance: 80}, "3.5 mm", "No rain"},
+		{"probability only", "rain", &DailyItem{WillRain: true, RainChance: 60}, "Chance of rain: 60%", "0.0 mm"},
+		{"low probability", "rain", &DailyItem{RainChance: 20}, "Chance of rain: 20%", "No rain"},
+		{"rain flag only", "rain", &DailyItem{WillRain: true}, "Rain is possible today", "0.0 mm"},
+		{"no rain indicated", "rain", &DailyItem{Description: "Sunny"}, "No rain is indicated", "Rain is forecast"},
+		{"missing today", "rain", nil, "rain forecast is unavailable", "No rain"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			resetCache()
+			t.Cleanup(resetCache)
+			stubGeocoder(t, []Place{{Name: "London", Country: "United Kingdom", Lat: 51.5, Lon: -0.1}})
+			forecast := &WeatherForecast{Location: "London", Current: &CurrentConditions{TempC: 18, Description: "Cloudy"}, ObservedAt: time.Now().UTC()}
+			if tc.day != nil {
+				day := *tc.day
+				day.Date = time.Now().UTC()
+				forecast.DailyItems = []DailyItem{day}
+			}
+			storeForecast(51.5, -0.1, forecast)
+			var rsp ForecastResponse
+			if err := (Server{}).Lookup(context.Background(), &LookupRequest{Place: "London", Focus: tc.focus}, &rsp); err != nil {
+				t.Fatal(err)
+			}
+			if !strings.Contains(rsp.Summary, tc.want) || strings.Contains(rsp.Summary, tc.absent) {
+				t.Fatalf("unexpected summary: %s", rsp.Summary)
+			}
+			if strings.Contains(rsp.Summary, "Calendar rule") || strings.Contains(rsp.Summary, "Current request date:") {
+				t.Fatal("leaked model instructions")
+			}
+			if !strings.Contains(rsp.Summary, "United Kingdom") {
+				t.Fatal("resolved location not identified")
+			}
+		})
+	}
+}
+
+func TestLookupReportsGeocoderFailures(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		status int
+		body   string
+	}{
+		{"server failure", 503, `unavailable`}, {"invalid json", 200, `{broken`}, {"wrong schema", 200, `{"results":"bad"}`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(tc.status); fmt.Fprint(w, tc.body) }))
+			defer srv.Close()
+			old := geocodeURL
+			geocodeURL = srv.URL
+			defer func() { geocodeURL = old }()
+			var rsp ForecastResponse
+			if err := (Server{}).Lookup(context.Background(), &LookupRequest{Place: "London"}, &rsp); err == nil || rsp.Summary != "" {
+				t.Fatalf("failure treated as weather: %q %v", rsp.Summary, err)
+			}
+		})
+	}
+}
+
+func TestLookupCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	old := geocodeURL
+	geocodeURL = "http://127.0.0.1:1"
+	defer func() { geocodeURL = old }()
+	var rsp ForecastResponse
+	if err := (Server{}).Lookup(ctx, &LookupRequest{Place: "London"}, &rsp); err == nil {
+		t.Fatal("cancelled lookup succeeded")
+	}
+}
+
+func TestLookupUsesDatedRowsAndBoundsOutput(t *testing.T) {
+	at := time.Date(2026, 9, 7, 12, 0, 0, 0, time.UTC)
+	f := &WeatherForecast{DailyItems: []DailyItem{{Date: at.AddDate(0, 0, -1), RainMM: 99}}}
+	for i := 1; i <= 7; i++ {
+		f.DailyItems = append(f.DailyItems, DailyItem{Date: at.AddDate(0, 0, i), Description: fmt.Sprintf("day-%d", i)})
+	}
+	text := lookupForecastText(f, "London", "rain", at)
+	if !strings.Contains(text, "rain forecast is unavailable") || strings.Contains(text, "99") || strings.Contains(text, "day-6") || strings.Contains(text, "Forecast updated") {
+		t.Fatalf("invented current data or unbounded rows: %s", text)
+	}
+	if !strings.Contains(text, "Current conditions are unavailable") || !strings.Contains(text, "day-5") {
+		t.Fatal(text)
+	}
+}
+
+func TestLookupRejectsInvalidInputsBeforeFetching(t *testing.T) {
+	old := geocodeURL
+	geocodeURL = "http://127.0.0.1:1"
+	defer func() { geocodeURL = old }()
+	for _, req := range []LookupRequest{{Place: strings.Repeat("a", 201)}, {Place: "London", Focus: "unknown"}} {
+		var rsp ForecastResponse
+		err := (Server{}).Lookup(context.Background(), &req, &rsp)
+		if err == nil || strings.Contains(err.Error(), "connect") {
+			t.Fatalf("input was not rejected before network: %v", err)
+		}
+	}
+}
+func TestLookupRejectsInvalidResolvedCoordinates(t *testing.T) {
+	stubGeocoder(t, []Place{{Name: "Broken", Lat: 1000, Lon: 0}})
+	var rsp ForecastResponse
+	err := (Server{}).Lookup(context.Background(), &LookupRequest{Place: "Broken"}, &rsp)
+	if err == nil || !strings.Contains(err.Error(), "invalid coordinates") {
+		t.Fatalf("accepted invalid location: %v", err)
+	}
+}

--- a/service/weather/service.go
+++ b/service/weather/service.go
@@ -180,6 +180,16 @@ var Spec = service.Spec{
 	Icon:        "weather.svg",
 	Card:        service.Personal(CardHTML),
 	Endpoints: map[string]service.Endpoint{
+		"Lookup": {Doc: "Look up the weather by town or city name", Cost: quota.OpWeatherForecast, Commands: []service.Command{
+			{Pattern: "what's the weather like in {place}"}, {Pattern: "what is the weather in {place}"}, {Pattern: "is it going to rain in {place}", Defaults: map[string]any{"focus": "rain"}}, {Pattern: "weather in {place}"}, {Pattern: "weather {place}"},
+			{Pattern: "what's the weather like"}, {Pattern: "what’s the weather like"},
+			{Pattern: "what's the weather today"}, {Pattern: "what’s the weather today"},
+			{Pattern: "what is the weather today"}, {Pattern: "weather"}, {Pattern: "weather today"}, {Pattern: "what’s the weather"}, {Pattern: "what's the weather"},
+			{Pattern: "is it going to rain today", Defaults: map[string]any{"focus": "rain"}},
+			{Pattern: "is it going to rain", Defaults: map[string]any{"focus": "rain"}},
+			{Pattern: "will it rain", Defaults: map[string]any{"focus": "rain"}},
+			{Pattern: "will it rain in {place}", Defaults: map[string]any{"focus": "rain"}},
+		}},
 		"Forecast": {Doc: "Get the weather forecast for a location — current conditions, the days " +
 			"ahead, and today's sunrise, sunset and how much daylight is left, which is the fact " +
 			"that decides an afternoon outdoors",

--- a/service/web/command_test.go
+++ b/service/web/command_test.go
@@ -1,0 +1,76 @@
+package web
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+type commandTransport func(*http.Request) (*http.Response, error)
+
+func (f commandTransport) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+func TestCommandSearchResultsAndCache(t *testing.T) {
+	t.Setenv("BRAVE_API_KEY", "test-command-key")
+	old := httpClient
+	calls := 0
+	httpClient = &http.Client{Transport: commandTransport(func(r *http.Request) (*http.Response, error) {
+		calls++
+		if r.URL.Query().Get("q") != "Sam Altman and OpenAI" || r.URL.Query().Get("count") != "5" {
+			t.Errorf("wrong query: %s", r.URL.String())
+		}
+		return &http.Response{StatusCode: 200, Body: io.NopCloser(strings.NewReader(`{"web":{"results":[{"title":"A source","url":"https://example.com/story","description":"Useful text"}]}}`)), Header: make(http.Header)}, nil
+	})}
+	t.Cleanup(func() { httpClient = old })
+	// Unique query cache entry for this test, restored so test order is irrelevant.
+	braveCache.Lock()
+	saved := braveCache.entries
+	braveCache.entries = make(map[string]braveCacheEntry)
+	braveCache.Unlock()
+	t.Cleanup(func() { braveCache.Lock(); braveCache.entries = saved; braveCache.Unlock() })
+	for i := 0; i < 2; i++ {
+		var rsp SearchResponse
+		if err := (Server{}).Search(context.Background(), &SearchRequest{Query: "Sam Altman and OpenAI", Limit: 5}, &rsp); err != nil {
+			t.Fatal(err)
+		}
+		if len(rsp.Items) != 1 || rsp.Items[0].Title != "A source" || rsp.Items[0].URL != "https://example.com/story" || !strings.Contains(rsp.Text, "A source") {
+			t.Fatalf("lost results: %+v", rsp)
+		}
+	}
+	if calls != 1 {
+		t.Fatalf("repeated search made %d provider calls", calls)
+	}
+}
+
+func TestCommandSearchFailureAndEmptyResults(t *testing.T) {
+	t.Setenv("BRAVE_API_KEY", "test-command-key")
+	old := httpClient
+	t.Cleanup(func() { httpClient = old })
+	for _, tc := range []struct {
+		name   string
+		status int
+		body   string
+		fail   bool
+	}{
+		{"empty", 200, `{"web":{"results":[]}}`, false},
+		{"provider error", 503, `unavailable`, true},
+		{"bad json", 200, `{broken`, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			httpClient = &http.Client{Transport: commandTransport(func(*http.Request) (*http.Response, error) {
+				return &http.Response{StatusCode: tc.status, Status: fmt.Sprint(tc.status), Body: io.NopCloser(strings.NewReader(tc.body)), Header: make(http.Header)}, nil
+			})}
+			var rsp SearchResponse
+			err := (Server{}).Search(context.Background(), &SearchRequest{Query: "command-fixture-" + tc.name}, &rsp)
+			if (err != nil) != tc.fail {
+				t.Fatalf("err=%v", err)
+			}
+			if !tc.fail && (rsp.Text != "No web results found." || len(rsp.Items) != 0) {
+				t.Fatalf("empty results: %+v", rsp)
+			}
+		})
+	}
+}

--- a/service/web/service.go
+++ b/service/web/service.go
@@ -35,13 +35,30 @@ type SearchRequest struct {
 
 // SearchResponse is a model-ready set of results.
 type SearchResponse struct {
+	Items []BraveResult `json:"items,omitempty"`
+
 	Text string `json:"text" description:"Search results for the query"`
 }
 
 // Search searches the web for current information and news.
 // @example {"query": "latest AI news"}
 func (Server) Search(_ context.Context, req *SearchRequest, rsp *SearchResponse) error {
-	rsp.Text = SearchText(req.Query, req.Limit)
+	if req.Limit <= 0 || req.Limit > 10 {
+		req.Limit = 6
+	}
+	results, err := SearchBraveCached(req.Query, req.Limit)
+	if err != nil {
+		return err
+	}
+	if len(results) > req.Limit {
+		results = results[:req.Limit]
+	}
+	rsp.Items = results
+	if len(results) == 0 {
+		rsp.Text = "No web results found."
+	} else {
+		rsp.Text = formatWebSearchResults(req.Query, results)
+	}
 	return nil
 }
 
@@ -114,6 +131,6 @@ var Spec = service.Spec{
 			// agent along with the anonymous one.
 			Needs: service.Caller,
 		},
-		"Search": {Aliases: []string{"search_web"}, Doc: "Search the web for current information and news", Cost: quota.OpWebSearch},
+		"Search": {Commands: []service.Command{{Pattern: "search the web for {query}", Defaults: map[string]any{"limit": 5}}, {Pattern: "web search {query}", Defaults: map[string]any{"limit": 5}}}, Aliases: []string{"search_web"}, Doc: "Search the web for current information and news", Cost: quota.OpWebSearch},
 	},
 }


### PR DESCRIPTION
Simple requests such as headlines, weather in London, and explicit web searches currently wait for a model to choose a tool and compose an answer. Add a small command grammar declared on service endpoints and resolved before native model construction.

The first vocabulary covers news/headlines, web search phrases, and common weather/rain questions. Matching is scoped, read-only, conservative about compound requests, and preserves search terms. Exact phrases and more specific prefixes win; ambiguous declarations do not execute. Specialist instructions and attached source context keep the existing agent path.

Recognised commands use the existing service gateway, preserving caller identity and service charges without an agent-run charge in Ask. Failures are returned directly. Existing SSE and conversation recording remain in place. News and web results render structured source links, and a new weather Lookup endpoint resolves named places and returns a human-readable forecast. Missing locations prompt for a town/city. No model router, second agent loop, shell execution or composition engine is introduced.

Extensive tests cover hundreds of case/whitespace/Unicode/punctuation variants, query preservation, negation, incomplete commands, compound requests, invalid declarations, scope and ambiguity, all declared command phrases, guest identity isolation, gateway billing/refusal, cancellation, provider failures, empty responses, safe rendering, weather dates/rain probabilities, and cached web search. Tests caught and fixed a low-rain-probability misstatement and model-instruction leakage into weather output.

Validation: focused regression tests passed across service runtime, agent, weather, web and news. Race checks passed for the command/lookup suites; parser fuzzing executed 26,546 inputs without a failure. New parser, dispatcher and weather-answer functions have 92–100% statement coverage (command rendering 95.2%). Full binary build, focused go vet and formatting checks pass. All provider fixtures are local; no paid live-provider calls or production latency measurement were performed.