### PR TITLE
Expose Gemini key and model in admin; default to Flash

### DIFF
--- a/admin/config.go
+++ b/admin/config.go
@@ -56,6 +56,8 @@ var settingGroups = []settingGroup{
 			"AGENT_MODEL",
 			"ATLASCLOUD_API_KEY",
 			"ATLAS_MODEL",
+			"GEMINI_API_KEY",
+			"GEMINI_MODEL",
 			"OPENROUTER_API_KEY",
 			"OPENROUTER_MODEL",
 			"OPENAI_BASE_URL",

--- a/internal/ai/providers.go
+++ b/internal/ai/providers.go
@@ -80,7 +80,7 @@ func GeminiModel() string {
 	if m := settings.Get("GEMINI_MODEL"); m != "" {
 		return m
 	}
-	return ModelGeminiPro
+	return ModelGeminiFlash
 }
 
 // Configured reports whether at least one AI provider is available — a key or


### PR DESCRIPTION
Gemini was supported by provider resolution but absent from the Admin Config AI group. Add GEMINI_API_KEY and GEMINI_MODEL using the existing secret handling and config persistence. Default GeminiModel to the existing gemini-flash-latest alias when no override is configured, matching the latency preference for interactive requests.

Validation: admin and internal/ai short suites pass. Existing model overrides remain authoritative. No live configuration or credentials were changed.