### PR TITLE
Fix Home shortcuts, complete answer delivery and agent creation controls

### DIFF
--- a/admin/config.go
+++ b/admin/config.go
@@ -279,10 +279,11 @@ var settingGroups = []settingGroup{
 	// service/video/searchlimit.go, where the numbers can be read next to what
 	// they bound.
 	{Name: "Platform",
-		Does:  "This instance itself: what it is called.",
+		Does:  "This instance itself: its domain and IANA timezone (TZ, such as Europe/London).",
 		Needs: nil,
 		Vars: []string{
 			"MU_DOMAIN",
+			"TZ",
 		}},
 	// "The agent" was a group of three and is now a group of none. AGENT_NATIVE
 	// and AGENT_NATIVE_STREAM chose between two agent loops, and there is one.

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -106,12 +106,11 @@ type QueryOpts struct {
 	History []QueryMessage
 	Public  bool   // if true, skip private context (mail, wallet, etc.)
 	System  string // optional custom system prompt (user-defined agent)
-	// Extra is context for this call only — today, the summary of the cards
-	// the reader watches, passed when they ask for it. Per-call rather than a
-	// package hook because it is a choice made per message: context costs
-	// tokens on every turn and most questions have nothing to do with it.
+	// Extra is explicit source material attached to this conversation.
 	Extra string
-	Tools []string // optional tool allow-list (user-defined agent); empty = all
+	// CardContext is ambient Home data, not an explicit reading attachment.
+	CardContext string
+	Tools       []string // optional tool allow-list (user-defined agent); empty = all
 	// Model is which model to answer with, when this caller has a preference.
 	//
 	// Per-agent rather than per-instance because the jobs differ in what they
@@ -1244,7 +1243,7 @@ func sse(w http.ResponseWriter, event map[string]any) {
 }
 
 // streamNativeSSE drives the agent and translates its stream into the SSE
-// events the chat UI expects (tool_start/tool_done, stream_start/stream_token,
+// events the chat UI expects (tool_start/tool_done,
 // response, done).
 //
 // It used to return a bool saying whether it had handled the request, so the
@@ -1291,9 +1290,7 @@ func streamNativeSSE(w http.ResponseWriter, accountID, prompt string, opts Query
 		}
 	}()
 
-	streaming := false
 	emitted := false
-	var captured strings.Builder
 	var nativeTools []string
 	// Pairing a start with its end, by the provider's call id.
 	//
@@ -1318,12 +1315,6 @@ func streamNativeSSE(w http.ResponseWriter, accountID, prompt string, opts Query
 	// frames and owns nothing else about the run.
 	sopts := opts
 	sopts.Stream = StreamHooks{
-		Start: func() {
-			wmu.Lock()
-			defer wmu.Unlock()
-			streaming = false
-			captured.Reset()
-		},
 		ToolStart: func(run ToolRun) {
 			wmu.Lock()
 			key := keyOf(run)
@@ -1367,20 +1358,6 @@ func streamNativeSSE(w http.ResponseWriter, accountID, prompt string, opts Query
 			}
 			send(map[string]any{"type": "tool_done", "name": run.Label, "message": run.Label + " — done"})
 		},
-		Token: func(tok string) {
-			wmu.Lock()
-			defer wmu.Unlock()
-			captured.WriteString(tok)
-			if shouldHoldNativeNewsStreamTokens(prompt, nativeTools) {
-				return
-			}
-			if !streaming {
-				streaming = true
-				emitted = true
-				sse(w, map[string]any{"type": "stream_start"})
-			}
-			sse(w, map[string]any{"type": "stream_token", "token": tok})
-		},
 	}
 	answer, err := runNative(accountID, prompt, sopts)
 	if err != nil {
@@ -1407,17 +1384,8 @@ func streamNativeSSE(w http.ResponseWriter, accountID, prompt string, opts Query
 		return
 	}
 
-	if answer == "" {
-		answer = app.StripLatexDollars(captured.String())
-	}
 	answer = completeNativeToolAnswer(answer, nativeTools)
 	answer = app.NormalizeAnswerMarkdown(answer)
-	if !streaming && shouldReplayFinalNativeAnswer(prompt, nativeTools, captured.Len()) {
-		streaming = true
-		emitted = true
-		send(map[string]any{"type": "stream_start"})
-		send(map[string]any{"type": "stream_token", "token": answer})
-	}
 	// What was said, in the record. The workflow record below is how it was
 	// produced; this is the answer itself, and it is what the next message in
 	// this conversation will be given as history.
@@ -1651,7 +1619,9 @@ func handleQuery(w http.ResponseWriter, r *http.Request) {
 	nopts := QueryOpts{Public: guest}
 	nopts.Extra = reading
 	if !guest && req.Cards && CardContextFunc != nil {
-		nopts.Extra += "\n\n" + CardContextFunc(accountID)
+		if _, direct := promptCommand(req.Prompt, nopts); !direct {
+			nopts.CardContext = CardContextFunc(accountID)
+		}
 	}
 	if ua := resolveAgent(accountID, req.Agent); ua != nil && !guest {
 		nopts.System = ua.SystemPrompt

--- a/agent/agents.go
+++ b/agent/agents.go
@@ -42,21 +42,17 @@ func AgentsHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if r.Method == http.MethodPost {
-		switch r.FormValue("action") {
-		case "generate":
-			spec, err := generateAgentSpec(strings.TrimSpace(r.FormValue("brief")))
-			if err != nil {
-				w.WriteHeader(http.StatusServiceUnavailable)
-				_ = json.NewEncoder(w).Encode(map[string]any{"error": err.Error()})
-				return
-			}
-			_ = json.NewEncoder(w).Encode(spec)
+		if action := r.FormValue("action"); action != "" && action != "save" && action != "delete" {
+			w.WriteHeader(http.StatusBadRequest)
+			_ = json.NewEncoder(w).Encode(map[string]any{"error": "Unknown action"})
 			return
+		}
+		switch r.FormValue("action") {
 		case "delete":
 			_ = RemoveAgent(acc.ID, r.FormValue("id"))
 			_ = json.NewEncoder(w).Encode(map[string]any{"ok": true})
 			return
-		default: // save
+		case "save", "":
 			name := strings.TrimSpace(r.FormValue("name"))
 			// The body only. This is the agent's system prompt — what it is for,
 			// in the owner's words — and FormValue would take it from ?prompt=
@@ -69,17 +65,28 @@ func AgentsHandler(w http.ResponseWriter, r *http.Request) {
 			}
 			// Into the roster, the one store — and this is now the only place
 			// an agent is made.
+
+			mode := r.FormValue("scope_mode")
+			selected := r.Form["tools"]
+			if mode == "all" {
+				selected = nil
+			}
+			if (mode != "" && mode != "all" && mode != "select") || (mode == "select" && len(validServices(selected)) == 0) {
+				w.WriteHeader(http.StatusBadRequest)
+				_ = json.NewEncoder(w).Encode(map[string]any{"error": "Select at least one valid service"})
+				return
+			}
 			desc := strings.TrimSpace(r.FormValue("description"))
 			var saved *Agent
 			var secret string
 			var err error
 			if id := r.FormValue("id"); id != "" && For(acc.ID, id) != nil {
-				saved, err = UpdateAgent(acc.ID, id, name, prompt, desc, r.Form["tools"])
+				saved, err = UpdateAgent(acc.ID, id, name, prompt, desc, selected)
 			} else {
 				// No token at creation. An agent is something you talk to; a
 				// token is what you additionally hand to a program outside, and
 				// the Connect page is where you ask for one.
-				saved, secret, err = CreateAgent(acc.ID, name, Hosted, prompt, desc, r.Form["tools"], false)
+				saved, secret, err = CreateAgent(acc.ID, name, Hosted, prompt, desc, selected, false)
 			}
 			if err != nil {
 				w.WriteHeader(http.StatusBadRequest)
@@ -199,68 +206,6 @@ func firstLine(stored, fallback string) string {
 	}
 	return s
 }
-
-// generateAgentSpec turns a one-line brief into a full agent spec (name,
-// description, system prompt) using the LLM — the "describe it and it becomes an
-// agent" flow.
-func generateAgentSpec(brief string) (map[string]string, error) {
-	if brief == "" {
-		return nil, errBadBrief
-	}
-	if !ai.Configured() {
-		return nil, errNoAI
-	}
-	// The tool list comes from the registry, so a generated agent can only be
-	// scoped to services that exist. Naming them in the prompt by hand is how
-	// you get an agent told to "lean on social" on an instance where social is
-	// not registered — which then reports that source unavailable on every
-	// answer.
-	available := strings.Join(AllAgentTools(), ", ")
-	sys := `You design AI agent personas for Mu, a personal assistant whose tools are grouped by service. The services available on this instance are: ` + available + `.
-
-Given a brief, output ONLY minified JSON with exactly these keys:
-"name": a short label, <=40 chars, no emoji;
-"description": one line, <=120 chars, saying what it does for the user — not a list of the data it reads;
-"prompt": a system prompt of 2-4 sentences in second person ("You are ...") defining the persona, tone and priorities. Say what to do with the data, not which tools to call: the tools are chosen for it and naming them adds nothing. Never instruct it to "lean on" a source;
-"tools": an array of service names taken ONLY from the list above — the smallest set the brief actually needs. Omit anything it would not use. An empty array means every tool, so avoid it unless the brief is genuinely general.
-No markdown, no code fences, no commentary — just the JSON object.`
-	out, err := ai.Ask(&ai.Prompt{System: sys, Question: "Brief: " + brief, Caller: "agent_builder", MaxTokens: 500})
-	if err != nil {
-		return nil, err
-	}
-	out = strings.TrimSpace(out)
-	out = strings.TrimPrefix(out, "```json")
-	out = strings.TrimPrefix(out, "```")
-	out = strings.TrimSuffix(out, "```")
-	out = strings.TrimSpace(out)
-	var raw struct {
-		Name        string   `json:"name"`
-		Description string   `json:"description"`
-		Prompt      string   `json:"prompt"`
-		Tools       []string `json:"tools"`
-	}
-	if err := json.Unmarshal([]byte(out), &raw); err != nil || strings.TrimSpace(raw.Prompt) == "" {
-		// Model didn't return clean JSON — fall back to using the text as the prompt.
-		return map[string]string{"name": "", "description": "", "prompt": out}, nil
-	}
-	// validServices drops anything the model invented, so a hallucinated
-	// service name cannot end up as a scope that matches nothing.
-	return map[string]string{
-		"name":        raw.Name,
-		"description": raw.Description,
-		"prompt":      raw.Prompt,
-		"tools":       strings.Join(validServices(raw.Tools), ","),
-	}, nil
-}
-
-var (
-	errBadBrief = &agentErr{"describe the agent in a sentence first"}
-	errNoAI     = &agentErr{"AI is not configured on this instance"}
-)
-
-type agentErr struct{ s string }
-
-func (e *agentErr) Error() string { return e.s }
 
 // renderAgentsPanel renders the lean "Agents" card for the rail: pick the
 // default or one of your agents. Creating/editing happens on /agent/new.
@@ -476,24 +421,24 @@ func NewAgentHandler(w http.ResponseWriter, r *http.Request) {
 	// "is this scope right" with a list of prompts, which is the question but
 	// not an answer to it — and what an answer actually called is now beside
 	// the answer in the conversation, where somebody looking at an odd one is.
+	scopeOptions, scopeHidden := `<option value="all">All</option><option value="select">Select</option>`, ` hidden`
+	if len(selTools) > 0 {
+		scopeOptions = `<option value="all">All</option><option value="select" selected>Select</option>`
+		scopeHidden = ""
+	}
 	b := `<div class="builder">
-  <p class="builder-sub">Describe an agent and Mu will draft it, or write the system prompt yourself. Pick what it may reach — it will be refused everything else, even though it is your account behind it.</p>
   <form id="bform" onsubmit="return bSave(event)">
     <input type="hidden" id="b-id" value="` + html.EscapeString(editID) + `">
     <input type="hidden" id="b-fork" value="` + html.EscapeString(forkFrom) + `">
-    <label class="b-label">Describe it (optional)</label>
-    <div class="b-gen">
-      <input id="b-brief" placeholder="e.g. a meticulous crypto research analyst that always cites sources">
-      <button type="button" id="b-genbtn" onclick="bGen()">✨ Generate</button>
-    </div>
     <label class="b-label">Name</label>
     <input id="b-name" maxlength="60" required value="` + html.EscapeString(name) + `">
     <label class="b-label">Description</label>
     <input id="b-desc" maxlength="140" value="` + html.EscapeString(desc) + `">
     <label class="b-label">System prompt</label>
     <textarea id="b-prompt" rows="9" required>` + html.EscapeString(prompt) + `</textarea>
-    <label class="b-label">What may it reach? <span class="b-hint">— none selected means everything you can</span></label>
-    <div class="b-tools">` + toolsHTML.String() + `</div>
+    <label class="b-label" for="b-scope">Services</label>
+    <select id="b-scope" onchange="document.getElementById('b-service-list').hidden=this.value!=='select'">` + scopeOptions + `</select>
+    <div id="b-service-list"` + scopeHidden + `><div class="b-tools">` + toolsHTML.String() + `</div></div>
     ` + modelHTML + `
     
     <div class="b-actions">
@@ -511,10 +456,6 @@ func NewAgentHandler(w http.ResponseWriter, r *http.Request) {
 .b-hint{font-weight:400;color:#9ca3af}
 #bform input,#bform textarea,#bform select{width:100%;box-sizing:border-box;padding:9px 11px;font-size:14px;border:1px solid #d1d5db;border-radius:6px;font-family:inherit;background:#fff;color:inherit}
 #bform textarea{line-height:1.5;resize:vertical}
-.b-gen{display:flex;gap:8px}
-.b-gen input{flex:1}
-.b-gen button{white-space:nowrap;padding:9px 14px;font-size:14px;border:1px solid var(--border-color,#ddd);border-radius:var(--border-radius,6px);cursor:pointer;background:#fff;color:var(--text-primary,#111);font-weight:500}
-.b-gen button[disabled]{opacity:.6;cursor:default}
 .b-tools{display:flex;flex-wrap:wrap;gap:6px;margin-top:2px}
 .b-actions{display:flex;align-items:center;gap:12px;margin-top:22px}
 .b-save{padding:10px 22px;font-size:14px;font-weight:600;border:0;border-radius:var(--border-radius,6px);background:var(--btn-primary,#000);color:#fff;cursor:pointer}
@@ -524,23 +465,6 @@ func NewAgentHandler(w http.ResponseWriter, r *http.Request) {
 </style>` + chipCSS + `
 <script>
 function bCsrf(){var m=document.cookie.match(/(?:^|; )csrf_token=([^;]+)/);return m?decodeURIComponent(m[1]):'';}
-function bGen(){var brief=document.getElementById('b-brief').value.trim();if(!brief)return;
-  var btn=document.getElementById('b-genbtn');btn.disabled=true;btn.textContent='Generating…';
-  var b=new URLSearchParams();b.append('action','generate');b.append('brief',brief);
-  fetch('/agents/data',{method:'POST',headers:{'Content-Type':'application/x-www-form-urlencoded','X-CSRF-Token':bCsrf()},body:b.toString()})
-    .then(function(r){return r.json();}).then(function(d){btn.disabled=false;btn.textContent='✨ Generate';
-      if(d.error){alert(d.error);return;}
-      if(d.name)document.getElementById('b-name').value=d.name;
-      if(d.description)document.getElementById('b-desc').value=d.description;
-      if(d.prompt)document.getElementById('b-prompt').value=d.prompt;
-      // Tick the scope it chose. Picking the tools by hand was the one step the
-      // generator left to you, and it is the step you have least information
-      // for: you have not read the prompt it just wrote.
-      if(typeof d.tools==='string'){
-        var want={};d.tools.split(',').forEach(function(t){if(t)want[t]=true;});
-        document.querySelectorAll('.b-tools input[name="tool"]').forEach(function(c){c.checked=!!want[c.value];});
-      }
-    }).catch(function(){btn.disabled=false;btn.textContent='✨ Generate';});}
 function bSave(e){e.preventDefault();
   var b=new URLSearchParams();b.append('action','save');
   b.append('id',document.getElementById('b-id').value);
@@ -548,7 +472,11 @@ function bSave(e){e.preventDefault();
   b.append('name',document.getElementById('b-name').value);
   b.append('description',document.getElementById('b-desc').value);
   b.append('prompt',document.getElementById('b-prompt').value);
-  document.querySelectorAll('.b-tools input:checked').forEach(function(el){b.append('tools',el.value);});
+  var mode=document.getElementById('b-scope').value;
+  var selected=Array.from(document.querySelectorAll('.b-tools input:checked'));
+  if(mode==='select'&&!selected.length){alert('Select at least one service');return false;}
+  b.append('scope_mode',mode);
+  if(mode==='select')selected.forEach(function(el){b.append('tools',el.value);});
   // Only when the select is on the page. One provider means no menu, and
   // sending an empty model then would be sending a choice nobody made — which
   // is the same value it already has, but says so on every save.

--- a/agent/builder_scope_test.go
+++ b/agent/builder_scope_test.go
@@ -1,0 +1,73 @@
+package agent
+
+import (
+	"mu/internal/auth"
+	"mu/internal/service"
+	"mu/service/news"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+func TestBuilderAllSelectAndRemovedGenerator(t *testing.T) {
+	const who = "builder_scope"
+	if err := auth.Create(&auth.Account{ID: who, Admin: true, Approved: true}); err != nil {
+		t.Fatal(err)
+	}
+	sess, err := auth.CreateSession(who)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := service.Register(news.Spec); err != nil {
+		t.Fatal(err)
+	}
+	cookie := &http.Cookie{Name: "session", Value: sess.Token}
+	req := httptest.NewRequest("GET", "/agent/new", nil)
+	req.AddCookie(cookie)
+	rec := httptest.NewRecorder()
+	NewAgentHandler(rec, req)
+	page := rec.Body.String()
+	for _, want := range []string{`id="b-scope"`, `value="all">All`, `value="select">Select`, `id="b-service-list" hidden`} {
+		if !strings.Contains(page, want) {
+			t.Errorf("missing %q", want)
+		}
+	}
+	for _, bad := range []string{"Describe it", "bGen()", "b-genbtn", "What may it reach?"} {
+		if strings.Contains(page, bad) {
+			t.Errorf("old builder feature %q", bad)
+		}
+	}
+	for _, tc := range []struct {
+		action, mode, tools string
+		status              int
+	}{{"generate", "all", "", 400}, {"save", "select", "", 400}, {"save", "select", "unknown", 400}, {"save", "select", "news", 200}, {"save", "all", "news", 200}} {
+		before := len(Agents(who))
+		form := url.Values{"action": {tc.action}, "scope_mode": {tc.mode}, "name": {"Example" + tc.mode}, "prompt": {"Be useful"}, "tools": {tc.tools}}
+		req := httptest.NewRequest("POST", "/agents/data", strings.NewReader(form.Encode()))
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		req.AddCookie(cookie)
+		rec := httptest.NewRecorder()
+		AgentsHandler(rec, req)
+		if rec.Code != tc.status {
+			t.Fatalf("%+v: %d %s", tc, rec.Code, rec.Body.String())
+		}
+		if rec.Code == 400 && len(Agents(who)) != before {
+			t.Fatal("invalid request created agent")
+		}
+	}
+	for _, a := range Agents(who) {
+		if (a.Name == "Exampleselect") != (len(a.Services) > 0) {
+			t.Fatalf("incorrect services: %+v", a.Services)
+		}
+		req := httptest.NewRequest("GET", "/agent/new?id="+a.ID, nil)
+		req.AddCookie(cookie)
+		rec := httptest.NewRecorder()
+		NewAgentHandler(rec, req)
+		if a.Name == "Exampleselect" && !strings.Contains(rec.Body.String(), `value="select" selected`) {
+			t.Fatal("edit lost selection")
+		}
+		RemoveAgent(who, a.ID)
+	}
+}

--- a/agent/native.go
+++ b/agent/native.go
@@ -348,6 +348,9 @@ func buildNativeAgent(accountID, prompt string, opts QueryOpts, wrappers ...gmai
 	// instructions and this is context, not instruction, so there is no branch
 	// here that could silently drop it — which is what the old placement, after
 	// a line that replaced sys outright, had to be careful about.
+	if strings.TrimSpace(opts.CardContext) != "" {
+		facts = append(facts, strings.TrimSpace(opts.CardContext))
+	}
 	if strings.TrimSpace(opts.Extra) != "" {
 		facts = append(facts, strings.TrimSpace(opts.Extra))
 	}
@@ -724,7 +727,7 @@ func runNative(accountID, prompt string, opts QueryOpts) (string, error) {
 	defer cancel()
 
 	final := ""
-	if opts.Stream.wants() {
+	if opts.Stream.Token != nil || opts.Stream.Start != nil {
 		liveCtx, live := ai.LiveTokens(ctx, run.provider, run.baseURL, opts.Stream.Start, func(tok string) {
 			if !shouldBufferNativeToken(recorder) && opts.Stream.Token != nil {
 				opts.Stream.Token(tok)

--- a/agent/pending.go
+++ b/agent/pending.go
@@ -29,6 +29,8 @@ package agent
 // appears on this page the same way.
 
 import (
+	"errors"
+	"mu/internal/ai"
 	"net/http"
 	"strings"
 
@@ -78,6 +80,32 @@ func PendingHandler(w http.ResponseWriter, r *http.Request) {
 	id := strings.TrimSpace(r.URL.Query().Get("thread"))
 	if id == "" {
 		app.RespondJSON(w, map[string]any{"waiting": false})
+		return
+	}
+
+	if runID := strings.TrimSpace(r.URL.Query().Get("flow")); runID != "" {
+		flowMu.RLock()
+		f := flowStore[runID]
+		var run Flow
+		owned := f != nil && f.AccountID == acc.ID && f.ThreadID == id
+		if owned {
+			run = *f
+		}
+		flowMu.RUnlock()
+		if !owned {
+			app.RespondJSON(w, map[string]any{"waiting": false})
+			return
+		}
+		result := map[string]any{"waiting": run.Status != "done" && run.Status != "error"}
+		if run.Status == "done" {
+			result["html"] = `<div class="mu-agent">` + run.HTML + `</div>`
+			result["answer_html"] = run.HTML
+			result["text"] = run.Answer
+		}
+		if run.Status == "error" {
+			result["error"] = ai.FailureMessage(errors.New(run.Error))
+		}
+		app.RespondJSON(w, result)
 		return
 	}
 

--- a/agent/prompt_completion_test.go
+++ b/agent/prompt_completion_test.go
@@ -1,0 +1,94 @@
+package agent
+
+import (
+	"encoding/json"
+	"mu/internal/auth"
+	"mu/internal/service"
+	"mu/service/news"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestHomeNewsShortcutReturnsFinalAnswerWithoutCardOrModelWork(t *testing.T) {
+	if err := service.Register(news.Spec); err != nil {
+		t.Fatal(err)
+	}
+	const who = "home_command"
+	if err := auth.Create(&auth.Account{ID: who, Approved: true}); err != nil {
+		t.Fatal(err)
+	}
+	sess, err := auth.CreateSession(who)
+	if err != nil {
+		t.Fatal(err)
+	}
+	old := CardContextFunc
+	t.Cleanup(func() { CardContextFunc = old })
+	CardContextFunc = func(string) string {
+		t.Fatal("shortcut assembled ambient cards instead of returning directly")
+		return ""
+	}
+	for _, prompt := range []string{"News", "news", " NEWS "} {
+		body, _ := json.Marshal(map[string]any{"prompt": prompt, "cards": true})
+		req := httptest.NewRequest("POST", "/agent", strings.NewReader(string(body)))
+		req.Header.Set("Content-Type", "application/json")
+		req.AddCookie(&http.Cookie{Name: "session", Value: sess.Token})
+		rec := httptest.NewRecorder()
+		started := time.Now()
+		handleQuery(rec, req)
+		if time.Since(started) > 2*time.Second {
+			t.Fatal("local shortcut took too long")
+		}
+		text := rec.Body.String()
+		if !strings.Contains(text, `"type":"response"`) || !strings.Contains(text, `"type":"done"`) || strings.Contains(text, `"type":"error"`) {
+			t.Fatalf("missing completion: %s", text)
+		}
+		if strings.Contains(text, "stream_token") || strings.Contains(text, "stream_start") {
+			t.Fatal("web still emits partial prose")
+		}
+	}
+	if _, ok := promptCommand("news", QueryOpts{CardContext: "ambient cards"}); !ok {
+		t.Fatal("ambient context blocks shortcut")
+	}
+	if _, ok := promptCommand("news", QueryOpts{Extra: "attached article"}); ok {
+		t.Fatal("attached material bypassed")
+	}
+}
+
+func TestRecoveryIsBoundToTheOwnedRun(t *testing.T) {
+	const who = "run_recovery"
+	th := waiting(t, who)
+	sess, err := auth.CreateSession(who)
+	if err != nil {
+		t.Fatal(err)
+	}
+	flow := &Flow{ID: "recover-one", AccountID: who, ThreadID: th, Status: "done", Answer: "Recovered", HTML: `<div class="card">Recovered</div>`}
+	if err := saveFlow(flow); err != nil {
+		t.Fatal(err)
+	}
+	// A newer turn must not replace the answer to the run this browser started.
+	saveFlow(&Flow{ID: "recover-other", AccountID: who, ThreadID: th, Status: "done", Answer: "Other", HTML: "Other"})
+	for _, tc := range []struct {
+		run, thread string
+		want        bool
+	}{{flow.ID, th, true}, {"missing", th, false}, {flow.ID, "wrong-thread", false}} {
+		req := httptest.NewRequest("GET", "/agent/pending?thread="+tc.thread+"&flow="+tc.run, nil)
+		req.AddCookie(&http.Cookie{Name: "session", Value: sess.Token})
+		rec := httptest.NewRecorder()
+		PendingHandler(rec, req)
+		if strings.Contains(rec.Body.String(), "Recovered") != tc.want {
+			t.Fatalf("wrong run returned: %s", rec.Body.String())
+		}
+	}
+	auth.Create(&auth.Account{ID: "recovery_other"})
+	other, _ := auth.CreateSession("recovery_other")
+	req := httptest.NewRequest("GET", "/agent/pending?thread="+th+"&flow="+flow.ID, nil)
+	req.AddCookie(&http.Cookie{Name: "session", Value: other.Token})
+	rec := httptest.NewRecorder()
+	PendingHandler(rec, req)
+	if strings.Contains(rec.Body.String(), "Recovered") {
+		t.Fatal("cross-account disclosure")
+	}
+}

--- a/agent/roster_page.go
+++ b/agent/roster_page.go
@@ -193,7 +193,7 @@ func RosterHandler(w http.ResponseWriter, r *http.Request) {
 	// is the page where that is decided. So the way in is from here — but below
 	// what the page is about, because somebody arrives to see their agents and
 	// not to browse tools, and the link was above both the list and the button.
-	b.WriteString(`<p class="lens-go">` + app.TextLink("See the tools", "/tools") + `</p>`)
+	b.WriteString(`<p class="lens-go">` + app.TextLink("Tools", "/tools") + `</p>`)
 
 	// The instance's own agents are listed here, at the top, by the loop over
 	// PlatformNames above.

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -961,17 +961,22 @@ func CardWithIcon(id, title, icon, content string) string {
 //
 // For repo-shipped markdown that deliberately embeds HTML, use RenderTrusted.
 func Render(md []byte) []byte {
-	return render(md, false)
+	return render(md, false, false)
 }
 
 // RenderTrusted converts markdown to HTML with raw HTML passed through. Only
 // for content that ships in the binary (the docs) — never for anything
 // that arrived over the network.
 func RenderTrusted(md []byte) []byte {
-	return render(md, true)
+	return render(md, true, false)
 }
 
-func render(md []byte, trusted bool) []byte {
+// RenderNoImages formats private conversation context without loading sender images.
+func RenderNoImages(md []byte) []byte {
+	return render(md, false, true)
+}
+
+func render(md []byte, trusted, noImages bool) []byte {
 	// Strip LaTeX dollar sign escapes and protect plain currency before
 	// parsing markdown so downstream MathJax scanners do not treat blog cards
 	// or other rendered content as inline math.
@@ -986,6 +991,9 @@ func render(md []byte, trusted bool) []byte {
 
 	// create HTML renderer with extensions
 	htmlFlags := html.CommonFlags | html.HrefTargetBlank
+	if noImages {
+		htmlFlags |= html.SkipImages
+	}
 	if !trusted {
 		// SkipHTML drops raw HTML blocks and inline tags; Safelink limits link
 		// destinations to http/https/mailto and friends. Safelink does not cover

--- a/internal/app/chat.go
+++ b/internal/app/chat.go
@@ -841,6 +841,7 @@ function ask(q){
   var a=document.createElement('div');a.className='mu-agent';conv.appendChild(a);
   input.value='';saveDraft();input.style.height='auto';input.focus();
 
+  var terminal=false,flowID='',recoveryThread='',completionTimer=null;
   var workLabel='Working';
   var t0=Date.now();
   var timer=null;
@@ -853,6 +854,7 @@ function ask(q){
   // the record is the run.
   var done=[];
   function renderWork(){
+    if(terminal)return;
     var dots=['.','..','...'][Math.floor((Date.now()-t0)/450)%3];
     var secs=Math.round((Date.now()-t0)/1000);
     var past='';
@@ -866,6 +868,7 @@ function ask(q){
   // startWork moves the current label into the list behind it, so each step
   // stays on screen once the next one starts.
   function startWork(label){
+    if(terminal)return;
     if(label&&label!==workLabel){
       if(workLabel&&workLabel!=='Working'&&done[done.length-1]!==workLabel)done.push(workLabel);
       workLabel=label;
@@ -891,17 +894,41 @@ function ask(q){
   // Home wants: you typed at the top and the answer appears under it.
   if(transcript){ toBottom(true,true); } else { u.scrollIntoView({behavior:'smooth',block:'start'}); }
   var streamText='';
-  var streaming=false;
   var body=JSON.stringify({prompt:q,attachment:(!contextId?attachment:""),history:history.slice(-6),context_id:contextId||'',agent:(window.muActiveAgent||''),cards:true});
   // Accept says which of the two doors at /agent this is.
   //
   // The same path answers a program with JSON and this box with an event
   // stream, and what separates them is what they ask for — not the shape of
   // what they send, which is how it was told apart for one commit and which
-  // made a naming inconsistency load-bearing. This wants tokens as they
-  // arrive, so it says so.
+  // made a naming inconsistency load-bearing. This receives tool progress
+  // followed by one complete answer.
+  var recoveryUntil=Date.now()+600000;
+  function checkCompletion(){
+    if(terminal||epoch!==viewEpoch)return;
+    fetch('/agent/pending?thread='+encodeURIComponent(recoveryThread)+'&flow='+encodeURIComponent(flowID),
+      {headers:{'Accept':'application/json'},credentials:'same-origin'})
+      .then(function(r){return r.ok?r.json():null;})
+      .then(function(d){
+        if(terminal||epoch!==viewEpoch)return;
+        if(d&&d.html){
+          terminal=true;stopWork();clearTimeout(completionTimer);
+          if(d.answer_html)a.innerHTML=d.answer_html;else a.outerHTML=d.html;
+          if(typeof d.text==='string')history.push({prompt:q,answer:d.text});
+          save();toBottom(false);streamController.abort();return;
+        }
+        if(d&&!d.waiting){
+          terminal=true;stopWork();a.innerHTML='<div class="mu-err">'+esc(d.error||'The run stopped without returning an answer.')+'</div>';save();streamController.abort();return;
+        }
+        retryCompletion();
+      }).catch(retryCompletion);
+  }
+  function retryCompletion(){
+    if(terminal||epoch!==viewEpoch)return;
+    if(Date.now()>recoveryUntil){terminal=true;stopWork();a.innerHTML='<div class="mu-err">No answer came back. Please try again.</div>';save();streamController.abort();return;}
+    completionTimer=setTimeout(checkCompletion,3000);
+  }
   var streamController=new AbortController();
-  detachActive=function(){stopWork();streamController.abort();};
+  detachActive=function(){terminal=true;clearTimeout(completionTimer);stopWork();streamController.abort();};
   fetch('/agent',{signal:streamController.signal,method:'POST',headers:{'Content-Type':'application/json','Accept':'text/event-stream'},body:body,credentials:'same-origin'})
   .then(function(resp){
     if(epoch!==viewEpoch)throw 'handled';
@@ -937,7 +964,7 @@ function ask(q){
     function read(){
       return reader.read().then(function(chunk){
         if(epoch!==viewEpoch){stopWork();reader.cancel();return;}
-        if(chunk.done){stopWork();save();return;}
+        if(chunk.done){stopWork();if(!terminal)throw Error('Response connection closed before the answer arrived');save();return;}
         buf+=decoder.decode(chunk.value,{stream:true});
         var lines=buf.split('\n');
         buf=lines.pop();
@@ -945,7 +972,10 @@ function ask(q){
           if(line.indexOf('data: ')!==0)return;
           try{
             var ev=JSON.parse(line.slice(6));
+            if(terminal)return;
             if(ev.type==='flow_id'){
+              flowID=ev.flow_id||'';recoveryThread=ev.thread||'';
+              if(ev.thread&&!completionTimer)completionTimer=setTimeout(checkCompletion,4000);
               // Continue this server session on the next message. Persist it now
               // (it arrives before the answer) so a reload mid-stream still
               // threads the follow-up onto this same conversation.
@@ -993,20 +1023,12 @@ function ask(q){
               if(running>0)running--;
               if(running===0)startWork('Working');
             }else if(ev.type==='stream_start'){
-              streamText='';streaming=false;startWork('Composing');
+              streamText='';
             }else if(ev.type==='stream_token'){
+              // Compatibility with older servers: buffer, never paint partial prose.
               streamText+=ev.token;
-              if(!streaming){
-                streaming=true;stopWork();
-                a.innerHTML='<div class="whitespace-pre-wrap"><span id="mu-stream-out"></span><span class="mu-cursor"></span></div>';
-              }
-              var el=document.getElementById('mu-stream-out');
-              if(el)el.textContent=protectCurrencyDollars(streamText);
-              // Follow the answer down, unless the reader has scrolled away to
-              // look at something else.
-              toBottom(false);
             }else if(ev.type==='response'){
-              stopWork();
+              terminal=true;clearTimeout(completionTimer);stopWork();
               a.innerHTML=ev.html;
               if(typeof ev.text==='string')streamText=ev.text;
               history.push({prompt:q,answer:streamText});
@@ -1016,7 +1038,7 @@ function ask(q){
               // a voice reading markup says "less than div" at you.
               if(window.muSay)window.muSay(streamText);
             }else if(ev.type==='error'){
-              stopWork();
+              terminal=true;clearTimeout(completionTimer);stopWork();
               a.innerHTML='<div class="mu-err">'+esc(ev.message)+'</div>';
               save();
             }
@@ -1029,45 +1051,10 @@ function ask(q){
   })
   .catch(function(err){
     stopWork();
-    if(err==='handled'||epoch!==viewEpoch)return;
-    // Losing the stream is not the same as losing the run. The server uses a
-    // run context independent of this request and records the eventual answer
-    // in the conversation. Stay attached to that record instead of replacing
-    // a still-running answer with the browser's unhelpful "network error".
-    if(contextId){
-      var reconnectUntil=Date.now()+600000;
-      a.innerHTML='<div class="mu-think"><span class="mu-spin"></span><span>Connection lost. Reconnecting...</span></div>';
-      save();
-      (function recover(){
-        if(epoch!==viewEpoch)return;
-        fetch('/agent/pending?thread='+encodeURIComponent(contextId),
-          {headers:{'Accept':'application/json'},credentials:'same-origin'})
-          .then(function(r){return r.ok?r.json():null})
-          .then(function(d){
-            if(epoch!==viewEpoch)return;
-            if(d&&d.html){a.outerHTML=d.html;save();toBottom(false);return;}
-            if(d&&Array.isArray(d.steps)&&d.steps.length){
-              done=[];workLabel='Working';
-              d.steps.forEach(function(s){if(s.status==='running')workLabel=s.label;else done.push(s.label);});
-              renderWork();save();
-            }
-            if(d&&!d.waiting){
-              a.innerHTML='<div class="mu-err">'+esc(d.error||'The run stopped without returning an answer.')+'</div>';save();return;
-            }
-            if(Date.now()>reconnectUntil){
-              a.innerHTML='<div class="mu-err">The connection was lost and no answer came back. Please try again.</div>';save();return;
-            }
-            setTimeout(recover,3000);
-          })
-          .catch(function(){
-            if(epoch!==viewEpoch)return;
-            if(Date.now()>reconnectUntil){
-              a.innerHTML='<div class="mu-err">The connection was lost and no answer came back. Please try again.</div>';save();return;
-            }
-            setTimeout(recover,3000);
-          });
-      })();
-      return;
+    if(terminal||err==='handled'||epoch!==viewEpoch)return;
+    if(recoveryThread&&flowID){
+      a.innerHTML='<div class="mu-think"><span class="mu-spin"></span><span>Reconnecting...</span></div>';
+      clearTimeout(completionTimer);checkCompletion();return;
     }
     a.innerHTML='<div class="mu-err">Error: '+esc(err&&err.message||err)+'</div>';save();
   });

--- a/internal/app/chat_completion_test.go
+++ b/internal/app/chat_completion_test.go
@@ -1,0 +1,32 @@
+package app
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+func TestChatCompletionAndRecovery(t *testing.T) {
+	node, err := exec.LookPath("node")
+	if err != nil {
+		t.Skip("Node is needed for the browser response state test")
+	}
+	src, err := os.ReadFile("chat.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(src)
+	start := strings.Index(text, "function ask(q){")
+	end := strings.Index(text, "form.addEventListener('submit',")
+	if start < 0 || end <= start {
+		t.Fatal("chat function not found")
+	}
+	body, _ := json.Marshal(text[start:end])
+	cmd := exec.Command(node, "testdata/chat_completion.js")
+	cmd.Stdin = strings.NewReader(string(body))
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("completion test: %v\n%s", err, out)
+	}
+}

--- a/internal/app/html/mu.css
+++ b/internal/app/html/mu.css
@@ -154,17 +154,17 @@ html, body {
   box-sizing: inherit;
 }
 
-/* Links - minimalist style with hover underline */
+/* Links share one bold, un-underlined treatment. */
 a {
   color: #000;
-  text-decoration: none;
+  text-decoration: none !important;
   font-size: 0.9em;
-  font-weight: bold;
+  font-weight: bold !important;
   transition: opacity var(--transition-fast);
 }
 
 a:hover {
-  text-decoration: underline;
+  text-decoration: none;
 }
 
 /* Except the ones that are buttons.

--- a/internal/app/render_security_test.go
+++ b/internal/app/render_security_test.go
@@ -157,3 +157,10 @@ func TestRenderHTMLEscapesTitleAndDescription(t *testing.T) {
 		t.Error("body should not be escaped — handlers pass HTML")
 	}
 }
+
+func TestConversationContextDoesNotLoadImages(t *testing.T) {
+	out := string(RenderNoImages([]byte("**Sender**\n\n![pixel](https://sender.example/pixel) <img src=\"https://sender.example/raw\">\n\n[Source](https://example.com)")))
+	if strings.Contains(out, "<img") || !strings.Contains(out, "<strong>Sender</strong>") || !strings.Contains(out, "href=") {
+		t.Fatal(out)
+	}
+}

--- a/internal/app/testdata/chat_completion.js
+++ b/internal/app/testdata/chat_completion.js
@@ -1,0 +1,28 @@
+const fs=require('fs'),assert=require('assert');
+const source=JSON.parse(fs.readFileSync(0,'utf8'));
+const frame=e=>'data: '+JSON.stringify(e)+'\n\n';
+async function scenario(frames,stall=false){
+ const paints=[],children=[],timeouts=[];
+ const element=()=>({className:'',style:{},isConnected:true,focus(){},scrollIntoView(){},set innerHTML(v){this.html=v;paints.push(v)},get innerHTML(){return this.html||''}});
+ let idx=0,polls=0;
+ const env={viewEpoch:0,detachActive:null,hideBrief(){},sugDiv:element(),conv:{appendChild(e){children.push(e)}},document:{createElement:element},input:element(),saveDraft(){},save(){},esc:String,agentName(){return 'Micro'},toBottom(){},transcript:false,history:[],contextId:'',attachment:'',window:{dispatchEvent(){}},CustomEvent:class{},TextDecoder,AbortController,
+ setInterval(){return 1},clearInterval(){},setTimeout(fn,ms){timeouts.push({fn,ms});return timeouts.length},clearTimeout(){},
+ fetch(url){
+  if(url.startsWith('/agent/pending')){polls++;return Promise.resolve({ok:true,json:()=>Promise.resolve({waiting:false,html:'<div>Recovered</div>',answer_html:'Recovered',text:'Recovered'})})}
+  return Promise.resolve({ok:true,status:200,body:{getReader(){return {read(){if(idx<frames.length)return Promise.resolve({value:new TextEncoder().encode(frames[idx++]),done:false});if(stall)return new Promise(()=>{});return Promise.resolve({done:true})},cancel(){}}}}})
+ }};
+ new Function('env','with(env){'+source+'; return ask;}')(env)('News');
+ for(let i=0;i<100;i++)await Promise.resolve();
+ if(stall){const timer=timeouts.find(t=>t.ms===4000);assert(timer,'missing live completion watchdog');timer.fn();for(let i=0;i<100;i++)await Promise.resolve();}
+ return {paints,answer:children[children.length-1],polls,history:env.history};
+}
+(async()=>{
+ const id=frame({type:'flow_id',thread:'thread',flow_id:'flow'});
+ let r=await scenario([id,frame({type:'stream_token',token:'partial words'}),frame({type:'response',html:'Complete answer',text:'Complete answer'}),frame({type:'tool_done'})]);
+ assert.equal(r.answer.innerHTML,'Complete answer');assert.equal(r.history.length,1);assert(!r.paints.some(x=>x.includes('partial words')));assert.equal(r.polls,0);
+ r=await scenario([id]);assert.equal(r.answer.innerHTML,'Recovered');assert.equal(r.history.length,1);assert.equal(r.polls,1);
+ r=await scenario([id],true);assert.equal(r.answer.innerHTML,'Recovered');assert.equal(r.history.length,1);
+ r=await scenario([id,'data: {"type":"response"']);assert.equal(r.answer.innerHTML,'Recovered');
+ r=await scenario([id,frame({type:'error',message:'Failed'}),frame({type:'tool_done'})]);assert(r.answer.innerHTML.includes('Failed'));assert.equal(r.polls,0);
+ console.log('completion scenarios passed');
+})().catch(e=>{console.error(e);process.exitCode=1});

--- a/service/images/images.go
+++ b/service/images/images.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	_ "time/tzdata"
 
 	"mu/internal/ai"
 	"mu/internal/app"
@@ -137,8 +138,20 @@ func Load() {
 	go scheduler()
 }
 
+// imageLocation uses an explicit IANA timezone even in minimal containers.
+// UTC is the default for the shared site image, independent of reader timezones.
+func imageLocation() *time.Location {
+	zone := strings.TrimSpace(settings.Get("TZ"))
+	if zone != "" && zone != "Local" {
+		if loc, err := time.LoadLocation(zone); err == nil {
+			return loc
+		}
+	}
+	return time.UTC
+}
+
 // today returns the current site-local date as YYYY-MM-DD.
-func today() string { return time.Now().Format("2006-01-02") }
+func today() string { return time.Now().In(imageLocation()).Format("2006-01-02") }
 
 // themeStride is how far along the list one day moves.
 //
@@ -163,7 +176,7 @@ func scheduler() {
 	// Small delay so AI settings/env are wired before the first attempt.
 	time.Sleep(5 * time.Second)
 	for {
-		now := time.Now()
+		now := time.Now().In(imageLocation())
 		target := imageTime(now)
 		if now.Before(target) {
 			time.Sleep(time.Until(target))
@@ -182,7 +195,7 @@ func scheduler() {
 			time.Sleep(time.Hour)
 			continue
 		}
-		time.Sleep(time.Until(imageTime(time.Now()).AddDate(0, 0, 1)))
+		time.Sleep(time.Until(imageTime(time.Now().In(imageLocation())).AddDate(0, 0, 1)))
 	}
 }
 
@@ -192,7 +205,7 @@ func generateDaily() {
 	if !aiReady() {
 		return // no provider configured — try again next cycle
 	}
-	theme := themeFor(time.Now().YearDay())
+	theme := themeFor(time.Now().In(imageLocation()).YearDay())
 	url, err := ai.GenerateImage(theme.prompt)
 	if err != nil {
 		app.Log("images", "daily image generation failed: %v", err)

--- a/service/images/timezone_test.go
+++ b/service/images/timezone_test.go
@@ -1,0 +1,18 @@
+package images
+
+import (
+	"testing"
+	"time"
+)
+
+func TestConfiguredImageTimezone(t *testing.T) {
+	t.Setenv("TZ", "America/New_York")
+	now := time.Date(2026, 9, 8, 9, 0, 0, 0, time.UTC).In(imageLocation())
+	if now.Hour() != 5 || imageTime(now).UTC().Hour() != 10 {
+		t.Fatal(now, imageTime(now))
+	}
+	t.Setenv("TZ", "invalid")
+	if imageLocation() != time.UTC {
+		t.Fatal("invalid zone must default to UTC")
+	}
+}

--- a/service/tasks/handler.go
+++ b/service/tasks/handler.go
@@ -215,7 +215,7 @@ func taskRow(t *Task, csrf string, labels ...string) string {
 		if t.Thread != "" {
 			b.WriteString(`<details class="task-context"><summary>Conversation context</summary>`)
 		}
-		fmt.Fprintf(&b, `<div class="task-detail">%s</div>`, app.Render([]byte(t.Detail)))
+		fmt.Fprintf(&b, `<div class="task-detail">%s</div>`, app.RenderNoImages([]byte(t.Detail)))
 		if t.Thread != "" {
 			b.WriteString(`</details>`)
 		}


### PR DESCRIPTION
Home's ambient card context blocked direct service commands, and a missing final stream event could leave the answer invisible until refresh. Separate ambient context from explicit attachments, bypass card assembly for direct commands, and display one complete answer while retaining tool progress. Poll the exact owned run to recover dropped, truncated or stalled response connections.

Simplify agent creation: remove Describe it/Generate and its endpoint, use Services → All/Select with server validation and preserved edit selections, rename See the tools to Tools, and apply bold links without underlines globally.

Also addresses both Codex findings on #1550: render handed-off task context without images, and schedule the shared daily image using settings.Get("TZ") with embedded timezone data, an admin setting and UTC default.

Validation: focused agent tests including real Home News/news requests and All/Select creation/edit cases passed, also under race detection. Node tests execute the actual client ask function for complete answers and connection recovery. App rendering, tasks, images and admin tests, targeted vet, build and diff checks passed.