### PR TITLE
Restore Stream activity and user status; improve Places, Maps and Markets

### DIFF
--- a/agent/brief/brief.go
+++ b/agent/brief/brief.go
@@ -57,6 +57,7 @@ import (
 	"mu/internal/app"
 	"mu/internal/auth"
 	"mu/internal/data"
+	"mu/internal/event"
 )
 
 // sources are what the line is written from.
@@ -255,6 +256,7 @@ func write() {
 		app.Log("brief", "nothing worth saying about today")
 		return
 	}
+	event.Announce("brief", text, "/home", "")
 	app.Log("brief", "wrote: %s", text)
 }
 

--- a/agent/work/work.go
+++ b/agent/work/work.go
@@ -276,6 +276,9 @@ func deliver(r request, answer string, err error) {
 		return
 	}
 	if e := events.Brief(r.Account); e != nil && e.ID == r.ID {
+		if err == nil {
+			event.Announce("brief", body, "/inbox", r.Account)
+		}
 		body += "\n\n---\n[Disable or manage your morning brief](" + origin.Self() + "/events#morning-brief)."
 	}
 	mail.SendMessageTo(mail.Delivery{ //nolint:errcheck

--- a/home/home.go
+++ b/home/home.go
@@ -266,6 +266,10 @@ func ForceRefresh() {
 }
 
 func Handler(w http.ResponseWriter, r *http.Request) {
+	if r.Method == http.MethodPost && r.FormValue("action") == "status" {
+		statusHandler(w, r)
+		return
+	}
 	// An installed app opens on the app, not on a pitch.
 	//
 	// The manifest's start_url was "/", so tapping the icon on a home screen
@@ -531,6 +535,7 @@ function fetchW(la,lo){
 		// screen is already talking to the agent; the address is for reaching it
 		// when you are not here, which is exactly the moment this line is not on
 		// the screen.
+		b.WriteString(statusForm(r, viewerID))
 		b.WriteString(`</div>`)
 
 		// No Online strip here, and no chat panel below.

--- a/home/status.go
+++ b/home/status.go
@@ -1,0 +1,47 @@
+package home
+
+import (
+	"html"
+	"net/http"
+
+	"mu/internal/app"
+	"mu/internal/auth"
+	"mu/internal/user"
+)
+
+func statusHandler(w http.ResponseWriter, r *http.Request) {
+	_, acc, err := auth.RequireSession(r)
+	if err != nil {
+		app.RedirectToLogin(w, r)
+		return
+	}
+	if !auth.ValidCSRF(r) || !auth.CanPost(acc.ID) {
+		http.Error(w, "You cannot update your status with this session.", http.StatusForbidden)
+		return
+	}
+	if err := auth.CheckPostRate(acc.ID); err != nil {
+		http.Error(w, err.Error(), http.StatusTooManyRequests)
+		return
+	}
+	text := r.FormValue("status")
+	if r.FormValue("clear") == "1" {
+		text = ""
+	}
+	if err := user.SetStatus(acc.ID, text); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	http.Redirect(w, r, "/home", http.StatusSeeOther)
+}
+
+func statusForm(r *http.Request, id string) string {
+	if id == "" {
+		return ""
+	}
+	return `<details class="disclosure page-section"><summary>Your status</summary>` +
+		`<form class="form" method="post" action="/home">` +
+		`<input type="hidden" name="action" value="status">` +
+		`<input type="hidden" name="csrf_token" value="` + html.EscapeString(auth.CSRFToken(r)) + `">` +
+		`<label class="field-label">Shown on your profile<input class="field field-wide" name="status" maxlength="160" placeholder="What are you up to?" value="` + html.EscapeString(user.Status(id)) + `"></label>` +
+		`<div class="form-actions"><button type="submit">Save</button><button type="submit" name="clear" value="1">Clear</button></div></form></details>`
+}

--- a/inbox/person.go
+++ b/inbox/person.go
@@ -60,8 +60,8 @@ import (
 
 	"mu/internal/app"
 	"mu/internal/auth"
-	"mu/internal/user"
 	"mu/internal/thread"
+	"mu/internal/user"
 )
 
 // PersonHandler serves /@name.

--- a/inbox/person.go
+++ b/inbox/person.go
@@ -60,6 +60,7 @@ import (
 
 	"mu/internal/app"
 	"mu/internal/auth"
+	"mu/internal/user"
 	"mu/internal/thread"
 )
 
@@ -124,6 +125,9 @@ func PersonHandler(w http.ResponseWriter, r *http.Request) {
 	b.WriteString(`<div class="ib-person">`)
 	b.WriteString(`<p class="ib-person-sub">` + html.EscapeString(handle) + `</p>`)
 	b.WriteString(personFacts(them))
+	if status := user.Status(them.ID); status != "" {
+		b.WriteString(`<p class="text-secondary">` + html.EscapeString(status) + `</p>`)
+	}
 	// New message belongs on a page that already has one.
 	//
 	// On an empty page it was the fourth thing saying the same thing: the name,

--- a/internal/app/html/mu.css
+++ b/internal/app/html/mu.css
@@ -4830,7 +4830,8 @@ a.card-hover:hover {
   color: #ccc;
 }
 .recent-search-item.active .recent-search-close:hover,
-.recent-search-item.active:visited .recent-search-close:hover {
+.recent-search-item.active:visited .recent-search-item button { background: transparent; border: 0; padding: 0 6px; font: inherit; color: inherit; }
+.recent-search-close:hover {
   color: white;
 }
 .recent-search-label {
@@ -4843,6 +4844,7 @@ a.card-hover:hover {
   cursor: pointer;
   font-weight: bold;
 }
+.recent-search-item button { background: transparent; border: 0; padding: 0 6px; font: inherit; color: inherit; }
 .recent-search-close:hover {
   color: #000;
 }

--- a/internal/server/boot.go
+++ b/internal/server/boot.go
@@ -62,6 +62,9 @@ func boot() {
 	// load the data index
 	data.Load()
 
+	// Subscribe before services start publishing their first refresh.
+	stream.Load()
+
 	// load admin/flags
 	admin.Load()
 

--- a/internal/server/hooks.go
+++ b/internal/server/hooks.go
@@ -49,6 +49,7 @@ import (
 	"mu/internal/service"
 	"mu/internal/settings"
 	"mu/internal/thread"
+	"mu/internal/user"
 	"mu/internal/world"
 	"mu/internal/x402"
 	"mu/service/apps"
@@ -495,9 +496,6 @@ func wireHooks() {
 	// load docs
 	help.Load()
 
-	// Load the stream (platform event timeline).
-	stream.Load()
-
 	// Keep copies of the data directory. It takes one at startup, because the
 	// most useful snapshot is the one from before whatever is about to go
 	// wrong, and the search index goes in through VACUUM rather than a file
@@ -548,6 +546,7 @@ func wireHooks() {
 		social.DeleteByAuthor,
 		apps.DeleteAppsByAuthor,
 		stream.DeleteByAccount,
+		user.DeleteProfile,
 		mail.DeleteInbox,
 		chat.Forget,
 		func(id string) { account.DeleteCredits(id) },

--- a/internal/user/status.go
+++ b/internal/user/status.go
@@ -1,0 +1,63 @@
+package user
+
+import (
+	"fmt"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"mu/internal/data"
+	"mu/internal/event"
+)
+
+// Status is the line somebody chose to display on their profile.
+func Status(id string) string {
+	profileMutex.RLock()
+	defer profileMutex.RUnlock()
+	if p := profiles[id]; p != nil {
+		return p.Status
+	}
+	return ""
+}
+
+func SetStatus(id, text string) error {
+	text = strings.Join(strings.Fields(text), " ")
+	if id == "" || !utf8.ValidString(text) || utf8.RuneCountInString(text) > 160 {
+		return fmt.Errorf("status must be at most 160 characters")
+	}
+	profileMutex.Lock()
+	if profiles == nil {
+		profiles = map[string]*Profile{}
+	}
+	old := profiles[id]
+	if old != nil && old.Status == text {
+		profileMutex.Unlock()
+		return nil
+	}
+	profiles[id] = &Profile{UserID: id, Status: text, UpdatedAt: time.Now()}
+	err := data.SaveJSON("profiles.json", profiles)
+	if err != nil {
+		if old == nil {
+			delete(profiles, id)
+		} else {
+			profiles[id] = old
+		}
+	}
+	profileMutex.Unlock()
+	if err != nil {
+		return err
+	}
+	line := "@" + id + ": " + text
+	if text == "" {
+		line = "@" + id + " cleared their status"
+	}
+	event.Announce("users", line, "/@"+id, "")
+	return nil
+}
+
+func DeleteProfile(id string) {
+	profileMutex.Lock()
+	defer profileMutex.Unlock()
+	delete(profiles, id)
+	data.SaveJSON("profiles.json", profiles) //nolint:errcheck
+}

--- a/internal/user/status_test.go
+++ b/internal/user/status_test.go
@@ -1,0 +1,25 @@
+package user
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestStatusIsOwnedBoundedAndClearable(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	if err := SetStatus("status-alice", "Working on Mu"); err != nil {
+		t.Fatal(err)
+	}
+	if Status("status-alice") != "Working on Mu" || Status("status-bob") != "" {
+		t.Fatal("status was stored against the wrong user")
+	}
+	if err := SetStatus("status-alice", strings.Repeat("x", 161)); err == nil {
+		t.Fatal("overlong status accepted")
+	}
+	if Status("status-alice") != "Working on Mu" {
+		t.Fatal("rejected status overwrote the old value")
+	}
+	if err := SetStatus("status-alice", ""); err != nil || Status("status-alice") != "" {
+		t.Fatalf("clear failed: %v", err)
+	}
+}

--- a/service/chat/activity.go
+++ b/service/chat/activity.go
@@ -1,0 +1,26 @@
+package chat
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+
+	"mu/internal/event"
+)
+
+func announceMessage(roomID string, message RoomMessage) {
+	if message.System || strings.TrimSpace(message.Content) == "" {
+		return
+	}
+	link := "/chat?id=" + url.QueryEscape(roomID) + fmt.Sprintf("#message-%d", message.Timestamp.UnixNano())
+	text := message.UserID + ": " + message.Content
+	if Private(roomID) {
+		for _, account := range Members(roomID) {
+			event.Announce("chat", text, link, account)
+		}
+		return
+	}
+	if Listable(roomID) {
+		event.Announce("chat", text, link, "")
+	}
+}

--- a/service/chat/chat.go
+++ b/service/chat/chat.go
@@ -948,6 +948,8 @@ func (room *Room) run() {
 			copy(messagesToSave, room.Messages)
 			room.mutex.Unlock()
 
+			announceMessage(room.ID, message)
+
 			// Persist messages for topic chat rooms
 			if strings.HasPrefix(room.ID, "chat_") {
 				go saveRoomMessages(room.ID, messagesToSave)

--- a/service/maps/maps.go
+++ b/service/maps/maps.go
@@ -269,7 +269,7 @@ func Load() {
 var Spec = service.Spec{
 	Name:        "maps",
 	Handler:     new(Server),
-	Description: "Explore maps of Britain",
+	Description: "Explore maps",
 	Page:        "/maps",
 	Icon:        "maps.svg",
 	Endpoints: map[string]service.Endpoint{

--- a/service/maps/page.go
+++ b/service/maps/page.go
@@ -125,18 +125,22 @@ func TileHandler(w http.ResponseWriter, r *http.Request) {
 // move around it. Rule 2 in that file, and the argument is the same as the one
 // that kept /flights.
 func Handler(w http.ResponseWriter, r *http.Request) {
-	style := styleName(r.URL.Query().Get("style"))
+	style := "world"
+	if raw := r.URL.Query().Get("style"); raw != "" && raw != "world" {
+		style = styleName(raw)
+	}
 
 	var b strings.Builder
 	b.WriteString(`<div class="maps-page">`)
 
-	if !Configured() {
+	if style != "world" && !Configured() {
 		b.WriteString(app.Problem("This instance has no Ordnance Survey key, so it can only " +
 			"serve tiles it already holds. An admin can set OS_MAPS_KEY under Maps in " +
 			"Settings — the free tier at osdatahub.os.uk is enough."))
 	}
 
 	b.WriteString(`<div class="maps-styles">`)
+	b.WriteString(app.PillLink("World", "/maps", style == "world"))
 	for _, s := range StyleNames() {
 		b.WriteString(app.PillLink(s, "/maps?style="+s, s == style))
 	}
@@ -185,14 +189,20 @@ const (
 // came into view; zooming recomputes the lot. No library, no canvas, no
 // WebGL — a hundred lines and it is the same interaction anybody expects.
 func mapPane(style string) string {
+	min, max := minZoom, maxZoom
+	if style == "world" {
+		min, max = 1, 19
+	} else {
+		style = styleName(style)
+	}
 	var b strings.Builder
 	b.WriteString(`<div class="map-wrap">`)
-	b.WriteString(`<div id="map" class="map" data-style="` + html.EscapeString(styleName(style)) +
+	b.WriteString(`<div id="map" class="map" data-style="` + html.EscapeString(style) +
 		`" data-lat="` + strconv.FormatFloat(homeLat, 'f', -1, 64) +
 		`" data-lon="` + strconv.FormatFloat(homeLon, 'f', -1, 64) +
 		`" data-zoom="` + strconv.Itoa(homeZoom) +
-		`" data-min="` + strconv.Itoa(minZoom) +
-		`" data-max="` + strconv.Itoa(maxZoom) + `">`)
+		`" data-min="` + strconv.Itoa(min) +
+		`" data-max="` + strconv.Itoa(max) + `">`)
 	b.WriteString(`<div id="map-layer" class="map-layer"></div>`)
 	b.WriteString(`</div>`)
 	b.WriteString(`<div class="map-controls">` +
@@ -200,6 +210,9 @@ func mapPane(style string) string {
 		`<button type="button" id="map-out" aria-label="Zoom out">&minus;</button>` +
 		`<button type="button" id="map-here" aria-label="Go to my location">Locate</button>` +
 		`</div>`)
+	if style == "world" {
+		b.WriteString(`<p class="map-note">© <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors</p>`)
+	}
 	b.WriteString(`<p class="map-note" id="map-where"></p>`)
 	b.WriteString(`</div>`)
 	b.WriteString(mapJS)
@@ -211,12 +224,7 @@ func mapPane(style string) string {
 // Impersonal — a tile is the same tile for everybody, and what this card says
 // is a fact about the instance rather than about the reader.
 func Card() string {
-	if !Configured() {
-		return `<p class="note">No Ordnance Survey key set, so only tiles already held ` +
-			`can be served. <a href="/maps">Maps →</a></p>`
-	}
-	return `<p class="note">Ordnance Survey raster tiles for Britain — road, outdoor and ` +
-		`light. Fetched once, then free. <a href="/maps">Maps →</a></p>`
+	return `<p class="note"><a href="/maps">Explore the world map</a></p>`
 }
 
 // mapJS moves the map.
@@ -271,7 +279,8 @@ const mapJS = `<script>
           img=new Image();
           img.className='map-tile';
           img.alt='';
-          img.src='/maps/tiles/'+style+'/'+z+'/'+wx+'/'+y+'.png';
+          img.referrerPolicy='strict-origin-when-cross-origin';
+          img.src=style==='world'?'https://tile.openstreetmap.org/'+z+'/'+wx+'/'+y+'.png':'/maps/tiles/'+style+'/'+z+'/'+wx+'/'+y+'.png';
           // A tile outside Britain is a 404 and that is normal here, so it
           // fades out rather than showing a broken image.
           img.onerror=function(){ this.classList.add('map-gap'); missing++; done(); };
@@ -300,8 +309,7 @@ const mapJS = `<script>
     if(!where) return;
     var at=latOf(cy,z).toFixed(4)+', '+lonOf(cx,z).toFixed(4)+'  ·  zoom '+z;
     if(asked>0 && arrived===0 && missing>=asked){
-      where.textContent=at+'  ·  no tiles came back. Ordnance Survey covers Britain only, '+
-        'so this may be outside it — or this instance has no OS_MAPS_KEY and holds none of these yet.';
+      where.textContent=at+(style==='world'?' · Map tiles could not be loaded.':' · No tiles loaded. This layer covers Britain and requires an Ordnance Survey key.');
       return;
     }
     where.textContent=at;

--- a/service/markets/converter.go
+++ b/service/markets/converter.go
@@ -85,6 +85,11 @@ func converterHTML(r *http.Request) string {
 	}
 
 	var sb strings.Builder
+	open := ""
+	if q.Has("amount") {
+		open = " open"
+	}
+	sb.WriteString(`<details class="disclosure page-section"` + open + `><summary class="btn">Convert</summary><div>`)
 	sb.WriteString(`<form class="fx-form" method="get" action="/markets">`)
 	fmt.Fprintf(&sb, `<input type="hidden" name="category" value="%s">`,
 		html.EscapeString(category))
@@ -101,17 +106,17 @@ func converterHTML(r *http.Request) string {
 	// Only answer when somebody asked. Landing on /markets should not fire a
 	// request at the ECB on the reader's behalf.
 	if q.Get("from") == "" && q.Get("to") == "" && q.Get("amount") == "" {
-		return sb.String()
+		return sb.String() + `</div></details>`
 	}
 
 	amount, err := strconv.ParseFloat(strings.ReplaceAll(amountStr, ",", ""), 64)
 	if err != nil {
-		return sb.String() + fxError("That amount is not a number.")
+		return sb.String() + fxError("That amount is not a number.") + `</div></details>`
 	}
 
 	c, err := convert(amount, from, to, date)
 	if err != nil {
-		return sb.String() + fxError(err.Error())
+		return sb.String() + fxError(err.Error()) + `</div></details>`
 	}
 
 	var out strings.Builder
@@ -134,7 +139,7 @@ func converterHTML(r *http.Request) string {
 	}
 	out.WriteString(`</div>`)
 
-	return sb.String() + out.String()
+	return sb.String() + out.String() + `</div></details>`
 }
 
 func fxError(msg string) string {

--- a/service/markets/markets.go
+++ b/service/markets/markets.go
@@ -14,6 +14,7 @@ import (
 
 	"mu/internal/app"
 	"mu/internal/data"
+	"mu/internal/event"
 	"mu/internal/service"
 	"mu/internal/snapshot"
 
@@ -287,6 +288,7 @@ func refreshMarkets() {
 	// So a failure retries soon and backs off, rather than waiting out the
 	// interval as though nothing had happened.
 	fail := 0
+	var announced time.Time
 	for {
 		prices, priceData := fetchPrices()
 		if prices != nil {
@@ -307,6 +309,18 @@ func refreshMarkets() {
 			// prices in two renderings and a second schedule would let them
 			// disagree.
 			snapshot.Channel(Spec.Name, "now").Publish(Now())
+			if time.Since(announced) >= time.Hour {
+				var lines []string
+				for _, symbol := range []string{"BTC", "ETH", "SOL"} {
+					if pd, ok := priceData[symbol]; ok && pd.Price > 0 {
+						lines = append(lines, fmt.Sprintf("%s $%s (%+.2f%%)", symbol, marketsPriceStr(pd.Price), pd.Change24h))
+					}
+				}
+				if len(lines) > 0 {
+					event.Announce("markets", strings.Join(lines, " · "), "/markets", "")
+					announced = time.Now()
+				}
+			}
 
 			indexMarketPrices(prices)
 			data.SaveFile("markets.html", html)

--- a/service/places/places.go
+++ b/service/places/places.go
@@ -729,22 +729,22 @@ func renderSearchFormHTML(q, near, nearLat, nearLon, radius, sortBy string) stri
 	if sortBy == "name" {
 		sortDistSel, sortNameSel = "", " selected"
 	}
-	return fmt.Sprintf(`<form id="places-form" action="/places/search" method="POST">
-    <input type="text" name="q" id="places-q" placeholder="What are you looking for? (leave empty for whatever is nearby)" value="%s">
-    <div class="places-location-row">
-      <input type="text" name="near" id="places-near" placeholder="Location (optional)" value="%s">
+	return fmt.Sprintf(`<form id="places-form" class="form" action="/places/search" method="POST">
+    <input type="text" class="field field-wide" name="q" id="places-q" placeholder="What are you looking for? (leave empty for whatever is nearby)" value="%s">
+    <div class="form-group">
+      <input type="text" class="field field-wide" name="near" id="places-near" placeholder="Location (optional)" value="%s">
       <input type="hidden" name="near_lat" id="places-near-lat" value="%s">
       <input type="hidden" name="near_lon" id="places-near-lon" value="%s">
-      <a href="#" onclick="usePlacesLocation(this);return false;" class="btn-link">&#128205; Use my location</a>
+      <div class="form-actions"><button type="button" onclick="usePlacesLocation(this)" class="btn btn-quiet">Use my location</button></div>
     </div>
-    <div class="places-options-row">
-      <select name="radius" id="places-radius">%s</select>
-      <select name="sort" id="places-sort">
+    <div class="form-group">
+      <select class="field field-wide" name="radius" id="places-radius">%s</select>
+      <select class="field field-wide" name="sort" id="places-sort">
         <option value="distance"%s>Sort by distance</option>
         <option value="name"%s>Sort by name</option>
       </select>
     </div>
-    <div class="places-actions-row">
+    <div class="form-actions">
       <button type="submit">Search</button>
       <button type="submit" formaction="/places/nearby" class="btn-secondary">What is nearby</button>
     </div>
@@ -760,7 +760,7 @@ func renderSavedSearchesSection(userID string) string {
 		return ""
 	}
 	var sb strings.Builder
-	sb.WriteString(`<div class="card places-saved-card"><h4>Recent searches</h4><ul class="saved-search-list">`)
+	sb.WriteString(`<div class="recent-searches"><h3>Recent searches</h3><div class="recent-searches-scroll">`)
 	for _, s := range searches {
 		latStr := fmt.Sprintf("%f", s.Lat)
 		lonStr := fmt.Sprintf("%f", s.Lon)
@@ -771,17 +771,17 @@ func renderSavedSearchesSection(userID string) string {
 			lonStr = ""
 		}
 		sb.WriteString(fmt.Sprintf(
-			`<li><a href="#" onclick="runSavedSearch(%s,%s,%s,%s,%s,%s,%s);return false;">%s</a> `+
+			`<span class="recent-search-item"><button type="button" class="recent-search-label" onclick="runSavedSearch(%s,%s,%s,%s,%s,%s,%s);">%s</button> `+
 				`<form class="d-inline" action="/places/save/delete" method="POST">`+
 				`<input type="hidden" name="id" value="%s">`+
-				`<button type="submit" class="btn-link text-muted" title="Remove">&#x2715;</button></form></li>`,
+				`<button type="submit" class="btn-link recent-search-close" aria-label="Remove search" title="Remove">&times;</button></form></span>`,
 			escapeHTML(jsonStr(s.Type)), escapeHTML(jsonStr(s.Query)), escapeHTML(jsonStr(s.Location)),
 			escapeHTML(jsonStr(latStr)), escapeHTML(jsonStr(lonStr)),
 			escapeHTML(jsonStr(fmt.Sprintf("%d", s.Radius))), escapeHTML(jsonStr(s.SortBy)),
 			escapeHTML(s.Label), escapeHTML(s.ID),
 		))
 	}
-	sb.WriteString(`</ul></div>`)
+	sb.WriteString(`</div></div>`)
 	return sb.String()
 }
 
@@ -872,15 +872,15 @@ func renderPlacesPageJS() string {
 	return `<script>
 function usePlacesLocation(btn) {
   if (!navigator.geolocation) { showToast('Geolocation is not supported by your browser', 'error'); return; }
-  if (btn) { btn.textContent = '⏳ Getting location...'; btn.style.pointerEvents = 'none'; }
+  if (btn) { btn.textContent = 'Getting location…'; btn.disabled = true; }
   navigator.geolocation.getCurrentPosition(function(pos) {
     var lat = pos.coords.latitude, lon = pos.coords.longitude;
     document.getElementById('places-near-lat').value = lat;
     document.getElementById('places-near-lon').value = lon;
     document.getElementById('places-near').value = lat.toFixed(4) + ', ' + lon.toFixed(4);
-    if (btn) { btn.innerHTML = '&#128205; Use my location'; btn.style.pointerEvents = ''; }
+    if (btn) { btn.textContent = 'Use my location'; btn.disabled = false; }
   }, function(err) {
-    if (btn) { btn.innerHTML = '&#128205; Use my location'; btn.style.pointerEvents = ''; }
+    if (btn) { btn.textContent = 'Use my location'; btn.disabled = false; }
     showToast('Could not get your location: ' + err.message, 'error');
   }, {timeout: 10000, maximumAge: 60000});
 }

--- a/service/places/recent_test.go
+++ b/service/places/recent_test.go
@@ -128,3 +128,19 @@ func TestCitiesAreLinks(t *testing.T) {
 		t.Errorf("a city does not link to a nearby search: %.200s", html)
 	}
 }
+
+func TestRecentSearchesCleanLegacyDuplicates(t *testing.T) {
+	reset(t)
+	a := SavedSearch{ID: "a", Type: "search", Query: "coffee  shop", Location: "London", Lat: 51.5, Lon: -0.1}
+	b := SavedSearch{ID: "b", Type: "search", Query: "Coffee Shop", Location: "london", Lat: 51.51, Lon: -0.11, Radius: defaultRadiusM, SortBy: "distance"}
+	savedMu.Lock()
+	savedData["reader"] = []SavedSearch{a, b}
+	savedMu.Unlock()
+	if got := getUserSavedSearches("reader"); len(got) != 1 {
+		t.Fatalf("duplicate searches remain: %v", got)
+	}
+	b.Radius = 500
+	if sameSearch(a, b) {
+		t.Fatal("different search radii collapsed")
+	}
+}

--- a/service/places/saved.go
+++ b/service/places/saved.go
@@ -69,8 +69,22 @@ func getUserSavedSearches(userID string) []SavedSearch {
 	savedMu.RLock()
 	defer savedMu.RUnlock()
 	src := savedData[userID]
-	out := make([]SavedSearch, len(src))
-	copy(out, src)
+	var out []SavedSearch
+	for _, item := range src {
+		duplicate := false
+		for _, old := range out {
+			if sameSearch(old, item) {
+				duplicate = true
+				break
+			}
+		}
+		if !duplicate {
+			out = append(out, item)
+		}
+		if len(out) == maxRecentSearches {
+			break
+		}
+	}
 	return out
 }
 
@@ -110,11 +124,31 @@ func addUserSavedSearch(userID string, s SavedSearch) {
 // is exactly what this has to see past. The label is derived from the rest, so
 // comparing it as well would only find disagreements between it and them.
 func sameSearch(a, b SavedSearch) bool {
+	a, b = normalizedSearch(a), normalizedSearch(b)
 	return a.Type == b.Type &&
 		strings.EqualFold(strings.TrimSpace(a.Query), strings.TrimSpace(b.Query)) &&
 		strings.EqualFold(strings.TrimSpace(a.Location), strings.TrimSpace(b.Location)) &&
 		a.Lat == b.Lat && a.Lon == b.Lon &&
 		a.Radius == b.Radius && a.SortBy == b.SortBy
+}
+
+func normalizedSearch(s SavedSearch) SavedSearch {
+	s.Query = strings.ToLower(strings.Join(strings.Fields(s.Query), " "))
+	s.Location = strings.ToLower(strings.Join(strings.Fields(s.Location), " "))
+	if s.Radius == 0 {
+		s.Radius = defaultRadiusM
+	}
+	if s.SortBy == "" {
+		s.SortBy = "distance"
+	}
+	if s.Type == "" {
+		s.Type = "search"
+	}
+	// Named locations are replayed by name; geocoding them again can shift coordinates.
+	if s.Location != "" && !strings.ContainsAny(s.Location, "0123456789") {
+		s.Lat, s.Lon = 0, 0
+	}
+	return s
 }
 
 // Remember records a search that just ran.
@@ -162,11 +196,21 @@ func searchLabel(query, location string) string {
 func deleteUserSavedSearch(userID, id string) {
 	savedMu.Lock()
 	searches := savedData[userID]
-	for i, s := range searches {
-		if s.ID == id {
-			savedData[userID] = append(searches[:i], searches[i+1:]...)
+	var target *SavedSearch
+	for i := range searches {
+		if searches[i].ID == id {
+			target = &searches[i]
 			break
 		}
+	}
+	if target != nil {
+		var kept []SavedSearch
+		for _, s := range searches {
+			if !sameSearch(s, *target) {
+				kept = append(kept, s)
+			}
+		}
+		savedData[userID] = kept
 	}
 	savedMu.Unlock()
 	go persistSavedSearches()

--- a/service/social/social.go
+++ b/service/social/social.go
@@ -74,6 +74,7 @@ func addMessage(p *Message) {
 	indexMessages([]*Message{p})
 	save()
 
+	event.Announce("social", p.Author+": "+p.Content, "/social/thread?id="+p.ID, "")
 	event.Published("social", p.ID, "", p.Content)
 	event.Publish(event.Event{Type: "social_updated"})
 }

--- a/service/stream/handlers.go
+++ b/service/stream/handlers.go
@@ -88,6 +88,9 @@ func RenderList(items []*Entry) string {
 // because an entry outliving the service that announced it should still say
 // where it came from.
 func source(name string) (label, icon, page string) {
+	if name == "brief" {
+		return "Brief", "home.png", "/home"
+	}
 	for _, s := range service.Specs() {
 		if s.Name == name {
 			return s.NavLabel(), s.NavIcon(), s.Page

--- a/service/stream/stream.go
+++ b/service/stream/stream.go
@@ -148,11 +148,8 @@ func add(e *Entry) {
 	if e == nil || e.Service == "" || e.Text == "" {
 		return
 	}
-	if repeat(e) {
-		return
-	}
-	if len(e.Text) > MaxTextLength {
-		e.Text = e.Text[:MaxTextLength-1] + "…"
+	if text := []rune(e.Text); len(text) > MaxTextLength {
+		e.Text = string(text[:MaxTextLength-1]) + "…"
 	}
 	if e.ID == "" {
 		e.ID = fmt.Sprintf("%d", time.Now().UnixNano())
@@ -162,6 +159,10 @@ func add(e *Entry) {
 	}
 
 	mu.Lock()
+	if repeat(e) {
+		mu.Unlock()
+		return
+	}
 	entries = append([]*Entry{e}, entries...)
 	if len(entries) > MaxEntries {
 		entries = entries[:MaxEntries]
@@ -170,7 +171,7 @@ func add(e *Entry) {
 	mu.Unlock()
 }
 
-// repeat reports whether the timeline already carries this entry.
+// repeat reports whether the timeline already carries this entry. Callers hold mu.
 //
 // Keyed on the service and the link, because the link is what identifies a
 // story; on the text when there is no link, which is what a personal entry has.
@@ -182,13 +183,14 @@ func repeat(e *Entry) bool {
 	if key == "" {
 		key = e.Text
 	}
-	mu.RLock()
-	defer mu.RUnlock()
 	for _, x := range entries {
 		if x.Service != e.Service || x.Account != e.Account {
 			continue
 		}
 		if x.URL == key || (x.URL == "" && x.Text == key) {
+			if e.Service == "brief" || e.Service == "markets" || e.Service == "users" {
+				return x.Text == e.Text
+			}
 			return true
 		}
 	}
@@ -203,6 +205,9 @@ func save() {
 // visible reports whether viewer may see this entry. An entry with no account
 // is public; one with an account is that account's alone.
 func visible(e *Entry, viewer string) bool {
+	if e.Service == "users" && viewer == "" {
+		return false
+	}
 	return e.Account == "" || e.Account == viewer
 }
 

--- a/service/stream/stream_test.go
+++ b/service/stream/stream_test.go
@@ -186,3 +186,25 @@ func TestTheSameTextForTwoAccountsIsTwoEntries(t *testing.T) {
 		t.Fatalf("bob's entry was dropped as a repeat of alice's")
 	}
 }
+
+func TestChangingUpdatesAtOneURLRemainVisible(t *testing.T) {
+	for _, source := range []string{"brief", "markets", "users"} {
+		reset(t)
+		for _, text := range []string{"first", "second", "second", "first"} {
+			add(&Entry{Service: source, Text: text, URL: "/same"})
+		}
+		if got := Recent(10, "reader"); len(got) != 3 {
+			t.Fatalf("%s: expected three changes, got %d", source, len(got))
+		}
+	}
+}
+
+func TestBriefAndChatEntriesStayWithTheirAccounts(t *testing.T) {
+	reset(t)
+	for _, source := range []string{"brief", "chat"} {
+		add(&Entry{Service: source, Text: "private", URL: "/same", Account: "alice"})
+	}
+	if len(Recent(10, "")) != 0 || len(Recent(10, "bob")) != 0 || len(Recent(10, "alice")) != 2 {
+		t.Fatal("private activity escaped its owner")
+	}
+}

--- a/test/profile_route_test.go
+++ b/test/profile_route_test.go
@@ -58,7 +58,6 @@ func TestTheAtRouteServesTheConversation(t *testing.T) {
 func TestThereIsNoProfilePageLeft(t *testing.T) {
 	for _, gone := range []string{
 		filepath.Join("internal", "user", "profile.go") + ":ProfileHandler",
-		filepath.Join("internal", "user", "status.go") + ":",
 		filepath.Join("internal", "user", "post.go") + ":",
 	} {
 		parts := strings.SplitN(gone, ":", 2)


### PR DESCRIPTION
Stream missed startup announcements and had no publishers for several requested sources. Subscribe before service startup; publish public briefs, hourly market snapshots, social posts and chat messages. Scope private chat to room members and scheduled briefs to their owner. Allow changed briefs, prices and user statuses at the same URL while retaining story deduplication; lock duplicate checks with insertion and truncate text on rune boundaries.

Restore the existing profile status store with a 160-character limit, persisted updates, clearing and account cleanup. A Home form changes only the authenticated user's status with CSRF, posting permission and rate checks. Profiles display it escaped; Stream shows status changes to signed-in viewers.

Places uses Video's recent-search chip styling, removes legacy duplicates when reading, normalizes search defaults and named locations, and removes all equivalent duplicates when deleting. Use shared field/form/action styles and a proper location button.

Maps defaults to worldwide OpenStreetMap tiles, directly requested by the browser with attribution, Referer and normal caching. Existing OS layers and API remain available. No tile prefetch or bulk-download path is added. Public OSM tiles are best-effort, subject to https://operations.osmfoundation.org/policies/tiles/.

Markets conversion is collapsed behind Convert and stays open for submitted results/errors.

Validation: JS syntax checks for Maps and Places, source review and git diff --check passed. Added regression tests for changing activity, private visibility, user-status bounds/clear and legacy search duplicates. Local Go toolchain is unavailable, so Go tests/build are not locally verified.