### PR TITLE
v2: persist task results awaiting delivery and retry replies safely

### DIFF
--- a/agent/ask.go
+++ b/agent/ask.go
@@ -444,6 +444,18 @@ func AnsweredAs(account, threadID, text, workflow, from string) {
 	})
 }
 
+// AnsweredOnce records a recoverable reply using a stable delivery reference.
+// Repeating it after a crash returns the existing message and waits for disk.
+func AnsweredOnce(account, threadID, text, from, ref string) error {
+	if ref == "" || thread.Add(thread.Message{
+		Thread: threadID, Account: account, Role: thread.RoleAgent,
+		Text: text, From: from, Ref: ref,
+	}) == "" {
+		return fmt.Errorf("could not record the answer in its source conversation")
+	}
+	return thread.Flush()
+}
+
 // History is a conversation's prior messages, as the model wants them.
 func History(account, threadID string, max int) []QueryMessage {
 	if threadID == "" || max <= 0 {

--- a/agent/work/delivery_test.go
+++ b/agent/work/delivery_test.go
@@ -1,0 +1,87 @@
+package work
+
+import (
+	"testing"
+	"time"
+
+	"mu/agent"
+	"mu/internal/thread"
+	"mu/service/tasks"
+)
+
+func TestDeliveryRetriesAfterRecordingWithoutRepeatingTheMessage(t *testing.T) {
+	const who = "delivery-retry"
+	th := thread.Open(who, thread.ChatClient, "private-source")
+	task, err := tasks.CreateOn(who, th.ID, "specialist", "Research", "", tasks.Agent, time.Time{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	pending, err := tasks.RecordOutcome(who, task.ID, tasks.StatusDone, "Saved answer", "Saved answer", "specialist", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The first process wrote the message but stopped before acknowledging it.
+	if err := agent.AnsweredOnce(who, th.ID, pending.Delivery.Text, pending.Delivery.From, "task-result:"+pending.Delivery.ID); err != nil {
+		t.Fatal(err)
+	}
+	// A fresh worker reads only persisted pending work, never calls a model.
+	loaded := tasks.PendingDeliveries(who, "")
+	if len(loaded) != 1 {
+		t.Fatal("pending result was not persisted")
+	}
+	if err := deliverTask(loaded[0]); err != nil {
+		t.Fatal(err)
+	}
+	if err := deliverTask(pending); err != nil {
+		t.Fatal(err)
+	}
+	msgs := thread.Messages(who, th.ID, 0)
+	if len(msgs) != 1 || msgs[0].Text != "Saved answer" || msgs[0].From != "specialist" {
+		t.Fatalf("duplicate or incorrect answer: %+v", msgs)
+	}
+	if len(tasks.PendingDeliveries(who, "")) != 0 {
+		t.Fatal("persisted message was not acknowledged")
+	}
+}
+
+func TestUnavailableConversationKeepsResultPending(t *testing.T) {
+	const who = "delivery-missing"
+	task, err := tasks.CreateOn(who, "unavailable", "specialist", "Research", "", tasks.Agent, time.Time{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	pending, err := tasks.RecordOutcome(who, task.ID, tasks.StatusDone, "Saved answer", "Saved answer", "specialist", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := deliverTask(pending); err == nil {
+		t.Fatal("missing conversation was reported as delivered")
+	}
+	got, _ := tasks.Get(who, task.ID)
+	if got.Delivery == nil || got.Status != tasks.StatusDone || got.Result != "Saved answer" {
+		t.Fatal("delivery failure lost the completed result")
+	}
+}
+
+func TestReplayedWorkDeliversTheSavedResultWithoutCallingTheModel(t *testing.T) {
+	const who = "delivery-replayed-work"
+	th := thread.Open(who, thread.ChatClient, "source")
+	task, err := tasks.CreateOn(who, th.ID, "specialist", "Research", "", tasks.Agent, time.Time{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tasks.RecordOutcome(who, task.ID, tasks.StatusDone, "Already done", "Already done", "specialist", nil); err != nil {
+		t.Fatal(err)
+	}
+	calls := 0
+	query := func(string, string, agent.QueryOpts) (string, error) {
+		calls++
+		return "Unwanted second run", nil
+	}
+	r := request{Account: who, ID: task.ID, Kind: tasks.Kind, Thread: th.ID, Prompt: "Research"}
+	runWithQuery(r, query)
+	runWithQuery(r, query)
+	if calls != 0 || len(thread.Messages(who, th.ID, 0)) != 1 || len(tasks.PendingDeliveries(who, "")) != 0 {
+		t.Fatal("replayed work repeated execution or lost the delivery")
+	}
+}

--- a/agent/work/work.go
+++ b/agent/work/work.go
@@ -44,6 +44,7 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"time"
 
 	"mu/agent"
 	"mu/internal/ai"
@@ -60,6 +61,7 @@ import (
 // Load subscribes to the work agents are asked to do.
 func Load() {
 	sub := event.Subscribe(event.WorkForAgent)
+	go retryDeliveries()
 	go func() {
 		for e := range sub.Chan {
 			r, ok := requestFrom(e.Data)
@@ -116,6 +118,23 @@ func run(r request) {
 }
 
 func runWithQuery(r request, query func(string, string, agent.QueryOpts) (string, error)) {
+	if r.Kind == tasks.Kind {
+		t, err := tasks.Get(r.Account, r.ID)
+		if err != nil {
+			app.Log("work", "task %s is unavailable: %v", r.ID, err)
+			return
+		}
+		if t.Delivery != nil {
+			if err := deliverTask(t); err != nil {
+				app.Log("work", "task %s result delivery pending: %v", r.ID, err)
+			}
+			return
+		}
+		if t.Status == tasks.StatusDone {
+			return
+		}
+	}
+
 	var steps []tasks.Step
 	var stepsMu sync.Mutex
 	defer func() {
@@ -124,8 +143,9 @@ func runWithQuery(r request, query func(string, string, agent.QueryOpts) (string
 			app.Log("work", "running %s %s panicked: %v", r.Kind, r.ID, rec)
 			if r.Kind == tasks.Kind {
 				finishTask(r, "", nil, failure)
+			} else {
+				answered(r, "", failure)
 			}
-			answered(r, "", failure)
 		}
 	}()
 
@@ -184,6 +204,7 @@ func runWithQuery(r request, query func(string, string, agent.QueryOpts) (string
 	switch r.Kind {
 	case tasks.Kind:
 		finishTask(r, answer, completedSteps, err)
+		return
 	case events.Kind:
 		deliver(r, answer, err)
 	default:
@@ -242,15 +263,65 @@ func answered(r request, answer string, err error) {
 // A failed run leaves the task open: work that failed is work still to do, not
 // work finished badly, and the reason belongs where somebody will see it.
 func finishTask(r request, answer string, steps []tasks.Step, err error) {
+	status, result := tasks.StatusDone, strings.TrimSpace(answer)
+	if result == "" && err == nil {
+		err = fmt.Errorf("the agent returned no outcome")
+	}
+	reply := result
 	if err != nil {
 		app.Log("work", "task %q failed for %s: %v", r.Title, r.Account, err)
-		if _, saveErr := tasks.Update(r.Account, r.ID, "", "", tasks.StatusTodo, "", "Last run failed: "+ai.FailureMessage(err), steps); saveErr != nil {
-			app.Log("work", "saving failed task %s: %v", r.ID, saveErr)
-		}
+		status = tasks.StatusTodo
+		result = "Last run failed: " + ai.FailureMessage(err)
+		reply = "That did not work: " + ai.FailureMessage(err)
+	}
+	from := r.Agent
+	if from == "" {
+		from = agent.DefaultName()
+	}
+	t, saveErr := tasks.RecordOutcome(r.Account, r.ID, status, result, reply, from, steps)
+	if saveErr != nil {
+		app.Log("work", "saving task outcome %s: %v", r.ID, saveErr)
 		return
 	}
-	if _, saveErr := tasks.Update(r.Account, r.ID, "", "", tasks.StatusDone, "", strings.TrimSpace(answer), steps); saveErr != nil {
-		app.Log("work", "saving completed task %s: %v", r.ID, saveErr)
+	if err := deliverTask(t); err != nil {
+		app.Log("work", "task %s result delivery pending: %v", r.ID, err)
+	}
+}
+
+// deliverTask never invokes the agent. The stable reference makes retrying
+// after the message was written but before acknowledgement safe.
+func deliverTask(t *tasks.Task) error {
+	if t == nil || t.Delivery == nil {
+		return nil
+	}
+	d := t.Delivery
+	if err := agent.AnsweredOnce(t.Owner, t.Thread, d.Text, d.From, "task-result:"+d.ID); err != nil {
+		return err
+	}
+	return tasks.AcknowledgeDelivery(t.Owner, t.ID, d.ID)
+}
+
+func retryDeliveries() {
+	for {
+		for _, acc := range auth.AllAccounts() {
+			if acc == nil {
+				continue
+			}
+			after := ""
+			for {
+				batch := tasks.PendingDeliveries(acc.ID, after)
+				if len(batch) == 0 {
+					break
+				}
+				for _, t := range batch {
+					after = t.Delivery.ID
+					if err := deliverTask(t); err != nil {
+						app.Log("work", "task %s result delivery pending: %v", t.ID, err)
+					}
+				}
+			}
+		}
+		time.Sleep(time.Minute)
 	}
 }
 

--- a/internal/thread/flush_error_test.go
+++ b/internal/thread/flush_error_test.go
@@ -1,0 +1,31 @@
+package thread
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestFailedFlushRemainsRetryable(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	file := filepath.Join(dir, ".mu", "data", "threads.json")
+	if err := os.MkdirAll(file, 0700); err != nil {
+		t.Fatal(err)
+	}
+	th := Open("flush-retry", ChatClient, "source")
+	Add(Message{Thread: th.ID, Account: "flush-retry", Text: "keep this", Ref: "reply-once"})
+	if err := Flush(); err == nil {
+		t.Fatal("failed write reported a durable conversation")
+	}
+	if err := os.Remove(file); err != nil {
+		t.Fatal(err)
+	}
+	if err := Flush(); err != nil {
+		t.Fatal(err)
+	}
+	b, err := os.ReadFile(file)
+	if err != nil || len(b) == 0 {
+		t.Fatalf("failed flush discarded the retry: %v", err)
+	}
+}

--- a/internal/thread/thread.go
+++ b/internal/thread/thread.go
@@ -659,7 +659,12 @@ func flusher() {
 //
 // Exported for the two callers that cannot wait for the tick: a test that wants
 // to know the file is on disk, and anything shutting down.
-func Flush() {
+func Flush() error {
+	// Serialize the dirty check, snapshot and write, not just the write. A
+	// caller awaiting durability must wait for an in-flight flush, and older
+	// snapshots must never overwrite newer ones.
+	writeMu.Lock()
+	defer writeMu.Unlock()
 	// Only back to the home it was read from. A tick that falls due after a
 	// test has restored HOME would otherwise write that test's fixtures into
 	// the real store, which is how 37 of them got there.
@@ -667,10 +672,10 @@ func Flush() {
 	ours := loaded && loadedFrom == os.Getenv("HOME")
 	mu.RUnlock()
 	if !ours {
-		return
+		return nil
 	}
 	if !dirty.Swap(false) {
-		return
+		return nil
 	}
 	var stored struct {
 		Threads  []Thread  `json:"threads"`
@@ -699,9 +704,11 @@ func Flush() {
 	}
 	mu.RUnlock()
 
-	writeMu.Lock()
-	defer writeMu.Unlock()
-	data.SaveJSON("threads.json", stored) //nolint:errcheck
+	if err := data.SaveJSON("threads.json", stored); err != nil {
+		dirty.Store(true)
+		return err
+	}
+	return nil
 }
 
 func sortByTime(m []*Message) {

--- a/internal/userdb/userdb.go
+++ b/internal/userdb/userdb.go
@@ -102,7 +102,9 @@ func Create(ns, owner, collection string, dataObj map[string]interface{}, public
 	now := time.Now()
 	rec := Record{ID: uuid.New().String(), Owner: owner, Public: public, Data: dataObj, Created: now, Updated: now}
 	recs = append(recs, rec)
-	data.SaveJSON(k, recs)
+	if err := data.SaveJSON(k, recs); err != nil {
+		return nil, err
+	}
 	return &rec, nil
 }
 
@@ -183,7 +185,9 @@ func Update(ns, caller, collection, id string, dataObj map[string]interface{}, p
 		}
 		recs[i].Public = public
 		recs[i].Updated = time.Now()
-		data.SaveJSON(k, recs)
+		if err := data.SaveJSON(k, recs); err != nil {
+			return nil, err
+		}
 		r := recs[i]
 		return &r, nil
 	}

--- a/internal/userdb/write_error_test.go
+++ b/internal/userdb/write_error_test.go
@@ -1,0 +1,22 @@
+package userdb
+
+import "testing"
+
+func TestWriteErrorsAreReturnedWithoutChangingTheRecord(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	bad := map[string]interface{}{"invalid": make(chan int)}
+	if _, err := Create("test", "alice", "records", bad, false); err == nil {
+		t.Fatal("unpersistable creation reported success")
+	}
+	rec, err := Create("test", "alice", "records", map[string]interface{}{"value": "before"}, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Update("test", "alice", "records", rec.ID, bad, false); err == nil {
+		t.Fatal("unpersistable update reported success")
+	}
+	got, err := Get("test", "alice", "records", rec.ID)
+	if err != nil || got.Data["value"] != "before" {
+		t.Fatalf("failed update changed the stored record: %+v, %v", got, err)
+	}
+}

--- a/service/tasks/delivery.go
+++ b/service/tasks/delivery.go
@@ -1,0 +1,93 @@
+package tasks
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+
+	"mu/internal/userdb"
+)
+
+// Delivery is a persisted outcome awaiting acknowledgement by its consumer.
+// The service stores the payload; it does not choose a transport or send it.
+type Delivery struct {
+	ID   string `json:"id"`
+	Text string `json:"text"`
+	From string `json:"from"`
+}
+
+func encodeDelivery(d *Delivery) string {
+	b, _ := json.Marshal(d)
+	return string(b)
+}
+
+func decodeDelivery(s string) *Delivery {
+	var d Delivery
+	if json.Unmarshal([]byte(s), &d) != nil || d.ID == "" {
+		return nil
+	}
+	return &d
+}
+
+// RecordOutcome saves the result and pending reply in one store write.
+func RecordOutcome(owner, id, status, result, reply, from string, steps []Step) (*Task, error) {
+	runMu.Lock()
+	defer runMu.Unlock()
+	t, err := Get(owner, id)
+	if err != nil {
+		return nil, err
+	}
+	if t.Delivery != nil {
+		return nil, fmt.Errorf("a result is already awaiting delivery")
+	}
+	extra := map[string]any{}
+	if t.Thread != "" && strings.TrimSpace(reply) != "" {
+		delivery := &Delivery{ID: uuid.NewString(), Text: reply, From: from}
+		extra["delivery"] = encodeDelivery(delivery)
+		extra["delivery_pending"] = true
+		extra["delivery_id"] = delivery.ID
+	}
+	return update(owner, id, "", "", status, "", result, extra, steps)
+}
+
+// PendingDeliveries returns a bounded batch; acknowledged items leave the set.
+func PendingDeliveries(owner, after string) []*Task {
+	if owner == "" {
+		return nil
+	}
+	where := map[string]any{"delivery_pending": true}
+	if after != "" {
+		where["delivery_id"] = map[string]any{"gt": after}
+	}
+	records, err := userdb.List(ns, owner, collection, "mine", where, "delivery_id", "asc", userdb.MaxListLimit)
+	if err != nil {
+		return nil
+	}
+	var out []*Task
+	for _, rec := range records {
+		if t := toTask(rec.ID, rec.Owner, rec.Data); t.Delivery != nil {
+			out = append(out, t)
+		}
+	}
+	return out
+}
+
+// AcknowledgeDelivery cannot clear a different, newer outcome.
+func AcknowledgeDelivery(owner, id, deliveryID string) error {
+	runMu.Lock()
+	defer runMu.Unlock()
+	t, err := Get(owner, id)
+	if err != nil {
+		return err
+	}
+	if t.Delivery == nil {
+		return nil
+	}
+	if t.Delivery.ID != deliveryID {
+		return fmt.Errorf("the pending delivery has changed")
+	}
+	_, err = update(owner, id, "", "", "", "", "", map[string]any{"delivery": nil, "delivery_pending": nil, "delivery_id": nil})
+	return err
+}

--- a/service/tasks/delivery_test.go
+++ b/service/tasks/delivery_test.go
@@ -1,0 +1,94 @@
+package tasks
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"mu/internal/userdb"
+)
+
+func TestOutcomeAndDeliveryStayTogether(t *testing.T) {
+	setupTasks(t)
+	task, err := CreateOn("alice", "source", "specialist", "Do work", "", Agent, time.Time{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	outcome, err := RecordOutcome("alice", task.ID, StatusDone, "Done", "The result", "specialist", []Step{{Tool: "news_list", OK: true}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	pending := PendingDeliveries("alice", "")
+	if len(pending) != 1 || pending[0].Status != StatusDone || pending[0].Result != "Done" || pending[0].Delivery.Text != "The result" || len(pending[0].Steps) != 1 {
+		t.Fatalf("incomplete persisted outcome: %+v", pending)
+	}
+	if len(PendingDeliveries("bob", "")) != 0 || len(PendingDeliveries("", "")) != 0 {
+		t.Fatal("delivery crossed accounts")
+	}
+	if _, err := Update("alice", task.ID, "Edited", "", "", "", ""); err != nil {
+		t.Fatal(err)
+	}
+	if got, _ := Get("alice", task.ID); got.Delivery == nil || got.Delivery.ID != outcome.Delivery.ID {
+		t.Fatal("editing dropped the pending reply")
+	}
+	if err := Run("alice", task.ID); err == nil {
+		t.Fatal("pending delivery permitted another execution")
+	}
+	if err := AcknowledgeDelivery("alice", task.ID, "older-delivery"); err == nil {
+		t.Fatal("stale acknowledgement cleared a newer outcome")
+	}
+	if err := AcknowledgeDelivery("bob", task.ID, outcome.Delivery.ID); err == nil {
+		t.Fatal("another owner acknowledged the outcome")
+	}
+	if err := AcknowledgeDelivery("alice", task.ID, outcome.Delivery.ID); err != nil {
+		t.Fatal(err)
+	}
+	got, _ := Get("alice", task.ID)
+	if got.Delivery != nil || got.Result != "Done" || got.Status != StatusDone || len(PendingDeliveries("alice", "")) != 0 {
+		t.Fatal("acknowledgement lost the result or left it pending")
+	}
+}
+
+func TestFailedOutcomeCanRunAgainOnlyAfterDelivery(t *testing.T) {
+	setupTasks(t)
+	task, err := CreateOn("alice", "source", "specialist", "Try work", "", Agent, time.Time{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	failed, err := RecordOutcome("alice", task.ID, StatusTodo, "Failed", "Could not finish", "specialist", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := Run("alice", task.ID); err == nil {
+		t.Fatal("retry could overwrite an undelivered failure")
+	}
+	if err := AcknowledgeDelivery("alice", task.ID, failed.Delivery.ID); err != nil {
+		t.Fatal(err)
+	}
+	if err := Run("alice", task.ID); err != nil {
+		t.Fatalf("explicit retry rejected: %v", err)
+	}
+}
+
+func TestPendingDeliveryCursorAdvancesPastUndeliverableFirstBatch(t *testing.T) {
+	setupTasks(t)
+	for i := 0; i < userdb.MaxListLimit+1; i++ {
+		id := fmt.Sprintf("reply-%03d", i)
+		if _, err := userdb.Create(ns, "alice", collection, map[string]interface{}{
+			"title": "Result", "status": StatusDone, "assignee": Agent,
+			"delivery":         encodeDelivery(&Delivery{ID: id, Text: "Answer"}),
+			"delivery_pending": true, "delivery_id": id,
+		}, false); err != nil {
+			t.Fatal(err)
+		}
+	}
+	first := PendingDeliveries("alice", "")
+	if len(first) != userdb.MaxListLimit {
+		t.Fatalf("first batch size: %d", len(first))
+	}
+	// No acknowledgements: all first-page destinations may be unavailable.
+	next := PendingDeliveries("alice", first[len(first)-1].Delivery.ID)
+	if len(next) != 1 || next[0].Delivery.ID != "reply-200" {
+		t.Fatalf("later pending outcome was starved: %+v", next)
+	}
+}

--- a/service/tasks/handler.go
+++ b/service/tasks/handler.go
@@ -206,6 +206,9 @@ func taskRow(t *Task, csrf string, labels ...string) string {
 	if !t.Due.IsZero() {
 		meta = append(meta, "due "+html.EscapeString(t.Due.Local().Format("2 Jan 15:04")))
 	}
+	if t.Delivery != nil {
+		meta = append(meta, "result delivery pending")
+	}
 	if Running(t) {
 		meta = append(meta, `<span class="task-running">working…</span>`)
 	}

--- a/service/tasks/run.go
+++ b/service/tasks/run.go
@@ -52,6 +52,9 @@ func Run(owner, id string) error {
 	if err != nil {
 		return err
 	}
+	if t.Delivery != nil {
+		return fmt.Errorf("the previous result is still being delivered")
+	}
 	if t.Status == StatusDone {
 		return fmt.Errorf("that task is already done")
 	}
@@ -64,7 +67,7 @@ func Run(owner, id string) error {
 	// was an in-memory map beside it doing the same job, which meant two
 	// answers to "is this running" and only one of them survived a restart —
 	// a task left "doing" by a crash could never be run again.
-	if _, err := Update(owner, t.ID, "", "", StatusDoing, Agent, ""); err != nil {
+	if _, err := update(owner, t.ID, "", "", StatusDoing, Agent, "", nil); err != nil {
 		return err
 	}
 

--- a/service/tasks/tasks.go
+++ b/service/tasks/tasks.go
@@ -101,7 +101,8 @@ type Task struct {
 	// bus, and the agent layer is what resolves a name to an instruction and a
 	// tool scope. A service that looked one up would be a service calling an
 	// agent.
-	Agent string `json:"agent,omitempty"`
+	Agent    string    `json:"agent,omitempty"`
+	Delivery *Delivery `json:"delivery,omitempty"`
 }
 
 // Open reports whether the task is still to be done.
@@ -218,6 +219,13 @@ func Next(owner string) *Task {
 // did without every other caller having to pass an empty slice for something
 // only a run produces.
 func Update(owner, id, title, detail, status, assignee, result string, runSteps ...[]Step) (*Task, error) {
+	runMu.Lock()
+	defer runMu.Unlock()
+	return update(owner, id, title, detail, status, assignee, result, nil, runSteps...)
+}
+
+// update is called with runMu held, so edits cannot overwrite a claim or receipt.
+func update(owner, id, title, detail, status, assignee, result string, extra map[string]any, runSteps ...[]Step) (*Task, error) {
 	existing, err := Get(owner, id)
 	if err != nil {
 		return nil, err
@@ -268,6 +276,18 @@ func Update(owner, id, title, detail, status, assignee, result string, runSteps 
 		fields["steps"] = encodeSteps(runSteps[0])
 	}
 
+	if existing.Delivery != nil {
+		fields["delivery"] = encodeDelivery(existing.Delivery)
+		fields["delivery_pending"] = true
+		fields["delivery_id"] = existing.Delivery.ID
+	}
+	for key, value := range extra {
+		if value == nil {
+			delete(fields, key)
+		} else {
+			fields[key] = value
+		}
+	}
 	rec, err := userdb.Update(ns, owner, collection, existing.ID, fields, false)
 	if err != nil {
 		return nil, err
@@ -281,6 +301,8 @@ func Update(owner, id, title, detail, status, assignee, result string, runSteps 
 
 // Remove deletes a task the caller owns.
 func Remove(owner, id string) error {
+	runMu.Lock()
+	defer runMu.Unlock()
 	if owner == "" {
 		return fmt.Errorf("sign in to use tasks")
 	}
@@ -369,7 +391,7 @@ func toTask(id, owner string, d map[string]any) *Task {
 		Result: str("result"), Due: when("due"),
 		Created: when("created"), Updated: when("updated"), Owner: owner,
 		Steps: decodeSteps(str("steps")), Thread: str("thread"),
-		Agent: str("agent"),
+		Agent: str("agent"), Delivery: decodeDelivery(str("delivery")),
 	}
 }
 

--- a/service/tasks/tasks_test.go
+++ b/service/tasks/tasks_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"mu/internal/auth"
+	"mu/internal/data"
 	"mu/internal/event"
 )
 
@@ -16,6 +17,10 @@ func TestMain(m *testing.M) {
 		panic(err)
 	}
 	os.Setenv("HOME", dir)
+	// Keep the process-wide index alive across individual test HOME changes.
+	if _, err := data.SearchSQLite("initialise", 1); err != nil {
+		panic(err)
+	}
 	code := m.Run()
 	os.RemoveAll(dir)
 	os.Exit(code)


### PR DESCRIPTION
Advances #1565 and #1585.

A completed task could save its outcome and lose the reply to its source conversation. There was no persisted pending delivery, and conversation writes were buffered without an error-bearing durability acknowledgement.

Save the task outcome and a stable pending reply in one record write. Retry saved replies at startup and every minute without model/tool execution. Record the reply with a stable reference, flush it successfully, then acknowledge the matching delivery. A crash between recording and acknowledgement produces one message on retry. Missing destinations leave the completed result visible and marked delivery pending. Cursor pagination prevents failed first-page deliveries starving later records. Pending results survive task edits and prevent execution retry until delivered; replayed completed work does not invoke the model.

Make thread flush return persistence errors, retain dirty state after a failed write and serialize snapshots with writes. Return userdb create/update save errors instead of reporting false success. These are prerequisites for a trustworthy delivery acknowledgement.

Validation: race-enabled suites and vet pass for service/tasks, agent/work, internal/thread and internal/userdb. Regressions cover record ownership, stale acknowledgements, preserved results/identity, duplicate recording, replay without model calls, missing destinations, multi-page queues, failed writes and retryable flushing. Fix the Tasks test index lifetime so early TempDir cleanup does not invalidate later search tests.

Scope: delivery here means the owner's persisted source conversation. This does not automatically send private result reports into public rooms or external mail, and it does not yet provide durable transport queues for scheduled email or general side-effect idempotency. Those remain in #1565.