### PR TITLE
Give Home status a heading and quiet quoted text

### DIFF
--- a/home/status.go
+++ b/home/status.go
@@ -54,9 +54,9 @@ func statusForm(r *http.Request, id string) string {
 		return ""
 	}
 	text := user.Status(id)
-	label := text
-	if label == "" {
+	label := "“" + text + "”"
+	if text == "" {
 		label = "What are you up to?"
 	}
-	return `<div id="home-status" class="page-section" data-csrf="` + html.EscapeString(auth.CSRFToken(r)) + `"><div class="form-actions inline-edit"><span class="muted">Status ·</span><button type="button" class="link-button" data-status-label aria-label="Change your public profile status">` + html.EscapeString(label) + `</button><input data-status-input hidden maxlength="160" aria-label="Your public profile status" value="` + html.EscapeString(text) + `"></div><small data-status-feedback role="status" aria-live="polite"></small></div><script>` + statusJS + `</script>`
+	return `<div id="home-status" class="page-section" data-csrf="` + html.EscapeString(auth.CSRFToken(r)) + `">` + sectionRule("Status") + `<div class="form-actions inline-edit"><button type="button" class="link-button inline-edit-value" data-status-label aria-label="Change your public profile status">` + html.EscapeString(label) + `</button><button type="button" class="link-button inline-edit-action" data-status-edit>Edit</button><input data-status-input hidden maxlength="160" aria-label="Your public profile status" value="` + html.EscapeString(text) + `"></div><small data-status-feedback role="status" aria-live="polite"></small></div><script>` + statusJS + `</script>`
 }

--- a/home/status.js
+++ b/home/status.js
@@ -2,6 +2,7 @@
   var root = document.getElementById('home-status');
   if (!root) return;
   var label = root.querySelector('[data-status-label]');
+  var edit = root.querySelector('[data-status-edit]');
   var input = root.querySelector('[data-status-input]');
   var feedback = root.querySelector('[data-status-feedback]');
   if (root.dataset.statusSaved === undefined) root.dataset.statusSaved = input.value;
@@ -9,22 +10,27 @@
   // Soft navigation serializes this DOM, including an in-flight editor.
   if (input.readOnly) feedback.textContent = 'Save interrupted. Press Enter or tap away to retry.';
   input.readOnly = false;
+  edit.hidden = editing;
   input.addEventListener('input', function () { input.defaultValue = input.value; });
   function close() {
     editing = false;
     input.hidden = true;
     label.hidden = false;
-    label.textContent = saved || 'What are you up to?';
+    edit.hidden = false;
+    label.textContent = saved ? '“' + saved + '”' : 'What are you up to?';
   }
