### PR TITLE
Default morning briefs to 6am local, managed in Events

### DIFF
--- a/agent/work/work.go
+++ b/agent/work/work.go
@@ -49,6 +49,7 @@ import (
 	"mu/internal/app"
 	"mu/internal/auth"
 	"mu/internal/event"
+	"mu/internal/origin"
 	"mu/internal/thread"
 	"mu/service/events"
 	"mu/service/mail"
@@ -269,6 +270,9 @@ func deliver(r request, answer string, err error) {
 	acc, accErr := auth.GetAccount(r.Account)
 	if accErr != nil {
 		return
+	}
+	if e := events.Brief(r.Account); e != nil && e.ID == r.ID {
+		body += "\n\n---\n[Disable or manage your morning brief](" + origin.Self() + "/events#morning-brief)."
 	}
 	mail.SendMessageTo(mail.Delivery{ //nolint:errcheck
 		From: "Mu", FromID: "agent@" + mail.ConfiguredDomain(),

--- a/home/brief.go
+++ b/home/brief.go
@@ -53,6 +53,7 @@ import (
 	"strings"
 	"time"
 
+	"mu/account"
 	"mu/agent/brief"
 	"mu/inbox"
 	"mu/internal/app"
@@ -89,9 +90,9 @@ import (
 // true on the quietest day. True and useless as a sentence — who is here is its
 // own block under the box now, and it names people rather than telling you
 // there are none.
-func briefHTML(accountID string, csrf ...string) string {
+func briefHTML(accountID string) string {
 	parts := briefParts(accountID)
-	if len(parts) == 0 && accountID == "" {
+	if len(parts) == 0 {
 		return ""
 	}
 
@@ -117,7 +118,7 @@ func briefHTML(accountID string, csrf ...string) string {
 	// saying Brief. It is its own block under the box now, and it names people
 	// rather than counting them.
 	return sectionRule("Brief") + `<div class="brief-peek">` +
-		`<p class="home-brief">` + strings.Join(parts, " ") + `</p>` + briefScheduleHTML(accountID, csrf...) + `</div>`
+		`<p class="home-brief">` + strings.Join(parts, " ") + `</p></div>`
 }
 
 // briefParts is the clauses, without deciding how they are set.
@@ -268,13 +269,13 @@ func owed(accountID string) string {
 // The next one is named, with its time, because that is the fact somebody
 // actually wants: not how many, but what and when. The count carries the rest.
 func onToday(accountID string) string {
-	now := time.Now()
+	now := account.LocalNow(accountID)
 	var ahead []*events.Event
 	for _, e := range events.List(accountID) {
 		if e == nil || e.Paused || e.When.IsZero() {
 			continue
 		}
-		if sameDay(e.When, now) && e.When.After(now) {
+		if sameDay(e.When.In(now.Location()), now) && e.When.After(now) {
 			ahead = append(ahead, e)
 		}
 	}
@@ -288,7 +289,7 @@ func onToday(accountID string) string {
 
 	next := ahead[0]
 	out := app.TextLink(next.Title, "/events") + " at " +
-		html.EscapeString(next.When.Format("15:04"))
+		html.EscapeString(next.When.In(now.Location()).Format("15:04"))
 	if rest := len(ahead) - 1; rest > 0 {
 		out += ", and " + strconv.Itoa(rest) + " more today"
 	}

--- a/home/brief_test.go
+++ b/home/brief_test.go
@@ -23,11 +23,11 @@ import (
 )
 
 // Quiet accounts still need access to brief scheduling.
-func TestAQuietAccountCanScheduleBrief(t *testing.T) {
+func TestAQuietAccountGetsNoBrief(t *testing.T) {
 	const who = "brief-quiet"
 	auth.Create(&auth.Account{ID: who, Name: who, Secret: "test-secret"}) //nolint:errcheck
 
-	if got := briefHTML(who); !strings.Contains(got, "<summary>Schedule</summary>") {
+	if got := briefHTML(who); got != "" {
 		t.Errorf("an account with nothing happening, alone, got %q", got)
 	}
 	if got := briefHTML(""); got != "" {

--- a/home/home.go
+++ b/home/home.go
@@ -266,10 +266,6 @@ func ForceRefresh() {
 }
 
 func Handler(w http.ResponseWriter, r *http.Request) {
-	if r.Method == http.MethodPost && r.FormValue("action") == "brief-schedule" {
-		briefScheduleHandler(w, r)
-		return
-	}
 	// An installed app opens on the app, not on a pitch.
 	//
 	// The manifest's start_url was "/", so tapping the icon on a home screen
@@ -577,7 +573,7 @@ function fetchW(la,lo){
 		// the brief further down the page. You are told, or you ask. See
 		// hideBrief in app.ChatComponent.
 		if viewerID != "" {
-			if brief := briefHTML(viewerID, auth.CSRFToken(r)); brief != "" {
+			if brief := briefHTML(viewerID); brief != "" {
 				b.WriteString(`<div id="home-brief" data-brief>` + brief + `</div>`)
 			}
 		}

--- a/service/events/brief.go
+++ b/service/events/brief.go
@@ -3,6 +3,8 @@ package events
 import (
 	"fmt"
 	"github.com/google/uuid"
+	"mu/internal/app"
+	"mu/internal/auth"
 	"mu/internal/data"
 	"time"
 	_ "time/tzdata"
@@ -21,6 +23,10 @@ func Brief(owner string) *Event {
 // ScheduleBrief updates one standing instruction atomically, without creating
 // calendar invitations. Repeated form submissions cannot duplicate the job.
 func ScheduleBrief(owner, clock, zone, repeat, period string, paused bool) error {
+	return scheduleBrief(owner, clock, zone, repeat, period, paused, false)
+}
+
+func scheduleBrief(owner, clock, zone, repeat, period string, paused, builtin bool) error {
 	if owner == "" {
 		return fmt.Errorf("sign in to schedule a brief")
 	}
@@ -55,12 +61,19 @@ func ScheduleBrief(owner, clock, zone, repeat, period string, paused bool) error
 			break
 		}
 	}
+	if builtin && old != nil {
+		return nil
+	}
 	e := &Event{ID: uuid.New().String(), Owner: owner, Created: time.Now().UTC()}
 	if old != nil {
 		*e = *old
 	}
 	e.Kind, e.Title, e.When, e.Zone, e.Repeat, e.Prompt, e.Paused = "brief", "Daily brief", next, zone, repeat, prompt, paused
 	e.Fired, e.FiredAt = false, time.Time{}
+	e.Builtin = builtin
+	if period == "morning" {
+		e.Title = "Morning brief"
+	}
 	e.Sequence++
 	events[e.ID] = e
 	list := make([]*Event, 0, len(events))
@@ -76,4 +89,24 @@ func ScheduleBrief(owner, clock, zone, repeat, period string, paused bool) error
 		return err
 	}
 	return nil
+}
+
+// Reconcile defaults for existing and newly created human accounts. Unknown
+// timezones wait rather than sending at the server's six o'clock. An existing
+// record, including a disabled one, is the durable choice and is never replaced.
+func ensureDefaultBriefs() {
+	for _, acc := range auth.AllAccounts() {
+		if acc.Agent || acc.Banned || acc.Unclaimed || acc.Zone == "" || acc.Zone == "Local" {
+			continue
+		}
+		if _, err := time.LoadLocation(acc.Zone); err != nil {
+			continue
+		}
+		if Brief(acc.ID) != nil {
+			continue
+		}
+		if err := scheduleBrief(acc.ID, "06:00", acc.Zone, "daily", "morning", false, true); err != nil {
+			app.Log("events", "default brief: %v", err)
+		}
+	}
 }

--- a/service/events/brief_page.go
+++ b/service/events/brief_page.go
@@ -1,10 +1,9 @@
-package home
+package events
 
 import (
 	"html"
 	"mu/internal/app"
 	"mu/internal/auth"
-	"mu/service/events"
 	"net/http"
 	"strings"
 	"time"
@@ -18,12 +17,12 @@ func briefScheduleHTML(owner string, csrf ...string) string {
 	if len(csrf) > 0 {
 		token = csrf[0]
 	}
-	clock, zone, repeat, period := "20:00", "", "daily", "evening"
-	label, status := "Schedule", ""
+	clock, zone, repeat, period := "06:00", "", "daily", "morning"
+	label, status := "Manage", "Daily at 06:00 once your timezone is set"
 	if acc, err := auth.GetAccount(owner); err == nil && acc != nil {
 		zone = acc.Zone
 	}
-	e := events.Brief(owner)
+	e := Brief(owner)
 	if e != nil {
 		zone, repeat = e.Zone, e.Repeat
 		loc, err := time.LoadLocation(zone)
@@ -37,11 +36,11 @@ func briefScheduleHTML(owner string, csrf ...string) string {
 		label = "Manage"
 		status = strings.Title(repeat) + " at " + clock + " (" + zone + ")"
 		if e.Paused {
-			status = "Paused"
+			status = "Disabled"
 		}
 	}
 	var b strings.Builder
-	b.WriteString(`<div class="mt-3"><span class="text-muted">` + html.EscapeString(status) + `</span><details><summary>` + label + `</summary><form method="POST" action="/home" class="col gap-2 mt-3">` + app.CSRFField(token) + `<input type="hidden" name="action" value="brief-schedule">`)
+	b.WriteString(`<section id="morning-brief" class="mb-6"><h3>Morning brief</h3><p>Your daily email brief, with today’s calendar, weather and relevant updates.</p><div class="mt-3"><span class="text-muted">` + html.EscapeString(status) + `</span><details><summary>` + label + `</summary><form method="POST" action="/events" class="col gap-2 mt-3">` + app.CSRFField(token) + `<input type="hidden" name="action" value="brief-schedule">`)
 	selectField := func(name, title, value string, values ...string) {
 		b.WriteString(`<label>` + title + `<select class="form-input" name="` + name + `">`)
 		for _, v := range values {
@@ -60,15 +59,15 @@ func briefScheduleHTML(owner string, csrf ...string) string {
 	if e == nil {
 		b.WriteString("Schedule")
 	} else if e.Paused {
-		b.WriteString("Resume")
+		b.WriteString("Enable")
 	} else {
 		b.WriteString("Save")
 	}
 	b.WriteString(`</button>`)
 	if e != nil && !e.Paused {
-		b.WriteString(`<button name="state" value="paused" class="btn-secondary">Pause</button>`)
+		b.WriteString(`<button name="state" value="paused" class="btn-secondary">Disable</button>`)
 	}
-	b.WriteString(`</div></form></details></div><script>(function(){var f=document.querySelector('form input[name="action"][value="brief-schedule"]');if(f){var z=f.form.elements.zone;if(!z.value){try{z.value=Intl.DateTimeFormat().resolvedOptions().timeZone}catch(e){}}}})();</script>`)
+	b.WriteString(`</div></form></details></div><script>(function(){var f=document.querySelector('form input[name="action"][value="brief-schedule"]');if(f){var z=f.form.elements.zone;if(!z.value){try{z.value=Intl.DateTimeFormat().resolvedOptions().timeZone}catch(e){}}}})();</script></section>`)
 	return b.String()
 }
 
@@ -79,7 +78,7 @@ func briefScheduleHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if !auth.StrictCSRF(r) {
-		http.Error(w, "Reload Home and try again", http.StatusForbidden)
+		http.Error(w, "Reload Events and try again", http.StatusForbidden)
 		return
 	}
 	state := r.FormValue("state")
@@ -87,10 +86,10 @@ func briefScheduleHandler(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Invalid schedule action", http.StatusBadRequest)
 		return
 	}
-	err := events.ScheduleBrief(sess.Account, r.FormValue("clock"), r.FormValue("zone"), r.FormValue("repeat"), r.FormValue("period"), state == "paused")
+	err := ScheduleBrief(sess.Account, r.FormValue("clock"), r.FormValue("zone"), r.FormValue("repeat"), r.FormValue("period"), state == "paused")
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
-	http.Redirect(w, r, "/home", http.StatusSeeOther)
+	http.Redirect(w, r, "/events", http.StatusSeeOther)
 }

--- a/service/events/brief_page_test.go
+++ b/service/events/brief_page_test.go
@@ -1,8 +1,7 @@
-package home
+package events
 
 import (
 	"mu/internal/auth"
-	"mu/service/events"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -17,9 +16,9 @@ func TestBriefScheduleFormAndAuthorization(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer events.DeleteAll(owner)
+	defer DeleteAll(owner)
 	cookie := &http.Cookie{Name: "session", Value: sess.Token}
-	get := httptest.NewRequest("GET", "/home", nil)
+	get := httptest.NewRequest("GET", "/events", nil)
 	get.AddCookie(cookie)
 	token := auth.CSRFToken(get)
 	for _, tc := range []struct {
@@ -28,7 +27,7 @@ func TestBriefScheduleFormAndAuthorization(t *testing.T) {
 		status int
 	}{{false, "", 401}, {true, "", 403}, {true, "bad", 403}, {true, token, 303}} {
 		form := url.Values{"action": {"brief-schedule"}, "clock": {"20:00"}, "zone": {"Europe/London"}, "period": {"evening"}, "repeat": {"daily"}, "state": {"active"}, "_csrf": {tc.token}, "owner": {"someone-else"}}
-		req := httptest.NewRequest("POST", "/home", strings.NewReader(form.Encode()))
+		req := httptest.NewRequest("POST", "/events", strings.NewReader(form.Encode()))
 		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 		if tc.signed {
 			req.AddCookie(cookie)
@@ -39,7 +38,7 @@ func TestBriefScheduleFormAndAuthorization(t *testing.T) {
 			t.Fatalf("status %d want %d: %s", rec.Code, tc.status, rec.Body.String())
 		}
 	}
-	if events.Brief(owner) == nil || events.Brief("someone-else") != nil {
+	if Brief(owner) == nil || Brief("someone-else") != nil {
 		t.Fatal("wrong owner")
 	}
 	got := briefScheduleHTML(owner, token)

--- a/service/events/default_brief_test.go
+++ b/service/events/default_brief_test.go
@@ -1,0 +1,74 @@
+package events
+
+import (
+	"encoding/json"
+	"mu/internal/auth"
+	"testing"
+	"time"
+)
+
+func TestDefaultBriefEnrollmentAndOptOut(t *testing.T) {
+	reset()
+	defer reset()
+	for _, a := range []*auth.Account{
+		{ID: "default_london", Zone: "Europe/London"},
+		{ID: "default_tokyo", Zone: "Asia/Tokyo"},
+		{ID: "default_unknown"},
+		{ID: "default_badzone", Zone: "bad/zone"},
+		{ID: "default_agent", Zone: "Europe/London", Agent: true},
+		{ID: "default_banned", Zone: "Europe/London", Banned: true},
+		{ID: "default_unclaimed", Zone: "Europe/London", Unclaimed: true},
+	} {
+		if err := auth.Create(a); err != nil {
+			t.Fatal(err)
+		}
+		id := a.ID
+		t.Cleanup(func() { auth.DeleteAccount(id) })
+	}
+	ensureDefaultBriefs()
+	ensureDefaultBriefs()
+	for _, id := range []string{"default_london", "default_tokyo"} {
+		e := Brief(id)
+		if e == nil {
+			t.Fatalf("missing %s", id)
+		}
+		loc, _ := time.LoadLocation(e.Zone)
+		if !e.Builtin || e.When.In(loc).Hour() != 6 || e.When.In(loc).Minute() != 0 || !e.When.After(time.Now()) || e.Prompt != "Give me a brief for today" || len(List(id)) != 1 {
+			t.Fatalf("bad default: %+v", e)
+		}
+	}
+	for _, id := range []string{"default_unknown", "default_badzone", "default_agent", "default_banned", "default_unclaimed"} {
+		if Brief(id) != nil {
+			t.Fatalf("ineligible %s", id)
+		}
+	}
+	e := Brief("default_london")
+	if err := Remove(e.Owner, e.ID); err != nil {
+		t.Fatal(err)
+	}
+	// Persisted paused state is what startup reads; reconciliation must retain it.
+	raw, _ := json.Marshal(Brief(e.Owner))
+	var restored Event
+	json.Unmarshal(raw, &restored)
+	mu.Lock()
+	events[e.ID] = &restored
+	mu.Unlock()
+	ensureDefaultBriefs()
+	if !Brief(e.Owner).Paused || len(List(e.Owner)) != 1 {
+		t.Fatal("opt-out was lost")
+	}
+	if err := ScheduleBrief("default_tokyo", "08:30", "Asia/Tokyo", "weekdays", "morning", false); err != nil {
+		t.Fatal(err)
+	}
+	ensureDefaultBriefs()
+	if Brief("default_tokyo").When.Hour() != 8 || Brief("default_tokyo").Repeat != "weekdays" {
+		t.Fatal("custom schedule overwritten")
+	}
+	a, _ := auth.GetAccount("default_unknown")
+	a.Zone = "America/New_York"
+	auth.UpdateAccount(a)
+	ensureDefaultBriefs()
+	if Brief(a.ID) == nil {
+		t.Fatal("timezone update did not enroll")
+	}
+}

--- a/service/events/events.go
+++ b/service/events/events.go
@@ -21,6 +21,7 @@ import (
 
 // Event is a scheduled reminder owned by a single user.
 type Event struct {
+	Builtin  bool      `json:"builtin,omitempty"`
 	Kind     string    `json:"kind,omitempty"`
 	Zone     string    `json:"zone,omitempty"`
 	Paused   bool      `json:"paused,omitempty"`
@@ -181,7 +182,11 @@ func Cancel(owner, id string) error {
 	if e == nil || e.Owner != owner {
 		return fmt.Errorf("event not found")
 	}
-	delete(events, id)
+	if e.Kind == "brief" {
+		e.Paused = true
+	} else {
+		delete(events, id)
+	}
 	saveLocked()
 	return nil
 }
@@ -200,6 +205,7 @@ func scheduler() {
 // fireDue marks every due event fired (under lock, persisting once) then
 // delivers them outside the lock so a slow channel can't block the store.
 func fireDue() {
+	ensureDefaultBriefs()
 	now := time.Now().UTC()
 	var due []*Event
 
@@ -228,7 +234,7 @@ func fireDue() {
 	mu.Unlock()
 
 	for _, e := range due {
-		if OnFire != nil {
+		if OnFire != nil && e.Kind != "brief" {
 			OnFire(e.Owner, e.Title, e.Note)
 		}
 		// And the work, where the event carries an instruction. Announced
@@ -263,7 +269,11 @@ func Remove(owner, id string) error {
 	if !ok || e.Owner != owner {
 		return fmt.Errorf("no such event")
 	}
-	delete(events, id)
+	if e.Kind == "brief" {
+		e.Paused = true
+	} else {
+		delete(events, id)
+	}
 	saveLocked()
 	return nil
 }

--- a/service/events/handler.go
+++ b/service/events/handler.go
@@ -16,6 +16,10 @@ import (
 // and cancel. GET with an Accept: application/json header returns the caller's
 // upcoming events as JSON.
 func Handler(w http.ResponseWriter, r *http.Request) {
+	if r.Method == http.MethodPost && r.FormValue("action") == "brief-schedule" {
+		briefScheduleHandler(w, r)
+		return
+	}
 	sess, _ := auth.TrySession(r)
 	if sess == nil {
 		http.Redirect(w, r, "/login?next=/events", http.StatusSeeOther)
@@ -49,6 +53,7 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 	// converts it to an RFC3339 UTC instant on submit so 3pm means the user's
 	// 3pm regardless of the server's timezone.
 	b.WriteString(`<div class="page-col">`)
+	b.WriteString(briefScheduleHTML(owner, csrf))
 	b.WriteString(`<form method="POST" action="/events" onsubmit="var d=this.whenlocal.value;if(d){this.when.value=new Date(d).toISOString()}" class="col m-0 mb-6">`)
 	b.WriteString(`<input type="hidden" name="_csrf" value="` + html.EscapeString(csrf) + `">`)
 	b.WriteString(`<input type="hidden" name="action" value="create">`)
@@ -72,7 +77,9 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 		b.WriteString(`<div class="d-flex flex-column gap-2">`)
 		for _, row := range mergedRows(up, ext) {
 			if row.Event != nil {
-				b.WriteString(eventRow(row.Event, csrf))
+				if row.Event.Kind != "brief" {
+					b.WriteString(eventRow(row.Event, csrf))
+				}
 			} else {
 				b.WriteString(externalRow(row.External))
 			}


### PR DESCRIPTION
Make the morning brief a built-in daily event for existing and new human accounts at 06:00 in their saved IANA timezone. Accounts without a valid timezone wait until one is known. Excludes agent, banned and unclaimed accounts from automatic enrollment; existing custom and disabled schedules are preserved.

Move schedule management from the Home brief card to Events, with Disable/Enable and a management link in delivered briefs. Cancellation retains a disabled record so reconciliation and restart cannot silently reenroll the account. Suppress the separate reminder-fired email for briefs. Reuse the existing scheduler, timezone-aware recurrence and worker mail delivery; no additional default evening/weather/check-in jobs.

Tests: Events and worker suites pass with race detector; focused Home tests, build, vet and diff checks pass. Covers local six o'clock, duplicate reconciliation, eligibility, missing timezone recovery, custom schedules and persisted opt-out. Also fixes Home event time display to use the viewer timezone consistently.