### PR TITLE
Use regular weight for service descriptions and sidebar links

### DIFF
--- a/internal/api/tools_page.go
+++ b/internal/api/tools_page.go
@@ -524,7 +524,7 @@ const toolsPageCSS = `<style>
    does on hover — this had a grey border of its own, which was a third answer
    beside the row on /agents and the cards on home. */
 .tool-tile-name{font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:13px;font-weight:600;color:#111}
-.tool-tile-desc{font-size:13px;color:#666;line-height:1.4}
+.tool-tile-desc{font-weight:var(--font-weight-normal,400);font-size:13px;color:#666;line-height:1.4}
 .tool-tile-price{font-size:12px;color:#6b7280;font-variant-numeric:tabular-nums;margin-top:2px}
 .tool-tile-price .free{color:#9ca3af}
 /* .card a sets a dark colour and won on specificity, so the label went black on

--- a/internal/app/html/mu.css
+++ b/internal/app/html/mu.css
@@ -564,7 +564,7 @@ td {
 
 #nav a {
   color: var(--text-primary);
-  font-weight: var(--font-weight-medium);
+  font-weight: var(--font-weight-normal);
   text-decoration: none;
   padding: 10px 14px;
   border-radius: var(--border-radius);
@@ -589,7 +589,7 @@ td {
    identical or "selected" and "under the cursor" become the same signal. */
 #nav a.active {
   background: var(--active-background, var(--hover-background));
-  font-weight: var(--font-weight-semibold);
+  font-weight: var(--font-weight-normal);
   box-shadow: inset 3px 0 0 var(--accent-color, currentColor);
 }
 
@@ -637,7 +637,7 @@ td {
 
 .nav-bottom a {
   color: var(--text-primary);
-  font-weight: var(--font-weight-medium);
+  font-weight: var(--font-weight-normal);
   text-decoration: none;
   padding: 6px 14px;
   border-radius: 8px;


### PR DESCRIPTION
Service card descriptions inherited the bold anchor weight. Set the shared tile description to normal weight and make sidebar links, including the active item and account links, normal weight.

Validation: inspected the CSS rules and git diff --check passed. Four CSS declarations changed.