### PR TITLE
Fix Gemini planning schema and fall back before work starts

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -249,7 +249,7 @@ func QueryWithOpts(accountID, prompt string, opts QueryOpts) (string, error) {
 	//
 	// So the error is the answer now. See ErrNoProvider in native.go for the
 	// same argument about an unconfigured instance.
-	answer, err := runNative(accountID, prompt, opts)
+	answer, err := queryWithFallback(accountID, prompt, opts)
 	if err != nil {
 		return "", err
 	}
@@ -1355,7 +1355,7 @@ func streamNativeSSE(w http.ResponseWriter, accountID, prompt string, opts Query
 			send(map[string]any{"type": "tool_done", "name": run.Label, "message": run.Label + " — done"})
 		},
 	}
-	answer, err := runNative(accountID, prompt, sopts)
+	answer, err := queryWithFallback(accountID, prompt, sopts)
 	if err != nil {
 		// Whether anything was on screen already decides how it reads, not
 		// whether it is reported. Mid-answer the error follows the tokens the

--- a/agent/fallback.go
+++ b/agent/fallback.go
@@ -1,0 +1,87 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	gmai "go-micro.dev/v6/ai"
+	"mu/internal/ai"
+	"mu/internal/app"
+	"mu/internal/settings"
+)
+
+// Only a failed attempt which has emitted no text or tools may be replayed.
+type retryableModelFailure struct{ error }
+
+func (e retryableModelFailure) Unwrap() error { return e.error }
+
+func fallbackAllowed(err error) bool {
+	var safe retryableModelFailure
+	if !errors.As(err, &safe) || errors.Is(err, context.Canceled) {
+		return false
+	}
+	switch gmai.ClassifyError(err) {
+	case gmai.ErrorKindTimeout, gmai.ErrorKindRateLimited, gmai.ErrorKindUnavailable, gmai.ErrorKindAuth, gmai.ErrorKindConfiguration, gmai.ErrorKindProvider:
+		return true
+	}
+	text := strings.ToLower(err.Error())
+	for _, code := range []string{"400", "401", "403", "404", "429", "500", "502", "503", "504"} {
+		if strings.Contains(text, "api error ("+code+" ") {
+			return true
+		}
+	}
+	return false
+}
+
+func queryWithFallback(account, prompt string, opts QueryOpts) (string, error) {
+	return tryModels(account, prompt, opts, runNative)
+}
+func tryModels(account, prompt string, opts QueryOpts, run func(string, string, QueryOpts) (string, error)) (string, error) {
+	answer, err := run(account, prompt, opts)
+	if !fallbackAllowed(err) {
+		return answer, err
+	}
+	provider, _, model, _, _ := nativeLLMFor(opts.Model, opts.Public)
+	seen := map[string]bool{provider + "/" + model: true}
+	for _, candidate := range fallbackModels(opts.Public) {
+		p, _, m, _, ok := nativeLLMFor(candidate, opts.Public)
+		if !ok || seen[p+"/"+m] {
+			continue
+		}
+		seen[p+"/"+m] = true
+		app.Log("ai", "model fallback from=%s/%s to=%s/%s reason=%s", provider, model, p, m, gmai.ClassifyError(err))
+		next := opts
+		next.Model = candidate
+		answer, err = run(account, prompt, next)
+		if !fallbackAllowed(err) {
+			return answer, err
+		}
+		provider, model = p, m
+	}
+	return answer, err
+}
+
+func fallbackModels(fast bool) []string {
+	var out []string
+	if settings.Get("ANTHROPIC_API_KEY") != "" {
+		model := strings.TrimSpace(settings.Get("ANTHROPIC_MODEL"))
+		if model == "" {
+			model = ai.ModelClaudeSonnet
+			if fast {
+				model = ai.ModelClaudeHaiku
+			}
+		}
+		out = append(out, model)
+	}
+	if ai.GeminiKey() != "" {
+		out = append(out, ai.PreferredModel("gemini", fast))
+	}
+	if ai.AtlasKey() != "" {
+		out = append(out, ai.PreferredModel("atlascloud", fast))
+	}
+	if ai.OpenRouterKey() != "" {
+		out = append(out, ai.OpenRouterModel())
+	}
+	return out
+}

