### PR TITLE
Rename Diagnostics to Status in admin

### DIFF
--- a/admin/admin.go
+++ b/admin/admin.go
@@ -29,7 +29,7 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 		<a href="/admin/alerts">Alerts</a>
 		<a href="/admin/backup">Backup</a>
 		<a href="/admin/config">Config</a>
-		<a href="/admin/diagnostics">Diagnostics</a>
+		<a href="/admin/diagnostics">Status</a>
 		<a href="/admin/log">Logs` + alertBadge() + `</a>
 		<a href="/admin/oauth">OAuth Clients</a>
 		<a href="/admin/moderate">Moderation</a>

--- a/admin/diagnostics.go
+++ b/admin/diagnostics.go
@@ -76,7 +76,7 @@ func DiagnosticsHandler(w http.ResponseWriter, r *http.Request) {
 
 	b.WriteString(back())
 
-	app.Respond(w, r, app.Response{Title: "Diagnostics", Description: "System health", HTML: b.String()})
+	app.Respond(w, r, app.Response{Title: "Status", Description: "System health", HTML: b.String()})
 }
 
 // renderChecks is one card per check.


### PR DESCRIPTION
Rename the admin navigation label and page title to Status. Keep the existing URL so bookmarks continue to work.

Checked both user-facing occurrences; text-only change.