### PR TITLE
Fix task readability, scheduling controls and account/article UI

### DIFF
--- a/account/pages.go
+++ b/account/pages.go
@@ -809,8 +809,7 @@ func Account(w http.ResponseWriter, r *http.Request) {
 	// Log out, so the control sat under the link that ends the session, where a
 	// page has plainly finished.
 	content := notice + BalanceCard(acc.ID) + usage.Card(acc.ID) + LedgerSection(acc.ID) +
-		app.Section("Access", `<a href="/token">Tokens</a>`) + profile +
-		mailClientCard() +
+		app.Section("Clients", `<a href="/token">Tokens</a> · <a href="/inbox/imap">IMAP</a>`) + profile +
 		passwordCard(acc) +
 		PlaceCard(r, acc.ID) +
 		emailCard +
@@ -1081,24 +1080,6 @@ func Verify(w http.ResponseWriter, r *http.Request) {
 // knows perfectly well they typed a password at signup. Being wrong about
 // somebody's own credentials is a good way to make them doubt the rest of the
 // page.
-// mailClientCard is the way to /inbox/imap.
-//
-// It lived on the inbox, beside New, as a text link. That is the screen an
-// account owner opens every day and this is a thing they do once in the life of
-// the account, if ever — so it was read past several thousand times to be used
-// never again, and it made the two controls at the top of the inbox look like
-// the same size of decision.
-//
-// Here instead, with the password, the passkeys and the phone: the things you
-// set up once and then forget. It has to be somewhere — /inbox/imap is served,
-// and a served page with nothing linking to it is a page nobody can find, which
-// TestTheMailClientPageIsReachable exists to prevent.
-func mailClientCard() string {
-	return app.Section("Mail client",
-		`<p>Read and send this account's mail from Apple Mail, Thunderbird, `+
-			`Gmail on Android — anything that speaks IMAP.</p>`+
-			app.Link("Server settings and addresses", "/inbox/imap"))
-}
 
 func passwordCard(acc *auth.Account) string {
 	note := "Signing up with Google or a passkey leaves no password you could type. " +

--- a/account/token.go
+++ b/account/token.go
@@ -120,20 +120,6 @@ func handleTokenPage(w http.ResponseWriter, r *http.Request, accountID, sessionI
 
 	var sb strings.Builder
 
-	// Mobile-friendly table styles
-	sb.WriteString(`<style>
-.token-table { width:100%; border-collapse:collapse; font-size:14px; }
-.token-table th { text-align:left; padding:8px; border-bottom:2px solid #eee; font-size:13px; color:#555; }
-.token-table td { padding:8px; border-bottom:1px solid #f5f5f5; vertical-align:top; }
-.token-table code { font-size:11px; word-break:break-all; }
-@media (max-width: 640px) {
-  .token-table thead { display:none; }
-  .token-table tr { display:block; padding:12px 0; border-bottom:1px solid #eee; }
-  .token-table td { display:block; padding:4px 0; border:none; }
-  .token-table td:before { content:attr(data-label); font-weight:600; font-size:12px; color:#888; display:block; margin-bottom:2px; }
-}
-</style>`)
-
 	// === OAuth Clients ===
 	// Yours, and only yours.
 	//
@@ -182,7 +168,7 @@ func handleTokenPage(w http.ResponseWriter, r *http.Request, accountID, sessionI
 	// in mu.css — it was a class name invented at the call site, so both tables
 	// on this page were unstyled browser defaults, and on a phone six columns
 	// squashed to a few characters each.
-	sb.WriteString(`<table class="data-table stacked"><thead><tr><th>Name</th><th>May reach</th><th>Created</th><th>Last Used</th><th>Expires</th><th></th></tr></thead><tbody>`)
+	sb.WriteString(`<table class="data-table stacked"><thead><tr><th>Name</th><th>Services</th><th>Created</th><th>Last Used</th><th>Expires</th><th></th></tr></thead><tbody>`)
 	tokens := auth.ListTokens(accountID)
 	if len(tokens) == 0 {
 		sb.WriteString(`<tr><td colspan="6" class="p-5 text-center text-secondary">No tokens yet.</td></tr>`)
@@ -200,7 +186,7 @@ func handleTokenPage(w http.ResponseWriter, r *http.Request, accountID, sessionI
 		if !token.Created.IsZero() {
 			created = app.TimeAgo(token.Created)
 		}
-		sb.WriteString(fmt.Sprintf(`<tr><td data-label="Name">%s</td><td data-label="May reach">%s</td><td data-label="Created">%s</td><td data-label="Last used">%s</td><td data-label="Expires">%s</td><td>
+		sb.WriteString(fmt.Sprintf(`<tr><td data-label="Name">%s</td><td data-label="Services">%s</td><td data-label="Created">%s</td><td data-label="Last used">%s</td><td data-label="Expires">%s</td><td>
 			<form method="POST" action="/token?id=%s" class="d-inline" onsubmit="return confirm('Delete?')">
 			<input type="hidden" name="_method" value="DELETE"><button type="submit" class="text-sm">Delete</button></form></td></tr>`,
 			token.Name, tokenScope(token), created, lastUsed, expires, token.ID))
@@ -236,15 +222,14 @@ func handleTokenPage(w http.ResponseWriter, r *http.Request, accountID, sessionI
 	// wallet. The scoped path existed on /agents and the README pointed here —
 	// so the documented road was the unsafe one and the safe one was
 	// undocumented. Same control, same meaning, on both pages now.
-	sb.WriteString(`<div id="tok-scope"><p class="tok-scope-head">What may it reach?</p>`)
-	sb.WriteString(`<p class="tok-scope-sub">Choose nothing and it reaches everything you can — ` +
-		`which is rarely what you meant for a credential you are about to paste somewhere.</p>`)
-	sb.WriteString(`<div class="tok-chips">`)
+	sb.WriteString(`<div id="tok-scope"><label class="field-label">Services<select class="field field-wide" name="scope_mode" onchange="document.getElementById('tok-service-list').hidden=this.value!=='select'"><option value="all">All</option><option value="select">Select</option></select></label>`)
+	sb.WriteString(`<div id="tok-service-list" hidden><div class="tok-chips">`)
+
 	for _, sp := range tokenScopeChoices() {
 		sb.WriteString(`<label class="tok-chip"><input type="checkbox" name="services" value="` +
 			htmlpkg.EscapeString(sp.Name) + `"><span>` + htmlpkg.EscapeString(sp.NavLabel()) + `</span></label>`)
 	}
-	sb.WriteString(`</div></div>`)
+	sb.WriteString(`</div></div></div>`)
 
 	sb.WriteString(`<button type="submit">Generate Token</button></form>`)
 	sb.WriteString(tokenScopeCSS)
@@ -315,11 +300,14 @@ func handleTokenPage(w http.ResponseWriter, r *http.Request, accountID, sessionI
 async function createToken(e) {
 	e.preventDefault();
 	var form = e.target;
+ var mode=form.scope_mode.value;
+ var services=mode==='select'?Array.from(form.querySelectorAll('input[name="services"]:checked')).map(function(c){return c.value}):[];
+ if(mode==='select' && !services.length){alert('Select at least one service');return;}
 	var res = await fetch('/token', {
 		method: 'POST',
 		headers: {'Content-Type': 'application/json'},
 		body: JSON.stringify({name: form.name.value, expires_in: parseInt(form.expires_in.value),
-			services: Array.from(form.querySelectorAll('input[name="services"]:checked')).map(function(c){return c.value})})
+			scope_mode: mode, services: services})
 	});
 	var result = await res.json();
 	if (result.success) {
@@ -410,10 +398,12 @@ func handleCreateToken(w http.ResponseWriter, r *http.Request, accountID string)
 	var name string
 	var permissions []string
 	var scope []string
+	var scopeMode string
 	var expiresIn int // days
 
 	if app.SendsJSON(r) {
 		var req struct {
+			ScopeMode   string   `json:"scope_mode"`
 			Name        string   `json:"name"`
 			Services    []string `json:"services"`
 			Permissions []string `json:"permissions"`
@@ -427,6 +417,7 @@ func handleCreateToken(w http.ResponseWriter, r *http.Request, accountID string)
 		permissions = req.Permissions
 		expiresIn = req.ExpiresIn
 		scope = req.Services
+		scopeMode = req.ScopeMode
 	} else {
 		if err := r.ParseForm(); err != nil {
 			http.Error(w, "Failed to parse form", http.StatusBadRequest)
@@ -436,11 +427,25 @@ func handleCreateToken(w http.ResponseWriter, r *http.Request, accountID string)
 		permissions = parseTokenPermissions(r.FormValue("permissions"))
 		expiresIn = parseTokenExpiresIn(r.FormValue("expires_in"))
 		scope = r.Form["services"]
+		scopeMode = r.FormValue("scope_mode")
 	}
 
 	// Validate
 	if name == "" {
 		http.Error(w, "Token name is required", http.StatusBadRequest)
+		return
+	}
+
+	if scopeMode != "" && scopeMode != "all" && scopeMode != "select" {
+		app.RespondError(w, http.StatusBadRequest, "Choose All or Select")
+		return
+	}
+	if scopeMode == "all" {
+		scope = nil
+	}
+	validScope := validScopeNames(scope)
+	if (scopeMode == "select" || len(scope) > 0) && len(validScope) == 0 {
+		app.RespondError(w, http.StatusBadRequest, "Select at least one valid service")
 		return
 	}
 
@@ -453,7 +458,7 @@ func handleCreateToken(w http.ResponseWriter, r *http.Request, accountID string)
 	// service:<name>, which is the one form the MCP boundary enforces — so a
 	// token made here is confined exactly as one made on /agents is, and the
 	// tools/list it reads is its own rather than the whole instance.
-	if named := auth.ScopeFor(validScopeNames(scope)); len(named) > 0 {
+	if named := auth.ScopeFor(validScope); len(named) > 0 {
 		permissions = append(permissions, named...)
 	}
 
@@ -561,7 +566,7 @@ const tokenScopeCSS = `<style>
 func tokenScope(t *auth.Token) string {
 	names := t.Services()
 	if len(names) == 0 {
-		return "Everything"
+		return "All"
 	}
 	out := make([]string, 0, len(names))
 	for _, n := range names {

--- a/account/token_scope_test.go
+++ b/account/token_scope_test.go
@@ -1,0 +1,74 @@
+package account
+
+import (
+	"context"
+	"encoding/json"
+	"mu/internal/auth"
+	"mu/internal/service"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+type ScopeProbe struct{}
+type ScopeRequest struct{}
+type ScopeResponse struct{}
+
+func (*ScopeProbe) List(context.Context, *ScopeRequest, *ScopeResponse) error { return nil }
+
+func TestTokenAllAndSelect(t *testing.T) {
+	const owner = "token_scope_ui"
+	if err := auth.Create(&auth.Account{ID: owner}); err != nil {
+		t.Fatal(err)
+	}
+	defer auth.DeleteAccount(owner)
+	if err := service.Register(service.Spec{Name: "scopeprobe", Handler: &ScopeProbe{}, Endpoints: map[string]service.Endpoint{"List": {}}}); err != nil {
+		t.Fatal(err)
+	}
+	for _, tc := range []struct {
+		mode   string
+		names  []string
+		status int
+		scoped bool
+	}{
+		{"select", nil, 400, false}, {"select", []string{"unknown"}, 400, false}, {"bad", nil, 400, false},
+		{"select", []string{"scopeprobe"}, 200, true}, {"all", []string{"scopeprobe"}, 200, false},
+		{"", []string{"scopeprobe"}, 200, true}, {"", nil, 200, false},
+	} {
+		before := len(auth.ListTokens(owner))
+		body, _ := json.Marshal(map[string]any{"name": "test", "scope_mode": tc.mode, "services": tc.names})
+		req := httptest.NewRequest("POST", "/token", strings.NewReader(string(body)))
+		req.Header.Set("Content-Type", "application/json")
+		rec := httptest.NewRecorder()
+		handleCreateToken(rec, req, owner)
+		if rec.Code != tc.status {
+			t.Fatalf("mode=%s status=%d", tc.mode, rec.Code)
+		}
+		if rec.Code == 400 {
+			if len(auth.ListTokens(owner)) != before {
+				t.Fatal("invalid selection created token")
+			}
+			continue
+		}
+		var result struct {
+			ID string `json:"id"`
+		}
+		json.Unmarshal(rec.Body.Bytes(), &result)
+		for _, tok := range auth.ListTokens(owner) {
+			if tok.ID == result.ID && (len(tok.Services()) > 0) != tc.scoped {
+				t.Fatal("wrong scope")
+			}
+		}
+	}
+	rec := httptest.NewRecorder()
+	handleTokenPage(rec, httptest.NewRequest("GET", "/token", nil), owner, "fixture")
+	page := rec.Body.String()
+	for _, want := range []string{`name="scope_mode"`, `value="all">All`, `value="select">Select`, `id="tok-service-list" hidden`, `data-label="Services"`} {
+		if !strings.Contains(page, want) {
+			t.Errorf("missing %q", want)
+		}
+	}
+	if strings.Contains(page, "What may it reach?") {
+		t.Fatal("old label")
+	}
+}

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"html"
+	"mu/internal/ai"
 	"net/http"
 	"net/url"
 	"sort"
@@ -1452,7 +1453,7 @@ func agentErrorMessage(err error) string {
 	if errors.Is(err, ErrNoProvider) {
 		return "The agent has no AI provider configured. Set a provider key in /admin/config."
 	}
-	return "Could not generate response: " + err.Error()
+	return "Could not generate response: " + ai.FailureMessage(err)
 }
 
 // handleQuery processes an agent query request with SSE streaming.

--- a/agent/work/timeout_test.go
+++ b/agent/work/timeout_test.go
@@ -1,0 +1,30 @@
+package work
+
+import (
+	"context"
+	"mu/agent"
+	"mu/service/tasks"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestTimeoutPreservesCompletedSteps(t *testing.T) {
+	const who = "timeout_steps"
+	task, err := tasks.CreateOn(who, "", "malten", "Reply", "Context", tasks.Agent, time.Time{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tasks.Remove(who, task.ID)
+	runWithQuery(request{Account: who, Kind: tasks.Kind, ID: task.ID, Agent: "malten", Prompt: "Reply"}, func(_, _ string, opts agent.QueryOpts) (string, error) {
+		opts.OnStep(agent.Step{Tool: "web_search", OK: true})
+		return "", context.DeadlineExceeded
+	})
+	got, err := tasks.Get(who, task.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != tasks.StatusTodo || len(got.Steps) != 1 || got.Steps[0].Tool != "web_search" || !strings.Contains(got.Result, "too long") {
+		t.Fatalf("failure lost work: %+v", got)
+	}
+}

--- a/agent/work/work.go
+++ b/agent/work/work.go
@@ -46,6 +46,7 @@ import (
 	"sync"
 
 	"mu/agent"
+	"mu/internal/ai"
 	"mu/internal/app"
 	"mu/internal/auth"
 	"mu/internal/event"
@@ -176,10 +177,13 @@ func runWithQuery(r request, query func(string, string, agent.QueryOpts) (string
 		steps = append(steps, tasks.Step{Tool: s.Tool, Detail: tasks.StepDetail(s.Args), OK: s.OK, Seconds: s.Took.Seconds()})
 	}
 	answer, err := query(r.Account, workPrompt(r), opts)
+	stepsMu.Lock()
+	completedSteps := append([]tasks.Step(nil), steps...)
+	stepsMu.Unlock()
 
 	switch r.Kind {
 	case tasks.Kind:
-		finishTask(r, answer, steps, err)
+		finishTask(r, answer, completedSteps, err)
 	case events.Kind:
 		deliver(r, answer, err)
 	default:
@@ -224,7 +228,7 @@ func answered(r request, answer string, err error) {
 	if err != nil {
 		// Said rather than swallowed, for the reason in the package comment:
 		// silence is indistinguishable from work nobody picked up.
-		text = "That did not work: " + err.Error()
+		text = "That did not work: " + ai.FailureMessage(err)
 	}
 	from := r.Agent
 	if from == "" {
@@ -240,7 +244,7 @@ func answered(r request, answer string, err error) {
 func finishTask(r request, answer string, steps []tasks.Step, err error) {
 	if err != nil {
 		app.Log("work", "task %q failed for %s: %v", r.Title, r.Account, err)
-		if _, saveErr := tasks.Update(r.Account, r.ID, "", "", tasks.StatusTodo, "", "Last run failed: "+err.Error(), steps); saveErr != nil {
+		if _, saveErr := tasks.Update(r.Account, r.ID, "", "", tasks.StatusTodo, "", "Last run failed: "+ai.FailureMessage(err), steps); saveErr != nil {
 			app.Log("work", "saving failed task %s: %v", r.ID, saveErr)
 		}
 		return
@@ -262,7 +266,7 @@ func deliver(r request, answer string, err error) {
 	body := strings.TrimSpace(answer)
 	if err != nil {
 		app.Log("work", "standing instruction %q failed for %s: %v", r.Title, r.Account, err)
-		body = "This scheduled task failed: " + err.Error()
+		body = "This scheduled task failed: " + ai.FailureMessage(err)
 	}
 	if body == "" {
 		return

--- a/inbox/act.go
+++ b/inbox/act.go
@@ -124,7 +124,7 @@ func hand(accountID string, t *thread.Thread, ask, agentID string) error {
 		for _, m := range msgs {
 			who := "They"
 			if m.Role == thread.RoleAgent {
-				who = "The agent"
+				who = messageAgentName(accountID, t, m)
 			} else if strings.TrimSpace(m.From) == "" || m.From == accountID {
 				who = "The owner"
 			}
@@ -132,7 +132,7 @@ func hand(accountID string, t *thread.Thread, ask, agentID string) error {
 			// them is the same conversation three times over in one prompt, and
 			// the agent is being handed all six anyway. See quoted.go.
 			text, _ := unquoted(m.Text)
-			detail.WriteString(who + ": " + strings.TrimSpace(text) + "\n\n")
+			detail.WriteString("**" + who + ":**\n\n" + strings.TrimSpace(text) + "\n\n")
 		}
 	}
 	detail.WriteString("What they have asked for: " + ask)

--- a/inbox/kinds.go
+++ b/inbox/kinds.go
@@ -147,7 +147,7 @@ func taskRow(t *tasks.Task) string {
 
 	// The result when there is one, because a finished task's answer is the
 	// thing worth previewing; the detail is what you asked for and you know it.
-	snippet := strings.TrimSpace(t.Result)
+	snippet := strings.TrimSpace(t.Outcome())
 	if snippet == "" {
 		snippet = strings.TrimSpace(t.Detail)
 	}

--- a/internal/ai/failure.go
+++ b/internal/ai/failure.go
@@ -1,0 +1,30 @@
+package ai
+
+import (
+	"context"
+	"errors"
+	"strings"
+)
+
+// FailureMessage translates provider failures for product surfaces. Detailed
+// diagnostics belong in logs and run history, not CLI advice in a task reply.
+func FailureMessage(err error) string {
+	if err == nil {
+		return ""
+	}
+	text := err.Error()
+	lower := strings.ToLower(text)
+	switch {
+	case errors.Is(err, context.DeadlineExceeded), strings.Contains(lower, "context deadline exceeded"), strings.Contains(lower, "provider call timed out"), strings.Contains(lower, "(timeout)"):
+		return "The model took too long to respond. This run stopped before completing."
+	case errors.Is(err, context.Canceled):
+		return "This run was cancelled before completing."
+	}
+	if i := strings.Index(text, "; inspect run history"); i >= 0 {
+		text = text[:i]
+	}
+	if strings.Contains(text, "docs/guides/debugging-agents.md") {
+		return "The model could not complete this run. Please try again later."
+	}
+	return text
+}

--- a/internal/ai/failure_test.go
+++ b/internal/ai/failure_test.go
@@ -1,0 +1,24 @@
+package ai
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestProviderFailureMessages(t *testing.T) {
+	for _, err := range []error{context.DeadlineExceeded, fmt.Errorf("wrapped: %w", context.DeadlineExceeded), errors.New("agent: ai generate failed after 3 attempt(s) (timeout): context deadline exceeded; agent provider call timed out; inspect run history with `micro inspect agent <name> --status timeout`, then adjust AgentModelCallTimeout/AgentModelRetry or see docs/guides/debugging-agents.md")} {
+		got := FailureMessage(err)
+		if !strings.Contains(got, "too long") || strings.Contains(got, "micro inspect") || strings.Contains(got, "AgentModel") {
+			t.Fatal(got)
+		}
+	}
+	if got := FailureMessage(errors.New("Insufficient credits")); got != "Insufficient credits" {
+		t.Fatal(got)
+	}
+	if FailureMessage(nil) != "" {
+		t.Fatal("nil failure")
+	}
+}

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -1236,28 +1236,6 @@ func VerifyBanner(r *http.Request) string {
 </div>`
 }
 
-// headAdmin is the operator's door, in the header rather than the rail.
-//
-// It has been three places. At the foot with Account and Log out, on the
-// reasoning that admin is a role and a role belongs with identity; then second
-// in the rail under Home, on the reasoning that an operator opens it several
-// times a day and the foot of a list is not where a thing used that often
-// belongs. The second reason was right about the frequency and wrong about the
-// list.
-//
-// The rail is the product: Home, Inbox, Agents, Services, and the account's
-// own. Admin is none of those — it is the instance with the lid off, and a
-// console sitting second among the four things this *is* made the rail read as
-// four destinations plus an exception. It is a different kind of thing, so it
-// goes somewhere that is a different kind of place.
-//
-// The header, beside the balance, which is the other item there that is a fact
-// about your standing rather than a page in the product. #head-right was built
-// as a flex cluster for exactly this: an item that comes and goes without
-// anything being nudged.
-//
-// Drawn only for an admin, and /admin checks the session itself regardless —
-// this is about not showing a door that is not yours, not about guarding it.
 // navMain is the menu: every destination, in one flat list.
 //
 // It was two lists. Four links here — Home, Inbox, Agents, Services — and five
@@ -1286,11 +1264,8 @@ func navMain(acc *auth.Account) string {
 	// beside Log out — which is where somebody looks when the question is "who
 	// am I signed in as and what is mine".
 	//
-	// Admin is not here either, and no longer in this rail at all. It is the
-	// one door in the list that is not a place in the product — Home, Inbox,
-	// Agents and Services are the four things this is, and an operator console
-	// wedged second among them made the rail read as a list of pages plus one
-	// exception. It is in the header now, beside the balance: see headAdmin.
+	// Admin belongs below Account in navBottom.
+
 	b += item("nav-inbox", "/inbox", "/mail.png", "Inbox")
 	b += item("nav-agents", "/agents", "/agent.svg", "Agents")
 	b += item("nav-services", "/services", "/services.svg", "Services")
@@ -1342,21 +1317,11 @@ func navTabs(acc *auth.Account) string {
 // put anything in.
 var TopUpConfigured func() bool
 
-func headAdmin(acc *auth.Account) string {
+func navAdmin(acc *auth.Account) string {
 	if acc == nil || !acc.Admin {
 		return ""
 	}
-	// The word, not a glyph.
-	//
-	// It was an icon with a label beside it, borrowed from the rail's markup,
-	// and the icon was doing nothing the word was not: a gear or a shield in a
-	// corner is a guess you have to make, and the guess is wrong often enough
-	// that the label had to be there anyway. Two things saying one thing, and
-	// on a phone the label was hidden so what was left was the guess alone.
-	//
-	// Set like the rest of this corner — it is a link to somewhere, the same as
-	// the name beside it, and it should read as one.
-	return `<a id="head-admin" class="mini-btn" href="/admin">Admin</a>`
+	return `<a id="nav-admin" href="/admin"><img src="/admin.png?` + Version + `"><span class="label">Admin</span></a>`
 }
 
 // navPinned is the reader's own services, under a heading of their own.
@@ -1455,7 +1420,7 @@ func headCorner(acc *auth.Account, here string) string {
 	// is where somebody goes to leave; the corner's job is to say which account
 	// this browser is, and on a shared or long-lived one that is a real
 	// question. It links to /account, which is where the answer leads.
-	return headAdmin(acc) + headBalance(acc) +
+	return headBalance(acc) +
 		`<a id="head-me" href="/account" title="Your account"><span class="label">@` +
 		htmlpkg.EscapeString(acc.ID) + `</span></a>`
 }
@@ -1496,7 +1461,7 @@ func navBottom(acc *auth.Account, here string) string {
 	// you any more, it is the conversation with somebody — and your own resolves
 	// to your inbox, which is already the first thing in the nav.
 	return `<div class="nav-me-who">Signed in as <span id="nav-username">@` + username + `</span></div>
-          <a id="nav-account" href="/account"><img src="/account.png?` + Version + `"><span class="label">Account</span></a>
+          <a id="nav-account" href="/account"><img src="/account.png?` + Version + `"><span class="label">Account</span></a>` + navAdmin(acc) + `
           <a id="nav-logout" href="/logout"><img src="/logout.png?` + Version + `"><span class="label">Log out</span></a>
           <a id="nav-login" href="/login" class="d-none"><img src="/account.png?` + Version + `"><span class="label">Login</span></a>`
 }

--- a/internal/app/html/mu.css
+++ b/internal/app/html/mu.css
@@ -3052,7 +3052,7 @@ a.highlight {
     margin-top: 8px;
     font-size: small;
   }
-  #blog > div:first-child {
+  #blog > div:first-child:not(.post-tags) {
     text-align: left;
   }
   
@@ -4242,14 +4242,17 @@ button.btn-plain { padding: 6px 12px; font: inherit; cursor: pointer; color: var
     background: none;
   }
   .data-table.stacked td {
-    display: flex;
-    gap: 16px;
+    display: grid;
+    grid-template-columns: minmax(72px, 30%) minmax(0, 1fr);
+    gap: 12px;
     align-items: baseline;
-    justify-content: space-between;
-    text-align: right;
+    text-align: left;
+    overflow-wrap: anywhere;
     border: 0;
-    padding: 3px 0;
+    padding: 6px 0;
   }
+  .data-table.stacked td > * { min-width: 0; white-space: normal; }
+
   /* The label is the column header, said per row. A cell with no data-label
      is an action — the Delete button — and gets the row to itself. */
   .data-table.stacked td[data-label]::before {
@@ -4259,7 +4262,7 @@ button.btn-plain { padding: 6px 12px; font: inherit; cursor: pointer; color: var
     font-size: 12px;
     text-align: left;
   }
-  .data-table.stacked td:not([data-label]) { justify-content: flex-start; padding-top: 8px; }
+  .data-table.stacked td:not([data-label]) { display: block; padding-top: 8px; }
   /* The empty-state row spans the table and has no labels to lay out. */
   .data-table.stacked td[colspan] { display: table-cell; text-align: center; }
 }
@@ -8059,3 +8062,25 @@ a:hover, a:hover * { text-decoration: none !important; }
  .record-controls { top:44px; }
  .page-action:first-child, #page-title + .page-action { justify-content:center; }
 }
+
+/* Scheduled brief controls use the same plus/minus convention as room details. */
+.brief-schedule { padding: 20px 0; }
+.brief-schedule > h3 { margin: 0 0 12px; }
+.brief-schedule > p { margin: 0 0 16px; }
+.brief-schedule-status { margin: 0 0 16px; }
+.brief-schedule-manage > summary {
+  list-style: none;
+  cursor: pointer;
+  padding: 8px 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+.brief-schedule-manage > summary::-webkit-details-marker { display: none; }
+.brief-schedule-manage > summary::after { content: '+'; }
+.brief-schedule-manage[open] > summary::after { content: '\2212'; }
+.brief-schedule-form { display: flex; flex-direction: column; gap: 16px; margin: 16px 0 0; }
+.brief-schedule-form > label { display: flex; flex-direction: column; gap: 8px; }
+.brief-schedule-form .form-input { box-sizing: border-box; width: 100%; min-width: 0; }
+.brief-schedule-form > p { margin: 0; }

--- a/internal/app/html/mu.js
+++ b/internal/app/html/mu.js
@@ -495,7 +495,7 @@ function setSession() {
     var navLogout = document.getElementById("nav-logout");
     var navLogin = document.getElementById("nav-login");
     var navUsername = document.getElementById("nav-username");
-    var navAdmin = document.getElementById("head-admin");
+    var navAdmin = document.getElementById("nav-admin");
 
     if (sess.type == "account") {
       isAuthenticated = true;
@@ -544,7 +544,7 @@ function setSession() {
     var navAccount = document.getElementById("nav-account");
     var navLogout = document.getElementById("nav-logout");
     var navLogin = document.getElementById("nav-login");
-    var navAdmin = document.getElementById("head-admin");
+    var navAdmin = document.getElementById("nav-admin");
     if (navAdmin) navAdmin.style.display = 'none';
     if (navAccount) navAccount.style.display = 'none';
     if (navLogout) navLogout.style.display = 'none';

--- a/internal/app/nav_admin_test.go
+++ b/internal/app/nav_admin_test.go
@@ -1,23 +1,6 @@
 package app
 
-// Running the place is a door, and not one of the four the product is.
-//
-// The admin dashboard was reachable only as "Admin Dashboard →" inside the
-// Settings card on /account — three clicks from anywhere, below passkeys and
-// blocked users, on the page you go to in order to change your language. It is
-// the page an operator opens most and it was the hardest one to reach.
-//
-// Then the bottom group with Account and Log out, on the reasoning that admin
-// is a role and roles sit with identity; then second in the rail under Home,
-// on the reasoning that the foot of a list is the wrong place for something
-// opened several times a day. That was right about the frequency and wrong
-// about the list: the rail is Home, Inbox, Agents, Services and the account's
-// own pages, and a console sitting second among them made the rail read as
-// four destinations plus an exception.
-//
-// It is in the header now, beside the balance — the other item there that is a
-// fact about your standing rather than a page in the product. So these tests
-// assert two things: an admin has the door, and it is not in the rail.
+// Admin lives directly below Account in the sidebar, for operators only.
 
 import (
 	"os"
@@ -28,34 +11,22 @@ import (
 )
 
 func TestAnAdminGetsTheLinkInTheNav(t *testing.T) {
-	nav := headAdmin(&auth.Account{ID: "boss", Admin: true})
+	nav := navAdmin(&auth.Account{ID: "boss", Admin: true})
 	if !strings.Contains(nav, `href="/admin"`) {
 		t.Fatal("an admin has no way to the dashboard from the sidebar")
 	}
 	if strings.Contains(nav, "display: none") {
 		t.Error("the admin's own link is hidden, so it needs JavaScript to appear")
 	}
-	// And it is in the header, before the rail starts.
-	//
-	// Read by position, because that is the whole claim. #head-right is in the
-	// markup above #container, so an Admin link that landed anywhere in the
-	// rail — where it was, second under Home — comes after it. Asserting on the
-	// id alone would pass with the link back in the list it left.
 	page := renderWithLang("t", "d", "", "en", &auth.Account{ID: "boss", Admin: true})
-	adm, rail, out := strings.Index(page, `id="head-admin"`), strings.Index(page, `id="nav"`),
-		strings.Index(page, `id="nav-logout"`)
-	if adm < 0 || rail < 0 || out < 0 {
-		t.Fatalf("the shell is missing a part (admin %d, rail %d, logout %d)", adm, rail, out)
+	account, admin, logout := strings.Index(page, `id="nav-account"`), strings.Index(page, `id="nav-admin"`), strings.Index(page, `id="nav-logout"`)
+	if account < 0 || admin <= account || logout <= admin {
+		t.Fatal("Admin must follow Account and precede Log out")
 	}
-	if adm > rail {
-		t.Errorf("admin is inside the rail rather than in the header (admin %d, rail %d) — "+
-			"the rail is the four things the product is, and an operator console is "+
-			"not one of them", adm, rail)
+	if strings.Contains(headCorner(&auth.Account{ID: "boss", Admin: true}, ""), `href="/admin"`) {
+		t.Fatal("Admin remains in header")
 	}
-	// Nothing named nav-admin anywhere: the rail entry is gone, not duplicated.
-	if strings.Contains(page, `id="nav-admin"`) {
-		t.Error("the rail still draws its own Admin entry, so the door is in two places")
-	}
+
 }
 
 // The bottom of the rail is who you are, what is yours, and the way out.
@@ -117,7 +88,7 @@ func TestTheBottomIsWhoYouAreAndTheWayOut(t *testing.T) {
 // Nothing at all for anybody else, rather than a hidden link JavaScript removes:
 // the shell is rendered per viewer, so there is no cached page to defend against.
 func TestAnOrdinaryAccountIsNotShownTheDoor(t *testing.T) {
-	if nav := headAdmin(&auth.Account{ID: "reader"}); nav != "" {
+	if nav := navAdmin(&auth.Account{ID: "reader"}); nav != "" {
 		t.Errorf("a non-admin is offered the admin dashboard: %s", nav)
 	}
 	if strings.Contains(navBottom(&auth.Account{ID: "reader"}, ""), "/admin") {
@@ -126,7 +97,7 @@ func TestAnOrdinaryAccountIsNotShownTheDoor(t *testing.T) {
 }
 
 func TestSignedOutGetsNoAdminLink(t *testing.T) {
-	if headAdmin(nil) != "" || strings.Contains(navBottom(nil, ""), "/admin") {
+	if navAdmin(nil) != "" || strings.Contains(navBottom(nil, ""), "/admin") {
 		t.Error("a signed-out visitor is offered the admin dashboard")
 	}
 }

--- a/internal/app/softnav_test.go
+++ b/internal/app/softnav_test.go
@@ -76,22 +76,13 @@ func TestTheAdminLinkIsFoundByTheIdItHas(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	js := string(b)
-	if strings.Contains(js, `getElementById("nav-admin")`) {
-		t.Error("mu.js still looks for nav-admin; the link is head-admin now, so " +
-			"the lookup returns nothing and the check it guards never runs")
+	if !strings.Contains(string(b), `getElementById("nav-admin")`) || strings.Contains(string(b), `getElementById("head-admin")`) {
+		t.Fatal("admin identity guard targets wrong element")
 	}
-	if !strings.Contains(js, `getElementById("head-admin")`) {
-		t.Error("nothing in mu.js finds the admin link, so a page cached for an " +
-			"admin keeps offering the door to whoever it is served to next")
+	if !strings.Contains(navAdmin(adminAccount()), `id="nav-admin"`) {
+		t.Fatal("sidebar link has wrong id")
 	}
-	// And the id really is what the shell renders.
-	page := renderWithLang("t", "d", "", "en", nil)
-	_ = page
-	if !strings.Contains(headAdmin(adminAccount()), `id="head-admin"`) {
-		t.Error("headAdmin does not render id=head-admin, so mu.js is looking for " +
-			"something that is not there")
-	}
+
 }
 
 // The loading dim waits, so quick navigations never show one.

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -526,8 +526,16 @@ func registerRoutes() {
 	// credential, the same as the inbound webhook beside it.
 	http.HandleFunc("/sms/status", sms.StatusHandler)
 	http.HandleFunc("/contacts/", contacts.Handler)
-	http.HandleFunc("/tasks", tasks.Handler)
-	http.HandleFunc("/tasks/", tasks.Handler)
+	taskPage := func(w http.ResponseWriter, r *http.Request) {
+		tasks.NamedHandler(w, r, func(owner, id string) string {
+			if id == "" {
+				return agent.DefaultName()
+			}
+			return agent.NameOf(owner, id)
+		})
+	}
+	http.HandleFunc("/tasks", taskPage)
+	http.HandleFunc("/tasks/", taskPage)
 	http.HandleFunc("/images", images.Handler)
 	http.HandleFunc("/images/daily/", images.DailyImageHandler)
 	http.HandleFunc("/images/file/", images.GeneratedImageHandler)

--- a/service/blog/blog.go
+++ b/service/blog/blog.go
@@ -1554,7 +1554,7 @@ func PostHandler(w http.ResponseWriter, r *http.Request) {
 		title = "Untitled"
 	}
 
-	// Add links and YouTube embeds for full post view
+	// Render the full post, preserving its inline citations.
 	contentHTML := Linkify(post.Content)
 
 	authorLink := post.Author
@@ -1684,26 +1684,10 @@ func renderComments(postID string, r *http.Request) string {
 	return commentsHTML.String()
 }
 
-// Linkify converts markdown to HTML and embeds YouTube videos (for full post display)
+// Linkify renders post markdown. Inline video citations stay links; replacing
+// them with the whole /video page breaks sentences and nests the app in itself.
 func Linkify(text string) string {
-	// Render markdown to HTML first (Render handles LaTeX stripping)
-	html := string(app.Render([]byte(text)))
-
-	// Find YouTube links in the rendered HTML and replace with embeds
-	// Pattern matches: <a href="youtube_url">youtube_url</a>
-	youtubePattern := regexp.MustCompile(`<a href="https?://(?:www\.)?(?:youtube\.com/watch\?v=|youtu\.be/)([a-zA-Z0-9_-]{11})[^"]*"[^>]*>.*?</a>`)
-	html = youtubePattern.ReplaceAllStringFunc(html, func(match string) string {
-		// Extract video ID from the match
-		idPattern := regexp.MustCompile(`(?:youtube\.com/watch\?v=|youtu\.be/)([a-zA-Z0-9_-]{11})`)
-		matches := idPattern.FindStringSubmatch(match)
-		if len(matches) > 1 {
-			videoID := matches[1]
-			return fmt.Sprintf(`<div class="iframe-container"><iframe src="/video?id=%s" allowfullscreen loading="lazy"></iframe></div>`, videoID)
-		}
-		return match
-	})
-
-	return html
+	return string(app.Render([]byte(text)))
 }
 
 // returnTo is where a finished post lands.

--- a/service/blog/render_test.go
+++ b/service/blog/render_test.go
@@ -18,3 +18,18 @@ func TestLinkifyProtectsCurrencyDollarsFromMathRendering(t *testing.T) {
 		}
 	}
 }
+
+func TestInlineVideoCitationsRemainReadableLinks(t *testing.T) {
+	got := Linkify(`Tehran warned of a [faster response](https://www.youtube.com/watch?v=Q_QEtgYTbfc), while [another report](https://youtu.be/58hVkLDMPdY) followed.`)
+	for _, want := range []string{`href="https://www.youtube.com/watch?v=Q_QEtgYTbfc"`, `>faster response</a>, while`, `>another report</a> followed.`} {
+		if !strings.Contains(got, want) {
+			t.Errorf("lost citation %q: %s", want, got)
+		}
+	}
+	if strings.Contains(got, "iframe") || strings.Contains(got, "/video?id=") {
+		t.Fatal("post embedded the video page")
+	}
+	if got := Linkify(`<iframe src="https://example.com"></iframe>`); strings.Contains(got, "<iframe") {
+		t.Fatal("raw iframe injected")
+	}
+}

--- a/service/events/brief_page.go
+++ b/service/events/brief_page.go
@@ -40,7 +40,7 @@ func briefScheduleHTML(owner string, csrf ...string) string {
 		}
 	}
 	var b strings.Builder
-	b.WriteString(`<section id="morning-brief" class="mb-6"><h3>Morning brief</h3><p>Your daily email brief, with today’s calendar, weather and relevant updates.</p><div class="mt-3"><span class="text-muted">` + html.EscapeString(status) + `</span><details><summary>` + label + `</summary><form method="POST" action="/events" class="col gap-2 mt-3">` + app.CSRFField(token) + `<input type="hidden" name="action" value="brief-schedule">`)
+	b.WriteString(`<section id="morning-brief" class="brief-schedule mb-6"><h3>Morning brief</h3><p>Your daily email brief, with today’s calendar, weather and relevant updates.</p><div class="brief-schedule-controls"><p class="brief-schedule-status text-muted">` + html.EscapeString(status) + `</p><details class="brief-schedule-manage"><summary>` + label + `</summary><form method="POST" action="/events" class="brief-schedule-form">` + app.CSRFField(token) + `<input type="hidden" name="action" value="brief-schedule">`)
 	selectField := func(name, title, value string, values ...string) {
 		b.WriteString(`<label>` + title + `<select class="form-input" name="` + name + `">`)
 		for _, v := range values {

--- a/service/images/images.go
+++ b/service/images/images.go
@@ -37,7 +37,7 @@ type Daily struct {
 	URL    string `json:"url"`
 	Prompt string `json:"prompt"`
 	Theme  string `json:"theme"`
-	Date   string `json:"date"` // YYYY-MM-DD (UTC)
+	Date   string `json:"date"` // YYYY-MM-DD (site timezone)
 	// File is the local storage key for the downloaded image, empty if the
 	// download failed and we are still relying on the provider URL.
 	File string `json:"file,omitempty"`
@@ -137,8 +137,8 @@ func Load() {
 	go scheduler()
 }
 
-// today returns the current UTC date as YYYY-MM-DD.
-func today() string { return time.Now().UTC().Format("2006-01-02") }
+// today returns the current site-local date as YYYY-MM-DD.
+func today() string { return time.Now().Format("2006-01-02") }
 
 // themeStride is how far along the list one day moves.
 //
@@ -158,20 +158,23 @@ func themeFor(day int) struct{ name, prompt string } {
 	return dailyThemes[(day*themeStride)%len(dailyThemes)]
 }
 
-// scheduler generates today's image if missing, then wakes each day at 06:00 UTC.
+// scheduler generates today's image if missing, then wakes each day at 06:00 in the site timezone.
 func scheduler() {
 	// Small delay so AI settings/env are wired before the first attempt.
 	time.Sleep(5 * time.Second)
 	for {
+		now := time.Now()
+		target := imageTime(now)
+		if now.Before(target) {
+			time.Sleep(time.Until(target))
+			continue
+		}
 		dailyMu.RLock()
-		have := daily.Date == today() && daily.URL != ""
+		due := imageDue(now, daily)
 		dailyMu.RUnlock()
-		if !have {
+		if due {
 			generateDaily()
 		}
-		// If we still don't have today's image (no provider yet, a transient
-		// model error), retry within the hour so it self-heals once the Atlas
-		// key is set — don't wait a whole day. Otherwise sleep until 06:00 UTC.
 		dailyMu.RLock()
 		ok := daily.Date == today() && daily.URL != ""
 		dailyMu.RUnlock()
@@ -179,12 +182,7 @@ func scheduler() {
 			time.Sleep(time.Hour)
 			continue
 		}
-		now := time.Now().UTC()
-		next := time.Date(now.Year(), now.Month(), now.Day(), 6, 0, 0, 0, time.UTC)
-		if !next.After(now) {
-			next = next.Add(24 * time.Hour)
-		}
-		time.Sleep(time.Until(next))
+		time.Sleep(time.Until(imageTime(time.Now()).AddDate(0, 0, 1)))
 	}
 }
 
@@ -194,7 +192,7 @@ func generateDaily() {
 	if !aiReady() {
 		return // no provider configured — try again next cycle
 	}
-	theme := themeFor(time.Now().UTC().YearDay())
+	theme := themeFor(time.Now().YearDay())
 	url, err := ai.GenerateImage(theme.prompt)
 	if err != nil {
 		app.Log("images", "daily image generation failed: %v", err)
@@ -690,4 +688,13 @@ func DeleteAll(owner string) {
 	} else if n > 0 {
 		app.Log("images", "deleted %d records for %s", n, owner)
 	}
+}
+
+// imageTime uses civil time so daylight-saving changes keep the six o'clock job.
+func imageTime(now time.Time) time.Time {
+	return time.Date(now.Year(), now.Month(), now.Day(), 6, 0, 0, 0, now.Location())
+}
+
+func imageDue(now time.Time, d Daily) bool {
+	return !now.Before(imageTime(now)) && (d.Date != now.Format("2006-01-02") || d.URL == "")
 }

--- a/service/images/schedule_test.go
+++ b/service/images/schedule_test.go
@@ -1,0 +1,28 @@
+package images
+
+import (
+	"testing"
+	"time"
+)
+
+func TestDailyImageWaitsForSixIncludingRestart(t *testing.T) {
+	loc, _ := time.LoadLocation("Europe/London")
+	for _, hour := range []int{0, 5, 6, 12, 23} {
+		now := time.Date(2026, 9, 8, hour, 0, 0, 0, loc)
+		if got := imageDue(now, Daily{}); got != (hour >= 6) {
+			t.Fatalf("hour %d due=%v", hour, got)
+		}
+		if imageDue(now, Daily{Date: "2026-09-08", URL: "already-generated"}) {
+			t.Fatal("duplicate image")
+		}
+		if got := imageDue(now, Daily{Date: "2026-09-07", URL: "yesterday"}); got != (hour >= 6) {
+			t.Fatal("yesterday image timing")
+		}
+	}
+	for _, now := range []time.Time{time.Date(2026, 3, 28, 12, 0, 0, 0, loc), time.Date(2026, 10, 24, 12, 0, 0, 0, loc)} {
+		next := imageTime(now).AddDate(0, 0, 1)
+		if next.Hour() != 6 || next.Sub(imageTime(now)) == 24*time.Hour {
+			t.Fatalf("DST drift: %v", next)
+		}
+	}
+}

--- a/service/news/news.go
+++ b/service/news/news.go
@@ -1682,7 +1682,7 @@ func handleArticleView(w http.ResponseWriter, r *http.Request, articleID string)
 			%s
 			%s
 			<div class="article-actions reading-actions">
-				<a href="%s" target="_blank" rel="noopener noreferrer">Read Original →</a>
+				<a class="mini-btn" href="%s" target="_blank" rel="noopener noreferrer">Read Original</a>
 				%s
 			</div>
 			<div class="article-back">

--- a/service/tasks/handler.go
+++ b/service/tasks/handler.go
@@ -21,6 +21,11 @@ import (
 
 // Handler serves /tasks.
 func Handler(w http.ResponseWriter, r *http.Request) {
+	NamedHandler(w, r, nil)
+}
+
+// NamedHandler receives the agent display-name resolver from the server.
+func NamedHandler(w http.ResponseWriter, r *http.Request, name func(string, string) string) {
 	if r.Method == http.MethodPost {
 		rest := strings.Trim(strings.TrimPrefix(r.URL.Path, "/tasks"), "/")
 		id, action, _ := strings.Cut(rest, "/")
@@ -31,7 +36,7 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 		handleJSON(w, r)
 		return
 	}
-	listPage(w, r)
+	listPage(w, r, name)
 }
 
 func handleJSON(w http.ResponseWriter, r *http.Request) {
@@ -95,7 +100,7 @@ func handleAction(w http.ResponseWriter, r *http.Request, id, action string) {
 	http.Redirect(w, r, dest, http.StatusSeeOther)
 }
 
-func listPage(w http.ResponseWriter, r *http.Request) {
+func listPage(w http.ResponseWriter, r *http.Request, names ...func(string, string) string) {
 	sess, _, err := auth.RequireSession(r)
 	if err != nil {
 		app.RedirectToLogin(w, r)
@@ -146,7 +151,11 @@ func listPage(w http.ResponseWriter, r *http.Request) {
 		if Running(t) {
 			running++
 		}
-		b.WriteString(taskRow(t, csrf))
+		label := ""
+		if len(names) > 0 && names[0] != nil {
+			label = names[0](t.Owner, t.Agent)
+		}
+		b.WriteString(taskRow(t, csrf, label))
 	}
 	b.WriteString(`</div>`)
 
@@ -175,8 +184,12 @@ func tab(b *strings.Builder, status, active, label string) {
 	fmt.Fprintf(b, `<a href="%s" class="%s">%s</a>`, href, class, html.EscapeString(label))
 }
 
-func taskRow(t *Task, csrf string) string {
+func taskRow(t *Task, csrf string, labels ...string) string {
 	var b strings.Builder
+	label := "Agent"
+	if len(labels) > 0 && strings.TrimSpace(labels[0]) != "" {
+		label = labels[0]
+	}
 	class := "task"
 	if !t.Open() {
 		class += " task-done"
@@ -188,7 +201,7 @@ func taskRow(t *Task, csrf string) string {
 	var meta []string
 	meta = append(meta, html.EscapeString(t.Status))
 	if t.Assignee == Agent {
-		meta = append(meta, "agent")
+		meta = append(meta, html.EscapeString(label))
 	}
 	if !t.Due.IsZero() {
 		meta = append(meta, "due "+html.EscapeString(t.Due.Local().Format("2 Jan 15:04")))
@@ -199,7 +212,13 @@ func taskRow(t *Task, csrf string) string {
 	fmt.Fprintf(&b, `<div class="task-meta">%s</div>`, strings.Join(meta, " · "))
 
 	if t.Detail != "" {
-		fmt.Fprintf(&b, `<div class="task-detail">%s</div>`, html.EscapeString(t.Detail))
+		if t.Thread != "" {
+			b.WriteString(`<details class="task-context"><summary>Conversation context</summary>`)
+		}
+		fmt.Fprintf(&b, `<div class="task-detail">%s</div>`, app.Render([]byte(t.Detail)))
+		if t.Thread != "" {
+			b.WriteString(`</details>`)
+		}
 	}
 	// What the agent did, before what it concluded. A paragraph on its own
 	// gives no way to tell research from invention; a list of the tools it ran
@@ -230,7 +249,7 @@ func taskRow(t *Task, csrf string) string {
 		// app.Render, not RenderTrusted — this text came out of a model that had
 		// just read news articles and web pages, so any HTML in it is HTML
 		// somebody else wrote.
-		fmt.Fprintf(&b, `<div class="task-result">%s</div>`, app.Render([]byte(t.Result)))
+		fmt.Fprintf(&b, `<div class="task-result">%s</div>`, app.Render([]byte(t.Outcome())))
 	}
 
 	b.WriteString(`<div class="task-actions">`)
@@ -297,8 +316,9 @@ const tasksPageCSS = `<style>
 .task-title{font-weight:var(--font-weight-medium)}
 .task-done .task-title{text-decoration:line-through;color:var(--text-muted)}
 .task-meta{font-size:12px;color:var(--text-muted);margin-top:2px}
-.task-detail{font-size:14px;margin-top:6px;color:var(--text-secondary)}
-.task-result{font-size:14px;margin-top:8px;padding:2px 12px;background:var(--hover-background);border-radius:6px}
+.task-context{margin-top:8px}.task-context summary{cursor:pointer;color:var(--text-muted)}
+.task-detail{overflow-wrap:anywhere;font-size:14px;margin-top:6px;color:var(--text-secondary)}
+.task-result{overflow-wrap:anywhere;font-size:14px;margin-top:8px;padding:2px 12px;background:var(--hover-background);border-radius:6px}
 .task-result > :first-child{margin-top:10px}
 .task-result > :last-child{margin-bottom:10px}
 .task-result pre{overflow-x:auto}

--- a/service/tasks/readability_test.go
+++ b/service/tasks/readability_test.go
@@ -1,0 +1,24 @@
+package tasks
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestTaskIdentityContextAndLegacyFailure(t *testing.T) {
+	task := &Task{ID: "task", Owner: "alice", Agent: "opaque-agent-id", Assignee: Agent, Thread: "thread", Title: "Reply", Detail: "## Conversation\n\nFirst paragraph.\n\n- One\n- Two\n\n<img src=x onerror=alert(1)>", Result: "Last run failed: agent: ai generate failed after 3 attempt(s) (timeout): context deadline exceeded; inspect run history with micro inspect agent"}
+	row := taskRow(task, "csrf", "Malten")
+	for _, want := range []string{"Malten", `<details class="task-context">`, `<h2`, `<li>`, "too long"} {
+		if !strings.Contains(row, want) {
+			t.Errorf("missing %s: %s", want, row)
+		}
+	}
+	for _, bad := range []string{"opaque-agent-id", "onerror=", "micro inspect", `class="task-context" open`} {
+		if strings.Contains(row, bad) {
+			t.Errorf("leaked %s", bad)
+		}
+	}
+	if row := taskRow(task, "csrf", `<script>alert(1)</script>`); strings.Contains(row, "<script>") {
+		t.Fatal("agent name injected markup")
+	}
+}

--- a/service/tasks/tasks.go
+++ b/service/tasks/tasks.go
@@ -18,7 +18,9 @@ package tasks
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
+	"mu/internal/ai"
 	"sort"
 	"strings"
 	"time"
@@ -448,4 +450,13 @@ func DeleteAll(owner string) {
 	for _, id := range ids {
 		unindex(owner, id)
 	}
+}
+
+// Outcome also translates legacy stored failures when they are displayed.
+func (t *Task) Outcome() string {
+	const prefix = "Last run failed: "
+	if strings.HasPrefix(t.Result, prefix) {
+		return prefix + ai.FailureMessage(errors.New(strings.TrimPrefix(t.Result, prefix)))
+	}
+	return t.Result
 }


### PR DESCRIPTION
Address the reported task, account and reading-page issues:

- Resolve the assigned agent's display name on Tasks through the server; collapse and render conversation context as sanitized Markdown. Preserve completed steps on timeout and translate both new and legacy provider timeout diagnostics into readable errors. Keep raw diagnostics in run history/logs; do not rerun live tasks or change the timeout policy.
- Daily shared image generation waits until 06:00 in the server's local timezone, including after restart, and keeps local time across DST.
- Move Admin beneath Account in the sidebar and update the client-side role guard. Account uses Clients with Tokens and IMAP links.
- Give schedule management proper spacing and plus/minus disclosure. Mobile stacked tables align labels and values on the left. Token scope is Services → All/Select, with the checklist revealed only for Select; empty/invalid selection is rejected instead of granting all access.
- Keep inline YouTube citations as links in blog posts instead of nesting /video pages in iframes. Verified against the latest digest's citations. Fix the selector overriding mobile post-tag centering. Style Read Original like the adjacent reading buttons.

Validation: targeted account/token, task/inbox/worker/events, image schedule, blog rendering, error-message and sidebar tests pass; task/inbox/worker/events pass with race detector; architecture checks, build, focused vet, gofmt and diff checks pass. No live messages sent or tasks retried. Browser visual verification was unavailable.