--- a/agent/fallback_test.go
+++ b/agent/fallback_test.go
@@ -1,0 +1,48 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestFallbackOnlyBeforeWork(t *testing.T) {
+	for _, tc := range []struct {
+		err     error
+		allowed bool
+	}{
+		{retryableModelFailure{errors.New("parameters.steps.items: missing field")}, true},
+		{retryableModelFailure{context.DeadlineExceeded}, true},
+		{retryableModelFailure{context.Canceled}, false},
+		{errors.New("missing field after tool ran"), false},
+		{nil, false},
+	} {
+		if fallbackAllowed(tc.err) != tc.allowed {
+			t.Errorf("unexpected fallback for %v", tc.err)
+		}
+	}
+}
+func TestFallbackUsesAnotherConfiguredModel(t *testing.T) {
+	noProviders(t)
+	t.Setenv("AI_PROVIDER", "gemini")
+	t.Setenv("GEMINI_API_KEY", "test")
+	t.Setenv("ANTHROPIC_API_KEY", "test")
+	calls := 0
+	opts := QueryOpts{System: "Keep this persona", Tools: []string{"news"}}
+	answer, err := tryModels("owner", "question", opts, func(a, p string, o QueryOpts) (string, error) {
+		calls++
+		if a != "owner" || p != "question" || o.System != opts.System || len(o.Tools) != 1 {
+			t.Fatal("fallback lost context")
+		}
+		if calls == 1 {
+			return "", retryableModelFailure{errors.New("missing field")}
+		}
+		if o.Model == "" {
+			t.Fatal("no fallback model")
+		}
+		return "answer", nil
+	})
+	if err != nil || answer != "answer" || calls != 2 {
+		t.Fatalf("%s %v calls=%d", answer, err, calls)
+	}
+}

--- a/agent/native.go
+++ b/agent/native.go
@@ -693,8 +693,29 @@ func runNative(accountID, prompt string, opts QueryOpts) (answer string, runErr 
 		return "", fmt.Errorf("unknown or unavailable command: %s", strings.Fields(prompt)[0])
 	}
 
+	var startedWork atomic.Bool
+	originalToken := opts.Stream.Token
+	if originalToken != nil {
+		opts.Stream.Token = func(text string) {
+			if text != "" {
+				startedWork.Store(true)
+			}
+			originalToken(text)
+		}
+	}
+	defer func() {
+		if runErr != nil && !startedWork.Load() {
+			runErr = retryableModelFailure{runErr}
+		}
+	}()
+	guard := func(next gmai.ToolHandler) gmai.ToolHandler {
+		return func(ctx context.Context, c gmai.ToolCall) gmai.ToolResult {
+			startedWork.Store(true)
+			return next(ctx, c)
+		}
+	}
 	recorder := newNativeToolRecorder()
-	wrappers := []gmai.ToolWrapper{recorder.wrap}
+	wrappers := []gmai.ToolWrapper{guard, recorder.wrap}
 	if opts.OnStep != nil {
 		wrappers = append(wrappers, stepReporter(opts.OnStep))
 	}

