### PR TITLE
v2: recover interrupted tasks after a server restart

### DIFF
--- a/service/tasks/recovery.go
+++ b/service/tasks/recovery.go
@@ -1,0 +1,40 @@
+package tasks
+
+import (
+	"fmt"
+
+	"mu/internal/userdb"
+)
+
+// recoverInterrupted runs during startup, before the task service accepts work.
+// An old doing state cannot represent a live agent after a process restart.
+// Do not replay it: a tool may have completed an external action before the
+// process stopped. Leave the task open for the owner to inspect and retry.
+func recoverInterrupted(owner string) error {
+	if owner == "" {
+		return nil
+	}
+	for {
+		// Filter before limiting so tasks beyond the first page are recovered
+		// too. Each successful update removes a record from the next batch.
+		records, err := userdb.List(ns, owner, collection, "mine", map[string]interface{}{
+			"status": StatusDoing, "assignee": Agent,
+		}, "", "", userdb.MaxListLimit)
+		if err != nil {
+			return err
+		}
+		if len(records) == 0 {
+			return nil
+		}
+		for _, rec := range records {
+			task := toTask(rec.ID, rec.Owner, rec.Data)
+			result := "This run was interrupted by a server restart. Review any actions already taken before running it again."
+			if task.Result != "" {
+				result += "\n\nPrevious result:\n" + task.Result
+			}
+			if _, err := Update(owner, task.ID, "", "", StatusTodo, "", result); err != nil {
+				return fmt.Errorf("recover task %s: %w", task.ID, err)
+			}
+		}
+	}
+}

--- a/service/tasks/recovery_test.go
+++ b/service/tasks/recovery_test.go
@@ -1,0 +1,81 @@
+package tasks
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"mu/internal/event"
+	"mu/internal/userdb"
+)
+
+func TestRecoveryPreservesWorkWithoutReplayingIt(t *testing.T) {
+	setupTasks(t)
+	task, err := CreateOn("alice", "source", "specialist", "Send reply", "context", Agent, time.Now())
+	if err != nil {
+		t.Fatal(err)
+	}
+	steps := []Step{{Tool: "mail_send", OK: true}}
+	if _, err := Update("alice", task.ID, "", "", StatusDoing, "", "A reply was sent", steps); err != nil {
+		t.Fatal(err)
+	}
+	sub := event.Subscribe(event.WorkForAgent)
+	defer sub.Close()
+	if err := recoverInterrupted("bob"); err != nil {
+		t.Fatal(err)
+	}
+	before, _ := Get("alice", task.ID)
+	if before.Status != StatusDoing {
+		t.Fatal("recovery crossed accounts")
+	}
+	if err := recoverInterrupted("alice"); err != nil {
+		t.Fatal(err)
+	}
+	got, err := Get("alice", task.ID)
+	if err != nil || got.Status != StatusTodo || got.Thread != "source" || got.Agent != "specialist" || len(got.Steps) != 1 || !strings.Contains(got.Result, "A reply was sent") || !strings.Contains(got.Result, "interrupted") {
+		t.Fatalf("recovery lost the work record: %+v, %v", got, err)
+	}
+	if err := recoverInterrupted("alice"); err != nil {
+		t.Fatal(err)
+	}
+	again, _ := Get("alice", task.ID)
+	if again.Result != got.Result {
+		t.Fatal("repeated startup duplicated the recovery notice")
+	}
+	select {
+	case <-sub.Chan:
+		t.Fatal("recovery replayed potentially completed actions")
+	default:
+	}
+}
+
+func TestRecoveryDrainsAllPagesAndLeavesOtherStatesAlone(t *testing.T) {
+	setupTasks(t)
+	for i := 0; i < userdb.MaxListLimit+1; i++ {
+		if _, err := userdb.Create(ns, "alice", collection, map[string]interface{}{
+			"title": "interrupted", "status": StatusDoing, "assignee": Agent,
+		}, false); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, state := range []string{StatusTodo, StatusDoing, StatusDone} {
+		if _, err := userdb.Create(ns, "bob", collection, map[string]interface{}{
+			"title": "personal", "status": state, "assignee": "me",
+		}, false); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := recoverInterrupted("alice"); err != nil {
+		t.Fatal(err)
+	}
+	left, err := userdb.List(ns, "alice", collection, "mine", map[string]interface{}{"status": StatusDoing}, "", "", 0)
+	if err != nil || len(left) != 0 {
+		t.Fatalf("interrupted tasks beyond first page remain: %d, %v", len(left), err)
+	}
+	if err := recoverInterrupted("bob"); err != nil {
+		t.Fatal(err)
+	}
+	if len(List("bob", StatusDoing)) != 1 || len(List("bob", StatusTodo)) != 1 || len(List("bob", StatusDone)) != 1 {
+		t.Fatal("recovery changed personal tasks")
+	}
+}

--- a/service/tasks/service.go
+++ b/service/tasks/service.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"mu/internal/app"
+	"mu/internal/auth"
 	"mu/internal/service"
 )
 
@@ -172,6 +173,16 @@ func ParseDue(s string) (time.Time, error) {
 }
 
 func Load() {
+	// Synchronous and before registration: no live task may be mistaken for
+	// an interrupted run while startup recovery is in progress.
+	for _, acc := range auth.AllAccounts() {
+		if acc != nil {
+			if err := recoverInterrupted(acc.ID); err != nil {
+				app.Log("tasks", "recovering interrupted work for %s: %v", acc.ID, err)
+			}
+		}
+	}
+
 	if err := service.Register(Spec); err != nil {
 		app.Log("tasks", "service register failed: %v", err)
 	}


### PR DESCRIPTION
Advances #1565 and #1585.

Agent tasks persisted as doing could remain there forever after the server stopped, and Run would refuse a retry. During startup, before registering the task service, return interrupted agent-owned work to todo with an interruption notice. Preserve previous results, tool steps, source thread, selected agent and task metadata. Do not automatically replay: external actions may already have happened.

Filter persisted records before applying the list limit and drain successive batches so recovery also covers tasks beyond the first 200. Personal tasks and other states remain unchanged. Stop and log persistence failures instead of looping indefinitely.

Regression coverage checks preserved outcome/identity, ownership isolation, repeated recovery, zero work events and multiple pages. Formatting/diff checks pass; the full Tasks race suite is running.

This is startup recovery for the single-process runtime. Durable dispatch, delivery retries and richer task states remain open in #1565.