### PR TITLE
Edit Home status directly in its text line

### DIFF
--- a/home/status.go
+++ b/home/status.go
@@ -1,6 +1,8 @@
 package home
 
 import (
+	_ "embed"
+	"encoding/json"
 	"html"
 	"net/http"
 
@@ -12,10 +14,14 @@ import (
 func statusHandler(w http.ResponseWriter, r *http.Request) {
 	_, acc, err := auth.RequireSession(r)
 	if err != nil {
-		app.RedirectToLogin(w, r)
+		if app.WantsJSON(r) {
+			http.Error(w, "Sign in again to save your status.", http.StatusUnauthorized)
+		} else {
+			app.RedirectToLogin(w, r)
+		}
 		return
 	}
-	if !auth.ValidCSRF(r) || !auth.CanPost(acc.ID) {
+	if !auth.StrictCSRF(r) || !auth.CanPost(acc.ID) {
 		http.Error(w, "You cannot update your status with this session.", http.StatusForbidden)
 		return
 	}
@@ -31,17 +37,26 @@ func statusHandler(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
+	if app.WantsJSON(r) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Cache-Control", "no-store")
+		json.NewEncoder(w).Encode(map[string]string{"status": user.Status(acc.ID)})
+		return
+	}
 	http.Redirect(w, r, "/home", http.StatusSeeOther)
 }
+
+//go:embed status.js
+var statusJS string
 
 func statusForm(r *http.Request, id string) string {
 	if id == "" {
 		return ""
 	}
-	return `<details class="disclosure page-section"><summary>Your status</summary>` +
-		`<form class="form" method="post" action="/home">` +
-		`<input type="hidden" name="action" value="status">` +
-		`<input type="hidden" name="_csrf" value="` + html.EscapeString(auth.CSRFToken(r)) + `">` +
-		`<label class="field-label">Shown on your profile<input class="field field-wide" name="status" maxlength="160" placeholder="What are you up to?" value="` + html.EscapeString(user.Status(id)) + `"></label>` +
-		`<div class="form-actions"><button type="submit">Save</button><button type="submit" name="clear" value="1">Clear</button></div></form></details>`
+	text := user.Status(id)
+	label := text
+	if label == "" {
+		label = "What are you up to?"
+	}
+	return `<div id="home-status" class="page-section" data-csrf="` + html.EscapeString(auth.CSRFToken(r)) + `"><div class="form-actions"><span class="muted">Status ·</span><button type="button" class="link-button" data-status-label aria-label="Change your public profile status">` + html.EscapeString(label) + `</button><input data-status-input hidden maxlength="160" aria-label="Your public profile status" value="` + html.EscapeString(text) + `"></div><small data-status-feedback role="status" aria-live="polite"></small></div><script>` + statusJS + `</script>`
 }

--- a/home/status.go
+++ b/home/status.go
@@ -58,5 +58,5 @@ func statusForm(r *http.Request, id string) string {
 	if label == "" {
 		label = "What are you up to?"
 	}
-	return `<div id="home-status" class="page-section" data-csrf="` + html.EscapeString(auth.CSRFToken(r)) + `"><div class="form-actions"><span class="muted">Status ·</span><button type="button" class="link-button" data-status-label aria-label="Change your public profile status">` + html.EscapeString(label) + `</button><input data-status-input hidden maxlength="160" aria-label="Your public profile status" value="` + html.EscapeString(text) + `"></div><small data-status-feedback role="status" aria-live="polite"></small></div><script>` + statusJS + `</script>`
+	return `<div id="home-status" class="page-section" data-csrf="` + html.EscapeString(auth.CSRFToken(r)) + `"><div class="form-actions inline-edit"><span class="muted">Status ·</span><button type="button" class="link-button" data-status-label aria-label="Change your public profile status">` + html.EscapeString(label) + `</button><input data-status-input hidden maxlength="160" aria-label="Your public profile status" value="` + html.EscapeString(text) + `"></div><small data-status-feedback role="status" aria-live="polite"></small></div><script>` + statusJS + `</script>`
 }

--- a/home/status.js
+++ b/home/status.js
@@ -4,7 +4,12 @@
   var label = root.querySelector('[data-status-label]');
   var input = root.querySelector('[data-status-input]');
   var feedback = root.querySelector('[data-status-feedback]');
-  var saved = input.value, editing = false, saving = false;
+  if (root.dataset.statusSaved === undefined) root.dataset.statusSaved = input.value;
+  var saved = root.dataset.statusSaved, editing = !input.hidden, saving = false;
+  // Soft navigation serializes this DOM, including an in-flight editor.
+  if (input.readOnly) feedback.textContent = 'Save interrupted. Press Enter or tap away to retry.';
+  input.readOnly = false;
+  input.addEventListener('input', function () { input.defaultValue = input.value; });
   function close() {
     editing = false;
     input.hidden = true;
@@ -13,7 +18,7 @@
   }
   label.addEventListener('click', function () {
     if (saving) return;
-    input.value = saved;
+    input.value = input.defaultValue = saved;
     label.hidden = true;
     input.hidden = false;
     editing = true;
@@ -38,6 +43,8 @@
       var result = await response.json();
       if (typeof result.status !== 'string') throw new Error('invalid response');
       saved = result.status;
+      root.dataset.statusSaved = saved;
+      input.value = input.defaultValue = saved;
       var hadFocus = document.activeElement === input;
       close();
       feedback.textContent = '';
@@ -56,7 +63,7 @@
     if (event.key === 'Enter') { event.preventDefault(); save(); }
     if (event.key === 'Escape') {
       event.preventDefault();
-      input.value = saved;
+      input.value = input.defaultValue = saved;
       feedback.textContent = '';
       close();
       label.focus();

--- a/home/status.js
+++ b/home/status.js
@@ -1,0 +1,65 @@
+(function () {
+  var root = document.getElementById('home-status');
+  if (!root) return;
+  var label = root.querySelector('[data-status-label]');
+  var input = root.querySelector('[data-status-input]');
+  var feedback = root.querySelector('[data-status-feedback]');
+  var saved = input.value, editing = false, saving = false;
+  function close() {
+    editing = false;
+    input.hidden = true;
+    label.hidden = false;
+    label.textContent = saved || 'What are you up to?';
+  }
+  label.addEventListener('click', function () {
+    if (saving) return;
+    input.value = saved;
+    label.hidden = true;
+    input.hidden = false;
+    editing = true;
+    feedback.textContent = '';
+    input.focus();
+  });
+  async function save() {
+    if (!editing || saving) return;
+    if (input.value === saved) { close(); return; }
+    saving = true;
+    input.readOnly = true;
+    feedback.textContent = 'Saving…';
+    var controller = new AbortController();
+    var timeout = setTimeout(function () { controller.abort(); }, 15000);
+    try {
+      var response = await fetch('/home', {
+        method: 'POST', credentials: 'same-origin', signal: controller.signal,
+        headers: {'Accept': 'application/json', 'Content-Type': 'application/x-www-form-urlencoded'},
+        body: new URLSearchParams({action: 'status', status: input.value, _csrf: root.dataset.csrf})
+      });
+      if (!response.ok) throw new Error('save failed');
+      var result = await response.json();
+      if (typeof result.status !== 'string') throw new Error('invalid response');
+      saved = result.status;
+      var hadFocus = document.activeElement === input;
+      close();
+      feedback.textContent = '';
+      if (hadFocus) label.focus();
+    } catch (err) {
+      feedback.textContent = 'Could not save. Your text is kept here; press Enter or tap away to retry.';
+    } finally {
+      clearTimeout(timeout);
+      input.readOnly = false;
+      saving = false;
+    }
+  }
+  input.addEventListener('blur', save);
+  input.addEventListener('keydown', function (event) {
+    if (event.isComposing || saving) return;
+    if (event.key === 'Enter') { event.preventDefault(); save(); }
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      input.value = saved;
+      feedback.textContent = '';
+      close();
+      label.focus();
+    }
+  });
+})();

--- a/home/status_test.go
+++ b/home/status_test.go
@@ -1,0 +1,44 @@
+package home
+
+import (
+	"net/http/httptest"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+func TestStatusInlineEditor(t *testing.T) {
+	if statusForm(httptest.NewRequest("GET", "/home", nil), "") != "" {
+		t.Fatal("guest status editor")
+	}
+	markup := statusForm(httptest.NewRequest("GET", "/home", nil), "status-test")
+	for _, unwanted := range []string{"<details", "<form", ">Save<", ">Clear<", ">Edit<"} {
+		if strings.Contains(markup, unwanted) {
+			t.Fatalf("unexpected control %s", unwanted)
+		}
+	}
+	if !strings.Contains(markup, "data-status-input hidden") {
+		t.Fatal("editor must start hidden")
+	}
+}
+
+func TestStatusEditorLifecycle(t *testing.T) {
+	node, err := exec.LookPath("node")
+	if err != nil {
+		t.Skip("node unavailable")
+	}
+	if out, err := exec.Command(node, "testdata/status.cjs").CombinedOutput(); err != nil {
+		t.Fatalf("%v\n%s", err, out)
+	}
+}
+
+func TestStatusSaveRequiresSession(t *testing.T) {
+	r := httptest.NewRequest("POST", "/home", strings.NewReader("action=status&status=Hello"))
+	r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	r.Header.Set("Accept", "application/json")
+	w := httptest.NewRecorder()
+	statusHandler(w, r)
+	if w.Code != 401 {
+		t.Fatalf("got %d, want unauthorized", w.Code)
+	}
+}

--- a/home/status_test.go
+++ b/home/status_test.go
@@ -1,10 +1,15 @@
 package home
 
 import (
+	"mu/internal/auth"
+	"mu/internal/user"
+	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os/exec"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestStatusInlineEditor(t *testing.T) {
@@ -40,5 +45,35 @@ func TestStatusSaveRequiresSession(t *testing.T) {
 	statusHandler(w, r)
 	if w.Code != 401 {
 		t.Fatalf("got %d, want unauthorized", w.Code)
+	}
+}
+
+func TestStatusSaveOwnsIdentityAndRequiresCSRF(t *testing.T) {
+	const who = "inline_status_owner"
+	if err := auth.Create(&auth.Account{ID: who, Created: time.Now().Add(-48 * time.Hour)}); err != nil {
+		t.Fatal(err)
+	}
+	sess, err := auth.CreateSession(who)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer auth.EndSession(sess.Token)
+	for _, valid := range []bool{false, true} {
+		r := httptest.NewRequest("POST", "/home", strings.NewReader(url.Values{"action": {"status"}, "status": {" Working   on Mu "}, "account_id": {"someone-else"}}.Encode()))
+		r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		r.Header.Set("Accept", "application/json")
+		r.AddCookie(&http.Cookie{Name: "session", Value: sess.Token})
+		if valid {
+			r.Header.Set("X-CSRF-Token", auth.CSRFToken(r))
+		}
+		w := httptest.NewRecorder()
+		statusHandler(w, r)
+		if !valid {
+			if w.Code != 403 || user.Status(who) != "" {
+				t.Fatalf("missing CSRF: %d", w.Code)
+			}
+		} else if w.Code != 200 || user.Status(who) != "Working on Mu" || user.Status("someone-else") != "" || !strings.Contains(w.Body.String(), `"status":"Working on Mu"`) {
+			t.Fatalf("save: %d %s", w.Code, w.Body.String())
+		}
 	}
 }

--- a/home/testdata/status.cjs
+++ b/home/testdata/status.cjs
@@ -2,12 +2,19 @@ const vm = require('node:vm');
 const fs = require('node:fs');
 const assert = require('node:assert/strict');
 const code = fs.readFileSync('status.js', 'utf8');
-function setup() {
+function setup(restored) {
  const document = {activeElement: null};
  function element(value) { return {value, hidden: false, textContent: '', listeners: {}, addEventListener(k, fn) {this.listeners[k] = fn;}, focus() {document.activeElement = this;}}; }
  const label = element(''), input = element('Working'), feedback = element('');
  input.hidden = true;
  const root = {dataset: {csrf: 'token'}, querySelector(s) {return s.includes('label') ? label : s.includes('input') ? input : feedback;}};
+ if (restored) {
+ root.dataset.statusSaved = restored.saved;
+ input.value = restored.draft;
+ input.hidden = false;
+ input.readOnly = true;
+ label.hidden = true;
+ }
  document.getElementById = () => root;
  const calls = [];
  let resolve;
@@ -35,5 +42,17 @@ function setup() {
  assert.match(s.feedback.textContent, /Could not save/);
  const retry = s.input.listeners.blur(); s.reply({ok:true,json:async()=>({status:'Keep my draft'})}); await retry;
  assert.equal(s.label.textContent, 'Keep my draft');
+ assert.equal(s.input.defaultValue, 'Keep my draft');
+ s = setup({saved:'Previous', draft:'Pending draft'});
+ assert.equal(s.input.readOnly, false);
+ assert.match(s.feedback.textContent, /interrupted/);
+ const resumed = s.input.listeners.blur();
+ assert.equal(s.calls.length, 1);
+ s.reply({ok:true,json:async()=>({status:'Pending draft'})}); await resumed;
+ assert.equal(s.input.defaultValue, 'Pending draft');
+ s.label.listeners.click(); assert.equal(s.input.value, 'Pending draft');
+ s.input.value = 'Another draft'; s.input.listeners.input();
+ assert.equal(s.input.defaultValue, 'Another draft');
+ s.key('Escape'); assert.equal(s.input.defaultValue, 'Pending draft');
  console.log('Status lifecycle passed');
 })().catch(e => {console.error(e); process.exitCode = 1;});

--- a/home/testdata/status.cjs
+++ b/home/testdata/status.cjs
@@ -1,0 +1,39 @@
+const vm = require('node:vm');
+const fs = require('node:fs');
+const assert = require('node:assert/strict');
+const code = fs.readFileSync('status.js', 'utf8');
+function setup() {
+ const document = {activeElement: null};
+ function element(value) { return {value, hidden: false, textContent: '', listeners: {}, addEventListener(k, fn) {this.listeners[k] = fn;}, focus() {document.activeElement = this;}}; }
+ const label = element(''), input = element('Working'), feedback = element('');
+ input.hidden = true;
+ const root = {dataset: {csrf: 'token'}, querySelector(s) {return s.includes('label') ? label : s.includes('input') ? input : feedback;}};
+ document.getElementById = () => root;
+ const calls = [];
+ let resolve;
+ vm.runInNewContext(code, {document, URLSearchParams, AbortController, setTimeout, clearTimeout, fetch: (url, opts) => {calls.push({url, opts}); return new Promise(r => resolve = r);}});
+ return {label, input, feedback, calls, reply: r => resolve(r), key: key => input.listeners.keydown({key, preventDefault(){}})};
+}
+(async () => {
+ let s = setup();
+ assert.equal(s.calls.length, 0);
+ s.label.listeners.click(); assert.equal(s.input.hidden, false);
+ s.input.value = 'Cancelled'; s.key('Escape'); await s.input.listeners.blur();
+ assert.equal(s.calls.length, 0); assert.equal(s.input.value, 'Working');
+ s.label.listeners.click(); s.input.value = 'New status'; s.key('Enter');
+ await s.input.listeners.blur(); assert.equal(s.calls.length, 1);
+ assert.equal(new URLSearchParams(s.calls[0].opts.body).get('status'), 'New status');
+ s.reply({ok:true,json:async()=>({status:'New status'})});
+ await new Promise(setImmediate);
+ assert.equal(s.label.textContent, 'New status'); assert.equal(s.input.hidden, true);
+ s.label.listeners.click(); s.input.value = ''; const cleared = s.input.listeners.blur();
+ s.reply({ok:true,json:async()=>({status:''})}); await cleared;
+ assert.equal(s.label.textContent, 'What are you up to?');
+ s.label.listeners.click(); s.input.value = 'Keep my draft'; const failed = s.input.listeners.blur();
+ s.reply({ok:false}); await failed;
+ assert.equal(s.input.value, 'Keep my draft'); assert.equal(s.input.hidden, false);
+ assert.match(s.feedback.textContent, /Could not save/);
+ const retry = s.input.listeners.blur(); s.reply({ok:true,json:async()=>({status:'Keep my draft'})}); await retry;
+ assert.equal(s.label.textContent, 'Keep my draft');
+ console.log('Status lifecycle passed');
+})().catch(e => {console.error(e); process.exitCode = 1;});

--- a/internal/app/html/composition.css
+++ b/internal/app/html/composition.css
@@ -90,3 +90,6 @@ a.btn-secondary:hover, .btn-secondary:hover {
   text-decoration: none;
 }
 
+
+/* Inline controls retain their hidden state inside action rows. */
+.form-actions > [hidden] { display: none; }

--- a/internal/app/html/composition.css
+++ b/internal/app/html/composition.css
@@ -93,3 +93,7 @@ a.btn-secondary:hover, .btn-secondary:hover {
 
 /* Inline controls retain their hidden state inside action rows. */
 .form-actions > [hidden] { display: none; }
+
+/* A text value edited in its own row, without a separate form panel. */
+.inline-edit > input { flex: 1; width: 0; min-width: 0; }
+.inline-edit > button { flex: 1; min-width: 0; padding: 0; display: block; text-align: left; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }


### PR DESCRIPTION
Replace the expanded status form with a quiet Status line. Tap the status to edit in place; Enter or blur saves through the existing owned endpoint, Escape cancels, and empty text clears it. No separate Edit/Save controls or page reload. Failed saves preserve the draft and allow retry; requests time out and duplicate Enter/blur submissions are prevented. The prompt is unchanged.

Require CSRF validation for status updates and return an explicit unauthorized response to expired JSON sessions. Reuse shared action spacing and an inline editor component that keeps the field beside its label at narrow widths.

Validation: focused Go/Node tests pass for initial hidden markup, unauthenticated saves, CSRF rejection, normalized saved text, caller ownership, cancel, duplicate submission, clear, failure and retry. Full Home suite has only the existing TestTheNameIsTheSameOnEverySurface branding failure. Browser installation timed out in this environment, so actual mobile/PWA rendering remains unverified. Related to #1572.