### PR TITLE
Simplify user cards with Chat, Mail and last seen

### DIFF
--- a/inbox/person.go
+++ b/inbox/person.go
@@ -204,31 +204,14 @@ func PersonHandler(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-// sendMailTo is the way to write to somebody, as an icon with a word.
-//
-// Mail and chat are different promises — one is answered when they get to it,
-// the other is answered now — and "Send a message" named neither. It also read
-// as a sentence where a button belongs. So the label says which door it is:
-// Send mail, because mail is what /inbox/new writes.
-//
-// The envelope and the bubble carry the distinction faster than the words do,
-// which is the point of having both: the icon separates the two at a glance and
-// the word says which is which for anybody who does not read icons.
-//
-// Chat is beside it now and was not, for a reason worth keeping: service/chat
-// had topic rooms and no concept of a room that is these two people, so the
-// only thing this could have linked to was an id assembled from two account
-// names that anybody could guess and open. A private conversation with a
-// guessable address is not private, and a button that lies about that is worse
-// than one that is not there. chat.Open and the membership check are what make
-// it honest — see service/chat/private.go.
+// reachTo opens private chat or a mail draft for this person.
 func reachTo(handle string) string {
 	to := html.EscapeString(url.QueryEscape(handle))
 	who := html.EscapeString(url.QueryEscape(strings.TrimPrefix(handle, "@")))
 	return `<a class="btn ib-act" href="/chat?with=` + who + `">` +
 		iconChat + `Chat</a>` +
 		`<a class="btn btn-quiet ib-act" href="/inbox/new?to=` + to + `">` +
-		iconMail + `Send mail</a>`
+		iconMail + `Mail</a>`
 }
 
 // iconChat is a speech bubble.

--- a/inbox/person_test.go
+++ b/inbox/person_test.go
@@ -119,12 +119,10 @@ func TestSomebodyYouHaveNeverWrittenToStillHasAPage(t *testing.T) {
 			w.Header().Get("Location"))
 	}
 	body := w.Body.String()
-	// "Send mail", not "Send a message" and not "Start a conversation". The
-	// first two name neither door: mail and chat are different promises — one
-	// answered when they get to it, the other answered now — and the label has
-	// to say which this is. It is also a button, not a sentence.
-	if !strings.Contains(body, "Send mail") {
-		t.Errorf("no way to write to them, or it does not say which door:\n%s", body)
+	for _, action := range []string{">Chat</a>", ">Mail</a>"} {
+		if !strings.Contains(body, action) {
+			t.Errorf("missing action %s", action)
+		}
 	}
 	// And it is still their page: it says whose, and where the button goes.
 	//

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -677,6 +677,13 @@ func UpdatePresence(username string) {
 	userPresence[username] = time.Now()
 }
 
+// LastSeen returns the latest recorded activity, or zero when none is known.
+func LastSeen(username string) time.Time {
+	presenceMutex.RLock()
+	defer presenceMutex.RUnlock()
+	return userPresence[username]
+}
+
 // OnlineUsers returns a list of currently online usernames
 func OnlineUsers() []string {
 	presenceMutex.RLock()

--- a/service/users/page.go
+++ b/service/users/page.go
@@ -22,6 +22,7 @@ package users
 import (
 	"html"
 	"net/http"
+	"net/url"
 	"strings"
 
 	"mu/internal/app"
@@ -88,7 +89,7 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 // rows is the list itself.
 func rows(list []User, me string) string {
 	var b strings.Builder
-	b.WriteString(`<table class="admin-table"><tbody>`)
+	b.WriteString(`<div class="page-stack">`)
 	for _, u := range list {
 		name := html.EscapeString(u.Display())
 		badge := ""
@@ -113,16 +114,22 @@ func rows(list []User, me string) string {
 		// bug rather than a feature.
 		act := ""
 		if u.ID != me {
-			act = `<a class="mini-btn" href="/inbox/new?to=` +
-				html.EscapeString(u.ID) + `">Send message</a>`
+			to := html.EscapeString(url.QueryEscape(u.ID))
+			act = `<div class="form-actions"><a class="mini-btn" href="/chat?with=` + to + `">Chat</a>` +
+				`<a class="mini-btn" href="/inbox/new?to=` + to + `">Mail</a></div>`
 		}
 
-		b.WriteString(`<tr>` +
-			`<td data-label="Name">` + who + `</td>` +
-			`<td data-label="" class="actions-cell">` + act + `</td>` +
-			`</tr>`)
+		seen := ""
+		if u.Profile.Online {
+			seen = "Here now"
+		} else if at := auth.LastSeen(u.ID); !at.IsZero() {
+			seen = "Last seen " + app.TimeAgo(at)
+		}
+		b.WriteString(`<div class="card page-stack"><div class="row-top">` +
+			`<div>` + who + `</div><span class="push-right text-muted text-xs">` +
+			html.EscapeString(seen) + `</span></div>` + act + `</div>`)
 	}
-	b.WriteString(`</tbody></table>`)
+	b.WriteString(`</div>`)
 	return b.String()
 }
 


### PR DESCRIPTION
Replace the users directory's labelled table with shared cards: the name appears directly, activity appears at the top right, and Chat/Mail open the private chat and mail composer. Keep self-message actions hidden. Use Chat/Mail labels on profiles too.

Presence uses existing in-memory activity records under the presence lock. Show Here now for online users, Last seen for known activity, and nothing for unknown activity (including after a restart).

Validation: git diff --check and source review completed; updated the profile action assertion. Go tests could not run because the previously available Go toolchain is absent from this environment.