### PR TITLE
Put inbox message dividers below messages

### DIFF
--- a/internal/app/html/mu.css
+++ b/internal/app/html/mu.css
@@ -6452,9 +6452,9 @@ button.pill:hover {
    the thread including your own. A thread is a stack of messages and what
    separates them is a line across, the way every mail client draws it: the
    eye needs to know where one ends, not that all of them are quotations. */
-.ib-msg { padding: 16px 0 }
+.ib-msg { padding: 16px 0; border-bottom: var(--border-width, 1px) solid var(--divider, #f0f0f0) }
 .ib-msg:first-child { padding-top: 0 }
-.ib-msg:last-child { padding-bottom: 0 }
+.ib-msg:last-child { border-bottom: none; padding-bottom: 0 }
 .ib-from { display: flex; align-items: baseline; gap: 10px; margin-bottom: 6px }
 .ib-who-l { font-size: 13px; font-weight: var(--font-weight-medium, 500); color: var(--text-primary, #1a1a1a) }
 .ib-at { margin-left: auto; flex: none; font-size: 11px; color: var(--text-muted, #888); white-space: nowrap }


### PR DESCRIPTION
Restore separation between inbox thread messages using border-bottom on .ib-msg. The final message has no bottom border. The first message retains its existing top spacing.

Validated the CSS declarations; this is a two-line style correction.