### PR TITLE
Shorten service descriptions

### DIFF
--- a/service/apps/service.go
+++ b/service/apps/service.go
@@ -117,7 +117,7 @@ func (Server) Read(_ context.Context, req *AppReadRequest, rsp *AppReadResponse)
 var Spec = service.Spec{
 	Name:        "apps",
 	Handler:     new(Server),
-	Description: "Small self-contained web tools, built and run in place",
+	Description: "Build and run web apps",
 	Page:        "/apps",
 	Icon:        "apps.svg",
 	Card:        service.Glance(Preview),

--- a/service/archive/archive.go
+++ b/service/archive/archive.go
@@ -208,7 +208,7 @@ func Load() {
 var Spec = service.Spec{
 	Name:        "archive",
 	Handler:     new(Server),
-	Description: "Everything this instance has collected — news, video, markets, posts — searchable as one thing",
+	Description: "Search collected content",
 	Page:        "/archive",
 	Icon:        "archive.svg",
 	Endpoints: map[string]service.Endpoint{

--- a/service/blog/service.go
+++ b/service/blog/service.go
@@ -31,7 +31,7 @@ func (Server) List(_ context.Context, req *ListRequest, rsp *ListResponse) error
 var Spec = service.Spec{
 	Name:        "blog",
 	Handler:     new(Server),
-	Description: "Microblogging with AI-generated daily digests, federated over ActivityPub",
+	Description: "Publish posts and daily digests",
 	Page:        "/blog",
 	Icon:        "post.png",
 	Card:        service.Timed(func() (string, time.Time) { return Preview(), CardAt() }),

--- a/service/bookmarks/saved.go
+++ b/service/bookmarks/saved.go
@@ -100,7 +100,7 @@ func DeleteAll(owner string) {
 	}
 }
 
-var Spec = service.Spec{Name: "bookmarks", Label: "Bookmarks", Description: "Your private saved articles, videos and links", Page: "/bookmarks", Icon: "bookmarks.svg", Scoped: true, Handler: new(Server), Endpoints: map[string]service.Endpoint{
+var Spec = service.Spec{Name: "bookmarks", Label: "Bookmarks", Description: "Save articles, videos and links", Page: "/bookmarks", Icon: "bookmarks.svg", Scoped: true, Handler: new(Server), Endpoints: map[string]service.Endpoint{
 	"Add":      {Aliases: []string{"saved_add"}, Writes: true, Doc: "Save an article, video, blog post or link privately. Re-saving preserves its note"},
 	"List":     {Aliases: []string{"saved_list"}, Doc: "Find your saved reading by text or kind, newest first. Private notes are searched too"},
 	"Get":      {Aliases: []string{"saved_get"}, Doc: "Read one saved item and its private note, with available archived text. Videos have descriptions, not transcripts"},

--- a/service/browser/browser.go
+++ b/service/browser/browser.go
@@ -233,7 +233,7 @@ func Load() {
 var Spec = service.Spec{
 	Name:        "browser",
 	Handler:     new(Server),
-	Description: "A real browser: read a page after its JavaScript has run, or photograph it",
+	Description: "Browse pages and take screenshots",
 	Page:        "/browser",
 	Icon:        "browser.svg",
 	Endpoints: map[string]service.Endpoint{

--- a/service/chat/service.go
+++ b/service/chat/service.go
@@ -268,7 +268,7 @@ func Card() string {
 var Spec = service.Spec{
 	Name:        "chat",
 	Handler:     new(Server),
-	Description: "Live discussion rooms attached to an item",
+	Description: "Chat in live rooms",
 	Page:        "/chat",
 	Icon:        "chat.png",
 	Card:        service.Glance(Card),

--- a/service/contacts/service.go
+++ b/service/contacts/service.go
@@ -157,7 +157,7 @@ func Load() {
 var Spec = service.Spec{
 	Name:        "contacts",
 	Handler:     new(Server),
-	Description: "The caller's own address book: turn a name into an address",
+	Description: "Manage your address book",
 	Page:        "/contacts",
 	Icon:        "contacts.svg",
 	Scoped:      true,

--- a/service/docs/docs.go
+++ b/service/docs/docs.go
@@ -353,7 +353,7 @@ var Spec = service.Spec{
 	// for a kind of thing somebody makes — a document, a note, a spreadsheet —
 	// never for how it is stored.
 	Label:       "Docs",
-	Description: "Your own documents — write, keep and come back to them",
+	Description: "Write and edit documents",
 	Page:        "/docs",
 	Icon:        "docs.svg",
 	Scoped:      true,

--- a/service/events/service.go
+++ b/service/events/service.go
@@ -255,7 +255,7 @@ func parseWhen(s string) (time.Time, error) {
 var Spec = service.Spec{
 	Name:        "events",
 	Handler:     new(Server),
-	Description: "Calendar: what is scheduled, and when you are free",
+	Description: "Schedule events and reminders",
 	Page:        "/events",
 	Scoped:      true,
 	Icon:        "events.svg",

--- a/service/files/service.go
+++ b/service/files/service.go
@@ -183,7 +183,7 @@ func Load() {
 var Spec = service.Spec{
 	Name:        "files",
 	Handler:     new(Server),
-	Description: "Per-user file storage: keep a file, get a URL, read it back",
+	Description: "Store and share files",
 	Page:        "/files",
 	Icon:        "files.svg",
 	Scoped:      true,

--- a/service/flights/service.go
+++ b/service/flights/service.go
@@ -282,7 +282,7 @@ func trim(b *strings.Builder) string {
 var Spec = service.Spec{
 	Name:        "flights",
 	Handler:     new(Server),
-	Description: "Where aircraft are, live from ADS-B",
+	Description: "Track live aircraft",
 	Page:        "/flights",
 	Icon:        "flights.svg",
 	Card:        service.Personal(CardHTML),

--- a/service/food/service.go
+++ b/service/food/service.go
@@ -248,7 +248,7 @@ func Load() {
 var Spec = service.Spec{
 	Name:        "food",
 	Handler:     new(Server),
-	Description: "What is in it and whether the kitchen is clean",
+	Description: "Check nutrition and food hygiene",
 	Page:        "/food",
 	Icon:        "food.svg",
 	Card:        service.Glance(Card),

--- a/service/hazards/service.go
+++ b/service/hazards/service.go
@@ -166,7 +166,7 @@ func Load() {
 var Spec = service.Spec{
 	Name:        "hazards",
 	Handler:     new(Server),
-	Description: "What is going wrong in the physical world: earthquakes and disaster alerts, live",
+	Description: "Track earthquakes and disaster alerts",
 	Page:        "/hazards",
 	Icon:        "hazards.svg",
 	Card:        service.Glance(Card),

--- a/service/images/service.go
+++ b/service/images/service.go
@@ -48,7 +48,7 @@ func (Server) Generate(ctx context.Context, req *GenerateRequest, rsp *GenerateR
 var Spec = service.Spec{
 	Name:        "images",
 	Handler:     new(Server),
-	Description: "Image generation, the daily image and its archive",
+	Description: "Generate and browse images",
 	Page:        "/images",
 	Scoped:      true,
 	Icon:        "images.svg",

--- a/service/mail/service.go
+++ b/service/mail/service.go
@@ -117,7 +117,7 @@ var Spec = service.Spec{
 	// need to know about to use the thing. An SMTP server is how one capability
 	// is delivered, not what the service is — that belongs in the install guide,
 	// where an operator goes looking for it.
-	Description: "Private messages, and an inbox each of your agents can be reached at",
+	Description: "Send and receive email",
 	Page:        "/mail",
 	Scoped:      true,
 	Icon:        "mail.png",

--- a/service/maps/maps.go
+++ b/service/maps/maps.go
@@ -269,7 +269,7 @@ func Load() {
 var Spec = service.Spec{
 	Name:        "maps",
 	Handler:     new(Server),
-	Description: "A map of Britain you can move around, and the tiles under it — Ordnance Survey, free",
+	Description: "Explore maps of Britain",
 	Page:        "/maps",
 	Icon:        "maps.svg",
 	Endpoints: map[string]service.Endpoint{

--- a/service/markets/service.go
+++ b/service/markets/service.go
@@ -94,7 +94,7 @@ func (Server) Convert(_ context.Context, req *ConvertRequest, rsp *ConvertRespon
 var Spec = service.Spec{
 	Name:        "markets",
 	Handler:     new(Server),
-	Description: "Live crypto, stock, futures, commodity and currency prices, and conversion between them",
+	Description: "Track prices and convert currencies",
 	Page:        "/markets",
 	Icon:        "markets.svg",
 	Card:        service.Glance(HTML),

--- a/service/news/service.go
+++ b/service/news/service.go
@@ -113,7 +113,7 @@ func (Server) Search(_ context.Context, req *SearchRequest, rsp *SearchResponse)
 var Spec = service.Spec{
 	Name:        "news",
 	Handler:     new(Server),
-	Description: "Headlines aggregated from RSS feeds, with search and full articles",
+	Description: "Read and search news",
 	Page:        "/news",
 	Icon:        "news.png",
 	Card:        service.Timed(func() (string, time.Time) { return Headlines(), CardAt() }),

--- a/service/notes/notes.go
+++ b/service/notes/notes.go
@@ -173,7 +173,7 @@ var Spec = service.Spec{
 	Name:        "notes",
 	Icon:        "notes.svg",
 	Handler:     new(Server),
-	Description: "What you wrote down, and what an agent wrote down for you",
+	Description: "Write and save notes",
 	Page:        "/notes",
 	Scoped:      true,
 	Endpoints: map[string]service.Endpoint{

--- a/service/notify/service.go
+++ b/service/notify/service.go
@@ -110,7 +110,7 @@ func LoadService() {
 var Spec = service.Spec{
 	Name:        "notify",
 	Handler:     new(Server),
-	Description: "Reach yourself when you are not looking at the page",
+	Description: "Receive push notifications",
 	Page:        "/notify",
 	Icon:        "notify.svg",
 	Scoped:      true,

--- a/service/places/service.go
+++ b/service/places/service.go
@@ -283,7 +283,7 @@ func formatDistance(m float64) string {
 var Spec = service.Spec{
 	Name:        "places",
 	Handler:     new(Server),
-	Description: "Places, points of interest and geocoding",
+	Description: "Find places nearby",
 	Page:        "/places",
 	Icon:        "places.svg",
 	Endpoints: map[string]service.Endpoint{

--- a/service/prayer/service.go
+++ b/service/prayer/service.go
@@ -127,7 +127,7 @@ func (Server) Qibla(_ context.Context, req *QiblaRequest, rsp *QiblaResponse) er
 var Spec = service.Spec{
 	Name:        "prayer",
 	Handler:     new(Server),
-	Description: "Islamic prayer times, qibla and a daily reflection",
+	Description: "Check prayer times and qibla",
 	Page:        "/prayer",
 	Card:        service.Personal(ReminderHTML),
 	Endpoints: map[string]service.Endpoint{

--- a/service/recall/recall.go
+++ b/service/recall/recall.go
@@ -247,7 +247,7 @@ func Load() {
 var Spec = service.Spec{
 	Name:        "recall",
 	Handler:     new(Server),
-	Description: "Search what you have said to an agent and been told, and read any conversation back",
+	Description: "Search past conversations",
 	Page:        "/recall",
 	Icon:        "saved.svg",
 	Scoped:      true,

--- a/service/routes/service.go
+++ b/service/routes/service.go
@@ -387,7 +387,7 @@ var Spec = service.Spec{
 	// domain. The same rule is why search became web — search.Search derived the
 	// tool name search_search.
 	Label:       "Routes",
-	Description: "How to get from one place to another — time, traffic and turn-by-turn",
+	Description: "Get directions and travel times",
 	Page:        "/routes",
 	Icon:        "routes.svg",
 	Endpoints: map[string]service.Endpoint{

--- a/service/shell/shell.go
+++ b/service/shell/shell.go
@@ -190,7 +190,7 @@ func Load() {
 var Spec = service.Spec{
 	Name:        "shell",
 	Handler:     new(Server),
-	Description: "Your persistent container sandbox: run commands, keep files, build things",
+	Description: "Run commands in a sandbox",
 	Page:        "/shell",
 	Icon:        "shell.svg",
 	// One container and one volume per account, so there is no such thing as

--- a/service/sms/service.go
+++ b/service/sms/service.go
@@ -175,7 +175,7 @@ var Spec = service.Spec{
 	Name:        "sms",
 	Label:       "SMS",
 	Handler:     new(Server),
-	Description: "Text somebody, and read what they text back",
+	Description: "Send and receive text messages",
 	Page:        "/sms",
 	Icon:        "sms.svg",
 	Scoped:      true,

--- a/service/social/service.go
+++ b/service/social/service.go
@@ -35,7 +35,7 @@ func (Server) List(_ context.Context, req *ListRequest, rsp *ListResponse) error
 var Spec = service.Spec{
 	Name:        "social",
 	Handler:     new(Server),
-	Description: "Public threads, replies and status",
+	Description: "Share posts and replies",
 	Page:        "/social",
 	Icon:        "social.svg",
 	Card:        service.Timed(func() (string, time.Time) { return CardHTML(), CardAt() }),

--- a/service/stream/service.go
+++ b/service/stream/service.go
@@ -74,7 +74,7 @@ func Card(v service.Viewer) string {
 var Spec = service.Spec{
 	Name:        "stream",
 	Handler:     new(Server),
-	Description: "What has been happening here — posts, headlines, video, mail",
+	Description: "See recent activity",
 	Page:        "/stream",
 	Icon:        "stream.svg",
 	Card:        service.Personal(Card),

--- a/service/tasks/service.go
+++ b/service/tasks/service.go
@@ -187,7 +187,7 @@ func Load() {
 var Spec = service.Spec{
 	Name:        "tasks",
 	Handler:     new(Server),
-	Description: "What is to be done: a list you keep, and work you can hand to the agent",
+	Description: "Manage tasks and assign work",
 	Page:        "/tasks",
 	Icon:        "tasks.svg",
 	Scoped:      true,

--- a/service/text/text.go
+++ b/service/text/text.go
@@ -92,7 +92,7 @@ func Load() {
 var Spec = service.Spec{
 	Name:        "text",
 	Handler:     new(Server),
-	Description: "Language work: summarise, extract structure, classify, translate",
+	Description: "Summarise and translate text",
 	Page:        "/text",
 	Icon:        "text.svg",
 	Endpoints: map[string]service.Endpoint{

--- a/service/transit/service.go
+++ b/service/transit/service.go
@@ -355,7 +355,7 @@ func Load() {
 var Spec = service.Spec{
 	Name:        "transit",
 	Handler:     new(Server),
-	Description: "Public transport: stops near you, what is due, and which lines are down",
+	Description: "Check public transport arrivals",
 	Page:        "/transit",
 	Icon:        "transit.svg",
 	Card:        service.Glance(Card),

--- a/service/users/service.go
+++ b/service/users/service.go
@@ -29,7 +29,7 @@ type Server struct{}
 var Spec = service.Spec{
 	Name:        "users",
 	Handler:     new(Server),
-	Description: "Who is on this instance: the people and the agents, and whether they are here now",
+	Description: "Find people and agents",
 	Page:        "/users",
 	Icon:        "account.png",
 	// Needs an account, all three, and the page needs a session for the same

--- a/service/video/service.go
+++ b/service/video/service.go
@@ -137,7 +137,7 @@ func (Server) Search(ctx context.Context, req *SearchRequest, rsp *SearchRespons
 var Spec = service.Spec{
 	Name:        "video",
 	Handler:     new(Server),
-	Description: "Video from curated channels, without ads or recommendations",
+	Description: "Videos from YouTube",
 	Page:        "/video",
 	Icon:        "video.png",
 	Card:        service.Timed(func() (string, time.Time) { return Latest(), CardAt() }),

--- a/service/wallet/service.go
+++ b/service/wallet/service.go
@@ -144,7 +144,7 @@ var Spec = service.Spec{
 	Name:        "wallet",
 	Icon:        "wallet.png",
 	Handler:     new(Server),
-	Description: "Your address and USDC balance on Base",
+	Description: "USDC base wallet",
 	Page:        "/wallet",
 	// Every method here reads or spends somebody's key. There is no public half.
 	Scoped: true,

--- a/service/weather/service.go
+++ b/service/weather/service.go
@@ -175,7 +175,7 @@ func (Server) History(_ context.Context, req *HistoryRequest, rsp *HistoryRespon
 var Spec = service.Spec{
 	Name:        "weather",
 	Handler:     new(Server),
-	Description: "Forecast, air quality, sea state and what the weather actually was",
+	Description: "Check weather and forecasts",
 	Page:        "/weather",
 	Icon:        "weather.svg",
 	Card:        service.Personal(CardHTML),

--- a/service/web/service.go
+++ b/service/web/service.go
@@ -104,7 +104,7 @@ func Load() {
 var Spec = service.Spec{
 	Name:        "web",
 	Handler:     new(Server),
-	Description: "The open web: search it, read a page from it",
+	Description: "Search the web",
 	Page:        "/web",
 	// No Label. It said "Search", which is what the service was called before
 	// it was renamed for its domain rather than its main action — and it left


### PR DESCRIPTION
Replace verbose descriptions across 36 service definitions with short, plain descriptions of what each service does. Includes the requested wording: “Search the web”, “USDC base wallet”, and “Videos from YouTube”.

Copy-only changes in the shared service catalogue. Formatted with gofmt and checked with git diff --check.