### PR TITLE
Expose response timings and model calls in admin logs

### DIFF
--- a/admin/log.go
+++ b/admin/log.go
@@ -64,7 +64,7 @@ func LogHandler(w http.ResponseWriter, r *http.Request) {
 	case mailTab:
 		title = "Mail Log"
 	}
-	app.Respond(w, r, app.Response{Title: title, Description: "Logs", HTML: content.String()})
+	app.Respond(w, r, app.Response{Title: title, Description: "Logs", HTML: `<div class="log-tables">` + content.String() + `</div>`})
 }
 
 // MailLogMoved sends the old mail-log address to its tab.
@@ -165,6 +165,13 @@ func apiLogCard() string {
 			statusClass = "dir-out"
 		}
 
+		if e.Kind == "model" {
+			statusLabel = html.EscapeString(e.Outcome)
+			if statusLabel == "done" {
+				statusClass = "dir-in"
+			}
+		}
+
 		errStr := ""
 		if e.Error != "" {
 			errStr = truncate(e.Error, 60)
@@ -180,14 +187,17 @@ func apiLogCard() string {
 			<td class="subject" title="%s">%s</td>
 		</tr>`,
 			e.Time.Format("Jan 2 15:04:05"),
-			e.Service,
-			e.Method,
-			e.URL, truncate(e.URL, 50),
+			html.EscapeString(e.Service),
+			html.EscapeString(e.Method),
+			html.EscapeString(e.URL), html.EscapeString(truncate(e.URL, 50)),
 			statusClass, statusLabel,
 			e.Duration.Milliseconds(),
-			e.Error, errStr,
+			html.EscapeString(e.Error), html.EscapeString(errStr),
 		))
 
+		if e.Kind == "model" {
+			fmt.Fprintf(&content, `<tr><td colspan="7">Model: %s · Run: %s · Attempt: %d · Tokens: %d in / %d out</td></tr>`, html.EscapeString(e.Model), html.EscapeString(e.RunID), e.Attempt, e.InputTokens, e.OutputTokens)
+		}
 		if e.RequestBody != "" || e.ResponseBody != "" {
 			content.WriteString(`<tr><td colspan="7">`)
 			if e.RequestBody != "" {

--- a/agent/cost.go
+++ b/agent/cost.go
@@ -96,7 +96,7 @@ func recordRunCost(st store.Store, agentName, caller string) {
 				})
 				continue
 			}
-			ai.RecordAgentUsage(caller, m.model, m.input, m.output, m.calls)
+			ai.RecordAgentUsage(caller, m.model, m.input, m.output, m.calls, ai.UsageTiming{RunID: s.RunID, ModelMS: m.latency})
 		}
 	}
 }
@@ -107,10 +107,11 @@ var noUsageReported sync.Once
 
 // modelSpend is one model's share of one run.
 type modelSpend struct {
-	model  string
-	input  int
-	output int
-	calls  int
+	model   string
+	input   int
+	output  int
+	calls   int
+	latency int64
 }
 
 // spendByModel sums a run's model calls, one entry per model, in a fixed order.
@@ -133,6 +134,7 @@ func spendByModel(events []gmagent.RunEvent) []modelSpend {
 		m.input += e.Tokens.InputTokens
 		m.output += e.Tokens.OutputTokens
 		m.calls++
+		m.latency += e.LatencyMS
 	}
 
 	names := make([]string, 0, len(byModel))

--- a/agent/native.go
+++ b/agent/native.go
@@ -395,6 +395,7 @@ func buildNativeAgent(accountID, prompt string, opts QueryOpts, wrappers ...gmai
 	runs := store.NewMemoryStore()
 	agentOpts := []gmagent.Option{
 		gmagent.Model(model),
+		gmagent.OnRunEvent(logRunTiming),
 		gmagent.WithStore(runs),
 		// What was said before, as turns. Read-only, which is what stops the
 		// question being counted twice — go-micro adds it to memory and then
@@ -670,7 +671,11 @@ type StreamHooks struct {
 //
 // This is the agent. There is no second one — see the note on ErrNoProvider,
 // and AGENTS.md for the rule that says so.
-func runNative(accountID, prompt string, opts QueryOpts) (string, error) {
+func runNative(accountID, prompt string, opts QueryOpts) (answer string, runErr error) {
+	started := time.Now()
+	defer func() {
+		app.Log("timing", "phase=agent_total caller=%s duration_ms=%.3f failed=%t", costCaller(opts), float64(time.Since(started))/float64(time.Millisecond), runErr != nil)
+	}()
 	if commands, ok := promptCommands(prompt, opts); ok {
 		ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 		defer cancel()
@@ -693,7 +698,9 @@ func runNative(accountID, prompt string, opts QueryOpts) (string, error) {
 	if opts.OnStep != nil {
 		wrappers = append(wrappers, stepReporter(opts.OnStep))
 	}
+	prepareStart := time.Now()
 	run, ok := buildNativeAgent(accountID, prompt, opts, wrappers...)
+	app.Log("timing", "phase=agent_prepare run=%s duration_ms=%.3f", run.name, float64(time.Since(prepareStart))/float64(time.Millisecond))
 	if !ok {
 		return "", ErrNoProvider
 	}
@@ -767,7 +774,7 @@ func runNative(accountID, prompt string, opts QueryOpts) (string, error) {
 		final = resp.Reply
 	}
 
-	answer := app.StripLatexDollars(final)
+	answer = app.StripLatexDollars(final)
 	// Told whether a named agent wrote this. The freshness guard replaces a
 	// whole answer with a list of the raw tool results when the news looks
 	// stale, which is right for the generalist and destroys a user-defined

--- a/agent/timing.go
+++ b/agent/timing.go
@@ -1,0 +1,15 @@
+package agent
+
+import (
+	gmagent "go-micro.dev/v6/agent"
+	"mu/internal/app"
+	"time"
+)
+
+func logRunTiming(e gmagent.RunEvent) {
+	app.Log("timing", "phase=%s run=%s agent=%s name=%s provider=%s model=%s attempt=%d status=%s duration_ms=%d input_tokens=%d output_tokens=%d", e.Kind, e.RunID, e.Agent, e.Name, e.Provider, e.Model, e.Attempt, e.Status, e.LatencyMS, e.Tokens.InputTokens, e.Tokens.OutputTokens)
+	if e.Kind != "model" && e.Kind != "stream" {
+		return
+	}
+	app.RecordExternalCall(app.APILogEntry{Kind: "model", Time: e.Time, Service: e.Provider, Method: e.Kind, Model: e.Model, RunID: e.RunID, Outcome: e.Status, Attempt: e.Attempt, Duration: time.Duration(e.LatencyMS) * time.Millisecond, Error: e.ErrorKind, InputTokens: e.Tokens.InputTokens, OutputTokens: e.Tokens.OutputTokens})
+}

--- a/agent/timing_test.go
+++ b/agent/timing_test.go
@@ -1,0 +1,21 @@
+package agent
+
+import (
+	gmagent "go-micro.dev/v6/agent"
+	"mu/internal/app"
+	"testing"
+	"time"
+)
+
+func TestModelTimingIncludesAttemptsAndFailures(t *testing.T) {
+	for _, status := range []string{"done", "timeout"} {
+		logRunTiming(gmagent.RunEvent{Kind: "model", RunID: "timing-test", Provider: "test", Model: "test-model", Status: status, Attempt: 2, LatencyMS: 123, Tokens: gmagent.Usage{InputTokens: 9, OutputTokens: 3}})
+		got := app.APILog()[0]
+		if got.Kind != "model" || got.RunID != "timing-test" || got.Outcome != status || got.Attempt != 2 || got.Duration != 123*time.Millisecond || got.InputTokens != 9 || got.OutputTokens != 3 {
+			t.Fatalf("bad model timing: %+v", got)
+		}
+		if got.Status != 0 {
+			t.Fatal("model event invented an HTTP status")
+		}
+	}
+}

--- a/internal/ai/micro.go
+++ b/internal/ai/micro.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"time"
 
 	gmai "go-micro.dev/v6/ai"
 	_ "go-micro.dev/v6/ai/anthropic"
@@ -170,6 +171,9 @@ func generateViaMicro(model, systemPrompt string, messages []map[string]string, 
 	}
 
 	app.Log("ai", "[LLM] via go-micro %s/%s", provider, useModel)
+	started := time.Now()
+	var used gmai.Usage
+	defer func() { logModelCall(provider, useModel, caller, "generate", started, err, used) }()
 	resp, err := m.Generate(context.Background(), &gmai.Request{
 		SystemPrompt: systemPrompt,
 		Messages:     history,
@@ -179,6 +183,7 @@ func generateViaMicro(model, systemPrompt string, messages []map[string]string, 
 		return "", fmt.Errorf("%s: %w", provider, err)
 	}
 
+	used = resp.Usage
 	recordUsage(caller, useModel, resp.Usage.InputTokens, resp.Usage.OutputTokens, 0, 0)
 	app.Log("ai", "[LLM] Usage [%s]: input=%d output=%d (go-micro %s)",
 		caller, resp.Usage.InputTokens, resp.Usage.OutputTokens, provider)
@@ -236,10 +241,19 @@ func streamViaMicro(model, systemPrompt string, messages []map[string]string, ca
 	}
 	req := &gmai.Request{SystemPrompt: systemPrompt, Messages: history, Prompt: question}
 
+	started := time.Now()
+	var used gmai.Usage
+	logStream := true
+	defer func() {
+		if logStream {
+			logModelCall(provider, useModel, caller, "stream", started, err, used)
+		}
+	}()
 	stream, err := m.Stream(context.Background(), req)
 	if err != nil {
 		// Provider can't stream — fall back to a single Generate.
 		if errors.Is(err, gmai.ErrStreamingUnsupported) {
+			logStream = false
 			out, gerr := generateViaMicro(model, systemPrompt, messages, caller, maxTok)
 			if gerr != nil {
 				return "", gerr
@@ -255,7 +269,7 @@ func streamViaMicro(model, systemPrompt string, messages []map[string]string, ca
 
 	app.Log("ai", "[LLM] streaming via go-micro %s/%s", provider, useModel)
 	var sb strings.Builder
-	var usage gmai.Usage
+
 	for {
 		resp, rerr := stream.Recv()
 		if rerr == io.EOF {
@@ -272,11 +286,21 @@ func streamViaMicro(model, systemPrompt string, messages []map[string]string, ca
 		}
 		// The final chunk carries token usage (no content).
 		if resp.Usage.TotalTokens > 0 || resp.Usage.InputTokens > 0 || resp.Usage.OutputTokens > 0 {
-			usage = resp.Usage
+			used = resp.Usage
 		}
 	}
-	recordUsage(caller, useModel, usage.InputTokens, usage.OutputTokens, 0, 0)
+	recordUsage(caller, useModel, used.InputTokens, used.OutputTokens, 0, 0)
 	app.Log("ai", "[LLM] Usage [%s]: input=%d output=%d (go-micro %s stream)",
-		caller, usage.InputTokens, usage.OutputTokens, provider)
+		caller, used.InputTokens, used.OutputTokens, provider)
 	return sb.String(), nil
+}
+
+func logModelCall(provider, model, caller, method string, started time.Time, err error, used gmai.Usage) {
+	outcome := "done"
+	if err != nil {
+		outcome = "error"
+	}
+	duration := time.Since(started)
+	app.RecordExternalCall(app.APILogEntry{Kind: "model", Time: started, Service: provider, Method: method, Model: model, Outcome: outcome, Duration: duration, InputTokens: used.InputTokens, OutputTokens: used.OutputTokens})
+	app.Log("timing", "phase=model caller=%s provider=%s model=%s status=%s duration_ms=%.3f", caller, provider, model, outcome, float64(duration)/float64(time.Millisecond))
 }

--- a/internal/ai/providers.go
+++ b/internal/ai/providers.go
@@ -249,9 +249,12 @@ func generate(prompt *Prompt) (string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), llmTimeout+5*time.Second)
 	defer cancel()
 
+	queueStart := time.Now()
 	if err := llmSemaphore.Acquire(ctx, 1); err != nil {
+		app.Log("timing", "phase=model_queue caller=%s duration_ms=%.3f status=error", prompt.Caller, float64(time.Since(queueStart))/float64(time.Millisecond))
 		return "", fmt.Errorf("LLM request queue full, please try again later")
 	}
+	app.Log("timing", "phase=model_queue caller=%s duration_ms=%.3f status=done", prompt.Caller, float64(time.Since(queueStart))/float64(time.Millisecond))
 	defer llmSemaphore.Release(1)
 
 	systemPromptText, err := BuildSystemPrompt(prompt)
@@ -295,9 +298,12 @@ func generateStream(prompt *Prompt, onToken func(string)) (string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), llmTimeout+5*time.Second)
 	defer cancel()
 
+	queueStart := time.Now()
 	if err := llmSemaphore.Acquire(ctx, 1); err != nil {
+		app.Log("timing", "phase=model_queue caller=%s duration_ms=%.3f status=error", prompt.Caller, float64(time.Since(queueStart))/float64(time.Millisecond))
 		return "", fmt.Errorf("LLM request queue full, please try again later")
 	}
+	app.Log("timing", "phase=model_queue caller=%s duration_ms=%.3f status=done", prompt.Caller, float64(time.Since(queueStart))/float64(time.Millisecond))
 	defer llmSemaphore.Release(1)
 
 	systemPromptText, err := BuildSystemPrompt(prompt)

--- a/internal/ai/usage.go
+++ b/internal/ai/usage.go
@@ -207,15 +207,19 @@ func providerName(model string) string {
 // Cache tokens are not a field: go-micro's ai.Usage has input, output and
 // total, so what is not reported cannot be recorded. It reads as a slightly
 // high bill on a provider that caches, which is the safe direction.
-func RecordAgentUsage(caller, model string, inputTokens, outputTokens, calls int) {
-	app.RecordUsage(providerName(model), caller,
-		estimateCostCents(model, inputTokens, outputTokens, 0, 0),
-		map[string]any{
-			"model":         model,
-			"input_tokens":  inputTokens,
-			"output_tokens": outputTokens,
-			"model_calls":   calls,
-		})
+// UsageTiming connects a cost entry to the model timeline.
+type UsageTiming struct {
+	RunID   string
+	ModelMS int64
+}
+
+func RecordAgentUsage(caller, model string, inputTokens, outputTokens, calls int, timing ...UsageTiming) {
+	details := map[string]any{"model": model, "input_tokens": inputTokens, "output_tokens": outputTokens, "model_calls": calls}
+	if len(timing) > 0 {
+		details["run_id"] = timing[0].RunID
+		details["model_duration_ms"] = timing[0].ModelMS
+	}
+	app.RecordUsage(providerName(model), caller, estimateCostCents(model, inputTokens, outputTokens, 0, 0), details)
 }
 
 func recordUsage(caller, model string, inputTokens, outputTokens, cacheReadTokens, cacheCreationTokens int) {

--- a/internal/app/apilog.go
+++ b/internal/app/apilog.go
@@ -12,6 +12,13 @@ const apiLogMaxEntries = 500
 
 // APILogEntry records a single external API call.
 type APILogEntry struct {
+	Kind         string        `json:"kind,omitempty"`
+	Model        string        `json:"model,omitempty"`
+	RunID        string        `json:"run_id,omitempty"`
+	Outcome      string        `json:"outcome,omitempty"`
+	Attempt      int           `json:"attempt,omitempty"`
+	InputTokens  int           `json:"input_tokens,omitempty"`
+	OutputTokens int           `json:"output_tokens,omitempty"`
 	Time         time.Time     `json:"time"`
 	Service      string        `json:"service"`
 	Method       string        `json:"method"`
@@ -63,6 +70,15 @@ func RecordAPICall(service, method, url string, status int, duration time.Durati
 	}
 	if callErr != nil {
 		entry.Error = callErr.Error()
+	}
+	RecordExternalCall(*entry)
+}
+
+// RecordExternalCall records metadata without retaining prompts or credentials.
+func RecordExternalCall(value APILogEntry) {
+	entry := &value
+	if entry.Time.IsZero() {
+		entry.Time = time.Now()
 	}
 	apiLogMu.Lock()
 	apiLogEntries = append(apiLogEntries, entry)

--- a/internal/app/html/composition.css
+++ b/internal/app/html/composition.css
@@ -102,3 +102,7 @@ a.btn-secondary:hover, .btn-secondary:hover {
 .inline-edit > .inline-edit-action { flex: 0 0 auto; font-size: var(--font-size-sm, 12px); text-decoration: none; }
 
 .inline-edit-feedback:empty { display: none; }
+
+/* Tables need the available page width, rather than a prose measure. */
+.log-tables .card { max-width: none; width: 100%; }
+#content:has(.log-tables) { max-width: none; }

--- a/internal/app/timing.go
+++ b/internal/app/timing.go
@@ -1,0 +1,42 @@
+package app
+
+import (
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/felixge/httpsnoop"
+)
+
+// TimeRequest preserves optional HTTP interfaces, including streaming and hijacking.
+func TimeRequest(w http.ResponseWriter, r *http.Request) (http.ResponseWriter, func()) {
+	start := time.Now()
+	status, size := 200, int64(0)
+	written := false
+	wrapped := httpsnoop.Wrap(w, httpsnoop.Hooks{
+		Flush: func(next httpsnoop.FlushFunc) httpsnoop.FlushFunc { return func() { written = true; next() } },
+		ReadFrom: func(next httpsnoop.ReadFromFunc) httpsnoop.ReadFromFunc {
+			return func(src io.Reader) (int64, error) { n, err := next(src); written = true; size += n; return n, err }
+		},
+		WriteHeader: func(next httpsnoop.WriteHeaderFunc) httpsnoop.WriteHeaderFunc {
+			return func(code int) {
+				if code >= 200 && !written {
+					written = true
+					status = code
+				}
+				next(code)
+			}
+		},
+		Write: func(next httpsnoop.WriteFunc) httpsnoop.WriteFunc {
+			return func(p []byte) (int, error) {
+				n, err := next(p)
+				written = true
+				size += int64(n)
+				return n, err
+			}
+		},
+	})
+	return wrapped, func() {
+		Log("http", "method=%s path=%q status=%d bytes=%d duration_ms=%.3f", r.Method, r.URL.Path, status, size, float64(time.Since(start))/float64(time.Millisecond))
+	}
+}

--- a/internal/app/timing_test.go
+++ b/internal/app/timing_test.go
@@ -1,0 +1,28 @@
+package app
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestRequestTimingPreservesStreamingAndResponse(t *testing.T) {
+	underlying := httptest.NewRecorder()
+	w, done := TimeRequest(underlying, httptest.NewRequest("POST", "/agent?secret=private", nil))
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		t.Fatal("streaming interface lost")
+	}
+	w.WriteHeader(http.StatusAccepted)
+	w.Write([]byte("answer"))
+	flusher.Flush()
+	done()
+	message := SysLog()[0].Message
+	if !strings.Contains(message, "status=202 bytes=6") || strings.Contains(message, "private") {
+		t.Fatalf("bad timing log: %s", message)
+	}
+	if underlying.Code != http.StatusAccepted || underlying.Body.String() != "answer" || !underlying.Flushed {
+		t.Fatal("response changed")
+	}
+}

--- a/internal/server/serve.go
+++ b/internal/server/serve.go
@@ -48,6 +48,8 @@ func serve(addr string) {
 	server := &http.Server{
 		Addr: addr,
 		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w, finishTiming := app.TimeRequest(w, r)
+			defer finishTiming()
 			// Block known bot paths silently
 			if strings.HasPrefix(r.URL.Path, "/audio/") {
 				http.NotFound(w, r)
@@ -60,19 +62,6 @@ func serve(addr string) {
 			if onion := os.Getenv("TOR_ONION"); onion != "" {
 				w.Header().Set("Onion-Location", "http://"+onion+r.URL.RequestURI())
 			}
-
-			// Request logging (Apache-style)
-			start := time.Now()
-			defer func() {
-				// Skip logging for static assets and frequent endpoints
-				if !strings.HasSuffix(r.URL.Path, ".css") &&
-					!strings.HasSuffix(r.URL.Path, ".js") &&
-					!strings.HasSuffix(r.URL.Path, ".png") &&
-					!strings.HasSuffix(r.URL.Path, ".ico") &&
-					!strings.HasPrefix(r.URL.Path, "/chat/ws") {
-					app.Log("http", "%s %s %s %v", r.Method, r.URL.Path, r.RemoteAddr, time.Since(start))
-				}
-			}()
 
 			if Env == "dev" {
 				w.Header().Set("Access-Control-Allow-Origin", "*")

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -49,6 +49,9 @@ func Run(addr string) {
 		}
 	})
 	app.OpenLog()
+	service.OnCallTiming = func(name, method string, elapsed time.Duration, err error) {
+		app.Log("timing", "phase=service service=%s method=%s duration_ms=%.3f failed=%t", name, method, float64(elapsed)/float64(time.Millisecond), err != nil)
+	}
 
 	// Timed, per phase, because "the restart takes ages" is not answerable
 	// without it. Boot is a tenth of a second on an empty data directory and

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -143,6 +143,7 @@ func Init() {
 	_ = br.Connect()
 	cl = client.NewClient(
 		client.Registry(reg),
+		client.Wrap(timingClientWrapper),
 		client.Selector(selector.NewSelector(selector.Registry(reg))),
 		client.Broker(br),
 		client.Transport(tr),

--- a/internal/service/timing.go
+++ b/internal/service/timing.go
@@ -1,0 +1,23 @@
+package service
+
+import (
+	"context"
+	"go-micro.dev/v6/client"
+	"time"
+)
+
+// OnCallTiming is wired once by the host before serving requests.
+var OnCallTiming func(string, string, time.Duration, error)
+
+type timedClient struct{ client.Client }
+
+func timingClientWrapper(c client.Client) client.Client { return &timedClient{c} }
+func (c *timedClient) Call(ctx context.Context, req client.Request, rsp interface{}, opts ...client.CallOption) (err error) {
+	start := time.Now()
+	defer func() {
+		if OnCallTiming != nil {
+			OnCallTiming(req.Service(), req.Endpoint(), time.Since(start), err)
+		}
+	}()
+	return c.Client.Call(ctx, req, rsp, opts...)
+}

--- a/internal/service/timing_test.go
+++ b/internal/service/timing_test.go
@@ -1,0 +1,35 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"go-micro.dev/v6/client"
+	"testing"
+	"time"
+)
+
+type timingStub struct {
+	client.Client
+	err error
+}
+
+func (c timingStub) Call(context.Context, client.Request, interface{}, ...client.CallOption) error {
+	return c.err
+}
+func TestTimingPreservesServiceErrors(t *testing.T) {
+	old := OnCallTiming
+	defer func() { OnCallTiming = old }()
+	expected := errors.New("failed")
+	calls := 0
+	OnCallTiming = func(s, m string, d time.Duration, e error) {
+		calls++
+		if s != "test" || m != "Test.Read" || e != expected || d < 0 {
+			t.Fatal("incorrect timing")
+		}
+	}
+	base := client.NewClient()
+	c := timingClientWrapper(timingStub{base, expected})
+	if err := c.Call(context.Background(), base.NewRequest("test", "Test.Read", nil), nil); err != expected || calls != 1 {
+		t.Fatal("call changed")
+	}
+}


### PR DESCRIPTION
Slow responses were difficult to diagnose: HTTP logging lacked status/size, AI queue waits and agent preparation were not timed, and the agent model timeline was absent from External calls.

Log HTTP method, path (without query), status, bytes and duration, preserving optional ResponseWriter interfaces. Time shared service client calls, AI queue waits, agent preparation and total runs. Record model and tool timeline events as they complete, with model calls in External calls including run, attempt, outcome and tokens. Ordinary generation/streaming also records model calls, including errors. Agent cost metadata includes run ID and summed model duration; existing pricing remains unchanged. New timing records omit prompts, responses and credentials.

Log tables use the available page width; external metadata is HTML escaped.

Validation: focused timing, streaming and retry tests pass. Broader app/AI/server/admin suites passed; agent suite hit two network-discovery permission failures in this environment, and a service retry test failed once then passed on rerun. No live model or production traffic used, no visual browser validation.

This starts instrumentation at shared request/service/model boundaries. It does not instrument every third-party HTTP client or eliminate deployment pauses.