--- a/internal/ai/gemini_schema.go
+++ b/internal/ai/gemini_schema.go
@@ -1,0 +1,50 @@
+package ai
+
+import (
+	"context"
+	gmai "go-micro.dev/v6/ai"
+	"go-micro.dev/v6/ai/gemini"
+)
+
+// The pinned framework's built-in plan tool omits the schema of its steps.
+// Repair that declaration at the Gemini boundary without mutating shared tools.
+func init() {
+	gmai.Register("gemini", func(opts ...gmai.Option) gmai.Model { return &geminiSchema{gemini.NewProvider(opts...)} })
+}
+
+type geminiSchema struct{ gmai.Model }
+
+func (m *geminiSchema) Generate(ctx context.Context, r *gmai.Request, o ...gmai.GenerateOption) (*gmai.Response, error) {
+	return m.Model.Generate(ctx, planSchema(r), o...)
+}
+func (m *geminiSchema) Stream(ctx context.Context, r *gmai.Request, o ...gmai.GenerateOption) (gmai.Stream, error) {
+	return m.Model.Stream(ctx, planSchema(r), o...)
+}
+func planSchema(r *gmai.Request) *gmai.Request {
+	if r == nil {
+		return r
+	}
+	cp := *r
+	cp.Tools = append([]gmai.Tool(nil), r.Tools...)
+	for i, t := range cp.Tools {
+		if t.Name != "plan" {
+			continue
+		}
+		steps, ok := t.Properties["steps"].(map[string]any)
+		if !ok || steps["type"] != "array" || steps["items"] != nil {
+			continue
+		}
+		props := make(map[string]any, len(t.Properties))
+		for k, v := range t.Properties {
+			props[k] = v
+		}
+		array := make(map[string]any, len(steps)+1)
+		for k, v := range steps {
+			array[k] = v
+		}
+		array["items"] = map[string]any{"type": "object", "properties": map[string]any{"task": map[string]any{"type": "string"}, "status": map[string]any{"type": "string", "enum": []string{"pending", "in_progress", "done"}}}, "required": []string{"task", "status"}}
+		props["steps"] = array
+		cp.Tools[i].Properties = props
+	}
+	return &cp
+}

--- a/internal/ai/gemini_schema_test.go
+++ b/internal/ai/gemini_schema_test.go
@@ -1,0 +1,31 @@
+package ai
+
+import (
+	gmagent "go-micro.dev/v6/agent"
+	gmai "go-micro.dev/v6/ai"
+	"testing"
+)
+
+func TestGeminiBuiltinPlanHasItems(t *testing.T) {
+	tools, _ := gmagent.Builtins()
+	before := &gmai.Request{Tools: tools}
+	after := planSchema(before)
+	found := false
+	for i, tool := range after.Tools {
+		if tool.Name != "plan" {
+			continue
+		}
+		found = true
+		steps := tool.Properties["steps"].(map[string]any)
+		items, ok := steps["items"].(map[string]any)
+		if !ok || items["type"] != "object" {
+			t.Fatal("plan missing array items")
+		}
+		if before.Tools[i].Properties["steps"].(map[string]any)["items"] != nil {
+			t.Fatal("shared tool mutated")
+		}
+	}
+	if !found {
+		t.Fatal("no built-in plan tested")
+	}
+}

--- a/internal/app/chat.go
+++ b/internal/app/chat.go
@@ -646,6 +646,10 @@ function nearBottom(){
   return (conv.scrollTop+conv.clientHeight)>=(conv.scrollHeight-nearEnough);
 }
 var nearEnough=120;
