### PR TITLE
Schedule daily briefs from the Home brief card

### DIFF
--- a/home/brief.go
+++ b/home/brief.go
@@ -89,9 +89,9 @@ import (
 // true on the quietest day. True and useless as a sentence — who is here is its
 // own block under the box now, and it names people rather than telling you
 // there are none.
-func briefHTML(accountID string) string {
+func briefHTML(accountID string, csrf ...string) string {
 	parts := briefParts(accountID)
-	if len(parts) == 0 {
+	if len(parts) == 0 && accountID == "" {
 		return ""
 	}
 
@@ -117,7 +117,7 @@ func briefHTML(accountID string) string {
 	// saying Brief. It is its own block under the box now, and it names people
 	// rather than counting them.
 	return sectionRule("Brief") + `<div class="brief-peek">` +
-		`<p class="home-brief">` + strings.Join(parts, " ") + `</p></div>`
+		`<p class="home-brief">` + strings.Join(parts, " ") + `</p>` + briefScheduleHTML(accountID, csrf...) + `</div>`
 }
 
 // briefParts is the clauses, without deciding how they are set.
@@ -271,7 +271,7 @@ func onToday(accountID string) string {
 	now := time.Now()
 	var ahead []*events.Event
 	for _, e := range events.List(accountID) {
-		if e == nil || e.When.IsZero() {
+		if e == nil || e.Paused || e.When.IsZero() {
 			continue
 		}
 		if sameDay(e.When, now) && e.When.After(now) {

--- a/home/brief_schedule.go
+++ b/home/brief_schedule.go
@@ -1,0 +1,96 @@
+package home
+
+import (
+	"html"
+	"mu/internal/app"
+	"mu/internal/auth"
+	"mu/service/events"
+	"net/http"
+	"strings"
+	"time"
+)
+
+func briefScheduleHTML(owner string, csrf ...string) string {
+	if owner == "" {
+		return ""
+	}
+	token := ""
+	if len(csrf) > 0 {
+		token = csrf[0]
+	}
+	clock, zone, repeat, period := "20:00", "", "daily", "evening"
+	label, status := "Schedule", ""
+	if acc, err := auth.GetAccount(owner); err == nil && acc != nil {
+		zone = acc.Zone
+	}
+	e := events.Brief(owner)
+	if e != nil {
+		zone, repeat = e.Zone, e.Repeat
+		loc, err := time.LoadLocation(zone)
+		if err != nil {
+			loc = time.UTC
+		}
+		clock = e.When.In(loc).Format("15:04")
+		if strings.Contains(e.Prompt, "today") {
+			period = "morning"
+		}
+		label = "Manage"
+		status = strings.Title(repeat) + " at " + clock + " (" + zone + ")"
+		if e.Paused {
+			status = "Paused"
+		}
+	}
+	var b strings.Builder
+	b.WriteString(`<div class="mt-3"><span class="text-muted">` + html.EscapeString(status) + `</span><details><summary>` + label + `</summary><form method="POST" action="/home" class="col gap-2 mt-3">` + app.CSRFField(token) + `<input type="hidden" name="action" value="brief-schedule">`)
+	selectField := func(name, title, value string, values ...string) {
+		b.WriteString(`<label>` + title + `<select class="form-input" name="` + name + `">`)
+		for _, v := range values {
+			selected := ""
+			if v == value {
+				selected = ` selected`
+			}
+			b.WriteString(`<option value="` + v + `"` + selected + `>` + strings.Title(v) + `</option>`)
+		}
+		b.WriteString(`</select></label>`)
+	}
+	selectField("period", "Brief", period, "evening", "morning")
+	b.WriteString(`<label>Time<input class="form-input" type="time" name="clock" required value="` + clock + `"></label><label>Timezone<input class="form-input" name="zone" required placeholder="Europe/London" value="` + html.EscapeString(zone) + `"></label>`)
+	selectField("repeat", "Frequency", repeat, "daily", "weekdays")
+	b.WriteString(`<p class="text-muted">Evening looks ahead to tomorrow; morning covers today. The brief is delivered to your Mu mail, using your connected calendar, email and saved location where available. Normal usage charges apply. <a href="/account">Manage connections and email delivery</a>.</p><div class="d-flex gap-2 flex-wrap"><button name="state" value="active">`)
+	if e == nil {
+		b.WriteString("Schedule")
+	} else if e.Paused {
+		b.WriteString("Resume")
+	} else {
+		b.WriteString("Save")
+	}
+	b.WriteString(`</button>`)
+	if e != nil && !e.Paused {
+		b.WriteString(`<button name="state" value="paused" class="btn-secondary">Pause</button>`)
+	}
+	b.WriteString(`</div></form></details></div><script>(function(){var f=document.querySelector('form input[name="action"][value="brief-schedule"]');if(f){var z=f.form.elements.zone;if(!z.value){try{z.value=Intl.DateTimeFormat().resolvedOptions().timeZone}catch(e){}}}})();</script>`)
+	return b.String()
+}
+
+func briefScheduleHandler(w http.ResponseWriter, r *http.Request) {
+	sess, _ := auth.TrySession(r)
+	if sess == nil {
+		http.Error(w, "Sign in to schedule a brief", http.StatusUnauthorized)
+		return
+	}
+	if !auth.StrictCSRF(r) {
+		http.Error(w, "Reload Home and try again", http.StatusForbidden)
+		return
+	}
+	state := r.FormValue("state")
+	if state != "active" && state != "paused" {
+		http.Error(w, "Invalid schedule action", http.StatusBadRequest)
+		return
+	}
+	err := events.ScheduleBrief(sess.Account, r.FormValue("clock"), r.FormValue("zone"), r.FormValue("repeat"), r.FormValue("period"), state == "paused")
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	http.Redirect(w, r, "/home", http.StatusSeeOther)
+}

--- a/home/brief_schedule_test.go
+++ b/home/brief_schedule_test.go
@@ -1,0 +1,54 @@
+package home
+
+import (
+	"mu/internal/auth"
+	"mu/service/events"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+func TestBriefScheduleFormAndAuthorization(t *testing.T) {
+	owner := "schedule_brief"
+	auth.Create(&auth.Account{ID: owner, Name: owner, Zone: "Europe/London"})
+	sess, err := auth.CreateSession(owner)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer events.DeleteAll(owner)
+	cookie := &http.Cookie{Name: "session", Value: sess.Token}
+	get := httptest.NewRequest("GET", "/home", nil)
+	get.AddCookie(cookie)
+	token := auth.CSRFToken(get)
+	for _, tc := range []struct {
+		signed bool
+		token  string
+		status int
+	}{{false, "", 401}, {true, "", 403}, {true, "bad", 403}, {true, token, 303}} {
+		form := url.Values{"action": {"brief-schedule"}, "clock": {"20:00"}, "zone": {"Europe/London"}, "period": {"evening"}, "repeat": {"daily"}, "state": {"active"}, "_csrf": {tc.token}, "owner": {"someone-else"}}
+		req := httptest.NewRequest("POST", "/home", strings.NewReader(form.Encode()))
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		if tc.signed {
+			req.AddCookie(cookie)
+		}
+		rec := httptest.NewRecorder()
+		Handler(rec, req)
+		if rec.Code != tc.status {
+			t.Fatalf("status %d want %d: %s", rec.Code, tc.status, rec.Body.String())
+		}
+	}
+	if events.Brief(owner) == nil || events.Brief("someone-else") != nil {
+		t.Fatal("wrong owner")
+	}
+	got := briefScheduleHTML(owner, token)
+	for _, s := range []string{"<summary>Manage</summary>", "Daily at 20:00", `value="paused"`, token} {
+		if !strings.Contains(got, s) {
+			t.Errorf("missing %q", s)
+		}
+	}
+	if briefScheduleHTML("") != "" {
+		t.Fatal("guest schedule exposed")
+	}
+}

--- a/home/brief_test.go
+++ b/home/brief_test.go
@@ -22,20 +22,12 @@ import (
 	"mu/service/tasks"
 )
 
-// A quiet account gets nothing, and that includes being alone.
-//
-// "Nothing new" costs a glance and gives nothing back, on the screen somebody
-// sees most often. For one commit this drew a section saying "Just you here"
-// over a link to the chat, on the argument that who is present is true on the
-// quietest day. True, and the two most useless sentences on the page: it told
-// somebody they were alone and then invited them to go and talk about it. Who
-// is here is a strip of names under the box now, which states the same fact
-// without the sentence.
-func TestAQuietAccountGetsNoBrief(t *testing.T) {
+// Quiet accounts still need access to brief scheduling.
+func TestAQuietAccountCanScheduleBrief(t *testing.T) {
 	const who = "brief-quiet"
 	auth.Create(&auth.Account{ID: who, Name: who, Secret: "test-secret"}) //nolint:errcheck
 
-	if got := briefHTML(who); got != "" {
+	if got := briefHTML(who); !strings.Contains(got, "<summary>Schedule</summary>") {
 		t.Errorf("an account with nothing happening, alone, got %q", got)
 	}
 	if got := briefHTML(""); got != "" {

--- a/home/home.go
+++ b/home/home.go
@@ -266,6 +266,10 @@ func ForceRefresh() {
 }
 
 func Handler(w http.ResponseWriter, r *http.Request) {
+	if r.Method == http.MethodPost && r.FormValue("action") == "brief-schedule" {
+		briefScheduleHandler(w, r)
+		return
+	}
 	// An installed app opens on the app, not on a pitch.
 	//
 	// The manifest's start_url was "/", so tapping the icon on a home screen
@@ -573,7 +577,7 @@ function fetchW(la,lo){
 		// the brief further down the page. You are told, or you ask. See
 		// hideBrief in app.ChatComponent.
 		if viewerID != "" {
-			if brief := briefHTML(viewerID); brief != "" {
+			if brief := briefHTML(viewerID, auth.CSRFToken(r)); brief != "" {
 				b.WriteString(`<div id="home-brief" data-brief>` + brief + `</div>`)
 			}
 		}

--- a/service/events/brief.go
+++ b/service/events/brief.go
@@ -1,0 +1,79 @@
+package events
+
+import (
+	"fmt"
+	"github.com/google/uuid"
+	"mu/internal/data"
+	"time"
+	_ "time/tzdata"
+)
+
+// Brief returns the owner's Home brief schedule, including a paused one.
+func Brief(owner string) *Event {
+	for _, e := range List(owner) {
+		if e.Kind == "brief" {
+			return e
+		}
+	}
+	return nil
+}
+
+// ScheduleBrief updates one standing instruction atomically, without creating
+// calendar invitations. Repeated form submissions cannot duplicate the job.
+func ScheduleBrief(owner, clock, zone, repeat, period string, paused bool) error {
+	if owner == "" {
+		return fmt.Errorf("sign in to schedule a brief")
+	}
+	loc, err := time.LoadLocation(zone)
+	if err != nil || zone == "" || zone == "Local" {
+		return fmt.Errorf("choose a valid timezone")
+	}
+	t, err := time.Parse("15:04", clock)
+	if err != nil {
+		return fmt.Errorf("choose a valid time")
+	}
+	if repeat != "daily" && repeat != "weekdays" {
+		return fmt.Errorf("choose daily or weekdays")
+	}
+	prompt := "Give me a brief for tomorrow"
+	if period == "morning" {
+		prompt = "Give me a brief for today"
+	} else if period != "evening" {
+		return fmt.Errorf("choose morning or evening")
+	}
+	now := time.Now().In(loc)
+	next := time.Date(now.Year(), now.Month(), now.Day(), t.Hour(), t.Minute(), 0, 0, loc)
+	for !next.After(now) || (repeat == "weekdays" && (next.Weekday() == time.Saturday || next.Weekday() == time.Sunday)) {
+		next = next.AddDate(0, 0, 1)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	var old *Event
+	for _, e := range events {
+		if e.Owner == owner && e.Kind == "brief" {
+			old = e
+			break
+		}
+	}
+	e := &Event{ID: uuid.New().String(), Owner: owner, Created: time.Now().UTC()}
+	if old != nil {
+		*e = *old
+	}
+	e.Kind, e.Title, e.When, e.Zone, e.Repeat, e.Prompt, e.Paused = "brief", "Daily brief", next, zone, repeat, prompt, paused
+	e.Fired, e.FiredAt = false, time.Time{}
+	e.Sequence++
+	events[e.ID] = e
+	list := make([]*Event, 0, len(events))
+	for _, v := range events {
+		list = append(list, v)
+	}
+	if err := data.SaveJSON(storeKey, list); err != nil {
+		if old == nil {
+			delete(events, e.ID)
+		} else {
+			events[e.ID] = old
+		}
+		return err
+	}
+	return nil
+}

--- a/service/events/brief_test.go
+++ b/service/events/brief_test.go
@@ -1,0 +1,78 @@
+package events
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+func TestBriefScheduleLifecycle(t *testing.T) {
+	reset()
+	defer reset()
+	for _, paused := range []bool{false, false, true, false} {
+		if err := ScheduleBrief("alice", "20:00", "Europe/London", "daily", "evening", paused); err != nil {
+			t.Fatal(err)
+		}
+		e := Brief("alice")
+		if e == nil || e.Paused != paused || e.Prompt != "Give me a brief for tomorrow" {
+			t.Fatalf("bad schedule: %+v", e)
+		}
+		if len(List("alice")) != 1 || Brief("bob") != nil {
+			t.Fatal("duplicate or cross-account schedule")
+		}
+		if paused && len(Upcoming("alice")) != 0 {
+			t.Fatal("paused event upcoming")
+		}
+	}
+	if err := ScheduleBrief("bob", "07:00", "Asia/Tokyo", "weekdays", "morning", false); err != nil {
+		t.Fatal(err)
+	}
+	if Brief("bob").Prompt != "Give me a brief for today" || Brief("alice").Zone != "Europe/London" {
+		t.Fatal("owner isolation")
+	}
+}
+
+func TestBriefScheduleValidation(t *testing.T) {
+	reset()
+	defer reset()
+	cases := [][5]string{{"", "20:00", "Europe/London", "daily", "evening"}, {"a", "25:00", "Europe/London", "daily", "evening"}, {"a", "20:00", "invalid", "daily", "evening"}, {"a", "20:00", "Local", "daily", "evening"}, {"a", "20:00", "Europe/London", "bad", "evening"}, {"a", "20:00", "Europe/London", "daily", "bad"}}
+	for _, c := range cases {
+		if err := ScheduleBrief(c[0], c[1], c[2], c[3], c[4], false); err == nil {
+			t.Fatalf("accepted %v", c)
+		}
+	}
+	if len(events) != 0 {
+		t.Fatal("invalid input wrote events")
+	}
+}
+
+func TestBriefClockSurvivesRestartAndDST(t *testing.T) {
+	loc, _ := time.LoadLocation("Europe/London")
+	for _, date := range []time.Time{time.Date(2026, 10, 24, 20, 0, 0, 0, loc), time.Date(2026, 3, 28, 20, 0, 0, 0, loc)} {
+		original := Event{When: date, Zone: "Europe/London", Repeat: "daily"}
+		raw, _ := json.Marshal(original)
+		var e Event
+		json.Unmarshal(raw, &e)
+		rescheduleLocked(&e, date.Add(time.Minute))
+		if e.When.In(loc).Hour() != 20 || e.When.Sub(date) == 24*time.Hour {
+			t.Fatalf("DST drift: %v", e.When)
+		}
+	}
+	friday := time.Date(2026, 9, 11, 20, 0, 0, 0, loc)
+	next, ok := nextOccurrence(friday, "weekdays")
+	if !ok || next.Weekday() != time.Monday || next.Hour() != 20 {
+		t.Fatal(next)
+	}
+}
+
+func TestPausedBriefDoesNotFire(t *testing.T) {
+	reset()
+	defer reset()
+	events["paused"] = &Event{ID: "paused", Owner: "alice", Kind: "brief", Paused: true, When: time.Now().Add(-time.Hour), Repeat: "daily"}
+	fired := false
+	OnFire = func(_, _, _ string) { fired = true }
+	fireDue()
+	if fired || events["paused"].Fired {
+		t.Fatal("paused brief fired")
+	}
+}

--- a/service/events/events.go
+++ b/service/events/events.go
@@ -21,6 +21,9 @@ import (
 
 // Event is a scheduled reminder owned by a single user.
 type Event struct {
+	Kind     string    `json:"kind,omitempty"`
+	Zone     string    `json:"zone,omitempty"`
+	Paused   bool      `json:"paused,omitempty"`
 	Sequence int       `json:"sequence,omitempty"`
 	ID       string    `json:"id"`
 	Owner    string    `json:"owner"`
@@ -163,7 +166,7 @@ func List(owner string) []*Event {
 func Upcoming(owner string) []*Event {
 	var out []*Event
 	for _, e := range List(owner) {
-		if !e.Fired {
+		if !e.Fired && !e.Paused {
 			out = append(out, e)
 		}
 	}
@@ -203,7 +206,7 @@ func fireDue() {
 	mu.Lock()
 	changed := false
 	for id, e := range events {
-		if !e.Fired && !e.When.After(now) {
+		if !e.Fired && !e.Paused && !e.When.After(now) {
 			e.Fired = true
 			e.FiredAt = now
 			cp := *e

--- a/service/events/repeat.go
+++ b/service/events/repeat.go
@@ -35,6 +35,8 @@ func ParseRepeat(s string) string {
 	switch strings.ToLower(strings.TrimSpace(s)) {
 	case "hourly", "hour", "every hour":
 		return RepeatHourly
+	case "weekdays":
+		return "weekdays"
 	case "daily", "day", "every day", "each day":
 		return RepeatDaily
 	case "weekly", "week", "every week":
@@ -52,6 +54,12 @@ func nextOccurrence(due time.Time, repeat string) (time.Time, bool) {
 	switch repeat {
 	case RepeatHourly:
 		return due.Add(time.Hour), true
+	case "weekdays":
+		next := due.AddDate(0, 0, 1)
+		for next.Weekday() == time.Saturday || next.Weekday() == time.Sunday {
+			next = next.AddDate(0, 0, 1)
+		}
+		return next, true
 	case RepeatDaily:
 		return due.AddDate(0, 0, 1), true
 	case RepeatWeekly:
@@ -88,7 +96,11 @@ func rescheduleLocked(e *Event, now time.Time) {
 	if e.Repeat == RepeatNone {
 		return
 	}
-	next, ok := nextOccurrence(e.When, e.Repeat)
+	due := e.When
+	if loc, err := time.LoadLocation(e.Zone); e.Zone != "" && err == nil {
+		due = due.In(loc)
+	}
+	next, ok := nextOccurrence(due, e.Repeat)
 	if !ok {
 		return
 	}


### PR DESCRIPTION
Users should not have to find Events to schedule their brief. Add Schedule inside the Home Brief card, followed by the configured time and Manage after saving. Supports morning/today or evening/tomorrow, daily or weekdays, time zone, pause and resume. Quiet signed-in accounts retain access to scheduling.

Reuses Events and agent work delivery. Saves one owner-specific standing instruction atomically, prevents duplicate form submissions from creating duplicate jobs, and persists IANA timezones so recurrence retains local time across DST and restarts. No calendar invitations or live user schedules are created by this change. Form uses strict CSRF and session ownership; delivery copy explains Mu mail and links to account forwarding controls.

Validation: focused Home brief/layout tests pass; Events suite passes with race detector; build and focused vet pass. Tests cover authorization, owner isolation, lifecycle, validation, pause, weekdays and both DST transitions after JSON round trip. Full Home suite has an existing unrelated branding assertion failure (TestTheNameIsTheSameOnEverySurface). Browser visual validation was not available.