-  label.addEventListener('click', function () {
+  function open() {
     if (saving) return;
     input.value = input.defaultValue = saved;
     label.hidden = true;
+    edit.hidden = true;
     input.hidden = false;
     editing = true;
     feedback.textContent = '';
     input.focus();
-  });
+  }
+  label.addEventListener('click', open);
+  edit.addEventListener('click', open);
   async function save() {
     if (!editing || saving) return;
     if (input.value === saved) { close(); return; }

--- a/home/status_test.go
+++ b/home/status_test.go
@@ -17,7 +17,7 @@ func TestStatusInlineEditor(t *testing.T) {
 		t.Fatal("guest status editor")
 	}
 	markup := statusForm(httptest.NewRequest("GET", "/home", nil), "status-test")
-	for _, unwanted := range []string{"<details", "<form", ">Save<", ">Clear<", ">Edit<"} {
+	for _, unwanted := range []string{"<details", "<form", ">Save<", ">Clear<"} {
 		if strings.Contains(markup, unwanted) {
 			t.Fatalf("unexpected control %s", unwanted)
 		}

--- a/home/testdata/status.cjs
+++ b/home/testdata/status.cjs
@@ -5,9 +5,9 @@ const code = fs.readFileSync('status.js', 'utf8');
 function setup(restored) {
  const document = {activeElement: null};
  function element(value) { return {value, hidden: false, textContent: '', listeners: {}, addEventListener(k, fn) {this.listeners[k] = fn;}, focus() {document.activeElement = this;}}; }
- const label = element(''), input = element('Working'), feedback = element('');
+ const label = element(''), input = element('Working'), feedback = element(''), edit = element('');
  input.hidden = true;
- const root = {dataset: {csrf: 'token'}, querySelector(s) {return s.includes('label') ? label : s.includes('input') ? input : feedback;}};
+ const root = {dataset: {csrf: 'token'}, querySelector(s) {return s.includes('label') ? label : s.includes('input') ? input : s.includes('edit') ? edit : feedback;}};
  if (restored) {
  root.dataset.statusSaved = restored.saved;
  input.value = restored.draft;
@@ -19,12 +19,12 @@ function setup(restored) {
  const calls = [];
  let resolve;
  vm.runInNewContext(code, {document, URLSearchParams, AbortController, setTimeout, clearTimeout, fetch: (url, opts) => {calls.push({url, opts}); return new Promise(r => resolve = r);}});
- return {label, input, feedback, calls, reply: r => resolve(r), key: key => input.listeners.keydown({key, preventDefault(){}})};
+ return {label, edit, input, feedback, calls, reply: r => resolve(r), key: key => input.listeners.keydown({key, preventDefault(){}})};
 }
 (async () => {
  let s = setup();
  assert.equal(s.calls.length, 0);
- s.label.listeners.click(); assert.equal(s.input.hidden, false);
+ s.edit.listeners.click(); assert.equal(s.input.hidden, false); assert.equal(s.edit.hidden, true);
  s.input.value = 'Cancelled'; s.key('Escape'); await s.input.listeners.blur();
  assert.equal(s.calls.length, 0); assert.equal(s.input.value, 'Working');
  s.label.listeners.click(); s.input.value = 'New status'; s.key('Enter');
@@ -32,7 +32,7 @@ function setup(restored) {
  assert.equal(new URLSearchParams(s.calls[0].opts.body).get('status'), 'New status');
  s.reply({ok:true,json:async()=>({status:'New status'})});
  await new Promise(setImmediate);
- assert.equal(s.label.textContent, 'New status'); assert.equal(s.input.hidden, true);
+ assert.equal(s.label.textContent, '“New status”'); assert.equal(s.input.hidden, true);
  s.label.listeners.click(); s.input.value = ''; const cleared = s.input.listeners.blur();
  s.reply({ok:true,json:async()=>({status:''})}); await cleared;
  assert.equal(s.label.textContent, 'What are you up to?');
@@ -41,7 +41,7 @@ function setup(restored) {
  assert.equal(s.input.value, 'Keep my draft'); assert.equal(s.input.hidden, false);
  assert.match(s.feedback.textContent, /Could not save/);
  const retry = s.input.listeners.blur(); s.reply({ok:true,json:async()=>({status:'Keep my draft'})}); await retry;
- assert.equal(s.label.textContent, 'Keep my draft');
+ assert.equal(s.label.textContent, '“Keep my draft”');
  assert.equal(s.input.defaultValue, 'Keep my draft');
  s = setup({saved:'Previous', draft:'Pending draft'});
  assert.equal(s.input.readOnly, false);

--- a/internal/app/html/composition.css
+++ b/internal/app/html/composition.css
@@ -97,3 +97,6 @@ a.btn-secondary:hover, .btn-secondary:hover {
 /* A text value edited in its own row, without a separate form panel. */
 .inline-edit > input { flex: 1; width: 0; min-width: 0; }
 .inline-edit > button { flex: 1; min-width: 0; padding: 0; display: block; text-align: left; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+
+.inline-edit > .inline-edit-value { flex: 0 1 auto; color: var(--text-secondary, #666); font-style: italic; text-decoration: none; }
+.inline-edit > .inline-edit-action { flex: 0 0 auto; font-size: var(--font-size-sm, 12px); text-decoration: none; }


### PR DESCRIPTION
Use the same section heading/divider as Brief without a card or box. Render the status in muted grey italics and quotation marks, without an underline, with a small Edit action beside it. Both text and Edit activate the existing inline editor. Keep autosave, Escape, failed-save recovery, and Back-navigation recovery. Empty status remains a prompt rather than pretending to be a user quotation.

Reuse shared inline-edit styling. Adapt existing lifecycle checks to exercise Edit and quoted saved text; focused Home status tests are running. No changes to save permissions or storage.