### PR TITLE
Retry external mail delivery without repeating agent work

### DIFF
--- a/internal/app/html/mu.css
+++ b/internal/app/html/mu.css
@@ -4704,7 +4704,8 @@ a.card-hover:hover {
   font-size: 13px;
 }
 
-.page-filters .tag.active {
+.page-filters .tag.active,
+.page-filters .tag.active:visited {
   background: var(--accent-color, #000);
   color: white;
 }

--- a/internal/userdb/userdb.go
+++ b/internal/userdb/userdb.go
@@ -212,8 +212,7 @@ func Delete(ns, caller, collection, id string) error {
 				return ErrForbidden
 			}
 			recs = append(recs[:i], recs[i+1:]...)
-			data.SaveJSON(k, recs)
-			return nil
+			return data.SaveJSON(k, recs)
 		}
 	}
 	return ErrNotFound
@@ -495,7 +494,9 @@ func DeleteOwner(ns, owner string) (int, error) {
 			kept = append(kept, rec)
 		}
 		if len(kept) != len(recs) {
-			data.SaveJSON(k, kept)
+			if err := data.SaveJSON(k, kept); err != nil {
+				return removed, err
+			}
 		}
 	}
 	return removed, nil

--- a/service/mail/client.go
+++ b/service/mail/client.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -318,28 +319,7 @@ func buildExternalTo(displayName, from, replyTo, to string, cc []string, subject
 // must be signed and relayed the same way — a second copy of this would be a
 // second place for DKIM to be forgotten.
 func finishExternal(message []byte, from, to string, cc []string, messageID string) (string, error) {
-	// Apply DKIM signing if configured
-	if dkimConfig != nil {
-		options := &dkim.SignOptions{
-			Domain:                 dkimConfig.Domain,
-			Selector:               dkimConfig.Selector,
-			Signer:                 dkimConfig.PrivateKey,
-			HeaderCanonicalization: dkim.CanonicalizationRelaxed,
-			BodyCanonicalization:   dkim.CanonicalizationRelaxed,
-			// Cc is signed too. A recipient list that is not covered by the
-			// signature can be rewritten in transit, which on a reply-all is
-			// the header that says who else is in the room.
-			HeaderKeys: []string{"from", "to", "cc", "subject", "date", "message-id", "mime-version", "content-type"},
-		}
-
-		var signedBuf bytes.Buffer
-		if err := dkim.Sign(&signedBuf, bytes.NewReader(message), options); err != nil {
-			app.Log("dkim", "WARNING: DKIM signing failed: %v", err)
-		} else {
-			message = signedBuf.Bytes()
-			app.Log("dkim", "Signed with DKIM (d=%s s=%s relaxed/relaxed)", dkimConfig.Domain, dkimConfig.Selector)
-		}
-	}
+	message = signExternal(message)
 
 	// Auto-whitelist: record outbound message ID + recipient so replies
 	// and future mail from this address are allowed through.
@@ -369,6 +349,33 @@ func finishExternal(message []byte, from, to string, cc []string, messageID stri
 
 	app.Log("mail", "✓ Email relayed successfully")
 	return messageID, nil
+}
+
+func signExternal(message []byte) []byte {
+	// Apply DKIM signing if configured
+	if dkimConfig != nil {
+		options := &dkim.SignOptions{
+			Domain:                 dkimConfig.Domain,
+			Selector:               dkimConfig.Selector,
+			Signer:                 dkimConfig.PrivateKey,
+			HeaderCanonicalization: dkim.CanonicalizationRelaxed,
+			BodyCanonicalization:   dkim.CanonicalizationRelaxed,
+			// Cc is signed too. A recipient list that is not covered by the
+			// signature can be rewritten in transit, which on a reply-all is
+			// the header that says who else is in the room.
+			HeaderKeys: []string{"from", "to", "cc", "subject", "date", "message-id", "mime-version", "content-type"},
+		}
+
+		var signedBuf bytes.Buffer
+		if err := dkim.Sign(&signedBuf, bytes.NewReader(message), options); err != nil {
+			app.Log("dkim", "WARNING: DKIM signing failed: %v", err)
+		} else {
+			message = signedBuf.Bytes()
+			app.Log("dkim", "Signed with DKIM (d=%s s=%s relaxed/relaxed)", dkimConfig.Domain, dkimConfig.Selector)
+		}
+	}
+
+	return message
 }
 
 // SendCalendarInvite sends an email carrying an iCalendar (.ics) invite so the
@@ -508,7 +515,8 @@ func SendReplyAll(fromID, displayName, from, to string, cc []string, subject, bo
 		}
 	}
 
-	// Everybody outside, in one message, so a thread stays one thread for them.
+	// Everybody outside, in one durable message. Each recipient has independent
+	// transport retries, so an unavailable server cannot lose somebody's copy.
 	//
 	// A failure here is remembered rather than returned, because the people on
 	// this instance are still owed their copy — the relay being down is not
@@ -517,7 +525,7 @@ func SendReplyAll(fromID, displayName, from, to string, cc []string, subject, bo
 	var messageID string
 	var relayErr error
 	if len(outside) > 0 {
-		id, err := SendExternalReplyAll(displayName, from, outside[0], outside[1:], subject,
+		id, err := queueReply(fromID, displayName, from, outside[0], outside[1:], subject,
 			bodyPlain, bodyHTML, inReplyTo, references)
 		if err != nil {
 			relayErr = err
@@ -557,6 +565,7 @@ func SendReplyAll(fromID, displayName, from, to string, cc []string, subject, bo
 			References: references,
 		}); err != nil {
 			app.Log("mail", "could not deliver the answer to %s: %v", addr, err)
+			relayErr = errors.Join(relayErr, err)
 		}
 	}
 	return messageID, relayErr

--- a/service/mail/local_delivery_test.go
+++ b/service/mail/local_delivery_test.go
@@ -139,18 +139,22 @@ func TestAnsweringSomebodyHereDeliversRatherThanRelaying(t *testing.T) {
 	}
 }
 
-// And somebody outside still goes out. A router that delivered everything
-// locally would pass the test above and break every real reply.
-func TestAnsweringSomebodyOutsideStillRelays(t *testing.T) {
+// External replies are accepted durably; transport failure no longer requires
+// running the agent again. The worker, rather than this request, owns retries.
+func TestAnsweringSomebodyOutsideQueuesTheReply(t *testing.T) {
 	withDomain(t, "mu.test")
-
-	// Nothing can relay in a test, so the proof that it tried is that it
-	// failed. Silence would mean the message was quietly dropped.
-	_, err := SendReplyAll("someone", "Agent", "agent@mu.test", "someone@example.com", nil,
-		"Re: hello", "hi", "<p>hi</p>", "", "")
-	if err == nil {
-		t.Error("an external reply reported success with no relay configured, so it " +
-			"went nowhere and said nothing")
+	id, err := SendReplyAll("someone", "Agent", "agent@mu.test", "someone@example.com", nil,
+		"Re: hello", "hi", "<p>hi</p>", "<parent@example.com>", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	rows := queuedForTest(t, "someone")
+	if len(rows) != 1 {
+		t.Fatalf("reply was not durably queued: %d", len(rows))
+	}
+	m, err := readQueued(&rows[0])
+	if err != nil || m.MessageID != id || m.Recipients[0] != "someone@example.com" {
+		t.Fatalf("wrong queued reply: %+v, %v", m, err)
 	}
 }
 
@@ -167,8 +171,7 @@ func TestAThreadWithBothKindsOfRecipientReachesBoth(t *testing.T) {
 
 	before := len(ListMessages("ccasim", 100))
 
-	// To is outside, so the relay is attempted and fails — but the local
-	// recipient in Cc must still be delivered to.
+	// To is outside and queued; the local recipient still gets its copy now.
 	_, _ = SendReplyAll("ccasim", "Agent", "agent@mu.test", "someone@example.com",
 		[]string{"ccasim@mu.test"}, "Re: both", "hi", "<p>hi</p>", "", "")
 

--- a/service/mail/mail.go
+++ b/service/mail/mail.go
@@ -174,6 +174,7 @@ func Load() {
 	// background because it is a boot-time cost proportional to the mailbox and
 	// nothing needs it before the first search.
 	go Reindex()
+	go retryOutbox()
 }
 
 // fixThreading repairs broken threading relationships and computes ThreadID after loading
@@ -570,6 +571,11 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 	_, acc, err := auth.RequireSession(r)
 	if err != nil {
 		app.Unauthorized(w, r)
+		return
+	}
+
+	if r.URL.Query().Get("view") == "outbox" {
+		outboxPage(w, r, acc.ID)
 		return
 	}
 
@@ -1427,7 +1433,7 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 	if len(spamMsgs) > 0 {
 		filteredLabel = fmt.Sprintf("Filtered (%d)", len(spamMsgs))
 	}
-	tabs := fmt.Sprintf(`<div class="mail-tabs"><a href="/mail" class="%s">%s</a><a href="/mail?view=sent" class="%s">Sent</a><a href="/mail?view=filtered" class="%s">%s</a></div>`,
+	tabs := fmt.Sprintf(`<div class="mail-tabs"><a href="/mail" class="%s">%s</a><a href="/mail?view=sent" class="%s">Sent</a><a href="/mail?view=outbox" class="mail-tab">Outbox</a><a href="/mail?view=filtered" class="%s">%s</a></div>`,
 		inboxClass, inboxLabel, sentClass, filteredClass, filteredLabel)
 
 	// Search bar
@@ -2281,6 +2287,7 @@ func RecentMessages(limit int) []*Message {
 // The same shape of bug as the one internal/thread had: a record written by the
 // machinery rather than owned by a service, so nothing deleted it.
 func DeleteInbox(userID string) {
+	deleteOutbox(userID)
 	mutex.Lock()
 	kept := messages[:0]
 	var gone []*Message

--- a/service/mail/outbound.go
+++ b/service/mail/outbound.go
@@ -103,7 +103,7 @@ func WroteToUs(owner, addr string) bool {
 	return false
 }
 
-// SendOut delivers one message off this instance and files a copy.
+// SendOut accepts one external message into the durable outbox.
 //
 // The order is the order everything else here charges in: everything that can
 // refuse does so before the provider is called, because after that the mail has
@@ -115,7 +115,7 @@ func SendOut(owner, displayName, to, subject, bodyPlain, bodyHTML, replyTo strin
 
 // ReplyOut is SendOut for a message that continues a thread.
 //
-// Same gate, same charge, same provider — the difference is two headers.
+// Same gate, same charge, same outbox — the difference is two headers.
 // In-Reply-To names the message being answered and References carries the whole
 // chain, and a receiving client needs both: Gmail threads on References, and one
 // that sees only In-Reply-To files a long conversation as a run of unrelated
@@ -146,7 +146,7 @@ func ReplyOut(owner, displayName, to, subject, bodyPlain, bodyHTML, inReplyTo, r
 		bodyHTML = convertPlainTextToHTML(bodyPlain)
 	}
 	from := EmailForUser(owner, ConfiguredDomain())
-	messageID, err := SendExternalReply(displayName, from, to, subject, bodyPlain, bodyHTML,
+	messageID, err := queueReply(owner, displayName, from, to, nil, subject, bodyPlain, bodyHTML,
 		inReplyTo, references)
 	if err != nil {
 		return "", err

--- a/service/mail/outbound.go
+++ b/service/mail/outbound.go
@@ -128,6 +128,9 @@ func SendOut(owner, displayName, to, subject, bodyPlain, bodyHTML, replyTo strin
 // this instance's own record and wrong in everybody else's.
 func ReplyOut(owner, displayName, to, subject, bodyPlain, bodyHTML, inReplyTo, references string) (string, error) {
 	to = strings.TrimSpace(to)
+	if len(bodyPlain)+len(bodyHTML) > maxOutgoingBytes {
+		return "", fmt.Errorf("outgoing message is too large")
+	}
 	if !IsExternalEmail(to) {
 		return "", fmt.Errorf("%s is on this instance — that is not mail leaving it", to)
 	}

--- a/service/mail/outbox.go
+++ b/service/mail/outbox.go
@@ -1,0 +1,206 @@
+package mail
+
+// An accepted send owns its transport retries. The model must not repeat its
+// work because SMTP is unavailable. Store the exact signed bytes and progress
+// per recipient; an uncertain SMTP acknowledgement may still cause a duplicate
+// at the far end, but retries retain the same Message-ID and MIME content.
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"mu/internal/app"
+	"mu/internal/auth"
+	"mu/internal/userdb"
+)
+
+const outboxCollection = "outbox"
+
+var outboxWake = make(chan struct{}, 1)
+var outboxRunMu sync.Mutex
+
+type queuedMail struct {
+	From       string          `json:"from"`
+	Subject    string          `json:"subject"`
+	MessageID  string          `json:"message_id"`
+	Message    []byte          `json:"message"`
+	Recipients []string        `json:"recipients"`
+	Delivered  map[string]bool `json:"delivered"`
+	Attempts   int             `json:"attempts"`
+	Created    time.Time       `json:"created"`
+	LastError  string          `json:"last_error,omitempty"`
+}
+
+func queueReply(owner, display, from, to string, cc []string, subject, plain, html, parent, refs string) (string, error) {
+	message, id := buildExternalTo(display, from, "", to, cc, subject, plain, html, parent, refs)
+	return enqueueMail(owner, queuedMail{From: from, Subject: subject, MessageID: id,
+		Message: signExternal(message), Recipients: append([]string{to}, cc...)})
+}
+
+func enqueueMail(owner string, m queuedMail) (string, error) {
+	if owner == "" || m.From == "" || m.MessageID == "" || len(m.Message) == 0 {
+		return "", fmt.Errorf("outgoing mail needs an owner, sender and message")
+	}
+	if len(m.Message) > maxOutgoingBytes*2 {
+		return "", fmt.Errorf("outgoing message is too large")
+	}
+	seen := map[string]bool{}
+	var recipients []string
+	for _, addr := range m.Recipients {
+		addr = strings.TrimSpace(addr)
+		if addr == "" || strings.ContainsAny(addr, "\r\n") || !IsExternalAddress(addr) {
+			return "", fmt.Errorf("invalid external recipient")
+		}
+		key := strings.ToLower(addr)
+		if !seen[key] {
+			recipients = append(recipients, addr)
+			seen[key] = true
+		}
+	}
+	if len(recipients) == 0 {
+		return "", fmt.Errorf("no recipients")
+	}
+	m.Recipients, m.Delivered, m.Created = recipients, map[string]bool{}, time.Now().UTC()
+	fields, err := outboxFields(m, true, time.Now())
+	if err != nil {
+		return "", err
+	}
+	if _, err := userdb.Create("mail", owner, outboxCollection, fields, false); err != nil {
+		return "", err
+	}
+	select {
+	case outboxWake <- struct{}{}:
+	default:
+	}
+	return m.MessageID, nil
+}
+
+func outboxFields(m queuedMail, pending bool, next time.Time) (map[string]any, error) {
+	b, err := json.Marshal(m)
+	if err != nil {
+		return nil, err
+	}
+	payload, err := encrypt(string(b))
+	if err != nil {
+		return nil, err
+	}
+	return map[string]any{"payload": payload, "pending": pending, "next": float64(next.Unix())}, nil
+}
+
+func readQueued(rec *userdb.Record) (queuedMail, error) {
+	var m queuedMail
+	payload, _ := rec.Data["payload"].(string)
+	plain, err := decrypt(payload)
+	if err != nil {
+		return m, err
+	}
+	err = json.Unmarshal([]byte(plain), &m)
+	return m, err
+}
+
+func saveQueued(owner, id string, m queuedMail, pending bool, next time.Time) error {
+	fields, err := outboxFields(m, pending, next)
+	if err != nil {
+		return err
+	}
+	_, err = userdb.Update("mail", owner, outboxCollection, id, fields, false)
+	return err
+}
+
+// processQueued takes its transport as an argument so failures and restart
+// recovery can be tested without an SMTP connection or a package-level hook.
+func processQueued(owner, id string, relay func(string, string, []byte) error) error {
+	outboxRunMu.Lock()
+	defer outboxRunMu.Unlock()
+	rec, err := userdb.Get("mail", owner, outboxCollection, id)
+	if err != nil {
+		return err
+	}
+	if rec.Data["pending"] != true {
+		return nil
+	}
+	m, err := readQueued(rec)
+	if err != nil {
+		return err
+	}
+	if m.Delivered == nil {
+		m.Delivered = map[string]bool{}
+	}
+	if time.Since(m.Created) >= 48*time.Hour {
+		m.LastError = "Delivery stopped after 48 hours. Review the recipients before retrying."
+		return saveQueued(owner, id, m, false, time.Now())
+	}
+	m.Attempts++
+	delay := time.Minute * time.Duration(1<<min(m.Attempts-1, 6))
+	next := time.Now().Add(delay)
+	// Persist the attempt before entering a transport that may not return.
+	if err := saveQueued(owner, id, m, true, next); err != nil {
+		return err
+	}
+	m.LastError = ""
+	for _, addr := range m.Recipients {
+		if m.Delivered[addr] {
+			continue
+		}
+		RecordOutbound(m.MessageID, addr)
+		if err := relay(m.From, addr, m.Message); err != nil {
+			m.LastError = err.Error()
+		} else {
+			m.Delivered[addr] = true
+		}
+		// A successful recipient must never be retried merely because a later
+		// recipient failed. If this write fails, stop rather than sending more.
+		if err := saveQueued(owner, id, m, true, next); err != nil {
+			return err
+		}
+	}
+	if len(m.Delivered) == len(m.Recipients) {
+		return userdb.Delete("mail", owner, outboxCollection, id)
+	}
+	return nil
+}
+
+func retryOutbox() {
+	for {
+		for _, acc := range auth.AllAccounts() {
+			if acc == nil {
+				continue
+			}
+			// Every processed record leaves the due set, so this also drains past
+			// the storage page limit without a failing first page starving others.
+			for {
+				batch, err := userdb.List("mail", acc.ID, outboxCollection, "mine", map[string]any{
+					"pending": true, "next": map[string]any{"lte": float64(time.Now().Unix())},
+				}, "next", "asc", userdb.MaxListLimit)
+				if err != nil || len(batch) == 0 {
+					break
+				}
+				failed := false
+				for _, rec := range batch {
+					if err := processQueued(acc.ID, rec.ID, RelayToExternal); err != nil {
+						app.Log("mail", "outbox %s: %v", rec.ID, err)
+						failed = true
+					}
+				}
+				if failed {
+					break
+				} // storage errors must not create a busy retry loop
+			}
+		}
+		select {
+		case <-outboxWake:
+		case <-time.After(time.Minute):
+		}
+	}
+}
+
+func deleteOutbox(owner string) {
+	outboxRunMu.Lock()
+	defer outboxRunMu.Unlock()
+	if _, err := userdb.DeleteOwner("mail", owner); err != nil {
+		app.Log("mail", "deleting outbox for %s: %v", owner, err)
+	}
+}

--- a/service/mail/outbox.go
+++ b/service/mail/outbox.go
@@ -6,14 +6,18 @@ package mail
 // at the far end, but retries retain the same Message-ID and MIME content.
 
 import (
+	"crypto/sha256"
 	"encoding/json"
 	"fmt"
+	"os"
 	"strings"
 	"sync"
 	"time"
 
+	"github.com/google/uuid"
 	"mu/internal/app"
 	"mu/internal/auth"
+	"mu/internal/data"
 	"mu/internal/userdb"
 )
 
@@ -26,7 +30,8 @@ type queuedMail struct {
 	From       string          `json:"from"`
 	Subject    string          `json:"subject"`
 	MessageID  string          `json:"message_id"`
-	Message    []byte          `json:"message"`
+	Message    []byte          `json:"-"`
+	File       string          `json:"file"`
 	Recipients []string        `json:"recipients"`
 	Delivered  map[string]bool `json:"delivered"`
 	Attempts   int             `json:"attempts"`
@@ -44,7 +49,7 @@ func enqueueMail(owner string, m queuedMail) (string, error) {
 	if owner == "" || m.From == "" || m.MessageID == "" || len(m.Message) == 0 {
 		return "", fmt.Errorf("outgoing mail needs an owner, sender and message")
 	}
-	if len(m.Message) > maxOutgoingBytes*2 {
+	if len(m.Message) > maxOutgoingBytes*8+(64<<10) {
 		return "", fmt.Errorf("outgoing message is too large")
 	}
 	seen := map[string]bool{}
@@ -64,6 +69,24 @@ func enqueueMail(owner string, m queuedMail) (string, error) {
 		return "", fmt.Errorf("no recipients")
 	}
 	m.Recipients, m.Delivered, m.Created = recipients, map[string]bool{}, time.Now().UTC()
+	m.File = outboxDirectory(owner) + "/" + uuid.NewString() + ".eml"
+	encrypted, err := encrypt(string(m.Message))
+	if err != nil {
+		return "", err
+	}
+	if err := data.SaveFile(m.File, encrypted); err != nil {
+		return "", err
+	}
+	// The generic record carries only encrypted envelope/progress metadata.
+	// MIME bodies can be megabytes and do not belong in its 64 KiB records.
+	m.Message = nil
+	keepFile := false
+	defer func() {
+		if !keepFile {
+			_ = data.DeleteFile(m.File)
+		}
+	}()
+
 	fields, err := outboxFields(m, true, time.Now())
 	if err != nil {
 		return "", err
@@ -71,6 +94,7 @@ func enqueueMail(owner string, m queuedMail) (string, error) {
 	if _, err := userdb.Create("mail", owner, outboxCollection, fields, false); err != nil {
 		return "", err
 	}
+	keepFile = true
 	select {
 	case outboxWake <- struct{}{}:
 	default:
@@ -129,6 +153,9 @@ func processQueued(owner, id string, relay func(string, string, []byte) error) e
 	if m.Delivered == nil {
 		m.Delivered = map[string]bool{}
 	}
+	if len(m.Delivered) == len(m.Recipients) {
+		return removeQueued(owner, id, m)
+	}
 	if time.Since(m.Created) >= 48*time.Hour {
 		m.LastError = "Delivery stopped after 48 hours. Review the recipients before retrying."
 		return saveQueued(owner, id, m, false, time.Now())
@@ -141,12 +168,17 @@ func processQueued(owner, id string, relay func(string, string, []byte) error) e
 		return err
 	}
 	m.LastError = ""
+	raw, err := queuedBytes(m)
+	if err != nil {
+		m.LastError = "The saved message could not be read. Restore it or discard this delivery."
+		return saveQueued(owner, id, m, false, next)
+	}
 	for _, addr := range m.Recipients {
 		if m.Delivered[addr] {
 			continue
 		}
 		RecordOutbound(m.MessageID, addr)
-		if err := relay(m.From, addr, m.Message); err != nil {
+		if err := relay(m.From, addr, raw); err != nil {
 			m.LastError = err.Error()
 		} else {
 			m.Delivered[addr] = true
@@ -158,7 +190,7 @@ func processQueued(owner, id string, relay func(string, string, []byte) error) e
 		}
 	}
 	if len(m.Delivered) == len(m.Recipients) {
-		return userdb.Delete("mail", owner, outboxCollection, id)
+		return removeQueued(owner, id, m)
 	}
 	return nil
 }
@@ -202,5 +234,39 @@ func deleteOutbox(owner string) {
 	defer outboxRunMu.Unlock()
 	if _, err := userdb.DeleteOwner("mail", owner); err != nil {
 		app.Log("mail", "deleting outbox for %s: %v", owner, err)
+		return
 	}
+	prefix := outboxDirectory(owner)
+	files, err := data.ListKeys(prefix)
+	if err != nil {
+		app.Log("mail", "listing outbox bodies: %v", err)
+		return
+	}
+	for _, name := range files {
+		if err := data.DeleteFile(prefix + "/" + name); err != nil {
+			app.Log("mail", "deleting outbox body: %v", err)
+		}
+	}
+}
+
+func outboxDirectory(owner string) string {
+	return fmt.Sprintf("mail/outbox/%x", sha256.Sum256([]byte(owner)))
+}
+
+func queuedBytes(m queuedMail) ([]byte, error) {
+	b, err := data.LoadFile(m.File)
+	if err != nil {
+		return nil, err
+	}
+	plain, err := decrypt(string(b))
+	return []byte(plain), err
+}
+
+// Progress is already durable. Removing the body before the receipt means a
+// crash during cleanup is retried without needing the body or sending again.
+func removeQueued(owner, id string, m queuedMail) error {
+	if err := data.DeleteFile(m.File); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return userdb.Delete("mail", owner, outboxCollection, id)
 }

--- a/service/mail/outbox_page.go
+++ b/service/mail/outbox_page.go
@@ -18,7 +18,13 @@ func outboxPage(w http.ResponseWriter, r *http.Request, owner string) {
 			app.Forbidden(w, r, "Invalid CSRF token")
 			return
 		}
-		if err := retryQueued(owner, r.FormValue("id")); err != nil {
+		var err error
+		if r.FormValue("action") == "discard" {
+			err = discardQueued(owner, r.FormValue("id"))
+		} else {
+			err = retryQueued(owner, r.FormValue("id"))
+		}
+		if err != nil {
 			app.Respond(w, r, app.Response{Title: "Outbox", HTML: `<p>` + html.EscapeString(err.Error()) + `</p>`})
 			return
 		}
@@ -56,7 +62,7 @@ func outboxPage(w http.ResponseWriter, r *http.Request, owner string) {
 			b.WriteString(`<p>` + html.EscapeString(m.LastError) + `</p>`)
 		}
 		if !pending {
-			fmt.Fprintf(&b, `<form method="post" action="/mail?view=outbox" class="form-actions"><input type="hidden" name="_csrf" value="%s"><input type="hidden" name="id" value="%s"><button type="submit">Retry</button></form>`, html.EscapeString(auth.CSRFToken(r)), html.EscapeString(rec.ID))
+			fmt.Fprintf(&b, `<form method="post" action="/mail?view=outbox" class="form-actions"><input type="hidden" name="_csrf" value="%s"><input type="hidden" name="id" value="%s"><button type="submit" name="action" value="retry">Retry</button><button type="submit" name="action" value="discard">Discard</button></form>`, html.EscapeString(auth.CSRFToken(r)), html.EscapeString(rec.ID))
 		}
 		b.WriteString(`</div>`)
 	}
@@ -88,4 +94,21 @@ func retryQueued(owner, id string) error {
 	default:
 	}
 	return nil
+}
+
+func discardQueued(owner, id string) error {
+	outboxRunMu.Lock()
+	defer outboxRunMu.Unlock()
+	rec, err := userdb.Get("mail", owner, outboxCollection, id)
+	if err != nil {
+		return fmt.Errorf("no outgoing message here with that id")
+	}
+	if rec.Data["pending"] == true {
+		return fmt.Errorf("this message is still being delivered")
+	}
+	m, err := readQueued(rec)
+	if err != nil {
+		return err
+	}
+	return removeQueued(owner, id, m)
 }

--- a/service/mail/outbox_page.go
+++ b/service/mail/outbox_page.go
@@ -1,0 +1,91 @@
+package mail
+
+import (
+	"fmt"
+	"html"
+	"net/http"
+	"strings"
+	"time"
+
+	"mu/internal/app"
+	"mu/internal/auth"
+	"mu/internal/userdb"
+)
+
+func outboxPage(w http.ResponseWriter, r *http.Request, owner string) {
+	if r.Method == http.MethodPost {
+		if !auth.StrictCSRF(r) {
+			app.Forbidden(w, r, "Invalid CSRF token")
+			return
+		}
+		if err := retryQueued(owner, r.FormValue("id")); err != nil {
+			app.Respond(w, r, app.Response{Title: "Outbox", HTML: `<p>` + html.EscapeString(err.Error()) + `</p>`})
+			return
+		}
+		http.Redirect(w, r, "/mail?view=outbox", http.StatusSeeOther)
+		return
+	}
+	auth.SetCSRFCookie(w, r)
+	rows, err := userdb.List("mail", owner, outboxCollection, "mine", nil, "", "", userdb.MaxListLimit)
+	if err != nil {
+		app.Respond(w, r, app.Response{Title: "Outbox", HTML: `<p>Could not load outgoing mail.</p>`})
+		return
+	}
+	var b strings.Builder
+	b.WriteString(`<div class="page-stack"><p>Outgoing mail retries automatically. Successful deliveries leave this list. A retry keeps the original message and skips recipients who already received it.</p>`)
+	if len(rows) == 0 {
+		b.WriteString(`<p>No pending deliveries.</p>`)
+	}
+	for _, rec := range rows {
+		m, err := readQueued(&rec)
+		if err != nil {
+			b.WriteString(`<div class="card">Could not read a saved delivery.</div>`)
+			continue
+		}
+		state := "Queued"
+		if m.Attempts > 0 {
+			state = "Retrying"
+		}
+		pending := rec.Data["pending"] == true
+		if !pending {
+			state = "Needs attention"
+		}
+		fmt.Fprintf(&b, `<div class="card page-stack"><strong>%s</strong><div>%s</div><div>%s · %d of %d recipients accepted</div>`,
+			html.EscapeString(m.Subject), html.EscapeString(strings.Join(m.Recipients, ", ")), state, len(m.Delivered), len(m.Recipients))
+		if m.LastError != "" {
+			b.WriteString(`<p>` + html.EscapeString(m.LastError) + `</p>`)
+		}
+		if !pending {
+			fmt.Fprintf(&b, `<form method="post" action="/mail?view=outbox" class="form-actions"><input type="hidden" name="_csrf" value="%s"><input type="hidden" name="id" value="%s"><button type="submit">Retry</button></form>`, html.EscapeString(auth.CSRFToken(r)), html.EscapeString(rec.ID))
+		}
+		b.WriteString(`</div>`)
+	}
+	b.WriteString(`</div>`)
+	page := app.Page(app.PageOpts{Filters: `<div class="mail-tabs"><a href="/mail" class="mail-tab">Inbox</a><a href="/mail?view=sent" class="mail-tab">Sent</a><a href="/mail?view=outbox" class="mail-tab active">Outbox</a></div>`, Content: b.String()})
+	app.Respond(w, r, app.Response{Title: "Outbox", HTML: page})
+}
+
+func retryQueued(owner, id string) error {
+	outboxRunMu.Lock()
+	defer outboxRunMu.Unlock()
+	rec, err := userdb.Get("mail", owner, outboxCollection, id)
+	if err != nil {
+		return fmt.Errorf("no outgoing message here with that id")
+	}
+	if rec.Data["pending"] == true {
+		return fmt.Errorf("this message is already queued")
+	}
+	m, err := readQueued(rec)
+	if err != nil {
+		return err
+	}
+	m.Created, m.Attempts, m.LastError = time.Now().UTC(), 0, ""
+	if err := saveQueued(owner, id, m, true, time.Now()); err != nil {
+		return err
+	}
+	select {
+	case outboxWake <- struct{}{}:
+	default:
+	}
+	return nil
+}

--- a/service/mail/outbox_test.go
+++ b/service/mail/outbox_test.go
@@ -1,0 +1,218 @@
+package mail
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"mu/internal/auth"
+	"mu/internal/userdb"
+)
+
+func queuedForTest(t *testing.T, owner string) []userdb.Record {
+	t.Helper()
+	rows, err := userdb.List("mail", owner, outboxCollection, "mine", nil, "", "", 200)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return rows
+}
+
+func makeQueued(t *testing.T, owner string, recipients ...string) userdb.Record {
+	t.Helper()
+	withDomain(t, "mu.test")
+	_, err := queueReply(owner, "Specialist", "agent@mu.test", recipients[0], recipients[1:],
+		"Re: Tomorrow", "A private answer", "<p>A private answer</p>", "<parent@example.com>", "<root@example.com>")
+	if err != nil {
+		t.Fatal(err)
+	}
+	rows := queuedForTest(t, owner)
+	if len(rows) != 1 {
+		t.Fatalf("want one outgoing record, got %d", len(rows))
+	}
+	return rows[0]
+}
+
+func TestOutboxRetriesOnlyFailedRecipientsUsingTheOriginalMessage(t *testing.T) {
+	owner := t.Name()
+	rec := makeQueued(t, owner, "first@example.com", "second@example.com", "FIRST@example.com")
+	m, err := readQueued(&rec)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(m.Recipients) != 2 {
+		t.Fatal("duplicate recipient was not removed")
+	}
+	calls := map[string]int{}
+	relay := func(from, to string, raw []byte) error {
+		calls[to]++
+		if from != m.From || !bytes.Equal(raw, m.Message) || !bytes.Contains(raw, []byte(m.MessageID)) || !bytes.Contains(raw, []byte("<root@example.com> <parent@example.com>")) {
+			t.Fatal("retry changed sender, message or threading")
+		}
+		if to == "second@example.com" && calls[to] == 1 {
+			return fmt.Errorf("temporary SMTP failure")
+		}
+		return nil
+	}
+	if err := processQueued(owner, rec.ID, relay); err != nil {
+		t.Fatal(err)
+	}
+	// Reloading is the restart boundary: progress exists only in the store.
+	rows := queuedForTest(t, owner)
+	got, err := readQueued(&rows[0])
+	if err != nil || !got.Delivered["first@example.com"] || got.Delivered["second@example.com"] || got.LastError == "" {
+		t.Fatalf("progress lost: %+v, %v", got, err)
+	}
+	if err := processQueued(owner, rec.ID, relay); err != nil {
+		t.Fatal(err)
+	}
+	if calls["first@example.com"] != 1 || calls["second@example.com"] != 2 || len(queuedForTest(t, owner)) != 0 {
+		t.Fatalf("incorrect retries: %+v", calls)
+	}
+}
+
+func TestOutboxConcurrentAttemptsDoNotResendAcceptedMail(t *testing.T) {
+	owner := t.Name()
+	rec := makeQueued(t, owner, "one@example.com")
+	var wg sync.WaitGroup
+	calls := 0
+	for range 12 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = processQueued(owner, rec.ID, func(string, string, []byte) error { calls++; return nil })
+		}()
+	}
+	wg.Wait()
+	if calls != 1 {
+		t.Fatalf("sent %d times", calls)
+	}
+}
+
+func TestOutboxExpiryExplicitRetryAndOwnership(t *testing.T) {
+	owner := t.Name()
+	rec := makeQueued(t, owner, "one@example.com", "two@example.com")
+	m, _ := readQueued(&rec)
+	m.Created = time.Now().Add(-49 * time.Hour)
+	m.Delivered["one@example.com"] = true
+	if err := saveQueued(owner, rec.ID, m, true, time.Now()); err != nil {
+		t.Fatal(err)
+	}
+	calls := 0
+	relay := func(string, string, []byte) error { calls++; return nil }
+	if err := processQueued("another-owner", rec.ID, relay); err == nil {
+		t.Fatal("cross-owner send")
+	}
+	if err := processQueued(owner, rec.ID, relay); err != nil {
+		t.Fatal(err)
+	}
+	if calls != 0 {
+		t.Fatal("expired message was sent")
+	}
+	if err := retryQueued("another-owner", rec.ID); err == nil {
+		t.Fatal("cross-owner retry")
+	}
+	if err := retryQueued(owner, rec.ID); err != nil {
+		t.Fatal(err)
+	}
+	if err := processQueued(owner, rec.ID, relay); err != nil {
+		t.Fatal(err)
+	}
+	if calls != 1 {
+		t.Fatal("retry repeated a previously accepted recipient")
+	}
+}
+
+func TestOutboxPersistsBeforeAcceptanceAndEncryptsThePayload(t *testing.T) {
+	oldKey, oldEnabled := encKey, encEnabled
+	encKey, encEnabled = bytes.Repeat([]byte{7}, 32), true
+	t.Cleanup(func() { encKey, encEnabled = oldKey, oldEnabled })
+	owner := t.Name()
+	rec := makeQueued(t, owner, "private@example.com")
+	payload, _ := rec.Data["payload"].(string)
+	if !strings.HasPrefix(payload, encPrefix) || strings.Contains(payload, "private@example.com") || strings.Contains(payload, "private answer") {
+		t.Fatal("outbox leaked plaintext")
+	}
+	m, err := readQueued(&rec)
+	if err != nil || !bytes.Contains(m.Message, []byte("A private answer")) {
+		t.Fatalf("could not recover encrypted message: %v", err)
+	}
+	// A store that cannot be written must never report acceptance.
+	t.Setenv("HOME", t.TempDir())
+	if err := os.MkdirAll(filepath.Join(os.Getenv("HOME"), ".mu", "data", "mail", "db", "outbox.json"), 0700); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := enqueueMail(owner, m); err == nil {
+		t.Fatal("unpersisted mail was accepted")
+	}
+}
+
+func TestOutboxDeletionAndStatusDoNotCrossAccounts(t *testing.T) {
+	rec := makeQueued(t, "outbox-owner", "private@example.com")
+	other := makeQueued(t, "outbox-other", "other@example.com")
+	w := httptest.NewRecorder()
+	outboxPage(w, httptest.NewRequest("GET", "/mail?view=outbox", nil), "outbox-other")
+	if strings.Contains(w.Body.String(), "private@example.com") || !strings.Contains(w.Body.String(), "other@example.com") {
+		t.Fatal("outbox page crossed ownership")
+	}
+	deleteOutbox("outbox-owner")
+	if _, err := userdb.Get("mail", "outbox-owner", outboxCollection, rec.ID); err == nil {
+		t.Fatal("deleted owner's mail remains queued")
+	}
+	if _, err := userdb.Get("mail", "outbox-other", outboxCollection, other.ID); err != nil {
+		t.Fatal("deleted another owner's mail")
+	}
+}
+
+func TestOutboxRetryRequiresTheOwnersSessionAndCSRF(t *testing.T) {
+	acc := mailAccount(t, "outboxcsrf")
+	sess, err := auth.CreateSession(acc.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rec := makeQueued(t, acc.ID, "one@example.com")
+	m, _ := readQueued(&rec)
+	if err := saveQueued(acc.ID, rec.ID, m, false, time.Now()); err != nil {
+		t.Fatal(err)
+	}
+	request := func(token string) *http.Request {
+		form := url.Values{"id": {rec.ID}}
+		if token != "" {
+			form.Set("_csrf", token)
+		}
+		r := httptest.NewRequest("POST", "/mail?view=outbox", strings.NewReader(form.Encode()))
+		r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		r.AddCookie(&http.Cookie{Name: "session", Value: sess.Token})
+		return r
+	}
+	r := request("")
+	w := httptest.NewRecorder()
+	Handler(w, r)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("missing CSRF accepted: %d", w.Code)
+	}
+	w = httptest.NewRecorder()
+	Handler(w, request(auth.CSRFToken(r)))
+	if w.Code != http.StatusSeeOther {
+		t.Fatalf("owned retry failed: %d, %s", w.Code, w.Body.String())
+	}
+	rows := queuedForTest(t, acc.ID)
+	if len(rows) != 1 || rows[0].Data["pending"] != true {
+		t.Fatal("retry did not become pending")
+	}
+}
+
+func TestReplyAllReportsLocalDeliveryFailure(t *testing.T) {
+	withDomain(t, "mu.test")
+	if _, err := SendReplyAll("outbox-local", "Agent", "agent@mu.test", "missing-local-recipient@mu.test", nil, "Reply", "Answer", "", "", ""); err == nil {
+		t.Fatal("missing local mailbox was reported as delivered")
+	}
+}

--- a/service/mail/outbox_test.go
+++ b/service/mail/outbox_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"mu/internal/auth"
+	"mu/internal/data"
 	"mu/internal/userdb"
 )
 
@@ -51,10 +52,14 @@ func TestOutboxRetriesOnlyFailedRecipientsUsingTheOriginalMessage(t *testing.T) 
 	if len(m.Recipients) != 2 {
 		t.Fatal("duplicate recipient was not removed")
 	}
+	original, err := queuedBytes(m)
+	if err != nil {
+		t.Fatal(err)
+	}
 	calls := map[string]int{}
 	relay := func(from, to string, raw []byte) error {
 		calls[to]++
-		if from != m.From || !bytes.Equal(raw, m.Message) || !bytes.Contains(raw, []byte(m.MessageID)) || !bytes.Contains(raw, []byte("<root@example.com> <parent@example.com>")) {
+		if from != m.From || !bytes.Equal(raw, original) || !bytes.Contains(raw, []byte(m.MessageID)) || !bytes.Contains(raw, []byte("<root@example.com> <parent@example.com>")) {
 			t.Fatal("retry changed sender, message or threading")
 		}
 		if to == "second@example.com" && calls[to] == 1 {
@@ -142,9 +147,11 @@ func TestOutboxPersistsBeforeAcceptanceAndEncryptsThePayload(t *testing.T) {
 		t.Fatal("outbox leaked plaintext")
 	}
 	m, err := readQueued(&rec)
-	if err != nil || !bytes.Contains(m.Message, []byte("A private answer")) {
+	raw, readErr := queuedBytes(m)
+	if err != nil || readErr != nil || !bytes.Contains(raw, []byte("A private answer")) {
 		t.Fatalf("could not recover encrypted message: %v", err)
 	}
+	m.Message = raw
 	// A store that cannot be written must never report acceptance.
 	t.Setenv("HOME", t.TempDir())
 	if err := os.MkdirAll(filepath.Join(os.Getenv("HOME"), ".mu", "data", "mail", "db", "outbox.json"), 0700); err != nil {
@@ -214,5 +221,42 @@ func TestReplyAllReportsLocalDeliveryFailure(t *testing.T) {
 	withDomain(t, "mu.test")
 	if _, err := SendReplyAll("outbox-local", "Agent", "agent@mu.test", "missing-local-recipient@mu.test", nil, "Reply", "Answer", "", "", ""); err == nil {
 		t.Fatal("missing local mailbox was reported as delivered")
+	}
+}
+
+func TestLargeMailUsesEncryptedBodyStorageAndCanBeDiscarded(t *testing.T) {
+	owner := t.Name()
+	withDomain(t, "mu.test")
+	oldKey, oldEnabled := encKey, encEnabled
+	encKey, encEnabled = bytes.Repeat([]byte{3}, 32), true
+	t.Cleanup(func() { encKey, encEnabled = oldKey, oldEnabled })
+	body := strings.Repeat("private body ", maxOutgoingBytes/len("private body "))
+	id, err := queueReply(owner, "Agent", "agent@mu.test", "one@example.com", nil, "Large answer", body, "", "", "")
+	if err != nil || id == "" {
+		t.Fatalf("mail-size body was rejected: %v", err)
+	}
+	rows := queuedForTest(t, owner)
+	m, err := readQueued(&rows[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, err := data.LoadFile(m.File)
+	if err != nil || bytes.Contains(raw, []byte("private body")) {
+		t.Fatal("body missing or stored unencrypted")
+	}
+	if err := saveQueued(owner, rows[0].ID, m, false, time.Now()); err != nil {
+		t.Fatal(err)
+	}
+	if err := discardQueued("stranger", rows[0].ID); err == nil {
+		t.Fatal("cross-owner discard")
+	}
+	if err := discardQueued(owner, rows[0].ID); err != nil {
+		t.Fatal(err)
+	}
+	if len(queuedForTest(t, owner)) != 0 {
+		t.Fatal("discard did not release record capacity")
+	}
+	if _, err := data.LoadFile(m.File); !os.IsNotExist(err) {
+		t.Fatal("discard retained the body")
 	}
 }

--- a/service/mail/relay.go
+++ b/service/mail/relay.go
@@ -70,11 +70,15 @@ func relayViaSubmission(host, from, to string, data []byte) error {
 		return fmt.Errorf("SMTP_RELAY_HOST is not a host and port: %v", err)
 	}
 
+	deadline := time.Now().Add(time.Minute)
 	conn, err := net.DialTimeout("tcp", host, 30*time.Second)
 	if err != nil {
 		return fmt.Errorf("could not reach the relay at %s: %v", host, err)
 	}
 	defer conn.Close()
+	if err := conn.SetDeadline(deadline); err != nil {
+		return err
+	}
 
 	c, err := smtp.NewClient(conn, name)
 	if err != nil {

--- a/service/mail/service.go
+++ b/service/mail/service.go
@@ -185,7 +185,9 @@ type SendRequest struct {
 }
 
 type SendResponse struct {
-	Result string `json:"result" description:"Confirmation, saying whether it went out over SMTP or stayed on this instance"`
+	MessageID string `json:"message_id,omitempty" description:"Stable identifier for the accepted message"`
+	State     string `json:"state,omitempty" description:"queued for external delivery, or delivered locally"`
+	Result    string `json:"result" description:"Confirmation: accepted into the external outbox, or delivered locally"`
 }
 
 // Send writes to somebody, wherever they are.
@@ -215,12 +217,14 @@ func (Server) Send(ctx context.Context, req *SendRequest, rsp *SendResponse) err
 	// had its own copy, and the copy dropped the tag on the way to DeliverHere,
 	// so mail to asim+research@ was filed and woke nothing.
 	if !IsExternalEmail(to) {
-		if _, err := Deliver(Outgoing{
+		messageID, err := Deliver(Outgoing{
 			FromID: acc.ID, Display: acc.Name, To: to,
 			Subject: req.Subject, Body: req.Body,
-		}); err != nil {
+		})
+		if err != nil {
 			return err
 		}
+		rsp.MessageID, rsp.State = messageID, "delivered"
 		rsp.Result = "Sent to " + to + " on this instance."
 		return nil
 	}
@@ -229,11 +233,12 @@ func (Server) Send(ctx context.Context, req *SendRequest, rsp *SendResponse) err
 	if err != nil {
 		return err
 	}
-	// Kept in Sent whether or not the copy succeeds: the mail has gone.
+	// The accepted message is durable in the outbox even if this sent copy fails.
 	if err := SendMessage(acc.Name, acc.ID, to, to, req.Subject, req.Body, "", messageID); err != nil {
 		app.Log("mail", "sent copy not stored: %v", err)
 	}
-	rsp.Result = "Sent to " + to + "."
+	rsp.MessageID, rsp.State = messageID, "queued"
+	rsp.Result = "Queued for delivery to " + to + ". Transport retries are automatic; do not send it again. Check /mail?view=outbox for pending or failed delivery."
 	return nil
 }
 

--- a/service/mail/smtp.go
+++ b/service/mail/smtp.go
@@ -2,6 +2,7 @@ package mail
 
 import (
 	"bytes"
+	"context"
 	"encoding/base64"
 	"fmt"
 	"io"
@@ -309,6 +310,10 @@ func relayToExternal(from, to string, data []byte) error {
 		return relayViaSubmission(host, from, to, data)
 	}
 
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+	deadline, _ := ctx.Deadline()
+
 	// Extract domain from recipient address
 	parts := strings.Split(to, "@")
 	if len(parts) != 2 {
@@ -317,7 +322,7 @@ func relayToExternal(from, to string, data []byte) error {
 	domain := parts[1]
 
 	// Look up MX records for the domain
-	mxRecords, err := net.LookupMX(domain)
+	mxRecords, err := net.DefaultResolver.LookupMX(ctx, domain)
 	if err != nil || len(mxRecords) == 0 {
 		app.Log("mail", "No MX records found for %s, trying domain directly", domain)
 		// Fallback to domain directly if no MX records
@@ -339,13 +344,17 @@ func relayToExternal(from, to string, data []byte) error {
 		addr := net.JoinHostPort(host, "25")
 
 		// Connect with timeout
-		conn, err := net.DialTimeout("tcp", addr, 30*time.Second)
+		conn, err := (&net.Dialer{Timeout: 30 * time.Second}).DialContext(ctx, "tcp", addr)
 		if err != nil {
 			app.Log("mail", "Failed to connect to %s: %v", addr, err)
 			lastErr = err
 			continue
 		}
 		defer conn.Close()
+		if err := conn.SetDeadline(deadline); err != nil {
+			lastErr = err
+			continue
+		}
 
 		// Create SMTP client
 		client, err := smtp.NewClient(conn, host)


### PR DESCRIPTION
External sends and agent email replies went straight to SMTP. A temporary failure lost the delivery, and failures to Cc recipients were only logged. Repeating the request risked repeating the model's work and sending another copy to people who already received it.

This adds an owned, encrypted outbox for account-originated external sends and agent reply-all. It persists the exact signed MIME message before accepting the send, preserves Message-ID/threading, saves acceptance independently for every recipient and retries remaining recipients with backoff. Startup resumes pending delivery without invoking a model or charging again. After 48 hours, delivery stops for review; Mail → Outbox shows pending/error state and offers a CSRF-protected owner-only retry that preserves recipients already accepted. Account deletion clears its queued mail.

The mail tool reports queued status and a stable message ID. Local delivery remains immediate and local reply-all errors are now returned. Direct and submission SMTP sessions have bounded deadlines so an unresponsive server cannot hold the worker forever. Instance transactional notifications keep their existing synchronous path.

Task completion reports remain private. Explicit mail sends use the outbox; originating from a third-party thread does not itself authorize publishing the private report.

Validation: full mail/agent-mail/work suites passed under the race detector; subsequent outbox/route regressions pass under race after the final changes. Mail tests, affected-package vet, formatting and diff checks pass. Tests use fake transports and cover restart reload, partial failures, unchanged MIME and threading, duplicate recipients, concurrent attempts, expiry/manual retry, storage failure, encryption, ownership, deletion and CSRF. No live mail or model calls.

SMTP cannot guarantee exactly-once receipt after an ambiguous network acknowledgement. A retry retains the same Message-ID, and recipients with a persisted acceptance are skipped. Advances #1565; room/XMPP acknowledgement work is separate.

Review follow-up: MIME bodies now live in separate encrypted files, leaving only small encrypted envelope/progress records in userdb. A regression queues a full 10 MiB body with encryption enabled. Failed deliveries have an owner-only, CSRF-protected Discard action that removes the body and releases the record slot; account deletion also removes body files. Receipt deletion propagates storage errors instead of claiming success. Both Codex review findings are addressed. Full affected suites pass under race after these changes. The new Outbox tab also exposed a visited-link selector check; the shared selected-filter rule now names its visited state, and that regression passes.

Final CI on c8b9cca: release builds, formatting and full vet pass. The test job has only the six unchanged baseline failures (TZ documentation, wordmark/origin expectations, two tool-count claims and weather_lookup permission metadata). Mail, agent-mail and userdb pass in CI; affected full suites pass locally under race. [CI run](https://github.com/micro/mu/actions/runs/34249698914). Both inline review threads have been fixed and resolved.