+function revealAnswer(node){
+  if(transcript){toBottom(false);return;}
+  requestAnimationFrame(function(){if(node&&node.isConnected)node.scrollIntoView({behavior:"smooth",block:"start"});});
+}
 function toBottom(force,smooth){
   if(!transcript) return;
   if(!force && !nearBottom()) return;
@@ -912,9 +916,9 @@ function ask(q){
         if(terminal||epoch!==viewEpoch)return;
         if(d&&d.html){
           terminal=true;stopWork();clearTimeout(completionTimer);
-          if(d.answer_html)a.innerHTML=d.answer_html;else a.outerHTML=d.html;
+          if(d.answer_html)a.innerHTML=d.answer_html;else a.innerHTML=d.html;
           if(typeof d.text==='string')history.push({prompt:q,answer:d.text});
-          save();toBottom(false);streamController.abort();return;
+          save();revealAnswer(a);streamController.abort();return;
         }
         if(d&&!d.waiting){
           terminal=true;stopWork();a.innerHTML='<div class="mu-err">'+esc(d.error||'The run stopped without returning an answer.')+'</div>';save();streamController.abort();return;
@@ -1033,7 +1037,7 @@ function ask(q){
               if(typeof ev.text==='string')streamText=ev.text;
               history.push({prompt:q,answer:streamText});
               save();
-              toBottom(false);
+              revealAnswer(a);
               // Out loud, when that was asked for. streamText and not ev.html:
               // a voice reading markup says "less than div" at you.
               if(window.muSay)window.muSay(streamText);

--- a/internal/app/testdata/chat_completion.js
+++ b/internal/app/testdata/chat_completion.js
@@ -4,8 +4,8 @@ const frame=e=>'data: '+JSON.stringify(e)+'\n\n';
 async function scenario(frames,stall=false){
  const paints=[],children=[],timeouts=[];
  const element=()=>({className:'',style:{},isConnected:true,focus(){},scrollIntoView(){},set innerHTML(v){this.html=v;paints.push(v)},get innerHTML(){return this.html||''}});
- let idx=0,polls=0;
- const env={viewEpoch:0,detachActive:null,hideBrief(){},sugDiv:element(),conv:{appendChild(e){children.push(e)}},document:{createElement:element},input:element(),saveDraft(){},save(){},esc:String,agentName(){return 'Micro'},toBottom(){},transcript:false,history:[],contextId:'',attachment:'',window:{dispatchEvent(){}},CustomEvent:class{},TextDecoder,AbortController,
+ let idx=0,polls=0,scrolls=0;
+ const env={viewEpoch:0,detachActive:null,hideBrief(){},sugDiv:element(),conv:{appendChild(e){children.push(e)}},document:{createElement:element},input:element(),saveDraft(){},save(){},esc:String,agentName(){return 'Micro'},toBottom(){},revealAnswer(node){assert(node.isConnected);scrolls++},transcript:false,history:[],contextId:'',attachment:'',window:{dispatchEvent(){}},CustomEvent:class{},TextDecoder,AbortController,
  setInterval(){return 1},clearInterval(){},setTimeout(fn,ms){timeouts.push({fn,ms});return timeouts.length},clearTimeout(){},
  fetch(url){
   if(url.startsWith('/agent/pending')){polls++;return Promise.resolve({ok:true,json:()=>Promise.resolve({waiting:false,html:'<div>Recovered</div>',answer_html:'Recovered',text:'Recovered'})})}
@@ -14,6 +14,7 @@ async function scenario(frames,stall=false){
  new Function('env','with(env){'+source+'; return ask;}')(env)('News');
  for(let i=0;i<100;i++)await Promise.resolve();
  if(stall){const timer=timeouts.find(t=>t.ms===4000);assert(timer,'missing live completion watchdog');timer.fn();for(let i=0;i<100;i++)await Promise.resolve();}
+ if(env.history.length)assert(scrolls>0,"completed landing answer was not revealed");
  return {paints,answer:children[children.length-1],polls,history:env.history};
 }
 (async()=>{


### PR DESCRIPTION
Gemini rejects the pinned framework's built-in plan tool because steps is an array without items. Repair that specific schema at the Gemini provider boundary for Generate and Stream, preserving the original shared declaration and defining task/status objects.

Agent requests, including the web path, can fall back to another configured cloud provider on model configuration/auth/rate-limit/timeout/provider failures. Preserve instructions, history and permissions; try each resolved provider/model only once and log switches. Each attempt retains its existing timeline and cost accounting. Do not replay after any tool invocation or emitted text, or on cancellation. This is guarded whole-attempt fallback before work begins, not mid-work migration; local endpoints and non-agent summary calls are not included in fallback.

Completed landing answers now scroll into view, including polling recovery. Transcript panel scrolling keeps its existing behavior.

Validation: internal/ai and internal/app short suites pass, including the completion/recovery JavaScript scenarios. Focused agent fallback and model tests pass. No live providers called and no browser visual QA.