### PR TITLE
Give failed and interrupted tasks explicit outcomes

### DIFF
--- a/agent/work/delivery_test.go
+++ b/agent/work/delivery_test.go
@@ -85,3 +85,34 @@ func TestReplayedWorkDeliversTheSavedResultWithoutCallingTheModel(t *testing.T) 
 		t.Fatal("replayed work repeated execution or lost the delivery")
 	}
 }
+
+func TestFailedAndBlockedWorkWaitsForExplicitRetry(t *testing.T) {
+	for _, state := range []string{tasks.StatusFailed, tasks.StatusBlocked} {
+		who := "review-" + state
+		task, err := tasks.Create(who, "Do work", "", tasks.Agent, time.Time{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := tasks.Update(who, task.ID, "", "", state, "", "Review first"); err != nil {
+			t.Fatal(err)
+		}
+		calls := 0
+		query := func(string, string, agent.QueryOpts) (string, error) {
+			calls++
+			return "Completed after review", nil
+		}
+		r := request{Account: who, ID: task.ID, Kind: tasks.Kind, Prompt: "Do work"}
+		runWithQuery(r, query)
+		if calls != 0 {
+			t.Fatal("stale request reran work requiring review")
+		}
+		if err := tasks.Run(who, task.ID); err != nil {
+			t.Fatal(err)
+		}
+		runWithQuery(r, query)
+		got, _ := tasks.Get(who, task.ID)
+		if calls != 1 || got.Status != tasks.StatusDone {
+			t.Fatalf("explicit retry did not finish: calls=%d, task=%+v", calls, got)
+		}
+	}
+}

--- a/agent/work/timeout_test.go
+++ b/agent/work/timeout_test.go
@@ -24,7 +24,7 @@ func TestTimeoutPreservesCompletedSteps(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got.Status != tasks.StatusTodo || len(got.Steps) != 1 || got.Steps[0].Tool != "web_search" || !strings.Contains(got.Result, "too long") {
+	if got.Status != tasks.StatusFailed || len(got.Steps) != 1 || got.Steps[0].Tool != "web_search" || !strings.Contains(got.Result, "too long") {
 		t.Fatalf("failure lost work: %+v", got)
 	}
 }

--- a/agent/work/work.go
+++ b/agent/work/work.go
@@ -130,7 +130,7 @@ func runWithQuery(r request, query func(string, string, agent.QueryOpts) (string
 			}
 			return
 		}
-		if t.Status == tasks.StatusDone {
+		if t.Status == tasks.StatusDone || t.Status == tasks.StatusFailed || t.Status == tasks.StatusBlocked {
 			return
 		}
 	}
@@ -260,8 +260,8 @@ func answered(r request, answer string, err error) {
 
 // finishTask writes the result back onto the task.
 //
-// A failed run leaves the task open: work that failed is work still to do, not
-// work finished badly, and the reason belongs where somebody will see it.
+// A failed run remains open with an explicit failed state. It is not picked
+// up automatically; the owner can review its steps before retrying.
 func finishTask(r request, answer string, steps []tasks.Step, err error) {
 	status, result := tasks.StatusDone, strings.TrimSpace(answer)
 	if result == "" && err == nil {
@@ -270,7 +270,7 @@ func finishTask(r request, answer string, steps []tasks.Step, err error) {
 	reply := result
 	if err != nil {
 		app.Log("work", "task %q failed for %s: %v", r.Title, r.Account, err)
-		status = tasks.StatusTodo
+		status = tasks.StatusFailed
 		result = "Last run failed: " + ai.FailureMessage(err)
 		reply = "That did not work: " + ai.FailureMessage(err)
 	}

--- a/agent/work/work_test.go
+++ b/agent/work/work_test.go
@@ -65,9 +65,8 @@ func TestAFinishedTaskKeepsItsResult(t *testing.T) {
 	}
 }
 
-// A failed run leaves the work to be done rather than marking it finished
-// badly, and says why where somebody will see it.
-func TestAFailedRunReopensTheTask(t *testing.T) {
+// A failed run is explicitly failed, with its reason preserved.
+func TestAFailedRunMarksTheTaskFailed(t *testing.T) {
 	const who = "work-failed"
 	auth.Create(&auth.Account{ID: who, Name: who, Secret: "test-secret"}) //nolint:errcheck
 
@@ -83,8 +82,8 @@ func TestAFailedRunReopensTheTask(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got.Status != tasks.StatusTodo {
-		t.Errorf("a failed run left the task %q, want todo", got.Status)
+	if got.Status != tasks.StatusFailed {
+		t.Errorf("a failed run left the task %q, want failed", got.Status)
 	}
 	if !strings.Contains(got.Result, "unavailable") {
 		t.Errorf("the reason is not on the task: %q", got.Result)

--- a/home/brief.go
+++ b/home/brief.go
@@ -142,6 +142,9 @@ func briefParts(accountID string) []string {
 		if s := working(accountID); s != "" {
 			parts = append(parts, s)
 		}
+		if s := taskAttention(accountID); s != "" {
+			parts = append(parts, s)
+		}
 		if s := owed(accountID); s != "" {
 			parts = append(parts, s)
 		}
@@ -204,6 +207,20 @@ func working(accountID string) string {
 		out += ", the longest since " + html.EscapeString(app.TimeAgo(oldest.Updated))
 	}
 	return out + "."
+}
+
+// taskAttention points to work that needs a decision, not another automatic run.
+func taskAttention(accountID string) string {
+	var parts []string
+	for _, status := range []string{tasks.StatusFailed, tasks.StatusBlocked} {
+		if n := len(tasks.List(accountID, status)); n > 0 {
+			parts = append(parts, app.TextLink(count(n, "task", "tasks")+" "+status, "/tasks?status="+status))
+		}
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+	return strings.Join(parts, " and ") + "; review before retrying."
 }
 
 // owed is what is waiting on you: due today, then everything else open.

--- a/home/task_attention_test.go
+++ b/home/task_attention_test.go
@@ -1,0 +1,32 @@
+package home
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"mu/service/tasks"
+)
+
+func TestTaskAttentionShowsFailedAndBlockedOwnedWork(t *testing.T) {
+	who := "home-task-attention"
+	defer tasks.DeleteAll(who)
+	for _, state := range []string{tasks.StatusFailed, tasks.StatusBlocked} {
+		task, err := tasks.Create(who, state, "", tasks.Agent, time.Time{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := tasks.Update(who, task.ID, "", "", state, "", "Review first"); err != nil {
+			t.Fatal(err)
+		}
+	}
+	out := taskAttention(who)
+	for _, want := range []string{"/tasks?status=failed", "/tasks?status=blocked", "review before retrying"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("attention summary missing %q: %s", want, out)
+		}
+	}
+	if taskAttention("unrelated-owner") != "" || taskAttention("") != "" {
+		t.Fatal("task attention crossed ownership")
+	}
+}

--- a/service/tasks/delivery_test.go
+++ b/service/tasks/delivery_test.go
@@ -55,7 +55,7 @@ func TestFailedOutcomeCanRunAgainOnlyAfterDelivery(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	failed, err := RecordOutcome("alice", task.ID, StatusTodo, "Failed", "Could not finish", "specialist", nil)
+	failed, err := RecordOutcome("alice", task.ID, StatusFailed, "Failed", "Could not finish", "specialist", nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/service/tasks/handler.go
+++ b/service/tasks/handler.go
@@ -125,7 +125,7 @@ func listPage(w http.ResponseWriter, r *http.Request, names ...func(string, stri
 	// Filters. Counted, because "3 open" is the thing you want to know before
 	// you decide whether to look.
 	all := List(sess.Account, "")
-	open, doing := 0, 0
+	open, doing, failed, blocked := 0, 0, 0, 0
 	for _, t := range all {
 		if t.Status == StatusTodo {
 			open++
@@ -133,11 +133,19 @@ func listPage(w http.ResponseWriter, r *http.Request, names ...func(string, stri
 		if t.Status == StatusDoing {
 			doing++
 		}
+		if t.Status == StatusFailed {
+			failed++
+		}
+		if t.Status == StatusBlocked {
+			blocked++
+		}
 	}
 	b.WriteString(`<div class="page-stack"><div class="task-tabs">`)
 	tab(&b, "", filter, fmt.Sprintf("All (%d)", len(all)))
 	tab(&b, StatusTodo, filter, fmt.Sprintf("To do (%d)", open))
 	tab(&b, StatusDoing, filter, fmt.Sprintf("Doing (%d)", doing))
+	tab(&b, StatusFailed, filter, fmt.Sprintf("Failed (%d)", failed))
+	tab(&b, StatusBlocked, filter, fmt.Sprintf("Blocked (%d)", blocked))
 	tab(&b, StatusDone, filter, "Done")
 	b.WriteString(`</div>`)
 
@@ -263,7 +271,13 @@ func taskRow(t *Task, csrf string, labels ...string) string {
 	if t.Open() {
 		button(&b, t.ID, "done", csrf, "Done", "")
 		if t.Assignee == Agent {
-			button(&b, t.ID, "run", csrf, "Run now", "")
+			if !Running(t) && t.Delivery == nil {
+				runLabel := "Run now"
+				if t.Status == StatusFailed || t.Status == StatusBlocked {
+					runLabel = "Retry"
+				}
+				button(&b, t.ID, "run", csrf, runLabel, "")
+			}
 			button(&b, t.ID, "unassign", csrf, "Take back", "")
 		} else {
 			button(&b, t.ID, "assign", csrf, "Give to agent", "")

--- a/service/tasks/recovery.go
+++ b/service/tasks/recovery.go
@@ -9,7 +9,7 @@ import (
 // recoverInterrupted runs during startup, before the task service accepts work.
 // An old doing state cannot represent a live agent after a process restart.
 // Do not replay it: a tool may have completed an external action before the
-// process stopped. Leave the task open for the owner to inspect and retry.
+// process stopped. Leave the task blocked for the owner to inspect and retry.
 func recoverInterrupted(owner string) error {
 	if owner == "" {
 		return nil
@@ -32,7 +32,7 @@ func recoverInterrupted(owner string) error {
 			if task.Result != "" {
 				result += "\n\nPrevious result:\n" + task.Result
 			}
-			if _, err := Update(owner, task.ID, "", "", StatusTodo, "", result); err != nil {
+			if _, err := Update(owner, task.ID, "", "", StatusBlocked, "", result); err != nil {
 				return fmt.Errorf("recover task %s: %w", task.ID, err)
 			}
 		}

--- a/service/tasks/recovery_test.go
+++ b/service/tasks/recovery_test.go
@@ -32,7 +32,7 @@ func TestRecoveryPreservesWorkWithoutReplayingIt(t *testing.T) {
 		t.Fatal(err)
 	}
 	got, err := Get("alice", task.ID)
-	if err != nil || got.Status != StatusTodo || got.Thread != "source" || got.Agent != "specialist" || len(got.Steps) != 1 || !strings.Contains(got.Result, "A reply was sent") || !strings.Contains(got.Result, "interrupted") {
+	if err != nil || got.Status != StatusBlocked || got.Thread != "source" || got.Agent != "specialist" || len(got.Steps) != 1 || !strings.Contains(got.Result, "A reply was sent") || !strings.Contains(got.Result, "interrupted") {
 		t.Fatalf("recovery lost the work record: %+v, %v", got, err)
 	}
 	if err := recoverInterrupted("alice"); err != nil {

--- a/service/tasks/run.go
+++ b/service/tasks/run.go
@@ -43,8 +43,8 @@ var runMu sync.Mutex
 //
 // It returns immediately because an agent run takes seconds to a minute, and a
 // request held open for that is a page that looks broken. The task moves to
-// "doing" now and to "done" with its result when the work finishes, so the list
-// is the progress indicator.
+// "doing" now, then to "done" or "failed" with its result when the work
+// finishes, so the list is the progress indicator.
 func Run(owner, id string) error {
 	runMu.Lock()
 	defer runMu.Unlock()

--- a/service/tasks/service.go
+++ b/service/tasks/service.go
@@ -32,7 +32,7 @@ type TaskResponse struct {
 type ListRequest struct {
 	Offset int    `json:"offset" description:"Tasks to skip"`
 	Limit  int    `json:"limit" description:"Maximum tasks, default 20, max 100"`
-	Status string `json:"status" description:"Optional filter: todo, doing or done"`
+	Status string `json:"status" description:"Optional filter: todo, doing, done, failed or blocked"`
 }
 
 // ListResponse is a model-ready list.
@@ -52,7 +52,7 @@ type UpdateRequest struct {
 	ID     string `json:"id" description:"The task's id" required:"true"`
 	Title  string `json:"title" description:"New title"`
 	Detail string `json:"detail" description:"New detail"`
-	Status string `json:"status" description:"todo, doing or done"`
+	Status string `json:"status" description:"todo, doing, done, failed or blocked"`
 	Result string `json:"result" description:"What came of it — the answer, the outcome, what was found"`
 }
 
@@ -128,7 +128,7 @@ func (Server) List(ctx context.Context, req *ListRequest, rsp *ListResponse) err
 func (Server) Next(ctx context.Context, _ *NextRequest, rsp *TaskResponse) error {
 	t := Next(service.AccountFrom(ctx))
 	if t == nil {
-		rsp.Text = "Nothing assigned to the agent."
+		rsp.Text = "No task is ready for the agent."
 		return nil
 	}
 	rsp.Item = t

--- a/service/tasks/states_test.go
+++ b/service/tasks/states_test.go
@@ -1,0 +1,73 @@
+package tasks
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"mu/internal/service"
+)
+
+func TestNextSkipsWorkThatIsNotReady(t *testing.T) {
+	setupTasks(t)
+	for _, state := range []string{StatusFailed, StatusBlocked, StatusDoing, StatusDone} {
+		task, err := Create("alice", state, "", Agent, time.Time{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := Update("alice", task.ID, "", "", state, "", "Previous result"); err != nil {
+			t.Fatal(err)
+		}
+	}
+	pending, err := CreateOn("alice", "source", "specialist", "Delivery pending", "", Agent, time.Time{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := RecordOutcome("alice", pending.ID, StatusTodo, "Saved", "Saved", "specialist", nil); err != nil {
+		t.Fatal(err)
+	}
+	if got := Next("alice"); got != nil {
+		t.Fatalf("picked work requiring review or delivery: %+v", got)
+	}
+	ready, err := Create("alice", "Ready", "", Agent, time.Time{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := Next("alice"); got == nil || got.ID != ready.ID {
+		t.Fatalf("ready work was not picked: %+v", got)
+	}
+}
+
+func TestOutcomeStatesPersistFilterAndOfferExplicitRetry(t *testing.T) {
+	setupTasks(t)
+	for _, state := range []string{StatusFailed, StatusBlocked} {
+		task, err := CreateOn("alice", "source", "specialist", state, "Context", Agent, time.Time{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		var rsp TaskResponse
+		if err := (Server{}).Update(service.WithAccount(context.Background(), "alice"), &UpdateRequest{ID: task.ID, Status: state, Result: "Review prior actions"}, &rsp); err != nil {
+			t.Fatal(err)
+		}
+		got := mustGet(t, "alice", task.ID)
+		if got.Status != state || !got.Open() || Running(got) || got.Thread != "source" || got.Agent != "specialist" {
+			t.Fatalf("state or identity lost: %+v", got)
+		}
+		var list ListResponse
+		if err := (Server{}).List(service.WithAccount(context.Background(), "alice"), &ListRequest{Status: state}, &list); err != nil || len(list.Items) != 1 || list.Items[0].ID != task.ID {
+			t.Fatalf("state filter failed: %+v, %v", list, err)
+		}
+		row := taskRow(got, "csrf", "Specialist")
+		if !strings.Contains(row, `data-task-status="`+state+`"`) || !strings.Contains(row, ">Retry</button>") || strings.Contains(row, "working…") {
+			t.Fatalf("state not actionable: %s", row)
+		}
+		if err := Run("alice", task.ID); err != nil {
+			t.Fatalf("explicit retry failed: %v", err)
+		}
+		running := mustGet(t, "alice", task.ID)
+		if running.Status != StatusDoing || strings.Contains(taskRow(running, "csrf"), "/run\"") {
+			t.Fatal("retry did not become working or still offers another run")
+		}
+	}
+}

--- a/service/tasks/states_test.go
+++ b/service/tasks/states_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"mu/internal/service"
+	"mu/internal/userdb"
 )
 
 func TestNextSkipsWorkThatIsNotReady(t *testing.T) {
@@ -36,6 +37,40 @@ func TestNextSkipsWorkThatIsNotReady(t *testing.T) {
 	}
 	if got := Next("alice"); got == nil || got.ID != ready.ID {
 		t.Fatalf("ready work was not picked: %+v", got)
+	}
+}
+
+func TestReadyWorkAndOutcomeFiltersSurviveALongTaskHistory(t *testing.T) {
+	setupTasks(t)
+	ready, err := Create("alice", "Ready", "", Agent, time.Time{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, state := range []string{StatusFailed, StatusBlocked} {
+		if _, err := userdb.Create(ns, "alice", collection, map[string]any{
+			"title": state, "status": state, "assignee": Agent,
+		}, false); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// More recent personal tasks must not crowd owned state filters or pickup.
+	for i := 0; i < userdb.MaxListLimit+1; i++ {
+		if _, err := userdb.Create(ns, "alice", collection, map[string]any{
+			"title": "Personal", "status": StatusTodo, "assignee": Me,
+		}, false); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if got := Next("alice"); got == nil || got.ID != ready.ID {
+		t.Errorf("task history hid ready work: %+v", got)
+	}
+	for _, state := range []string{StatusFailed, StatusBlocked} {
+		if got := List("alice", state); len(got) != 1 || got[0].Status != state {
+			t.Errorf("task history hid %s work: %+v", state, got)
+		}
+	}
+	if Next("") != nil || Next("bob") != nil {
+		t.Fatal("ready work crossed ownership")
 	}
 }
 

--- a/service/tasks/tasks.go
+++ b/service/tasks/tasks.go
@@ -164,18 +164,18 @@ func List(owner, status string) []*Task {
 	if owner == "" {
 		return nil
 	}
-	recs, err := userdb.List(ns, owner, collection, "mine", nil, "", "", 0)
+	var where map[string]any
+	if status != "" {
+		where = map[string]any{"status": status}
+	}
+	recs, err := userdb.List(ns, owner, collection, "mine", where, "", "", 0)
 	if err != nil {
 		return nil
 	}
 
 	out := make([]*Task, 0, len(recs))
 	for _, r := range recs {
-		t := toTask(r.ID, r.Owner, r.Data)
-		if status != "" && t.Status != status {
-			continue
-		}
-		out = append(out, t)
+		out = append(out, toTask(r.ID, r.Owner, r.Data))
 	}
 	sort.SliceStable(out, func(i, j int) bool {
 		if out[i].Open() != out[j].Open() {
@@ -205,12 +205,19 @@ func Get(owner, id string) (*Task, error) {
 // to it. This is the whole point of the assignee field — an agent asking "what
 // should I be doing?" gets an answer without a person having to say it again.
 func Next(owner string) *Task {
-	for _, t := range List(owner, "") {
-		if t.Status == StatusTodo && t.Assignee == Agent && t.Delivery == nil {
-			return t
-		}
+	if owner == "" {
+		return nil
 	}
-	return nil
+	// Filter before the storage limit, so recent personal or finished work
+	// cannot hide the oldest ready task.
+	recs, err := userdb.List(ns, owner, collection, "mine", map[string]any{
+		"status": StatusTodo, "assignee": Agent,
+		"delivery_pending": map[string]any{"ne": true},
+	}, "created", "asc", 1)
+	if err != nil || len(recs) == 0 {
+		return nil
+	}
+	return toTask(recs[0].ID, recs[0].Owner, recs[0].Data)
 }
 
 // Update changes a task. Empty strings leave a field as it was, so an agent

--- a/service/tasks/tasks.go
+++ b/service/tasks/tasks.go
@@ -34,13 +34,14 @@ const (
 	collection = "tasks"
 )
 
-// The states a task moves through. Three, because a fourth would be a
-// judgement nobody has to make: it is waiting, it is being worked on, or it is
-// finished.
+// Failed and blocked work needs attention before another attempt. Keeping it
+// separate from todo prevents ordinary pickup from replaying uncertain actions.
 const (
-	StatusTodo  = "todo"
-	StatusDoing = "doing"
-	StatusDone  = "done"
+	StatusTodo    = "todo"
+	StatusDoing   = "doing"
+	StatusDone    = "done"
+	StatusFailed  = "failed"
+	StatusBlocked = "blocked"
 )
 
 // Assignee values. A task is yours unless you hand it over.
@@ -200,12 +201,12 @@ func Get(owner, id string) (*Task, error) {
 	return toTask(rec.ID, rec.Owner, rec.Data), nil
 }
 
-// Next returns the task an agent should pick up: the oldest open one assigned
+// Next returns the task an agent should pick up: the oldest ready task assigned
 // to it. This is the whole point of the assignee field — an agent asking "what
 // should I be doing?" gets an answer without a person having to say it again.
 func Next(owner string) *Task {
 	for _, t := range List(owner, "") {
-		if t.Open() && t.Assignee == Agent {
+		if t.Status == StatusTodo && t.Assignee == Agent && t.Delivery == nil {
 			return t
 		}
 	}
@@ -232,7 +233,7 @@ func update(owner, id, title, detail, status, assignee, result string, extra map
 	}
 
 	if status != "" && !validStatus(status) {
-		return nil, fmt.Errorf("status must be %s, %s or %s", StatusTodo, StatusDoing, StatusDone)
+		return nil, fmt.Errorf("status must be %s, %s, %s, %s or %s", StatusTodo, StatusDoing, StatusDone, StatusFailed, StatusBlocked)
 	}
 
 	fields := map[string]any{
@@ -343,7 +344,7 @@ func Render(ts []*Task) string {
 }
 
 func validStatus(s string) bool {
-	return s == StatusTodo || s == StatusDoing || s == StatusDone
+	return s == StatusTodo || s == StatusDoing || s == StatusDone || s == StatusFailed || s == StatusBlocked
 }
 
 // normaliseAssignee accepts the words a person or a model would use and lands


### PR DESCRIPTION
Failed agent runs and work interrupted by a restart currently return to the ordinary to-do list. That hides the reason work stopped and allows normal task pickup to repeat actions whose outcome may be uncertain.

This adds `failed` and `blocked` task states. Provider failures and empty results become failed; startup recovery marks interrupted agent tasks blocked while preserving their result, steps and responsible agent. Normal pickup skips these states, active work and pending deliveries. State filters and ready-task selection run before the storage limit so a long task history cannot hide actionable work. A stale work event cannot restart a failed or blocked task; an explicit Retry transitions it back to doing.

Tasks has Failed/Blocked filters and Retry buttons, and Home links to tasks that need attention. Pending result delivery continues independently and must finish before a retry. The service status fields accept and describe both states.

Validation:
- `go test -race ./service/tasks ./agent/work` passed.
- `go test -race ./home -run TestTaskAttentionShowsFailedAndBlockedOwnedWork` passed.
- `go vet ./service/tasks ./agent/work ./home`, formatting and `git diff --check` passed.
- Regression coverage checks persisted state, owned filters, ready-task selection, explicit retries, stale events, restart recovery, more than 200 tasks and Home visibility. The long-history regression reproduced the missing-task bug before the query fix. No live model or outbound message calls.

Advances #1565. Waiting-for-user/cancellation states and general side-effect idempotency remain separate work. Existing failed tasks stored as todo are not guessed or migrated from their result text.

CI on `b86a10c`: all four release builds, formatting and full vet passed. The test job still fails on the six unchanged baseline checks: `TestEveryConfigVarIsDocumented` (TZ), `TestTheNameIsTheSameOnEverySurface`, `TestURLPreservesExplicitPublicSurface`, `TestTheOpeningCountsAreTrue`, `TestTheAdvertisedToolCountIsTheRealOne`, and `TestPermissionsAreUnchanged` (weather_lookup). These match the preceding main/PR runs; task and work packages pass in CI. Full-suite race execution is skipped after that failure; the affected task/work packages and Home regression pass locally under the race detector. [CI run](https://github.com/micro/mu/actions/runs/34242148578).

Codex completed its initial review with no findings. The follow-up query-order change was reviewed locally and is covered by the long-history regression.