### PR TITLE
Render morning briefs as formatted mail in Inbox

### DIFF
--- a/inbox/conversation.go
+++ b/inbox/conversation.go
@@ -474,7 +474,13 @@ func messageBlock(accountID string, t *thread.Thread, m thread.Message, subject 
 	// like, and this asks the second for the mail it already has. mail.Rendered
 	// is the same function /mail renders through — there is exactly one, and a
 	// test holds that — so the two pages cannot drift.
-	if rendered := mailBody(accountID, m); rendered != "" {
+	rendered := mailBody(accountID, m)
+	if rendered == "" && t.Client == "mail" {
+		// Older local mail has no Message-ID to join to its stored body.
+		// Render the owned transcript with the same mail renderer instead.
+		rendered = mail.Rendered(&mail.Message{Body: m.Text, FromID: m.From})
+	}
+	if rendered != "" {
 		return `<div class="ib-msg ib-person">` + fromLine(who, m.At) + addressLine(m) +
 			`<div class="ib-body">` + rendered + `</div></div>`
 	}

--- a/inbox/mailrender_test.go
+++ b/inbox/mailrender_test.go
@@ -134,3 +134,19 @@ func clip(s string) string {
 	}
 	return s
 }
+
+func TestOlderBriefWithoutMailReferenceRendersMarkdown(t *testing.T) {
+	body := "## Tomorrow\n\n**School run** at 08:00.\n\n- Take a coat\n\n[Manage brief](https://example.com/events)"
+	th := &thread.Thread{Client: "mail"}
+	out := messageBlock("brief_owner", th, thread.Message{Text: body, From: "agent@example.com"}, "")
+	for _, want := range []string{"<h2", "<strong>School run</strong>", "<li>Take a coat", `href="https://example.com/events"`} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("missing %s: %s", want, out)
+		}
+	}
+	// Ordinary chat continues to show exactly what the person typed.
+	th.Client = "chat"
+	if out := messageBlock("brief_owner", th, thread.Message{Text: "**literal**"}, ""); strings.Contains(out, "<strong>") {
+		t.Fatal("changed chat formatting")
+	}
+}

--- a/service/mail/duplicate_test.go
+++ b/service/mail/duplicate_test.go
@@ -81,8 +81,21 @@ func TestMailWithNoIdIsAlwaysNew(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	if n := countFor(who, ""); n != 2 {
-		t.Errorf("%d messages stored, want 2 — mail with no id was deduped against itself", n)
+	mutex.RLock()
+	defer mutex.RUnlock()
+	ids := map[string]bool{}
+	count := 0
+	for _, m := range messages {
+		if m.ToID == who {
+			count++
+			if m.MessageID == "" || ids[m.MessageID] {
+				t.Fatal("missing or repeated generated Message-ID")
+			}
+			ids[m.MessageID] = true
+		}
+	}
+	if count != 2 {
+		t.Fatalf("stored %d deliveries, want 2", count)
 	}
 }
 

--- a/service/mail/local_reference_test.go
+++ b/service/mail/local_reference_test.go
@@ -1,0 +1,36 @@
+package mail
+
+import (
+	"mu/internal/event"
+	"testing"
+	"time"
+)
+
+func TestLocalDeliveryKeepsAReferenceForInbox(t *testing.T) {
+	sub := event.Subscribe(event.MailReceived)
+	defer sub.Close()
+	const owner = "brief_reference"
+	if err := SendMessageTo(Delivery{FromID: "agent@example.test", ToID: owner, Body: "**Morning brief**", Tag: "scheduled"}); err != nil {
+		t.Fatal(err)
+	}
+	timeout := time.After(3 * time.Second)
+	for {
+		select {
+		case e := <-sub.Chan:
+			m, ok := MessageFrom(e.Data)
+			if !ok || m.Owner != owner {
+				continue
+			}
+			if m.MessageID == "" {
+				t.Fatal("local mail has no transcript reference")
+			}
+			stored := FindMessageByMessageID(m.MessageID)
+			if stored == nil || stored.ToID != owner || stored.Body != m.Body {
+				t.Fatal("reference does not join to owned mail")
+			}
+			return
+		case <-timeout:
+			t.Fatal("no mail arrival")
+		}
+	}
+}

--- a/service/mail/mail.go
+++ b/service/mail/mail.go
@@ -14,6 +14,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/google/uuid"
+
 	"mu/internal/app"
 	"mu/internal/auth"
 	"mu/internal/data"
@@ -1644,6 +1646,10 @@ type Delivery struct {
 // it: inbound SMTP, submission from a mail client, the web compose, the
 // mail_send tool and the agent's own replies.
 func SendMessageTo(d Delivery) error {
+	// Local deliveries need the same mailbox-to-Inbox reference as SMTP mail.
+	if d.MessageID == "" {
+		d.MessageID = fmt.Sprintf("<%s@%s>", uuid.NewString(), ConfiguredDomain())
+	}
 	msg := &Message{
 		ID:          fmt.Sprintf("%d", time.Now().UnixNano()),
 		From:        d.From,


### PR DESCRIPTION
Scheduled delivery did not supply a Message-ID. Inbox could not join the recorded message to the mailbox renderer and displayed its Markdown source as plain text.

Generate a Message-ID for local deliveries that lack one, using it in storage and the arrival event. For existing mail transcripts without a stored body, use the same mail renderer on their owned text. This repairs existing brief messages without regeneration or migration. Ordinary chat text rendering stays unchanged.

Regression tests cover an older brief without a reference and a local delivery whose arrival reference resolves to its stored mail. Inbox suite passes; mail suite is running. No live email or model calls.