### PR TITLE
Fix broken admin sidebar icon

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -1329,7 +1329,7 @@ func navAdmin(acc *auth.Account) string {
 	if acc == nil || !acc.Admin {
 		return ""
 	}
-	return `<a id="nav-admin" href="/admin"><img src="/admin.png?` + Version + `"><span class="label">Admin</span></a>`
+	return `<a id="nav-admin" href="/admin"><img src="/admin.svg?` + Version + `"><span class="label">Admin</span></a>`
 }
 
 // navPinned is the reader's own services, under a heading of their own.


### PR DESCRIPTION
The sidebar referenced admin.png, but the embedded asset is admin.svg. Correct the extension so the icon loads. Verified with TestEveryNavIconExists and local browser rendering.