### PR TITLE
Remove Tools link from agents page

### DIFF
--- a/agent/roster_page.go
+++ b/agent/roster_page.go
@@ -193,7 +193,6 @@ func RosterHandler(w http.ResponseWriter, r *http.Request) {
 	// is the page where that is decided. So the way in is from here — but below
 	// what the page is about, because somebody arrives to see their agents and
 	// not to browse tools, and the link was above both the list and the button.
-	b.WriteString(`<div class="section-actions">` + app.TextLink("Tools", "/tools") + `</div>`)
 
 	// The instance's own agents are listed here, at the top, by the loop over
 	// PlatformNames above.

--- a/internal/app/testdata/layout.cjs
+++ b/internal/app/testdata/layout.cjs
@@ -33,9 +33,6 @@ const {chromium}=require(process.env.MU_PLAYWRIGHT_MODULE||'playwright');
     await page.selectOption(select,'all');assert(await page.locator(list).isHidden());
     await page.selectOption(select,'select');assert(await checks.first().isChecked());
    }
-   if(path==='/agents'){
-    const space=await gap('.page-stack > .col','.section-actions');assert(space>=15&&space<=17,`Tools gap ${space}`);
-   }
    if(path==='/chat'){
     await page.locator('#messages').evaluate(e=>e.innerHTML='<p>Long conversation</p>'.repeat(100));
     await page.waitForTimeout(100);


### PR DESCRIPTION
Remove the Tools link and its action row from /agents as requested. Remove the browser spacing assertion for the deleted row.

Validation: git diff --check passed; inspected the two small deletions.