### PR TITLE
Execute familiar requests directly without model interpretation

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1611,7 +1611,8 @@ func handleQuery(w http.ResponseWriter, r *http.Request) {
 		nopts.System = ua.SystemPrompt
 		nopts.Tools = ua.Tools
 	}
-	_, directCommand := promptCommand(req.Prompt, nopts)
+	_, directCommand := promptCommands(req.Prompt, nopts)
+	directCommand = directCommand || commandDenied(req.Prompt, nopts)
 	if !guest && !directCommand && !explicitCommand(req.Prompt) {
 		go extractMemory(accountID, req.Prompt, scopeOf(req.Agent))
 	}

--- a/agent/ask.go
+++ b/agent/ask.go
@@ -329,8 +329,8 @@ func Ask(r AskRequest) (Answer, error) {
 	// lands in the conversation like any other reply — somebody who asked a
 	// question on their phone should read why nothing happened in the place
 	// they asked, not find out by opening a wallet page.
-	_, directCommand := promptCommand(r.Text, opts)
-	directCommand = directCommand || explicitCommand(r.Text)
+	_, directCommand := promptCommands(r.Text, opts)
+	directCommand = directCommand || explicitCommand(r.Text) || commandDenied(r.Text, opts)
 	if reason, ok := affordable(r.Account); !ok && !directCommand {
 		Answered(r.Account, threadID(th), reason, "")
 		return Answer{Text: reason, Thread: threadID(th)}, nil

--- a/agent/command_language_test.go
+++ b/agent/command_language_test.go
@@ -1,0 +1,144 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"mu/internal/service"
+	"mu/service/markets"
+	"mu/service/news"
+	"mu/service/users"
+	"mu/service/video"
+	"mu/service/weather"
+)
+
+type commandNetworkSpy struct{ calls atomic.Int32 }
+
+func (s *commandNetworkSpy) RoundTrip(*http.Request) (*http.Response, error) {
+	s.calls.Add(1)
+	return nil, fmt.Errorf("network forbidden in direct command test")
+}
+
+func TestNaturalCommandsNeverCallAModel(t *testing.T) {
+	spy := new(commandNetworkSpy)
+	old := http.DefaultTransport
+	http.DefaultTransport = spy
+	t.Cleanup(func() { http.DefaultTransport = old })
+	t.Setenv("OPENAI_API_KEY", "test")
+	t.Setenv("OPENAI_BASE_URL", "https://model.invalid/v1")
+	for _, spec := range []service.Spec{news.Spec, weather.Spec, markets.Spec, video.Spec, users.Spec} {
+		if err := service.Register(spec); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, tc := range []struct{ input, svc string }{
+		{"News today", "news"}, {"Please show me news", "news"}, {"markets", "markets"}, {"latest videos", "video"}, {"users", "users"}, {"weather in London tomorrow", "weather"},
+	} {
+		calls, ok := promptCommands(tc.input, QueryOpts{})
+		if !ok || len(calls) != 1 || calls[0].Service != tc.svc {
+			t.Errorf("%q: %+v %v", tc.input, calls, ok)
+		}
+	}
+	for _, prompt := range []string{"News today", "please news today", "weather tomorrow", "weather and news today", "/weather and news today", "/help", "/nonexistent-command", "users"} {
+		text, err := QueryWithOpts("", prompt, QueryOpts{Public: true})
+		if prompt == "/nonexistent-command" || prompt == "users" {
+			if err == nil {
+				t.Fatal("unknown explicit command guessed")
+			}
+			continue
+		}
+		if err != nil || text == "" {
+			t.Errorf("%q: %q %v", prompt, text, err)
+		}
+	}
+	if spy.calls.Load() != 0 {
+		t.Fatalf("direct route made %d network/model requests", spy.calls.Load())
+	}
+	if _, ok := promptCommands("news and weather", QueryOpts{Extra: "interpret this attachment"}); ok {
+		t.Fatal("discarded attachment")
+	}
+	if _, ok := promptCommands("/news and weather", QueryOpts{Extra: "attachment"}); !ok {
+		t.Fatal("explicit command lost")
+	}
+	if _, ok := promptCommands("users", QueryOpts{Public: true}); ok {
+		t.Fatal("guest directory access")
+	}
+}
+
+type ParallelReadProbe struct {
+	started chan string
+	release chan struct{}
+}
+type ParallelReadRequest struct {
+	Value string `json:"value"`
+}
+
+func (p *ParallelReadProbe) Read(ctx context.Context, req *ParallelReadRequest, rsp *CommandProbeResponse) error {
+	select {
+	case p.started <- req.Value:
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+	select {
+	case <-p.release:
+		rsp.Text = req.Value
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func TestComposedCommandsExecuteConcurrentlyAndRenderInOrder(t *testing.T) {
+	p := &ParallelReadProbe{started: make(chan string, 2), release: make(chan struct{})}
+	if err := service.Register(service.Spec{Name: "parallelreads", Handler: p, Endpoints: map[string]service.Endpoint{"Read": {}}}); err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	result := make(chan string, 1)
+	var starts, ends, steps int
+	go func() {
+		text, err := executeCommands(ctx, "", []service.CommandCall{{Service: "parallelreads", Method: "Read", Args: map[string]any{"value": "First result"}}, {Service: "parallelreads", Method: "Read", Args: map[string]any{"value": "Second result"}}}, QueryOpts{Stream: StreamHooks{ToolStart: func(ToolRun) { starts++ }, ToolEnd: func(ToolRun) { ends++ }}, OnStep: func(Step) { steps++ }})
+		if err != nil {
+			text = err.Error()
+		}
+		result <- text
+	}()
+	for i := 0; i < 2; i++ {
+		select {
+		case <-p.started:
+		case <-ctx.Done():
+			t.Fatal("reads did not start in parallel")
+		}
+	}
+	close(p.release)
+	text := <-result
+	if !strings.Contains(text, "First result") || strings.Index(text, "First result") > strings.Index(text, "Second result") || starts != 2 || ends != 2 || steps != 2 {
+		t.Fatalf("%q lifecycle=%d/%d/%d", text, starts, ends, steps)
+	}
+}
+
+func TestComposedCommandFailureIsNotASecondModelAttempt(t *testing.T) {
+	if err := service.Register(service.Spec{Name: "composedfailure", Handler: CommandProbe{}, Endpoints: map[string]service.Endpoint{"Read": {}}}); err != nil {
+		t.Fatal(err)
+	}
+	for _, allFail := range []bool{false, true} {
+		second := "success"
+		if allFail {
+			second = "fail"
+		}
+		text, err := executeCommands(context.Background(), "owner", []service.CommandCall{{Service: "composedfailure", Method: "Read", Args: map[string]any{"mode": "fail"}}, {Service: "composedfailure", Method: "Read", Args: map[string]any{"mode": second}}}, QueryOpts{})
+		if allFail {
+			if err == nil {
+				t.Fatal("all failed marked success")
+			}
+		} else if err != nil || !strings.Contains(text, "provider unavailable") || !strings.Contains(text, "Ready for owner") {
+			t.Fatalf("lost partial outcome: %q %v", text, err)
+		}
+	}
+}

--- a/agent/command_language_test.go
+++ b/agent/command_language_test.go
@@ -102,8 +102,9 @@ func TestComposedCommandsExecuteConcurrentlyAndRenderInOrder(t *testing.T) {
 	defer cancel()
 	result := make(chan string, 1)
 	var starts, ends, steps int
+	ids := map[string]bool{}
 	go func() {
-		text, err := executeCommands(ctx, "", []service.CommandCall{{Service: "parallelreads", Method: "Read", Args: map[string]any{"value": "First result"}}, {Service: "parallelreads", Method: "Read", Args: map[string]any{"value": "Second result"}}}, QueryOpts{Stream: StreamHooks{ToolStart: func(ToolRun) { starts++ }, ToolEnd: func(ToolRun) { ends++ }}, OnStep: func(Step) { steps++ }})
+		text, err := executeCommands(ctx, "", []service.CommandCall{{Service: "parallelreads", Method: "Read", Args: map[string]any{"value": "First result"}}, {Service: "parallelreads", Method: "Read", Args: map[string]any{"value": "Second result"}}}, QueryOpts{Stream: StreamHooks{ToolStart: func(r ToolRun) { starts++; ids[r.ID] = true }, ToolEnd: func(ToolRun) { ends++ }}, OnStep: func(Step) { steps++ }})
 		if err != nil {
 			text = err.Error()
 		}
@@ -118,7 +119,7 @@ func TestComposedCommandsExecuteConcurrentlyAndRenderInOrder(t *testing.T) {
 	}
 	close(p.release)
 	text := <-result
-	if !strings.Contains(text, "First result") || strings.Index(text, "First result") > strings.Index(text, "Second result") || starts != 2 || ends != 2 || steps != 2 {
+	if !strings.Contains(text, "First result") || strings.Index(text, "First result") > strings.Index(text, "Second result") || starts != 2 || ends != 2 || steps != 2 || len(ids) != 2 {
 		t.Fatalf("%q lifecycle=%d/%d/%d", text, starts, ends, steps)
 	}
 }
@@ -139,6 +140,24 @@ func TestComposedCommandFailureIsNotASecondModelAttempt(t *testing.T) {
 			}
 		} else if err != nil || !strings.Contains(text, "provider unavailable") || !strings.Contains(text, "Ready for owner") {
 			t.Fatalf("lost partial outcome: %q %v", text, err)
+		}
+	}
+}
+
+func TestDirectListsRenderTheirRegisteredResponseShapes(t *testing.T) {
+	for _, tc := range []struct {
+		result map[string]any
+		want   string
+	}{
+		{map[string]any{"notes": []any{map[string]any{"title": "School run", "text": "Leave at eight"}}}, "School run — Leave at eight"},
+		{map[string]any{"notes": nil}, "No results."},
+		{map[string]any{"entries": []any{map[string]any{"text": "Alice is home", "at": "2026-09-09T08:00:00Z"}}}, "Alice is home"},
+		{map[string]any{"entries": []any{}}, "No results."},
+		{map[string]any{"events": "Tomorrow at eight: school run"}, "Tomorrow at eight"},
+		{map[string]any{"files": []any{map[string]any{"name": "Family photo"}}}, "Family photo"},
+	} {
+		if got := commandText(tc.result); !strings.Contains(got, tc.want) {
+			t.Fatalf("%v rendered as %q", tc.result, got)
 		}
 	}
 }

--- a/agent/commands.go
+++ b/agent/commands.go
@@ -2,20 +2,104 @@ package agent
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/url"
 	"strings"
+	"sync"
 	"time"
 
 	"mu/internal/service"
 )
 
-func promptCommand(prompt string, opts QueryOpts) (service.CommandCall, bool) {
-	// Explicit commands ignore attached prose; inferred phrases retain its context.
+func promptCommands(prompt string, opts QueryOpts) ([]service.CommandCall, bool) {
 	if !explicitCommand(prompt) && strings.TrimSpace(opts.Extra) != "" {
+		return nil, false
+	}
+	return service.MatchCommandsFor(strings.TrimPrefix(strings.TrimSpace(prompt), "/"), filterServices(nativeServices(opts.Public), opts.Tools), !opts.Public)
+}
+
+func promptCommand(prompt string, opts QueryOpts) (service.CommandCall, bool) {
+	calls, ok := promptCommands(prompt, opts)
+	if !ok || len(calls) != 1 {
 		return service.CommandCall{}, false
 	}
-	return service.MatchCommandFor(strings.TrimPrefix(strings.TrimSpace(prompt), "/"), filterServices(nativeServices(opts.Public), opts.Tools), !opts.Public)
+	return calls[0], true
+}
+
+func executeCommands(ctx context.Context, account string, calls []service.CommandCall, opts QueryOpts) (string, error) {
+	if len(calls) == 1 {
+		return executeCommand(ctx, account, calls[0], opts)
+	}
+	// Hooks write to a shared response/record. Serialize them while the service
+	// reads run concurrently, and publish the complete answer in request order.
+	var mu sync.Mutex
+	child := opts
+	child.Stream.Token = nil
+	child.Stream.ToolStart = func(r ToolRun) {
+		mu.Lock()
+		defer mu.Unlock()
+		if opts.Stream.ToolStart != nil {
+			opts.Stream.ToolStart(r)
+		}
+	}
+	child.Stream.ToolEnd = func(r ToolRun) {
+		mu.Lock()
+		defer mu.Unlock()
+		if opts.Stream.ToolEnd != nil {
+			opts.Stream.ToolEnd(r)
+		}
+	}
+	child.OnStep = func(s Step) {
+		mu.Lock()
+		defer mu.Unlock()
+		if opts.OnStep != nil {
+			opts.OnStep(s)
+		}
+	}
+	results := make([]string, len(calls))
+	errs := make([]error, len(calls))
+	var wg sync.WaitGroup
+	for i, call := range calls {
+		wg.Add(1)
+		go func(i int, call service.CommandCall) {
+			defer wg.Done()
+			text, err := executeCommand(ctx, account, call, child)
+			if err != nil {
+				errs[i] = err
+				text = "Could not complete this request: " + err.Error()
+			}
+			results[i] = "### " + service.Label(call.Service+"_"+strings.ToLower(call.Method)) + "\n\n" + text
+		}(i, call)
+	}
+	wg.Wait()
+	failed := 0
+	for _, err := range errs {
+		if err != nil {
+			failed++
+		}
+	}
+	if failed == len(calls) {
+		return "", errors.Join(errs...)
+	}
+	text := strings.Join(results, "\n\n")
+	if opts.Stream.Token != nil {
+		opts.Stream.Token(text)
+	}
+	return text, nil
+}
+
+// A known read outside the current scope is a refusal, not an invitation to
+// spend a model turn trying the same unavailable operation.
+func commandDenied(prompt string, opts QueryOpts) bool {
+	if !explicitCommand(prompt) && strings.TrimSpace(opts.Extra) != "" {
+		return false
+	}
+	if _, ok := promptCommands(prompt, opts); ok {
+		return false
+	}
+	_, known := service.MatchCommandsFor(strings.TrimPrefix(strings.TrimSpace(prompt), "/"), service.Services(), true)
+	return known
 }
 
 func explicitCommand(prompt string) bool {
@@ -24,7 +108,7 @@ func explicitCommand(prompt string) bool {
 
 func executeCommand(ctx context.Context, account string, call service.CommandCall, opts QueryOpts) (string, error) {
 	name := call.Service + "_" + strings.ToLower(call.Method)
-	run := ToolRun{ID: "command", Name: name, Label: toolLabel(name)}
+	run := ToolRun{ID: "command-" + name, Name: name, Label: toolLabel(name)}
 	if opts.Stream.ToolStart != nil {
 		opts.Stream.ToolStart(run)
 	}

--- a/agent/commands.go
+++ b/agent/commands.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/url"
@@ -64,7 +65,7 @@ func executeCommands(ctx context.Context, account string, calls []service.Comman
 		wg.Add(1)
 		go func(i int, call service.CommandCall) {
 			defer wg.Done()
-			text, err := executeCommand(ctx, account, call, child)
+			text, err := executeCommandRun(ctx, account, call, child, fmt.Sprintf("command-%d", i))
 			if err != nil {
 				errs[i] = err
 				text = "Could not complete this request: " + err.Error()
@@ -107,8 +108,12 @@ func explicitCommand(prompt string) bool {
 }
 
 func executeCommand(ctx context.Context, account string, call service.CommandCall, opts QueryOpts) (string, error) {
+	return executeCommandRun(ctx, account, call, opts, "command")
+}
+
+func executeCommandRun(ctx context.Context, account string, call service.CommandCall, opts QueryOpts, id string) (string, error) {
 	name := call.Service + "_" + strings.ToLower(call.Method)
-	run := ToolRun{ID: "command-" + name, Name: name, Label: toolLabel(name)}
+	run := ToolRun{ID: id, Name: name, Label: toolLabel(name)}
 	if opts.Stream.ToolStart != nil {
 		opts.Stream.ToolStart(run)
 	}
@@ -161,11 +166,68 @@ func commandText(result map[string]any) string {
 			return b.String()
 		}
 	}
-	for _, key := range []string{"summary", "text"} {
+	for _, key := range []string{"summary", "text", "events"} {
 		if s, ok := result[key].(string); ok && s != "" {
 			return s
 		}
 	}
 
+	for _, key := range []string{"notes", "entries"} {
+		if raw, exists := result[key]; exists {
+			rows, _ := raw.([]any)
+			if len(rows) == 0 {
+				return "No results."
+			}
+			var lines []string
+			escape := strings.NewReplacer("\\", "\\\\", "*", "\\*", "_", "\\_", "[", "\\[", "]", "\\]", "<", "&lt;", ">", "&gt;", "`", "\\`", "\n", " ")
+			for _, raw := range rows {
+				row, ok := raw.(map[string]any)
+				if !ok {
+					continue
+				}
+				title, _ := row["title"].(string)
+				text, _ := row["text"].(string)
+				if title != "" && text != "" {
+					text = title + " — " + text
+				} else if title != "" {
+					text = title
+				}
+				if text != "" {
+					lines = append(lines, "- "+escape.Replace(text))
+				}
+			}
+			if len(lines) > 0 {
+				return strings.Join(lines, "\n")
+			}
+		}
+	}
+	if len(result) == 1 {
+		for _, key := range []string{"text", "summary"} {
+			if _, exists := result[key]; exists {
+				return ""
+			}
+		}
+	}
+	if items, ok := result["items"].([]any); ok {
+		for _, raw := range items {
+			if item, ok := raw.(map[string]any); ok {
+				if link, ok := item["url"].(string); ok {
+					u, err := url.Parse(link)
+					if err != nil || (u.Scheme != "https" && u.Scheme != "http") || u.Host == "" {
+						return ""
+					}
+				}
+			}
+		}
+	}
+	// Other registered read responses still have a useful exact representation.
+	// Do not execute a service successfully and then claim it returned nothing
+	// merely because its field names differ from news and weather.
+	if len(result) > 0 {
+		b, err := json.MarshalIndent(result, "", "  ")
+		if err == nil {
+			return "```json\n" + string(b) + "\n```"
+		}
+	}
 	return ""
 }

--- a/agent/commands_test.go
+++ b/agent/commands_test.go
@@ -81,7 +81,7 @@ func TestCommandCatalogueAndNativeFastPath(t *testing.T) {
 			t.Errorf("%q: %+v %v", tc.input, call, ok)
 		}
 	}
-	for _, input := range []string{"don't show headlines", "compare the weather in London and Paris", "weather in London tomorrow"} {
+	for _, input := range []string{"don't show headlines", "compare the weather in London and Paris"} {
 		if _, ok := promptCommand(input, QueryOpts{Public: true}); ok {
 			t.Errorf("overmatched %q", input)
 		}
@@ -94,7 +94,7 @@ func TestCommandCatalogueAndNativeFastPath(t *testing.T) {
 	for _, spec := range []service.Spec{news.Spec, weather.Spec, web.Spec} {
 		for method, ep := range spec.Endpoints {
 			for _, command := range ep.Commands {
-				input := strings.ReplaceAll(strings.ReplaceAll(command.Pattern, "{place}", "São Paulo"), "{query}", "Sam Altman and OpenAI")
+				input := strings.ReplaceAll(strings.ReplaceAll(command.Pattern+" "+command.Suffix, "{place}", "São Paulo"), "{query}", "Sam Altman and OpenAI")
 				call, ok := promptCommand(input, QueryOpts{Public: true})
 				if !ok || call.Service != spec.Name || call.Method != method {
 					t.Errorf("declared command %q failed: %+v %v", input, call, ok)
@@ -130,7 +130,7 @@ func TestExplicitCommandsNeverUseModel(t *testing.T) {
 	}
 	for _, input := range []string{"/unknown-command", "/news"} {
 		answer, err := runNative("", input, QueryOpts{System: "Selected agent", Tools: []string{"weather"}})
-		if err == nil || !strings.Contains(err.Error(), "unknown or unavailable command") || answer != "" {
+		if err == nil || !strings.Contains(err.Error(), "command") || answer != "" {
 			t.Fatalf("%s: %q %v", input, answer, err)
 		}
 	}

--- a/agent/native.go
+++ b/agent/native.go
@@ -671,12 +671,19 @@ type StreamHooks struct {
 // This is the agent. There is no second one — see the note on ErrNoProvider,
 // and AGENTS.md for the rule that says so.
 func runNative(accountID, prompt string, opts QueryOpts) (string, error) {
-	if command, ok := promptCommand(prompt, opts); ok {
+	if commands, ok := promptCommands(prompt, opts); ok {
 		ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 		defer cancel()
-		return executeCommand(ctx, accountID, command, opts)
+		return executeCommands(ctx, accountID, commands, opts)
 	}
 
+	if commandDenied(prompt, opts) {
+		return "", fmt.Errorf("command unavailable in this context")
+	}
+	if strings.EqualFold(strings.TrimSpace(prompt), "/help") {
+		examples := service.CommandExamples(filterServices(nativeServices(opts.Public), opts.Tools), !opts.Public)
+		return "Type a command directly, with or without /. Combine independent reads with ‘and’.\n\n" + strings.Join(examples, " · "), nil
+	}
 	if explicitCommand(prompt) {
 		return "", fmt.Errorf("unknown or unavailable command: %s", strings.Fields(prompt)[0])
 	}

--- a/internal/service/command_language.go
+++ b/internal/service/command_language.go
@@ -1,0 +1,66 @@
+package service
+
+import (
+	"strings"
+	"unicode"
+	"unicode/utf8"
+)
+
+// MatchCommandsFor composes up to four independent reads. It uses the service
+// declarations for every clause; it never guesses a tool or discards a clause.
+// A complete match wins before splitting, so search terms retain their meaning.
+func MatchCommandsFor(input string, allowed []string, private bool) ([]CommandCall, bool) {
+	if len(input) > 8000 || !utf8.ValidString(input) {
+		return nil, false
+	}
+	for _, r := range input {
+		if unicode.IsControl(r) && r != '\t' {
+			return nil, false
+		}
+	}
+	input = strings.TrimSpace(input)
+	if call, ok := MatchCommandFor(input, allowed, private); ok {
+		return []CommandCall{call}, true
+	}
+	// Only a leading request wrapper is removable. Negation, dates, quoted
+	// queries and trailing qualifications are never treated as stop words.
+	for _, prefix := range []string{"please ", "can you ", "could you "} {
+		if len(input) >= len(prefix) && strings.EqualFold(input[:len(prefix)], prefix) {
+			input = strings.TrimSpace(input[len(prefix):])
+			break
+		}
+	}
+	if call, ok := MatchCommandFor(input, allowed, private); ok {
+		return []CommandCall{call}, true
+	}
+	// Quoting protects literal conjunctions; unfamiliar composition belongs to
+	// the assistant, rather than partly executing a sentence we did not parse.
+	if strings.ContainsAny(input, "\"“”‘’;") {
+		return nil, false
+	}
+	words := strings.Fields(input)
+	var parts []string
+	start := 0
+	for i, word := range words {
+		if strings.EqualFold(word, "and") || word == "&" {
+			if i == start {
+				return nil, false
+			}
+			parts = append(parts, strings.Join(words[start:i], " "))
+			start = i + 1
+		}
+	}
+	if start == 0 || start == len(words) || len(parts) >= 4 {
+		return nil, false
+	}
+	parts = append(parts, strings.Join(words[start:], " "))
+	calls := make([]CommandCall, 0, len(parts))
+	for _, part := range parts {
+		call, ok := MatchCommandFor(part, allowed, private)
+		if !ok {
+			return nil, false
+		}
+		calls = append(calls, call)
+	}
+	return calls, true
+}

--- a/internal/service/command_language_test.go
+++ b/internal/service/command_language_test.go
@@ -1,0 +1,52 @@
+package service
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestCommandLanguageComposesOnlyCompleteReads(t *testing.T) {
+	specMu.Lock()
+	old := specs
+	specs = map[string]Spec{
+		"news":    {Name: "news", Handler: ListProbe{}, Endpoints: map[string]Endpoint{"List": {Commands: []Command{{Pattern: "headlines"}}}}},
+		"weather": {Name: "weather", Endpoints: map[string]Endpoint{"Lookup": {Commands: []Command{{Pattern: "weather"}, {Pattern: "weather in {place}"}, {Pattern: "weather in {place}", Suffix: "tomorrow", Defaults: map[string]any{"day": "tomorrow"}}}}}},
+		"web":     {Name: "web", Endpoints: map[string]Endpoint{"Search": {Commands: []Command{{Pattern: "web search {query}"}}}}},
+		"mail":    {Name: "mail", Scoped: true, Handler: ListProbe{}, Endpoints: map[string]Endpoint{"List": {Needs: Caller}, "Send": {Writes: true, Commands: []Command{{Pattern: "send mail"}}}}},
+	}
+	specMu.Unlock()
+	defer func() { specMu.Lock(); specs = old; specMu.Unlock() }()
+	allowed := []string{"news", "weather", "web", "mail"}
+	for _, tc := range []struct {
+		input string
+		count int
+	}{
+		{"news", 1}, {"Please news", 1}, {"can you show me news?", 1}, {"could you weather in London", 1},
+		{"weather and latest news", 2}, {"weather & news", 2}, {"PLEASE weather in London tomorrow and headlines!", 2},
+		{"weather and news and weather and news", 4},
+		{"web search Sam Altman and OpenAI", 1}, {`web search "news and weather"`, 1},
+		{"don't show news", 0}, {"please don't show news", 0}, {"news and send mail", 0}, {"weather and compare my plans", 0},
+		{"news then weather", 0}, {"weather in London and Paris", 0}, {"news and", 0}, {"and news", 0},
+		{"news and news and news and news and news", 0}, {"news\nweather", 0}, {"news and mail", 0},
+		{"weather in London tomorrow and email it to me", 0}, {"weather in London yesterday", 0},
+	} {
+		calls, ok := MatchCommandsFor(tc.input, allowed, false)
+		if ok != (tc.count > 0) || len(calls) != tc.count {
+			t.Errorf("%q: %+v %v", tc.input, calls, ok)
+		}
+	}
+	calls, ok := MatchCommandsFor("please weather in São Paulo tomorrow and news", allowed, false)
+	if !ok || !reflect.DeepEqual(calls[0].Args, map[string]any{"place": "São Paulo", "day": "tomorrow"}) {
+		t.Fatalf("lost slots: %+v", calls)
+	}
+	calls, ok = MatchCommandsFor("web search Sam Altman and OpenAI", allowed, false)
+	if !ok || calls[0].Args["query"] != "Sam Altman and OpenAI" {
+		t.Fatalf("changed query: %+v", calls)
+	}
+	if _, ok := MatchCommandsFor("news and mail", allowed, true); !ok {
+		t.Fatal("owner's private read was lost")
+	}
+	if _, ok := MatchCommandsFor("news and weather", []string{"news"}, true); ok {
+		t.Fatal("widened scope")
+	}
+}

--- a/internal/service/commands.go
+++ b/internal/service/commands.go
@@ -12,6 +12,7 @@ import (
 // ending in one {argument}. Endpoints opt in; writes cannot be prompt commands.
 type Command struct {
 	Pattern  string
+	Suffix   string // optional fixed words after the final argument
 	Defaults map[string]any
 }
 
@@ -62,9 +63,9 @@ func MatchCommandFor(input string, allowed []string, private bool) (CommandCall,
 				if !ok {
 					continue
 				}
-				score := len(command.Pattern)
+				score := len(command.Pattern) + len(command.Suffix)
 				if i := strings.Index(command.Pattern, "{"); i >= 0 {
-					score = i
+					score = i + len(command.Suffix)
 				} else {
 					score += 10000
 				}
@@ -97,6 +98,14 @@ func (c Command) match(input string) (map[string]any, bool) {
 		if unicode.IsControl(r) && r != '\t' {
 			return nil, false
 		}
+	}
+	if c.Suffix != "" {
+		value := strings.TrimSpace(strings.TrimRight(input, "?!."))
+		end := len(value) - len(c.Suffix)
+		if end <= 0 || !strings.EqualFold(value[end:], c.Suffix) || !unicode.IsSpace(rune(value[end-1])) {
+			return nil, false
+		}
+		input = strings.TrimSpace(value[:end])
 	}
 	words := strings.Fields(c.Pattern)
 	if len(words) == 0 {
@@ -194,6 +203,7 @@ func commandsFor(spec Spec, method string, ep Endpoint) []Command {
 		}
 	}
 	names := append([]string{spec.Name, strings.ToLower(spec.NavLabel())}, ep.Aliases...)
+	out = append(out, Command{Pattern: spec.Name + " list", Defaults: defaults})
 	seen := map[string]bool{}
 	for _, c := range out {
 		seen[strings.ToLower(c.Pattern)] = true

--- a/service/news/agent.go
+++ b/service/news/agent.go
@@ -23,7 +23,9 @@ import (
 // what to read in full via news_read. Categories are interleaved round-robin
 // and ordered by recency, so every topic is represented near the top
 // regardless of its name. An optional topic filters to matching categories.
-func HeadlinesText(topic string, limit int) string {
+func HeadlinesText(topic string, limit int) string { return headlinesText(GetFeed(), topic, limit) }
+
+func headlinesText(posts []*Post, topic string, limit int) string {
 	if limit <= 0 || limit > 100 {
 		limit = 30
 	}
@@ -31,7 +33,7 @@ func HeadlinesText(topic string, limit int) string {
 
 	byCat := map[string][]*Post{}
 	var catOrder []string
-	for _, p := range GetFeed() {
+	for _, p := range posts {
 		if p == nil || strings.TrimSpace(p.Title) == "" {
 			continue
 		}
@@ -273,14 +275,16 @@ func metaTime(v interface{}) time.Time {
 // agent/blog researches the top few of a category, and getting the titles back
 // out of the formatted text it had just been handed is what made it import this
 // package instead of calling it.
-func HeadlineItems(topic string, limit int) []Headline {
+func HeadlineItems(topic string, limit int) []Headline { return headlineItems(GetFeed(), topic, limit) }
+
+func headlineItems(posts []*Post, topic string, limit int) []Headline {
 	if limit <= 0 || limit > 100 {
 		limit = 30
 	}
 	topic = strings.TrimSpace(strings.ToLower(topic))
 
 	var out []Headline
-	for _, p := range GetFeed() {
+	for _, p := range posts {
 		if p == nil || strings.TrimSpace(p.Title) == "" {
 			continue
 		}

--- a/service/news/agent.go
+++ b/service/news/agent.go
@@ -23,9 +23,11 @@ import (
 // what to read in full via news_read. Categories are interleaved round-robin
 // and ordered by recency, so every topic is represented near the top
 // regardless of its name. An optional topic filters to matching categories.
-func HeadlinesText(topic string, limit int) string { return headlinesText(GetFeed(), topic, limit) }
+func HeadlinesText(topic string, limit int) string {
+	return headlinesText(GetFeed(), topic, limit, time.Now().UTC())
+}
 
-func headlinesText(posts []*Post, topic string, limit int) string {
+func headlinesText(posts []*Post, topic string, limit int, at time.Time) string {
 	if limit <= 0 || limit > 100 {
 		limit = 30
 	}
@@ -84,7 +86,7 @@ func headlinesText(posts []*Post, topic string, limit int) string {
 	}
 
 	var sb strings.Builder
-	fmt.Fprintf(&sb, "Current request date: %s.\n", time.Now().UTC().Format("Monday, 2 January 2006 (2006-01-02, UTC)"))
+	fmt.Fprintf(&sb, "Current request date: %s.\n", at.Format("Monday, 2 January 2006 (2006-01-02, MST)"))
 	if topic != "" {
 		fmt.Fprintf(&sb, "Latest %q headlines (%d). Use news_read with an id to read one in full.\n\n", topic, len(picked))
 	} else {

--- a/service/news/command_date_test.go
+++ b/service/news/command_date_test.go
@@ -2,6 +2,7 @@ package news
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 )
@@ -14,6 +15,10 @@ func TestNewsTodayUsesLocalDateAndExcludesFuture(t *testing.T) {
 	got := newsForDay([]*Post{nil, yesterday, today, future, {Title: "Undated"}}, at)
 	if len(got) != 1 || got[0] != today {
 		t.Fatalf("wrong calendar day: %+v", got)
+	}
+	text := headlinesText(got, "", 5, at)
+	if !strings.Contains(text, "2026-09-09") || strings.Contains(text, "2026-09-08") {
+		t.Fatalf("contradictory date: %s", text)
 	}
 	var rsp ListResponse
 	if err := (Server{}).List(context.Background(), &ListRequest{Day: "tomorrow"}, &rsp); err == nil {

--- a/service/news/command_date_test.go
+++ b/service/news/command_date_test.go
@@ -1,0 +1,22 @@
+package news
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestNewsTodayUsesLocalDateAndExcludesFuture(t *testing.T) {
+	at := time.Date(2026, 9, 9, 0, 30, 0, 0, time.FixedZone("home", 14*3600))
+	today := &Post{Title: "Today", PostedAt: at.Add(-15 * time.Minute)}
+	yesterday := &Post{Title: "Yesterday", PostedAt: at.Add(-time.Hour)}
+	future := &Post{Title: "Future", PostedAt: at.Add(time.Hour)}
+	got := newsForDay([]*Post{nil, yesterday, today, future, {Title: "Undated"}}, at)
+	if len(got) != 1 || got[0] != today {
+		t.Fatalf("wrong calendar day: %+v", got)
+	}
+	var rsp ListResponse
+	if err := (Server{}).List(context.Background(), &ListRequest{Day: "tomorrow"}, &rsp); err == nil {
+		t.Fatal("unsupported date ignored")
+	}
+}

--- a/service/news/service.go
+++ b/service/news/service.go
@@ -2,6 +2,8 @@ package news
 
 import (
 	"context"
+	"fmt"
+	"mu/internal/auth"
 	"time"
 
 	"mu/internal/quota"
@@ -35,6 +37,7 @@ func (Server) Headlines(_ context.Context, _ *HeadlinesRequest, rsp *HeadlinesRe
 
 // ListRequest filters the headline list.
 type ListRequest struct {
+	Day   string `json:"day,omitempty" description:"today to restrict headlines to the caller’s local calendar day"`
 	Topic string `json:"topic" description:"Optional topic/category filter (e.g. tech, world, business)"`
 	Limit int    `json:"limit" description:"Optional max number of headlines (default 30)"`
 }
@@ -66,10 +69,36 @@ type ListResponse struct {
 // List returns recent news headlines with short summaries, balanced across
 // topics (not dominated by one topic like crypto).
 // @example {"topic": "tech"}
-func (Server) List(_ context.Context, req *ListRequest, rsp *ListResponse) error {
-	rsp.Text = HeadlinesText(req.Topic, req.Limit)
-	rsp.Items = HeadlineItems(req.Topic, req.Limit)
+func (Server) List(ctx context.Context, req *ListRequest, rsp *ListResponse) error {
+	posts := GetFeed()
+	if req.Day != "" {
+		if req.Day != "today" {
+			return fmt.Errorf("day must be today or empty")
+		}
+		at := time.Now().UTC()
+		if account, err := auth.GetAccount(service.AccountFrom(ctx)); err == nil && account != nil {
+			if zone, err := time.LoadLocation(account.Zone); err == nil {
+				at = at.In(zone)
+			}
+		}
+		posts = newsForDay(posts, at)
+	}
+	rsp.Text = headlinesText(posts, req.Topic, req.Limit)
+	rsp.Items = headlineItems(posts, req.Topic, req.Limit)
+	if req.Day != "" && len(rsp.Items) == 0 {
+		rsp.Text = "No headlines available for today yet."
+	}
 	return nil
+}
+
+func newsForDay(posts []*Post, at time.Time) []*Post {
+	var out []*Post
+	for _, post := range posts {
+		if post != nil && !post.PostedAt.After(at) && post.PostedAt.In(at.Location()).Format("2006-01-02") == at.Format("2006-01-02") {
+			out = append(out, post)
+		}
+	}
+	return out
 }
 
 // ReadRequest selects one article.
@@ -122,7 +151,7 @@ var Spec = service.Spec{
 	Now: Now,
 	Endpoints: map[string]service.Endpoint{
 		"Headlines": {Doc: "Read the home card headlines: latest story per topic, freshest first, at most ten"},
-		"List":      {Commands: []service.Command{{Pattern: "news", Defaults: map[string]any{"limit": 5}}, {Pattern: "headlines", Defaults: map[string]any{"limit": 5}}, {Pattern: "latest headlines", Defaults: map[string]any{"limit": 5}}, {Pattern: "show me the news", Defaults: map[string]any{"limit": 5}}}, Aliases: []string{"news"}, Doc: "Read recent news headlines with short summaries, balanced across topics"},
+		"List":      {Commands: []service.Command{{Pattern: "news today", Defaults: map[string]any{"limit": 5, "day": "today"}}, {Pattern: "headlines today", Defaults: map[string]any{"limit": 5, "day": "today"}}, {Pattern: "news", Defaults: map[string]any{"limit": 5}}, {Pattern: "headlines", Defaults: map[string]any{"limit": 5}}, {Pattern: "latest headlines", Defaults: map[string]any{"limit": 5}}, {Pattern: "show me the news", Defaults: map[string]any{"limit": 5}}}, Aliases: []string{"news"}, Doc: "Read recent news headlines with short summaries, balanced across topics"},
 		"Read":      {Doc: "Read one news article in full by its id or URL"},
 		"Search":    {Doc: "Search indexed and live news for a topic", Cost: quota.OpNewsSearch},
 	},

--- a/service/news/service.go
+++ b/service/news/service.go
@@ -71,11 +71,11 @@ type ListResponse struct {
 // @example {"topic": "tech"}
 func (Server) List(ctx context.Context, req *ListRequest, rsp *ListResponse) error {
 	posts := GetFeed()
+	at := time.Now().UTC()
 	if req.Day != "" {
 		if req.Day != "today" {
 			return fmt.Errorf("day must be today or empty")
 		}
-		at := time.Now().UTC()
 		if account, err := auth.GetAccount(service.AccountFrom(ctx)); err == nil && account != nil {
 			if zone, err := time.LoadLocation(account.Zone); err == nil {
 				at = at.In(zone)
@@ -83,7 +83,7 @@ func (Server) List(ctx context.Context, req *ListRequest, rsp *ListResponse) err
 		}
 		posts = newsForDay(posts, at)
 	}
-	rsp.Text = headlinesText(posts, req.Topic, req.Limit)
+	rsp.Text = headlinesText(posts, req.Topic, req.Limit, at)
 	rsp.Items = headlineItems(posts, req.Topic, req.Limit)
 	if req.Day != "" && len(rsp.Items) == 0 {
 		rsp.Text = "No headlines available for today yet."

--- a/service/weather/lookup.go
+++ b/service/weather/lookup.go
@@ -12,11 +12,15 @@ import (
 
 // LookupRequest names a place rather than requiring coordinates.
 type LookupRequest struct {
+	Day   string `json:"day,omitempty" description:"today or tomorrow; empty returns the current multi-day forecast"`
 	Place string `json:"place" description:"Town or city to look up"`
 	Focus string `json:"focus,omitempty" description:"rain for a rain-focused answer, otherwise a general forecast"`
 }
 
 func (Server) Lookup(ctx context.Context, req *LookupRequest, rsp *ForecastResponse) error {
+	if req.Day != "" && req.Day != "today" && req.Day != "tomorrow" {
+		return fmt.Errorf("day must be today or tomorrow")
+	}
 	if len(req.Place) > 200 {
 		return fmt.Errorf("place name is too long")
 	}
@@ -63,7 +67,15 @@ func (Server) Lookup(ctx context.Context, req *LookupRequest, rsp *ForecastRespo
 	if forecast == nil {
 		return fmt.Errorf("forecast unavailable")
 	}
-	rsp.Summary = lookupForecastText(forecast, place.Label(), req.Focus, localLookupTime(owner))
+	at := localLookupTime(owner)
+	if req.Day == "tomorrow" {
+		at = at.AddDate(0, 0, 1)
+	}
+	if req.Day != "" {
+		rsp.Summary = lookupDayText(forecast, place.Label(), at)
+	} else {
+		rsp.Summary = lookupForecastText(forecast, place.Label(), req.Focus, at)
+	}
 	return nil
 }
 
@@ -130,4 +142,31 @@ func lookupForecastText(f *WeatherForecast, place, focus string, at time.Time) s
 		fmt.Fprintf(&b, "\nForecast updated %s UTC.", f.GeneratedAt.UTC().Format("2 Jan 15:04"))
 	}
 	return b.String()
+}
+
+// Date words are declared by the service that can honour them, not stripped
+// globally by the command parser.
+func lookupCommands(base []service.Command) []service.Command {
+	out := append([]service.Command(nil), base...)
+	for i := range out {
+		if strings.HasSuffix(out[i].Pattern, " today") {
+			out[i].Defaults = map[string]any{"day": "today"}
+		}
+	}
+	for _, day := range []string{"today", "tomorrow"} {
+		for _, pattern := range []string{"weather", "weather in {place}", "weather {place}", "will it rain", "will it rain in {place}"} {
+			out = append(out, service.Command{Pattern: pattern, Suffix: day, Defaults: map[string]any{"day": day}})
+		}
+		out = append(out, service.Command{Pattern: "weather " + day + " in {place}", Defaults: map[string]any{"day": day}})
+	}
+	return out
+}
+
+func lookupDayText(f *WeatherForecast, place string, at time.Time) string {
+	day, ok := dailyItemForDate(f.DailyItems, at)
+	label := at.Format("Monday 2 January")
+	if !ok {
+		return fmt.Sprintf("%s\n\nThe forecast for %s is unavailable.", place, label)
+	}
+	return fmt.Sprintf("%s\n\n%s: %.0f–%.0f°C, %s. Rain: %.1f mm; chance of rain: %d%%.", place, label, day.MinTempC, day.MaxTempC, day.Description, day.RainMM, day.RainChance)
 }

--- a/service/weather/lookup_test.go
+++ b/service/weather/lookup_test.go
@@ -206,3 +206,23 @@ func TestLookupRainUsesLocalCalendarDate(t *testing.T) {
 		}
 	}
 }
+
+func TestLookupTomorrowSelectsRequestedDate(t *testing.T) {
+	at := time.Date(2026, 9, 9, 0, 30, 0, 0, time.FixedZone("home", 14*3600))
+	f := &WeatherForecast{Current: &CurrentConditions{TempC: 99}, DailyItems: []DailyItem{
+		{Date: at.AddDate(0, 0, -1), Description: "old"},
+		{Date: at, MinTempC: 11, MaxTempC: 18, Description: "Rain", RainMM: 4, RainChance: 80},
+		{Date: at.AddDate(0, 0, 1), Description: "later"},
+	}}
+	text := lookupDayText(f, "Hampton", at)
+	if !strings.Contains(text, "Wednesday 9 September") || !strings.Contains(text, "11–18°C") || !strings.Contains(text, "80%") || strings.Contains(text, "old") || strings.Contains(text, "later") || strings.Contains(text, "99") {
+		t.Fatal(text)
+	}
+	if text = lookupDayText(f, "Hampton", at.AddDate(0, 0, 5)); !strings.Contains(text, "unavailable") {
+		t.Fatal(text)
+	}
+	var rsp ForecastResponse
+	if err := (Server{}).Lookup(context.Background(), &LookupRequest{Day: "next week"}, &rsp); err == nil {
+		t.Fatal("ignored unsupported date")
+	}
+}

--- a/service/weather/service.go
+++ b/service/weather/service.go
@@ -180,7 +180,7 @@ var Spec = service.Spec{
 	Icon:        "weather.svg",
 	Card:        service.Personal(CardHTML),
 	Endpoints: map[string]service.Endpoint{
-		"Lookup": {Doc: "Look up the weather by town or city name", Cost: quota.OpWeatherForecast, Commands: []service.Command{
+		"Lookup": {Doc: "Look up the weather by town or city name", Cost: quota.OpWeatherForecast, Commands: lookupCommands([]service.Command{
 			{Pattern: "what's the weather like in {place}"}, {Pattern: "what is the weather in {place}"}, {Pattern: "is it going to rain in {place}", Defaults: map[string]any{"focus": "rain"}}, {Pattern: "weather in {place}"}, {Pattern: "weather {place}"},
 			{Pattern: "what's the weather like"}, {Pattern: "what’s the weather like"},
 			{Pattern: "what's the weather today"}, {Pattern: "what’s the weather today"},
@@ -189,7 +189,7 @@ var Spec = service.Spec{
 			{Pattern: "is it going to rain", Defaults: map[string]any{"focus": "rain"}},
 			{Pattern: "will it rain", Defaults: map[string]any{"focus": "rain"}},
 			{Pattern: "will it rain in {place}", Defaults: map[string]any{"focus": "rain"}},
-		}},
+		})},
 		"Forecast": {Doc: "Get the weather forecast for a location — current conditions, the days " +
 			"ahead, and today's sunrise, sunset and how much daylight is left, which is the fact " +
 			"that decides an afternoon outdoors",


### PR DESCRIPTION
Known requests such as “news today” and “weather in London tomorrow” still fell through to a model, adding latency before a service lookup. This extends the existing command path without creating a second tool catalogue.

- Recognize bounded leading request phrases and up to four independent reads joined by “and” or “&”. Every clause must resolve; queries, negation, unsupported qualifiers and writes are not guessed.
- Run independent service reads concurrently, serialize response hooks, preserve request order and show partial failures without retrying through a model. All failed reads return an error.
- Honour today for news in the caller’s timezone, and today/tomorrow for weather. Missing location still uses the caller’s saved location or asks for it.
- Add derived “service list” spelling and /help. Known unavailable commands fail directly. Include composed commands in the existing no-agent-charge/no-memory-extraction decisions.

Validation: service/news/weather and command-focused agent tests pass, including race runs, parallel execution barriers, authorization boundaries, local date selection and an HTTP spy proving zero network/model calls on direct routes. Local full-agent tests hit two existing environment-dependent netlink discovery failures; CI will check the full suite. Build uses -buildvcs=false locally because the workspace cannot obtain Go VCS stamping. No live model or external delivery used in the new tests.

Related to #1567. Consumer/home/group direction is recorded in #1585. The requested higher-quality Hey Micro voice path is tracked separately in #1582; the browser wake prototype is not included. No README edits.