### PR TITLE
Keep chat answers available after disconnect and restart

### DIFF
--- a/agent/chat/chat_test.go
+++ b/agent/chat/chat_test.go
@@ -126,10 +126,8 @@ func TestAnAnswerToAnEmptyRoomIsDropped(t *testing.T) {
 		t.Error("Say creates the room it is answering into, so a reply to a " +
 			"conversation nobody is in conjures the conversation")
 	}
-	if !strings.Contains(body, "default:") {
-		t.Error("Say blocks when a room has stopped reading, which stalls the " +
-			"whole subscriber rather than one message")
-	}
+	// Bounded acknowledgement and stopped-room behaviour are exercised with
+	// real channels in service/chat/delivery_test.go.
 }
 
 func read(t *testing.T, path string) string {

--- a/internal/app/html/mu.js
+++ b/internal/app/html/mu.js
@@ -885,8 +885,11 @@ function connectRoomWebSocket(roomId) {
     }
   };
   
-  roomWs.onclose = function() {
+  roomWs.onclose = function(event) {
     console.log('Disconnected from room');
+    if (event.code === 1013 && event.reason) {
+      showToast(event.reason, 'error');
+    }
     // Only reconnect if authenticated and still on same room
     if (isAuthenticated && currentRoomId === roomId) {
       setTimeout(() => connectRoomWebSocket(roomId), 3000);

--- a/service/chat/chat.go
+++ b/service/chat/chat.go
@@ -890,7 +890,26 @@ func (room *Room) run() {
 			return
 
 		case client := <-room.Register:
+			if !Member(room.ID, client.UserID) {
+				client.Conn.Close()
+				continue
+			}
 			room.mutex.Lock()
+			// The room loop is the only data-frame writer. Send history before
+			// registration so live broadcasts cannot race or overtake the replay.
+			failed := false
+			for _, msg := range room.Messages {
+				client.Conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
+				if err := client.Conn.WriteJSON(msg); err != nil {
+					failed = true
+					break
+				}
+			}
+			if failed {
+				room.mutex.Unlock()
+				client.Conn.Close()
+				continue
+			}
 			// Already here on another tab, so nobody arrived. Without this a
 			// second window announces you to a room you are standing in, and
 			// closing it announces that you left while you are still talking.
@@ -933,16 +952,23 @@ func (room *Room) run() {
 			}
 			announceMessage(room.ID, message)
 
-			// Broadcast to all clients
-			room.mutex.Lock()
+			// Snapshot under the lock; a failed or deleted connection can then be
+			// removed safely without keeping readers behind network IO.
+			room.mutex.RLock()
+			var clients []*websocket.Conn
 			for conn := range room.Clients {
-				err := conn.WriteJSON(message)
-				if err != nil {
+				clients = append(clients, conn)
+			}
+			room.mutex.RUnlock()
+			for _, conn := range clients {
+				_ = conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
+				if err := conn.WriteJSON(message); err != nil {
 					conn.Close()
+					room.mutex.Lock()
 					delete(room.Clients, conn)
+					room.mutex.Unlock()
 				}
 			}
-			room.mutex.Unlock()
 		}
 	}
 }
@@ -1059,17 +1085,13 @@ func handleWebSocket(w http.ResponseWriter, r *http.Request, room *Room) {
 
 	room.Register <- client
 
-	// Send room history to new client
-	room.mutex.RLock()
-	for _, msg := range room.Messages {
-		conn.WriteJSON(msg)
-	}
-	room.mutex.RUnlock()
-
 	// Read messages from client
 	go func() {
 		defer func() {
-			room.Unregister <- client
+			select {
+			case room.Unregister <- client:
+			case <-room.Shutdown:
+			}
 		}()
 
 		for {
@@ -1087,7 +1109,16 @@ func handleWebSocket(w http.ResponseWriter, r *http.Request, room *Room) {
 					Timestamp: time.Now(),
 					IsLLM:     false,
 				}
-				room.Broadcast <- userMsg
+				if !Member(room.ID, client.UserID) {
+					conn.Close()
+					return
+				}
+				if err := post(context.Background(), room, userMsg); err != nil {
+					// Control frames may be written concurrently with the room writer.
+					_ = conn.WriteControl(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseTryAgainLater, "Your message was not saved. Please retry."), time.Now().Add(time.Second))
+					conn.Close()
+					return
+				}
 
 				// Check if micro should respond:
 				// For item-specific rooms (news_, video_, post_), ALWAYS respond - these are AI discussions
@@ -1467,8 +1498,8 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 
 	// /chat?with=henrik — the conversation between you and one person.
 	//
-	// A door rather than an id, because the id is derived: PairRoom sorts the
-	// two names so both of you reach the same room, and nobody should have to
+	// A door rather than an id: PairRoom reserves the shared private room,
+	// so both people reach the same conversation without needing to
 	// know that to link to it. This is the one place a private room comes into
 	// being from a request, and it can, because the request names the person
 	// asking as one of its two members.

--- a/service/chat/chat.go
+++ b/service/chat/chat.go
@@ -934,7 +934,7 @@ func (room *Room) run() {
 			announceMessage(room.ID, message)
 
 			// Broadcast to all clients
-			room.mutex.RLock()
+			room.mutex.Lock()
 			for conn := range room.Clients {
 				err := conn.WriteJSON(message)
 				if err != nil {
@@ -942,7 +942,7 @@ func (room *Room) run() {
 					delete(room.Clients, conn)
 				}
 			}
-			room.mutex.RUnlock()
+			room.mutex.Unlock()
 		}
 	}
 }

--- a/service/chat/chat.go
+++ b/service/chat/chat.go
@@ -1,6 +1,7 @@
 package chat
 
 import (
+	"context"
 	"embed"
 	"encoding/json"
 	"fmt"
@@ -240,9 +241,8 @@ const agentName = "micro"
 const AgentName = agentName
 
 // Room represents a discussion room for a specific item.
-// Room state is ephemeral - messages exist only in memory while the server runs.
-// The last 20 messages are kept in memory for new joiners.
-// Client-side sessionStorage is used so participants see their conversation until they leave.
+// The recent transcript is persisted before acknowledging a message.
+// The last 20 messages are kept for reconnecting clients.
 type Room struct {
 	ID           string                      // e.g., "post_123", "news_456", "video_789"
 	Type         string                      // "post", "news", "video"
@@ -253,7 +253,7 @@ type Room struct {
 	LastRefresh  time.Time                   // Last time external content was refreshed
 	LastActivity time.Time                   // Last time room had any activity (for cleanup)
 	LastAIMsg    time.Time                   // Last time AI sent an auto-message
-	Messages     []RoomMessage               // Last 20 messages (in-memory only)
+	Messages     []RoomMessage               // Last 20 persisted messages
 	Clients      map[*websocket.Conn]*Client // Connected clients
 	Broadcast    chan RoomMessage            // Broadcast channel
 	Register     chan *Client                // Register client
@@ -264,10 +264,11 @@ type Room struct {
 
 // RoomMessage represents a message in a chat room
 type RoomMessage struct {
-	UserID    string    `json:"username"`
-	Content   string    `json:"content"`
-	Timestamp time.Time `json:"timestamp"`
-	IsLLM     bool      `json:"is_llm"`
+	ack       chan error // optional acknowledgement after durable room storage
+	UserID    string     `json:"username"`
+	Content   string     `json:"content"`
+	Timestamp time.Time  `json:"timestamp"`
+	IsLLM     bool       `json:"is_llm"`
 
 	// System marks a line the room is saying about itself — somebody arriving
 	// or leaving — rather than a line somebody said.
@@ -297,20 +298,17 @@ var rooms = make(map[string]*Room)
 var roomsMutex sync.RWMutex
 
 // saveRoomMessages persists room messages to disk
-func saveRoomMessages(roomID string, messages []RoomMessage) {
+func saveRoomMessages(roomID string, messages []RoomMessage) error {
 	filename := "room_" + strings.ReplaceAll(roomID, "/", "_") + ".json"
 	b, err := json.Marshal(messages)
 	if err != nil {
-		app.Log("chat", "Error marshaling room messages: %v", err)
-		return
+		return err
 	}
-	if err := data.SaveFile(filename, string(b)); err != nil {
-		app.Log("chat", "Error saving room messages: %v", err)
-	}
+	return data.SaveFile(filename, string(b))
 }
 
 // loadRoomMessages loads persisted room messages from disk
-// Messages older than 24 hours are pruned
+// Keep the recent transcript across restarts, even when the room is quiet.
 func loadRoomMessages(roomID string) []RoomMessage {
 	filename := "room_" + strings.ReplaceAll(roomID, "/", "_") + ".json"
 	b, err := data.LoadFile(filename)
@@ -323,21 +321,11 @@ func loadRoomMessages(roomID string) []RoomMessage {
 		return nil
 	}
 
-	// Prune messages older than 24 hours
-	cutoff := time.Now().Add(-24 * time.Hour)
-	var recent []RoomMessage
-	for _, msg := range messages {
-		if msg.Timestamp.After(cutoff) {
-			recent = append(recent, msg)
-		}
+	if len(messages) > 20 {
+		messages = messages[len(messages)-20:]
 	}
-
-	if len(recent) < len(messages) {
-		app.Log("chat", "Pruned %d old messages for room %s", len(messages)-len(recent), roomID)
-	}
-
-	app.Log("chat", "Loaded %d messages for room %s", len(recent), roomID)
-	return recent
+	app.Log("chat", "Loaded %d messages for room %s", len(messages), roomID)
+	return messages
 }
 
 // handlePatternMatch handles predictable queries with direct lookups, skipping LLM
@@ -478,21 +466,13 @@ func Say(roomID, from, text string) bool {
 	if !ok {
 		return false
 	}
-	// Non-blocking. Broadcast is consumed by the room's own goroutine, and a
-	// room whose reader has stopped would otherwise hold this one forever —
-	// which for a subscriber means the whole event loop, not one message.
-	select {
-	case room.Broadcast <- RoomMessage{
-		UserID:    from,
-		Content:   text,
-		Timestamp: time.Now(),
-		IsLLM:     from == agentName,
-	}:
-		return true
-	default:
-		app.Log("chat", "room %s is not reading, dropped a message from %s", roomID, from)
+	if err := post(context.Background(), room, RoomMessage{
+		UserID: from, Content: text, Timestamp: time.Now(), IsLLM: from == agentName,
+	}); err != nil {
+		app.Log("chat", "room %s: %v", roomID, err)
 		return false
 	}
+	return true
 }
 
 func getOrCreateRoom(id string) *Room {
@@ -739,6 +719,12 @@ func getOrCreateRoom(id string) *Room {
 		}
 	}
 
+	if itemType != "chat" && itemType != "reminder" {
+		if saved := loadRoomMessages(id); saved != nil {
+			room.Messages = saved
+		}
+	}
+
 	// Now acquire write lock only for the map update
 	roomsMutex.Lock()
 	// Check again if another goroutine created it while we were fetching data
@@ -937,23 +923,15 @@ func (room *Room) run() {
 			room.broadcastUserList()
 
 		case message := <-room.Broadcast:
-			// Add message to history (keep last 20)
-			room.mutex.Lock()
-			room.Messages = append(room.Messages, message)
-			if len(room.Messages) > 20 {
-				room.Messages = room.Messages[len(room.Messages)-20:]
+			err := room.keepMessage(message)
+			if message.ack != nil {
+				message.ack <- err
 			}
-			room.LastActivity = time.Now()
-			messagesToSave := make([]RoomMessage, len(room.Messages))
-			copy(messagesToSave, room.Messages)
-			room.mutex.Unlock()
-
+			if err != nil {
+				app.Log("chat", "room %s: %v", room.ID, err)
+				continue
+			}
 			announceMessage(room.ID, message)
-
-			// Persist messages for topic chat rooms
-			if strings.HasPrefix(room.ID, "chat_") {
-				go saveRoomMessages(room.ID, messagesToSave)
-			}
 
 			// Broadcast to all clients
 			room.mutex.RLock()

--- a/service/chat/delivery.go
+++ b/service/chat/delivery.go
@@ -33,6 +33,9 @@ func post(ctx context.Context, room *Room, message RoomMessage) error {
 func (room *Room) keepMessage(message RoomMessage) error {
 	room.mutex.Lock()
 	defer room.mutex.Unlock()
+	if !message.System && !message.IsLLM && !Member(room.ID, message.UserID) {
+		return fmt.Errorf("no access to this chat room")
+	}
 	next := append(append([]RoomMessage(nil), room.Messages...), message)
 	if len(next) > 20 {
 		next = next[len(next)-20:]

--- a/service/chat/delivery.go
+++ b/service/chat/delivery.go
@@ -1,0 +1,46 @@
+package chat
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+// post waits for the room to persist the message, not for a browser to remain
+// connected. A stopped room or a failed disk write must not report "sent".
+func post(ctx context.Context, room *Room, message RoomMessage) error {
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	message.ack = make(chan error, 1)
+	select {
+	case room.Broadcast <- message:
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+		return fmt.Errorf("chat room is busy or stopped")
+	}
+	select {
+	case err := <-message.ack:
+		return err
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (room *Room) keepMessage(message RoomMessage) error {
+	room.mutex.Lock()
+	defer room.mutex.Unlock()
+	next := append(append([]RoomMessage(nil), room.Messages...), message)
+	if len(next) > 20 {
+		next = next[len(next)-20:]
+	}
+	if err := saveRoomMessages(room.ID, next); err != nil {
+		return fmt.Errorf("chat message could not be saved: %w", err)
+	}
+	room.Messages = next
+	room.LastActivity = time.Now()
+	return nil
+}

--- a/service/chat/delivery_review_test.go
+++ b/service/chat/delivery_review_test.go
@@ -1,0 +1,139 @@
+package chat
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"mu/internal/auth"
+	"mu/internal/data"
+	"mu/internal/event"
+	"mu/internal/service"
+)
+
+func TestDeletedPrivateMemberCannotReopenOldTranscript(t *testing.T) {
+	const a, b = "deletedparticipant", "remainingparticipant"
+	id := PairRoom(a, b)
+	Open(id, a, b)
+	room := deliveryRoom(t, id)
+	if err := post(context.Background(), room, RoomMessage{UserID: a, Content: "Old private conversation"}); err != nil {
+		t.Fatal(err)
+	}
+	Forget(a)
+	loadPrivate()
+	if Member(id, a) || !Member(id, b) {
+		t.Fatal("deletion did not persist the correct membership")
+	}
+	var rsp MessagesResponse
+	if err := (Server{}).Messages(service.WithAccount(context.Background(), a), &MessagesRequest{Room: id}, &rsp); err == nil {
+		t.Fatal("deleted name can read old transcript")
+	}
+	if err := (Server{}).Messages(service.WithAccount(context.Background(), b), &MessagesRequest{Room: id}, &rsp); err != nil || len(rsp.Messages) != 1 {
+		t.Fatalf("surviving participant lost conversation: %v", err)
+	}
+	fresh := PairRoom(a, b)
+	if fresh == "" || fresh == id || Member(fresh, a) {
+		t.Fatal("reused name inherited old room or premature access")
+	}
+	Open(fresh, a, b)
+	loadPrivate()
+	if Member(id, a) || PairRoom(b, a) != fresh || len(loadRoomMessages(fresh)) != 0 {
+		t.Fatal("recreated account inherited old messages")
+	}
+	if err := post(context.Background(), room, RoomMessage{UserID: a, Content: "Revoked sender"}); err == nil {
+		t.Fatal("queued message bypassed revocation")
+	}
+	Forget(b)
+	if _, err := data.LoadFile("room_" + id + ".json"); !os.IsNotExist(err) {
+		t.Fatalf("empty room transcript retained: %v", err)
+	}
+}
+
+func TestLegacyPrivateMembershipRetainsRoom(t *testing.T) {
+	memberMu.Lock()
+	oldMembers, oldPairs := members, pairIDs
+	memberMu.Unlock()
+	t.Cleanup(func() { memberMu.Lock(); members, pairIDs = oldMembers, oldPairs; _ = savePrivate(); memberMu.Unlock() })
+	if err := data.SaveJSON("chat_private.json", map[string][]string{"dm_legacy_room": {"legacy-a", "legacy-b"}}); err != nil {
+		t.Fatal(err)
+	}
+	loadPrivate()
+	if got := PairRoom("legacy-a", "legacy-b"); got != "dm_legacy_room" {
+		t.Fatalf("lost legacy room: %s", got)
+	}
+	loadPrivate()
+	if !Member("dm_legacy_room", "legacy-a") {
+		t.Fatal("migration lost membership")
+	}
+}
+
+func TestWebsocketSavesBeforeRequestingAgent(t *testing.T) {
+	for _, failed := range []bool{false, true} {
+		name := "websocketsaved"
+		if failed {
+			name = "websocketfailed"
+		}
+		t.Run(name, func(t *testing.T) {
+			if err := auth.Create(&auth.Account{ID: name, Name: name}); err != nil {
+				t.Fatal(err)
+			}
+			sess, err := auth.CreateSession(name)
+			if err != nil {
+				t.Fatal(err)
+			}
+			room := deliveryRoom(t, "chat_"+name)
+			if failed {
+				path := filepath.Join(os.Getenv("HOME"), ".mu", "data", "room_"+room.ID+".json")
+				if err := os.MkdirAll(path, 0700); err != nil {
+					t.Fatal(err)
+				}
+				t.Cleanup(func() { os.RemoveAll(path) })
+			}
+			sub := event.Subscribe(event.ChatForAgent)
+			defer sub.Close()
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { handleWebSocket(w, r, room) }))
+			defer server.Close()
+			header := http.Header{"Cookie": []string{"session=" + sess.Token}}
+			conn, _, err := websocket.DefaultDialer.Dial("ws"+strings.TrimPrefix(server.URL, "http"), header)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer conn.Close()
+			conn.SetReadDeadline(time.Now().Add(3 * time.Second))
+			// The initial presence frame confirms registration is complete.
+			if _, _, err := conn.ReadMessage(); err != nil {
+				t.Fatal(err)
+			}
+			if err := conn.WriteJSON(map[string]string{"content": "@micro explain durable correspondence"}); err != nil {
+				t.Fatal(err)
+			}
+			if failed {
+				_, _, err := conn.ReadMessage()
+				if !websocket.IsCloseError(err, websocket.CloseTryAgainLater) {
+					t.Fatalf("no visible persistence failure: %v", err)
+				}
+				select {
+				case e := <-sub.Chan:
+					t.Fatalf("unsaved prompt requested agent: %+v", e)
+				case <-time.After(30 * time.Millisecond):
+				}
+			} else {
+				select {
+				case <-sub.Chan:
+				case <-time.After(3 * time.Second):
+					t.Fatal("saved prompt not dispatched")
+				}
+				stored := loadRoomMessages(room.ID)
+				if len(stored) != 1 || stored[0].Content != "@micro explain durable correspondence" {
+					t.Fatalf("dispatch before persistence: %+v", stored)
+				}
+			}
+		})
+	}
+}

--- a/service/chat/delivery_test.go
+++ b/service/chat/delivery_test.go
@@ -1,0 +1,185 @@
+package chat
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"mu/internal/service"
+)
+
+func deliveryRoom(t *testing.T, id string) *Room {
+	t.Helper()
+	room := &Room{ID: id, Broadcast: make(chan RoomMessage, 32), Shutdown: make(chan bool)}
+	roomsMutex.Lock()
+	old := rooms[id]
+	rooms[id] = room
+	roomsMutex.Unlock()
+	done := make(chan struct{})
+	go func() { defer close(done); room.run() }()
+	t.Cleanup(func() {
+		close(room.Shutdown)
+		<-done
+		roomsMutex.Lock()
+		if old == nil {
+			delete(rooms, id)
+		} else {
+			rooms[id] = old
+		}
+		roomsMutex.Unlock()
+	})
+	return room
+}
+
+func TestChatSendIsStoredBeforeAcknowledgementAndSurvivesDisconnect(t *testing.T) {
+	for _, id := range []string{"chat_delivery", "news_delivery", "dm_delivery"} {
+		t.Run(id, func(t *testing.T) {
+			Open(id, "alice", "bob")
+			room := deliveryRoom(t, id)
+			var rsp SendResponse
+			if err := (Server{}).Send(service.WithAccount(context.Background(), "alice"), &SendRequest{Room: id, Message: "The completed answer"}, &rsp); err != nil {
+				t.Fatal(err)
+			}
+			// No browser was connected. A success must still have a durable copy.
+			stored := loadRoomMessages(id)
+			if rsp.Result != "sent" || len(stored) != 1 || stored[0].Content != "The completed answer" {
+				t.Fatalf("acknowledged without saving: %+v", stored)
+			}
+			roomsMutex.Lock()
+			delete(rooms, id)
+			roomsMutex.Unlock()
+			var history MessagesResponse
+			if err := (Server{}).Messages(service.WithAccount(context.Background(), "bob"), &MessagesRequest{Room: id}, &history); err != nil || len(history.Messages) != 1 {
+				t.Fatalf("reconnect lost answer: %+v, %v", history, err)
+			}
+			if Private(id) {
+				if err := (Server{}).Messages(service.WithAccount(context.Background(), "stranger"), &MessagesRequest{Room: id}, &history); err == nil {
+					t.Fatal("private transcript leaked")
+				}
+			}
+			roomsMutex.Lock()
+			rooms[id] = room
+			roomsMutex.Unlock()
+		})
+	}
+}
+
+func TestChatStorageFailureIsNotAcknowledgedOrPublished(t *testing.T) {
+	id := "chat_failed_save"
+	room := deliveryRoom(t, id)
+	path := filepath.Join(os.Getenv("HOME"), ".mu", "data", "room_"+id+".json")
+	if err := os.MkdirAll(path, 0700); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.RemoveAll(path) })
+	var rsp SendResponse
+	if err := (Server{}).Send(service.WithAccount(context.Background(), "alice"), &SendRequest{Room: id, Message: "Must be saved"}, &rsp); err == nil {
+		t.Fatal("failed storage reported sent")
+	}
+	room.mutex.RLock()
+	n := len(room.Messages)
+	room.mutex.RUnlock()
+	if n != 0 || rsp.Result == "sent" {
+		t.Fatal("unpersisted message became visible")
+	}
+	if Say(id, AgentName, "Another answer") {
+		t.Fatal("agent delivery hid a disk failure")
+	}
+}
+
+func TestStoppedChatDeliveryIsBounded(t *testing.T) {
+	room := &Room{ID: "chat_stopped", Broadcast: make(chan RoomMessage, 1)}
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	if err := post(ctx, room, RoomMessage{Content: "No reader"}); err == nil {
+		t.Fatal("stopped room reported success")
+	}
+	// The first message fills the queue; the next caller must fail immediately.
+	start := time.Now()
+	if err := post(context.Background(), room, RoomMessage{Content: "Still stopped"}); err == nil {
+		t.Fatal("full room reported success")
+	}
+	if time.Since(start) > time.Second {
+		t.Fatal("full room blocked the caller")
+	}
+}
+
+func TestConcurrentChatSavesKeepEveryAcknowledgedMessage(t *testing.T) {
+	room := deliveryRoom(t, "chat_concurrent_delivery")
+	var wg sync.WaitGroup
+	for i := range 12 {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			if err := post(context.Background(), room, RoomMessage{UserID: "alice", Content: fmt.Sprintf("answer %d", i), Timestamp: time.Now()}); err != nil {
+				t.Error(err)
+			}
+		}(i)
+	}
+	wg.Wait()
+	if got := loadRoomMessages(room.ID); len(got) != 12 {
+		t.Fatalf("saved %d of 12 acknowledged answers", len(got))
+	}
+}
+
+func TestOfflineXMPPAnswerIsAvailableWhenTheClientReconnects(t *testing.T) {
+	t.Setenv("MU_DOMAIN", "example.test")
+	acc, token := accountWithToken(t, "offlinereply")
+	if SayTo(acc.ID, AgentAddress(), "Your task is finished") {
+		t.Fatal("offline account reported present")
+	}
+	// Reload the persisted archive before connecting a real test client.
+	LoadStore()
+	c := dial(t)
+	defer c.Close()
+	c.handshake(t, acc.ID, token)
+	c.write(mamQuery("offline-answer", AgentAddress(), ""))
+	got := c.until(t, "</iq>")
+	if !strings.Contains(got, "Your task is finished") || !strings.Contains(got, "urn:xmpp:delay") {
+		t.Fatalf("offline answer missing from archive: %s", clip(got))
+	}
+}
+
+func TestChatArchiveWriteFailureRollsBackMemory(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	if err := os.MkdirAll(filepath.Join(os.Getenv("HOME"), ".mu", "data", "chat.json"), 0700); err != nil {
+		t.Fatal(err)
+	}
+	if id, err := KeepSaved("failed-archive", Said{Conv: "test", Text: "Unsaved"}); err == nil || id != "" {
+		t.Fatal("unpersisted archive entry reported saved")
+	}
+	if len(Conversation("failed-archive", "test", 10)) != 0 {
+		t.Fatal("failed save changed visible archive")
+	}
+}
+
+func TestLiveXMPPAnswerUsesItsArchiveMessageID(t *testing.T) {
+	t.Setenv("MU_DOMAIN", "example.test")
+	acc, token := accountWithToken(t, "livereply")
+	c := dial(t)
+	defer c.Close()
+	c.handshake(t, acc.ID, token)
+	if !SayTo(acc.ID, AgentAddress(), "Here is the answer") {
+		t.Fatal("connected client was not delivered to")
+	}
+	got := c.until(t, "</message>")
+	history := Conversation(acc.ID, xmppRoom(AgentAddress(), acc.ID+"@"+Domain()), 10)
+	if len(history) != 1 || !strings.Contains(got, "id='"+history[0].ID+"'") {
+		t.Fatalf("live and archived IDs differ: %s", clip(got))
+	}
+}
+
+func TestQuietRoomDoesNotExpireAnUnreadAnswerOvernight(t *testing.T) {
+	id := "news_quiet_delivery"
+	if err := saveRoomMessages(id, []RoomMessage{{UserID: AgentName, Content: "The saved outcome", Timestamp: time.Now().Add(-48 * time.Hour)}}); err != nil {
+		t.Fatal(err)
+	}
+	if got := loadRoomMessages(id); len(got) != 1 || got[0].Content != "The saved outcome" {
+		t.Fatal("quiet room expired the answer before it was read")
+	}
+}

--- a/service/chat/delivery_test.go
+++ b/service/chat/delivery_test.go
@@ -10,12 +10,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gorilla/websocket"
 	"mu/internal/service"
 )
 
 func deliveryRoom(t *testing.T, id string) *Room {
 	t.Helper()
-	room := &Room{ID: id, Broadcast: make(chan RoomMessage, 32), Shutdown: make(chan bool)}
+	room := &Room{ID: id, Clients: make(map[*websocket.Conn]*Client), Register: make(chan *Client), Unregister: make(chan *Client), Broadcast: make(chan RoomMessage, 32), Shutdown: make(chan bool)}
 	roomsMutex.Lock()
 	old := rooms[id]
 	rooms[id] = room

--- a/service/chat/main_test.go
+++ b/service/chat/main_test.go
@@ -1,0 +1,19 @@
+package chat
+
+import (
+	"os"
+	"testing"
+)
+
+// Chat tests exercise durable transcripts and account setup. They must never
+// write into the developer's live chat archive.
+func TestMain(m *testing.M) {
+	scratch, err := os.MkdirTemp("", "mu-chat-test")
+	if err != nil {
+		panic(err)
+	}
+	os.Setenv("HOME", scratch)
+	code := m.Run()
+	os.RemoveAll(scratch)
+	os.Exit(code)
+}

--- a/service/chat/private.go
+++ b/service/chat/private.go
@@ -30,11 +30,13 @@ package chat
 // standing: for them, there is not.
 
 import (
+	"encoding/json"
 	"sort"
 	"strings"
 	"sync"
 	"time"
 
+	"mu/internal/app"
 	"mu/internal/data"
 )
 
@@ -54,18 +56,42 @@ const privatePrefix = "dm_"
 var (
 	memberMu sync.RWMutex
 	members  = map[string][]string{}
+	pairIDs  = map[string]string{}
 )
 
 // loadPrivate reads the membership record. Called once at Load.
+type privateState struct {
+	Members map[string][]string `json:"members"`
+	Pairs   map[string]string   `json:"pairs"`
+}
+
 func loadPrivate() {
 	memberMu.Lock()
 	defer memberMu.Unlock()
-	data.LoadJSON("chat_private.json", &members) //nolint:errcheck
+	b, err := data.LoadFile("chat_private.json")
+	if err != nil {
+		return
+	}
+	var state privateState
+	if err := json.Unmarshal(b, &state); err == nil && state.Members != nil {
+		members, pairIDs = state.Members, state.Pairs
+		if pairIDs == nil {
+			pairIDs = map[string]string{}
+		}
+		return
+	}
+	// Existing installations stored just the room-to-members map.
+	var legacy map[string][]string
+	if err := json.Unmarshal(b, &legacy); err != nil {
+		app.Log("chat", "loading private rooms: %v", err)
+		return
+	}
+	members, pairIDs = legacy, map[string]string{}
 }
 
-// savePrivate writes it. Caller holds memberMu.
-func savePrivate() {
-	data.SaveJSON("chat_private.json", members) //nolint:errcheck
+// savePrivate writes membership and pair allocation together. Caller holds memberMu.
+func savePrivate() error {
+	return data.SaveJSON("chat_private.json", privateState{Members: members, Pairs: pairIDs})
 }
 
 // Private reports whether an id names a room that is never public.
@@ -143,7 +169,9 @@ func Open(roomID string, accounts ...string) {
 			have[a] = true
 		}
 	}
-	savePrivate()
+	if err := savePrivate(); err != nil {
+		app.Log("chat", "saving private rooms: %v", err)
+	}
 }
 
 // Members is who is in a private room, for a caller that may see it.
@@ -190,15 +218,10 @@ func Mine(account string) []string {
 	return out
 }
 
-// PairRoom is the id of the room two people share.
-//
-// Sorted, so the room asim opens with henrik is the room henrik opens with
-// asim. Deterministic rather than stored, because two people have exactly one
-// conversation between them and a lookup table would be a second place for that
-// fact to be wrong.
-//
-// Guessable by construction, which is the whole reason for the membership check
-// above: knowing the name of a private room gets you nothing.
+// PairRoom finds or reserves the room two accounts share. Allocation is stable
+// but opaque, and does not grant membership until Open. Existing rooms retain
+// their IDs; a deleted participant's allocation is revoked so a reused account
+// name cannot reopen the previous person's transcript.
 func PairRoom(a, b string) string {
 	a, b = strings.TrimSpace(a), strings.TrimSpace(b)
 	if a == "" || b == "" || a == b {
@@ -207,7 +230,86 @@ func PairRoom(a, b string) string {
 	if a > b {
 		a, b = b, a
 	}
-	return privatePrefix + a + "_" + b
+	key := a + "\x00" + b
+	memberMu.Lock()
+	defer memberMu.Unlock()
+	if id := pairIDs[key]; id != "" {
+		return id
+	}
+	// Preserve pre-allocation rooms whose two members are still present.
+	var existing []string
+	for id, list := range members {
+		if len(list) == 2 && ((list[0] == a && list[1] == b) || (list[0] == b && list[1] == a)) {
+			existing = append(existing, id)
+		}
+	}
+	sort.Strings(existing)
+	id := privatePrefix + newID()
+	if len(existing) > 0 {
+		id = existing[0]
+	}
+	pairIDs[key] = id
+	if err := savePrivate(); err != nil {
+		delete(pairIDs, key)
+		app.Log("chat", "allocating private room: %v", err)
+		return ""
+	}
+	return id
+}
+
+// forgetPrivate revokes the deleted account while retaining the other members'
+// correspondence. Empty rooms have nobody left to retain their transcript for.
+func forgetPrivate(account string) {
+	memberMu.Lock()
+	var empty []string
+	for id, list := range members {
+		var keep []string
+		for _, who := range list {
+			if who != account {
+				keep = append(keep, who)
+			}
+		}
+		if len(keep) == len(list) {
+			continue
+		}
+		if len(keep) == 0 {
+			delete(members, id)
+			empty = append(empty, id)
+		} else {
+			members[id] = keep
+		}
+	}
+	for key := range pairIDs {
+		pair := strings.SplitN(key, "\x00", 2)
+		if len(pair) == 2 && (pair[0] == account || pair[1] == account) {
+			delete(pairIDs, key)
+		}
+	}
+	if err := savePrivate(); err != nil {
+		app.Log("chat", "revoking private rooms: %v", err)
+	}
+	memberMu.Unlock()
+	for _, id := range empty {
+		_ = data.DeleteFile("room_" + strings.ReplaceAll(id, "/", "_") + ".json")
+	}
+	roomsMutex.RLock()
+	var live []*Room
+	for _, room := range rooms {
+		live = append(live, room)
+	}
+	roomsMutex.RUnlock()
+	for _, room := range live {
+		room.mutex.Lock()
+		for conn, client := range room.Clients {
+			if client != nil && client.UserID == account {
+				delete(room.Clients, conn)
+				if conn != nil {
+					conn.Close()
+				}
+			}
+		}
+		room.mutex.Unlock()
+	}
 }
 
 // pairTitle names a room after the person you are not.

--- a/service/chat/service.go
+++ b/service/chat/service.go
@@ -61,7 +61,7 @@ func (Server) Rooms(_ context.Context, req *RoomsRequest, rsp *RoomsResponse) er
 		limit = 20
 	}
 
-	mutex.RLock()
+	roomsMutex.RLock()
 	out := make([]RoomInfo, 0, len(rooms))
 	for _, r := range rooms {
 		// Not somebody's conversation. This is the list a tool call gets and the
@@ -77,7 +77,7 @@ func (Server) Rooms(_ context.Context, req *RoomsRequest, rsp *RoomsResponse) er
 		})
 		r.mutex.RUnlock()
 	}
-	mutex.RUnlock()
+	roomsMutex.RUnlock()
 
 	sort.Slice(out, func(i, j int) bool { return out[i].LastActivity.After(out[j].LastActivity) })
 	if len(out) > limit {
@@ -116,9 +116,9 @@ func (Server) Messages(ctx context.Context, req *MessagesRequest, rsp *MessagesR
 		return fmt.Errorf("no room here called %q", id)
 	}
 
-	mutex.RLock()
+	roomsMutex.RLock()
 	room, ok := rooms[id]
-	mutex.RUnlock()
+	roomsMutex.RUnlock()
 
 	var msgs []RoomMessage
 	if ok {
@@ -175,7 +175,7 @@ type SendResponse struct {
 // somebody opens the discussion on it, so conjuring one from a tool call would
 // invent a conversation about nothing. chat_rooms is how you find the id.
 //
-// It goes through the room's broadcast channel rather than appending directly,
+// It goes through the room's broadcast channel and waits for durable storage,
 // which is what everyone connected sees, what gets persisted, and what moves
 // LastActivity — three things that would otherwise each need doing by hand and
 // drift apart the first time one of them changed.
@@ -200,14 +200,16 @@ func (Server) Send(ctx context.Context, req *SendRequest, rsp *SendResponse) err
 		return fmt.Errorf("no room here called %q", id)
 	}
 
-	mutex.RLock()
+	roomsMutex.RLock()
 	room, ok := rooms[id]
-	mutex.RUnlock()
+	roomsMutex.RUnlock()
 	if !ok {
 		return fmt.Errorf("no live discussion called %q — chat_rooms lists the ones there are", id)
 	}
 
-	room.Broadcast <- RoomMessage{UserID: who, Content: text, Timestamp: time.Now()}
+	if err := post(ctx, room, RoomMessage{UserID: who, Content: text, Timestamp: time.Now()}); err != nil {
+		return err
+	}
 	rsp.Result = "sent"
 	return nil
 }

--- a/service/chat/store.go
+++ b/service/chat/store.go
@@ -31,6 +31,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"sort"
 	"strings"
 	"sync"
@@ -98,42 +99,22 @@ func LoadStore() {
 	}
 }
 
-// saveStore writes the record out.
-//
-// The marshal is under the lock and the disk write is not.
-//
-// It used to be neither. Keep and Forget each took the lock, changed the map,
-// released it, and then called this — so the encoder walked a map that another
-// goroutine was free to be writing to. Two people talking at once is enough:
-// one Keep appending while this marshals is a concurrent map read and write,
-// which Go does not make recoverable. It kills the process.
-//
-// Found by the race detector, which was worth turning on the moment the suite
-// stopped flaking — the report came from a test, and nothing about the fault
-// was the test's. Every XMPP message goes through Keep.
-//
-// The disk write stays outside, because that is the slow half and no caller
-// should wait behind somebody else's fsync to say a sentence.
-func saveStore() {
-	saidMu.RLock()
-	b, err := json.Marshal(said)
-	saidMu.RUnlock()
+// Keep writes a message to the archive. Callers needing an acknowledgement use
+// KeepSaved so a failed disk write cannot be mistaken for durable delivery.
+func Keep(account string, m Said) string {
+	id, err := KeepSaved(account, m)
 	if err != nil {
-		app.Log("chat", "could not marshal the chat record: %v", err)
-		return
+		app.Log("chat", "could not save message: %v", err)
 	}
-	if err := data.SaveFile("chat.json", string(b)); err != nil {
-		app.Log("chat", "could not write the chat record: %v", err)
-	}
+	return id
 }
 
-// Keep writes one message down, for one account.
-//
-// Returns the id it was stored under, which is what MAM hands a client as the
-// archive id and what a client pages backwards from.
-func Keep(account string, m Said) string {
+// KeepSaved saves before publishing the new archive state. Serializing the
+// complete write with mutations also prevents an old snapshot overwriting a
+// newer one when two messages arrive together.
+func KeepSaved(account string, m Said) (string, error) {
 	if account == "" || strings.TrimSpace(m.Text) == "" || m.Conv == "" {
-		return ""
+		return "", fmt.Errorf("a chat message needs an account, conversation and text")
 	}
 	if m.ID == "" {
 		m.ID = newID()
@@ -141,16 +122,19 @@ func Keep(account string, m Said) string {
 	if m.At.IsZero() {
 		m.At = time.Now().UTC()
 	}
-
 	saidMu.Lock()
-	said[account] = append(said[account], &m)
-	if n := len(said[account]); n > heldPerAccount {
-		said[account] = said[account][n-heldPerAccount:]
+	defer saidMu.Unlock()
+	previous := said[account]
+	next := append(append([]*Said(nil), previous...), &m)
+	if len(next) > heldPerAccount {
+		next = next[len(next)-heldPerAccount:]
 	}
-	saidMu.Unlock()
-
-	saveStore()
-	return m.ID
+	said[account] = next
+	if err := data.SaveJSON("chat.json", said); err != nil {
+		said[account] = previous
+		return "", err
+	}
+	return m.ID, nil
 }
 
 // Conversation is what was said on one conversation, oldest first.
@@ -192,7 +176,9 @@ func filtered(account string, limit int, keep func(*Said) bool) []Said {
 // prevent — see TestEveryScopedServiceCleansUpWhenAnAccountIsDeleted.
 func Forget(account string) {
 	saidMu.Lock()
+	defer saidMu.Unlock()
 	delete(said, account)
-	saidMu.Unlock()
-	saveStore()
+	if err := data.SaveJSON("chat.json", said); err != nil {
+		app.Log("chat", "could not delete chat archive: %v", err)
+	}
 }

--- a/service/chat/store.go
+++ b/service/chat/store.go
@@ -175,6 +175,7 @@ func filtered(account string, limit int, keep func(*Said) bool) []Said {
 // person and cannot be told to stop is the thing every deletion hook exists to
 // prevent — see TestEveryScopedServiceCleansUpWhenAnAccountIsDeleted.
 func Forget(account string) {
+	forgetPrivate(account)
 	saidMu.Lock()
 	defer saidMu.Unlock()
 	delete(said, account)

--- a/service/chat/xmpp_stanza.go
+++ b/service/chat/xmpp_stanza.go
@@ -264,23 +264,36 @@ func (s *session) stanzaError(to, kind, condition string) {
 
 // deliverXMPP hands a message to every resource a local account has open, and
 // reports whether anybody was there.
-func deliverXMPP(from, to, text string) bool {
+func deliverXMPP(from, to, text string, ids ...string) bool {
 	sessions := sessionsFor(to)
 	if len(sessions) == 0 {
 		return false
 	}
-	for _, other := range sessions {
-		other.send(`<message type='chat' from='%s' to='%s'><body>%s</body></message>`,
-			xmlAttr(from), xmlAttr(other.jid()), xmlText(text)) //nolint:errcheck
+	idAttr := ""
+	if len(ids) > 0 && ids[0] != "" {
+		idAttr = " id='" + xmlAttr(ids[0]) + "'"
 	}
-	return true
+	delivered := false
+	for _, other := range sessions {
+		if err := other.send(`<message type='chat'%s from='%s' to='%s'><body>%s</body></message>`,
+			idAttr, xmlAttr(from), xmlAttr(other.jid()), xmlText(text)); err == nil {
+			delivered = true
+		}
+	}
+	return delivered
 }
 
 // SayTo delivers a message to an account's connected clients, from an address.
 //
 // The door agent/chat answers through, the same shape Say is for the websocket
-// rooms. Reports whether anybody was connected, so a caller can fall back to
-// leaving it somewhere rather than assume it landed.
+// rooms. The answer is saved for archive retrieval even when nobody is online.
+// Reports live delivery separately so an offline answer is not marked seen.
 func SayTo(accountID, from, text string) bool {
-	return deliverXMPP(from, strings.ToLower(accountID)+"@"+Domain(), text)
+	to := strings.ToLower(accountID) + "@" + Domain()
+	id, err := KeepSaved(accountID, Said{Conv: xmppRoom(from, to), From: from, To: to, Text: text})
+	if err != nil {
+		app.Log("chat", "could not save XMPP answer: %v", err)
+		return false
+	}
+	return deliverXMPP(from, to, text, id)
 }


### PR DESCRIPTION
Chat's send tool reported sent after putting a message on an in-memory channel. Only topic rooms saved history, in asynchronous writes that could finish out of order. An XMPP agent answer disappeared from its channel when the client disconnected before it arrived.

Room sends now wait for a bounded acknowledgement after persistence. Storage failure leaves the message unpublished and returns an error; a stopped/full room cannot block indefinitely. All room types persist their recent transcript, including private and item discussions, and restore it after restart. The recent 20-message history no longer expires solely because a room was quiet for 24 hours. Room service lookups use the mutex that protects the room map.

XMPP answers are saved before attempting live delivery, so reconnecting clients can retrieve them through MAM. The live stanza and archive use the same message ID. Archive writes are serialized with mutations and failed writes roll back the visible addition. Live delivery failures no longer count as successful writes to a client.

Validation: chat and agent-chat suites pass under race; the final retention regression and full affected suites pass, along with vet, formatting and diff checks. Regression coverage uses real room channels and local XMPP test clients: no connected browser, private ownership, restart reads, storage failure, stopped rooms, concurrent saves, offline/reconnected XMPP and matching archive/live IDs. Chat tests now isolate HOME at package level.

Advances #1565 alongside the external mail outbox in #1592. Private task reports remain private; explicit chat sends are saved on their chosen channel. Room history remains bounded to 20 messages, XMPP archives to the existing 2,000-message limit. This does not add durable remote XMPP federation retries or guarantee exactly-once delivery after an ambiguous caller timeout.