### PR TITLE
Fix status CSRF and preserve map and moderation privacy

### DIFF
--- a/home/status.go
+++ b/home/status.go
@@ -41,7 +41,7 @@ func statusForm(r *http.Request, id string) string {
 	return `<details class="disclosure page-section"><summary>Your status</summary>` +
 		`<form class="form" method="post" action="/home">` +
 		`<input type="hidden" name="action" value="status">` +
-		`<input type="hidden" name="csrf_token" value="` + html.EscapeString(auth.CSRFToken(r)) + `">` +
+		`<input type="hidden" name="_csrf" value="` + html.EscapeString(auth.CSRFToken(r)) + `">` +
 		`<label class="field-label">Shown on your profile<input class="field field-wide" name="status" maxlength="160" placeholder="What are you up to?" value="` + html.EscapeString(user.Status(id)) + `"></label>` +
 		`<div class="form-actions"><button type="submit">Save</button><button type="submit" name="clear" value="1">Clear</button></div></form></details>`
 }

--- a/service/maps/page.go
+++ b/service/maps/page.go
@@ -74,6 +74,10 @@ func TileHandler(w http.ResponseWriter, r *http.Request) {
 		Handler(w, r)
 		return
 	}
+	if parts[0] == "world" {
+		worldTile(w, r, parts[1:])
+		return
+	}
 	layer, err := styleOf(parts[0])
 	if err != nil {
 		app.NotFound(w, r, err.Error())
@@ -279,8 +283,7 @@ const mapJS = `<script>
           img=new Image();
           img.className='map-tile';
           img.alt='';
-          img.referrerPolicy='strict-origin-when-cross-origin';
-          img.src=style==='world'?'https://tile.openstreetmap.org/'+z+'/'+wx+'/'+y+'.png':'/maps/tiles/'+style+'/'+z+'/'+wx+'/'+y+'.png';
+          img.src='/maps/tiles/'+style+'/'+z+'/'+wx+'/'+y+'.png';
           // A tile outside Britain is a 404 and that is normal here, so it
           // fades out rather than showing a broken image.
           img.onerror=function(){ this.classList.add('map-gap'); missing++; done(); };

--- a/service/maps/world.go
+++ b/service/maps/world.go
@@ -1,0 +1,77 @@
+package maps
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"mu/internal/auth"
+	"mu/internal/blob"
+)
+
+// World tiles stay on this origin. The upstream request identifies the project,
+// never the instance or the viewer. Cache for seven days as OSM's tile policy
+// requires when upstream expiry headers are not interpreted.
+func worldTile(w http.ResponseWriter, r *http.Request, parts []string) {
+	z, e1 := strconv.Atoi(parts[0])
+	x, e2 := strconv.Atoi(parts[1])
+	y, e3 := strconv.Atoi(strings.TrimSuffix(parts[2], ".png"))
+	if e1 != nil || e2 != nil || e3 != nil || z < 1 || z > 19 || x < 0 || y < 0 || x >= 1<<z || y >= 1<<z {
+		http.NotFound(w, r)
+		return
+	}
+	key := fmt.Sprintf("tiles/world/%d/%d/%d.json", z, x, y)
+	var cached struct {
+		At   time.Time
+		Data []byte
+	}
+	if b, err := blob.Get(key); err == nil {
+		_ = json.Unmarshal(b, &cached)
+	}
+	if len(cached.Data) == 0 || time.Since(cached.At) >= 7*24*time.Hour {
+		_, acc := auth.TrySession(r)
+		if acc == nil {
+			http.Error(w, "Sign in to load new map tiles", http.StatusUnauthorized)
+			return
+		}
+		if err := mayFetch(acc.ID); err != nil {
+			http.Error(w, err.Error(), http.StatusTooManyRequests)
+			return
+		}
+		u := fmt.Sprintf("https://tile.openstreetmap.org/%d/%d/%d.png", z, x, y)
+		req, err := http.NewRequestWithContext(r.Context(), http.MethodGet, u, nil)
+		if err != nil {
+			http.Error(w, "Could not request map tile", http.StatusBadGateway)
+			return
+		}
+		req.Header.Set("User-Agent", "Mu/1.0 (+https://github.com/micro/mu)")
+		client := &http.Client{Timeout: 20 * time.Second}
+		resp, err := client.Do(req)
+		if err != nil {
+			http.Error(w, "Could not load map tile", http.StatusBadGateway)
+			return
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			http.Error(w, "Map tile unavailable", http.StatusBadGateway)
+			return
+		}
+		b, err := readAll(resp)
+		if err != nil {
+			http.Error(w, "Could not read map tile", http.StatusBadGateway)
+			return
+		}
+		cached.At, cached.Data = time.Now(), b
+		stored, _ := json.Marshal(cached)
+		if err := blob.Put(key, stored, "application/json"); err != nil {
+			http.Error(w, "Could not cache map tile", http.StatusInternalServerError)
+			return
+		}
+	}
+	w.Header().Set("Content-Type", "image/png")
+	w.Header().Set("Cache-Control", "public, max-age=86400")
+	_, _ = w.Write(cached.Data)
+}

--- a/service/maps/world_test.go
+++ b/service/maps/world_test.go
@@ -1,0 +1,16 @@
+package maps
+
+import (
+	"net/http/httptest"
+	"testing"
+)
+
+func TestWorldTileRejectsInvalidCoordinates(t *testing.T) {
+	for _, parts := range [][]string{{"0", "0", "0.png"}, {"20", "0", "0.png"}, {"2", "4", "0.png"}, {"2", "0", "-1.png"}, {"bad", "0", "0.png"}} {
+		w := httptest.NewRecorder()
+		worldTile(w, httptest.NewRequest("GET", "/maps/tiles/world", nil), parts)
+		if w.Code != 404 {
+			t.Fatalf("%v: status %d", parts, w.Code)
+		}
+	}
+}

--- a/service/social/social.go
+++ b/service/social/social.go
@@ -74,7 +74,6 @@ func addMessage(p *Message) {
 	indexMessages([]*Message{p})
 	save()
 
-	event.Announce("social", p.Author+": "+p.Content, "/social/thread?id="+p.ID, "")
 	event.Published("social", p.ID, "", p.Content)
 	event.Publish(event.Event{Type: "social_updated"})
 }

--- a/service/stream/stream.go
+++ b/service/stream/stream.go
@@ -115,7 +115,7 @@ func Load() {
 // Dropped on load rather than left to age out, because 500 entries is however
 // many months on a quiet instance, and no operator should have to be told to
 // delete a file.
-func theirsAlone(e *Entry) bool { return e.Service == "mail" }
+func theirsAlone(e *Entry) bool { return e.Service == "mail" || e.Service == "social" }
 
 func valid(e *Entry) bool {
 	return e != nil && e.Service != "" && e.Text != "" && !e.At.IsZero()


### PR DESCRIPTION
Address review findings on #1563. Submit the status token as _csrf. Remove social text copying until it supports moderation revocation; purge persisted social copies on Stream load. User status, chat, briefs and markets activity remain.

Serve worldwide tiles through the instance with a project-identifying User-Agent, seven-day persistent cache, existing cold-fetch account limits, bounded reads and timeout. Browser requests remain same-origin with no referrer override; OSM attribution remains visible. No prefetch. Invalid coordinate regression tests do not contact the provider.

The preceding PR passed release builds, vet and affected package tests. Its full-suite failures match the base branch exactly (documentation, naming, origin and weather tool metadata); race testing was skipped by CI.