### PR TITLE
v2: prevent duplicate task execution from concurrent starts

### DIFF
--- a/service/tasks/run.go
+++ b/service/tasks/run.go
@@ -25,6 +25,7 @@ package tasks
 
 import (
 	"fmt"
+	"sync"
 
 	"mu/internal/event"
 )
@@ -33,6 +34,11 @@ import (
 // from a standing instruction and put the answer in the right place.
 const Kind = "task"
 
+// runMu serializes the read-and-transition in Run. The durable status rejects
+// later starts; the mutex prevents simultaneous callers both observing todo.
+// It is held only while claiming and publishing, never during agent execution.
+var runMu sync.Mutex
+
 // Run hands a task to the agent and returns immediately.
 //
 // It returns immediately because an agent run takes seconds to a minute, and a
@@ -40,6 +46,8 @@ const Kind = "task"
 // "doing" now and to "done" with its result when the work finishes, so the list
 // is the progress indicator.
 func Run(owner, id string) error {
+	runMu.Lock()
+	defer runMu.Unlock()
 	t, err := Get(owner, id)
 	if err != nil {
 		return err

--- a/service/tasks/run_concurrent_test.go
+++ b/service/tasks/run_concurrent_test.go
@@ -1,0 +1,58 @@
+package tasks
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"mu/internal/event"
+)
+
+func TestConcurrentStartsPublishWorkOnce(t *testing.T) {
+	setupTasks(t)
+	task, err := CreateOn("alice", "source-thread", "specialist", "Do this once", "", Agent, time.Time{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	sub := event.Subscribe(event.WorkForAgent)
+	defer sub.Close()
+	var accepted atomic.Int32
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	for i := 0; i < 32; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			if Run("alice", task.ID) == nil {
+				accepted.Add(1)
+			}
+		}()
+	}
+	close(start)
+	wg.Wait()
+	if accepted.Load() != 1 {
+		t.Fatalf("accepted %d starts, want one", accepted.Load())
+	}
+	select {
+	case e := <-sub.Chan:
+		if e.Data["thread"] != "source-thread" || e.Data["agent"] != "specialist" || e.Data["account"] != "alice" {
+			t.Fatalf("lost delivery identity: %v", e.Data)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("accepted work was not published")
+	}
+	select {
+	case <-sub.Chan:
+		t.Fatal("duplicate work published")
+	default:
+	}
+	stored, err := Get("alice", task.ID)
+	if err != nil || stored.Status != StatusDoing {
+		t.Fatalf("claimed task not persisted: %v, %v", stored, err)
+	}
+	if err := Run("bob", task.ID); err == nil {
+		t.Fatal("another account claimed the task")
+	}
+}


### PR DESCRIPTION
First focused reliability change after the v1.7.4 breakpoint; advances #1565 and #1585 without closing the broader work.

Run previously read todo and wrote doing in separate operations. Concurrent requests could both pass the guard and publish the same work, potentially duplicating side effects and cost. Serialize the short claim-and-publish section; release before agent execution. Persisted status remains the guard for later requests.

Add a 32-caller regression that checks exactly one accepted start and work announcement, preserved source thread and specialist identity, persisted doing state and rejection of a different owner.

Scope: this fixes concurrent Run callers within the single Mu process. It does not claim durable queueing, restart recovery, delivery retries or general write idempotency. Those remain in #1565. Formatting and diff checks pass; targeted tests and CI are being run.