### PR TITLE
Show full provider errors and fix question scroll anchor

### DIFF
--- a/admin/log.go
+++ b/admin/log.go
@@ -195,6 +195,9 @@ func apiLogCard() string {
 			html.EscapeString(e.Error), html.EscapeString(errStr),
 		))
 
+		if e.Error != "" {
+			fmt.Fprintf(&content, `<tr><td colspan="7"><details class="disclosure"><summary>Error details</summary><pre class="raw-sm">%s</pre></details></td></tr>`, html.EscapeString(e.Error))
+		}
 		if e.Kind == "model" {
 			fmt.Fprintf(&content, `<tr><td colspan="7">Model: %s · Run: %s · Attempt: %d · Tokens: %d in / %d out</td></tr>`, html.EscapeString(e.Model), html.EscapeString(e.RunID), e.Attempt, e.InputTokens, e.OutputTokens)
 		}

--- a/agent/timing.go
+++ b/agent/timing.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	gmagent "go-micro.dev/v6/agent"
+	"mu/internal/ai"
 	"mu/internal/app"
 	"time"
 )
@@ -11,5 +12,15 @@ func logRunTiming(e gmagent.RunEvent) {
 	if e.Kind != "model" && e.Kind != "stream" {
 		return
 	}
-	app.RecordExternalCall(app.APILogEntry{Kind: "model", Time: e.Time, Service: e.Provider, Method: e.Kind, Model: e.Model, RunID: e.RunID, Outcome: e.Status, Attempt: e.Attempt, Duration: time.Duration(e.LatencyMS) * time.Millisecond, Error: e.ErrorKind, InputTokens: e.Tokens.InputTokens, OutputTokens: e.Tokens.OutputTokens})
+	outcome := e.Status
+	if outcome == "" {
+		outcome = "done"
+		if e.Error != "" || e.ErrorKind != "" {
+			outcome = e.ErrorKind
+			if outcome == "" {
+				outcome = "error"
+			}
+		}
+	}
+	app.RecordExternalCall(app.APILogEntry{Kind: "model", Time: e.Time, Service: e.Provider, Method: e.Kind, Model: e.Model, RunID: e.RunID, Outcome: outcome, Attempt: e.Attempt, Duration: time.Duration(e.LatencyMS) * time.Millisecond, Error: ai.ProviderErrorDetail(e.Error), ErrorKind: e.ErrorKind, InputTokens: e.Tokens.InputTokens, OutputTokens: e.Tokens.OutputTokens})
 }

--- a/agent/timing_test.go
+++ b/agent/timing_test.go
@@ -19,3 +19,11 @@ func TestModelTimingIncludesAttemptsAndFailures(t *testing.T) {
 		}
 	}
 }
+
+func TestModelTimingRetainsProviderError(t *testing.T) {
+	logRunTiming(gmagent.RunEvent{Kind: "model", ErrorKind: "rate_limited", Error: "HTTP 429 quota=RequestsPerDay limit=0 retryDelay=60s"})
+	got := app.APILog()[0]
+	if got.Outcome != "rate_limited" || got.Error != "HTTP 429 quota=RequestsPerDay limit=0 retryDelay=60s" {
+		t.Fatalf("lost provider diagnostic: %+v", got)
+	}
+}

--- a/internal/ai/error_detail.go
+++ b/internal/ai/error_detail.go
@@ -1,0 +1,22 @@
+package ai
+
+import (
+	"mu/internal/settings"
+	"regexp"
+	"strings"
+)
+
+var credentialField = regexp.MustCompile(`(?i)((?:[?&]|\b)(?:key|api[_-]?key|x-goog-api-key|x-api-key|access_token|token|authorization)["']?\s*[:=]\s*["']?)(?:bearer\s+)?[^\s&"'<>},]+`)
+var bearerCredential = regexp.MustCompile(`(?i)(\bbearer\s+)[a-z0-9._~+/=-]+`)
+
+// ProviderErrorDetail retains diagnostics while removing configured credentials
+// and credentials embedded in URLs or headers by a provider's HTTP client.
+func ProviderErrorDetail(detail string) string {
+	for _, key := range []string{"ANTHROPIC_API_KEY", "GEMINI_API_KEY", "ATLASCLOUD_API_KEY", "ATLAS_API_KEY", "OPENROUTER_API_KEY", "OPENAI_API_KEY"} {
+		if secret := settings.Get(key); secret != "" {
+			detail = strings.ReplaceAll(detail, secret, "[redacted]")
+		}
+	}
+	detail = credentialField.ReplaceAllString(detail, "${1}[redacted]")
+	return bearerCredential.ReplaceAllString(detail, "${1}[redacted]")
+}

--- a/internal/ai/error_detail_test.go
+++ b/internal/ai/error_detail_test.go
@@ -1,0 +1,22 @@
+package ai
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestProviderErrorKeepsQuotaDetailsAndRedactsCredentials(t *testing.T) {
+	t.Setenv("GEMINI_API_KEY", "private-google-credential")
+	input := `HTTP 429 RESOURCE_EXHAUSTED quota=GenerateRequestsPerDay limit=0 retryDelay=60s https://host/path?key=private-google-credential&model=gemini Authorization: Bearer other-secret x-api-key: third-secret`
+	got := ProviderErrorDetail(input)
+	for _, secret := range []string{"private-google-credential", "other-secret", "third-secret"} {
+		if strings.Contains(got, secret) {
+			t.Fatal("credential leaked")
+		}
+	}
+	for _, want := range []string{"HTTP 429", "RESOURCE_EXHAUSTED", "GenerateRequestsPerDay", "limit=0", "retryDelay=60s", "model=gemini"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("lost diagnostic %s: %s", want, got)
+		}
+	}
+}

--- a/internal/ai/micro.go
+++ b/internal/ai/micro.go
@@ -300,7 +300,11 @@ func logModelCall(provider, model, caller, method string, started time.Time, err
 	if err != nil {
 		outcome = "error"
 	}
+	detail := ""
+	if err != nil {
+		detail = ProviderErrorDetail(err.Error())
+	}
 	duration := time.Since(started)
-	app.RecordExternalCall(app.APILogEntry{Kind: "model", Time: started, Service: provider, Method: method, Model: model, Outcome: outcome, Duration: duration, InputTokens: used.InputTokens, OutputTokens: used.OutputTokens})
+	app.RecordExternalCall(app.APILogEntry{Kind: "model", Time: started, Service: provider, Method: method, Model: model, Outcome: outcome, Error: detail, ErrorKind: string(gmai.ClassifyError(err)), Duration: duration, InputTokens: used.InputTokens, OutputTokens: used.OutputTokens})
 	app.Log("timing", "phase=model caller=%s provider=%s model=%s status=%s duration_ms=%.3f", caller, provider, model, outcome, float64(duration)/float64(time.Millisecond))
 }

--- a/internal/app/apilog.go
+++ b/internal/app/apilog.go
@@ -12,6 +12,7 @@ const apiLogMaxEntries = 500
 
 // APILogEntry records a single external API call.
 type APILogEntry struct {
+	ErrorKind    string        `json:"error_kind,omitempty"`
 	Kind         string        `json:"kind,omitempty"`
 	Model        string        `json:"model,omitempty"`
 	RunID        string        `json:"run_id,omitempty"`

--- a/internal/app/chat.go
+++ b/internal/app/chat.go
@@ -646,9 +646,13 @@ function nearBottom(){
   return (conv.scrollTop+conv.clientHeight)>=(conv.scrollHeight-nearEnough);
 }
 var nearEnough=120;
-function revealAnswer(node){
+function revealQuestion(node){
   if(transcript){toBottom(false);return;}
-  requestAnimationFrame(function(){if(node&&node.isConnected)node.scrollIntoView({behavior:"smooth",block:"start"});});
+  requestAnimationFrame(function(){
+    if(!node||!node.isConnected)return;
+    node.style.scrollMarginTop=Math.max(64,(form?form.getBoundingClientRect().height:0)+24)+"px";
+    node.scrollIntoView({behavior:"smooth",block:"start"});
+  });
 }
 function toBottom(force,smooth){
   if(!transcript) return;
@@ -918,7 +922,7 @@ function ask(q){
           terminal=true;stopWork();clearTimeout(completionTimer);
           if(d.answer_html)a.innerHTML=d.answer_html;else a.innerHTML=d.html;
           if(typeof d.text==='string')history.push({prompt:q,answer:d.text});
-          save();revealAnswer(a);streamController.abort();return;
+          save();revealQuestion(u);streamController.abort();return;
         }
         if(d&&!d.waiting){
           terminal=true;stopWork();a.innerHTML='<div class="mu-err">'+esc(d.error||'The run stopped without returning an answer.')+'</div>';save();streamController.abort();return;
@@ -1037,7 +1041,7 @@ function ask(q){
               if(typeof ev.text==='string')streamText=ev.text;
               history.push({prompt:q,answer:streamText});
               save();
-              revealAnswer(a);
+              revealQuestion(u);
               // Out loud, when that was asked for. streamText and not ev.html:
               // a voice reading markup says "less than div" at you.
               if(window.muSay)window.muSay(streamText);

--- a/internal/app/html/mu.js
+++ b/internal/app/html/mu.js
@@ -505,7 +505,7 @@ function setSession() {
       if (navLogin) navLogin.style.display = 'none';
       if (navUsername && sess.account) {
         navUsername.textContent = '@' + sess.account;
-        navUsername.style.display = 'block';
+        navUsername.style.display = 'inline-block';
         var navMeAv = document.getElementById("nav-me-av");
         if (navMeAv) navMeAv.textContent = sess.account.charAt(0).toUpperCase();
       }

--- a/internal/app/testdata/chat_completion.js
+++ b/internal/app/testdata/chat_completion.js
@@ -5,7 +5,7 @@ async function scenario(frames,stall=false){
  const paints=[],children=[],timeouts=[];
  const element=()=>({className:'',style:{},isConnected:true,focus(){},scrollIntoView(){},set innerHTML(v){this.html=v;paints.push(v)},get innerHTML(){return this.html||''}});
  let idx=0,polls=0,scrolls=0;
- const env={viewEpoch:0,detachActive:null,hideBrief(){},sugDiv:element(),conv:{appendChild(e){children.push(e)}},document:{createElement:element},input:element(),saveDraft(){},save(){},esc:String,agentName(){return 'Micro'},toBottom(){},revealAnswer(node){assert(node.isConnected);scrolls++},transcript:false,history:[],contextId:'',attachment:'',window:{dispatchEvent(){}},CustomEvent:class{},TextDecoder,AbortController,
+ const env={viewEpoch:0,detachActive:null,hideBrief(){},sugDiv:element(),conv:{appendChild(e){children.push(e)}},document:{createElement:element},input:element(),saveDraft(){},save(){},esc:String,agentName(){return 'Micro'},toBottom(){},revealQuestion(node){assert(node.isConnected);assert.equal(node.className,"mu-user");scrolls++},transcript:false,history:[],contextId:'',attachment:'',window:{dispatchEvent(){}},CustomEvent:class{},TextDecoder,AbortController,
  setInterval(){return 1},clearInterval(){},setTimeout(fn,ms){timeouts.push({fn,ms});return timeouts.length},clearTimeout(){},
  fetch(url){
   if(url.startsWith('/agent/pending')){polls++;return Promise.resolve({ok:true,json:()=>Promise.resolve({waiting:false,html:'<div>Recovered</div>',answer_html:'Recovered',text:'Recovered'})})}


### PR DESCRIPTION
External model logs retained only the error category, hiding quota and retry diagnostics. Store the provider error separately from its category for native agent and ordinary AI calls; redact configured provider keys and credential fields before storage. Show escaped full errors in an expandable admin row. Derive a meaningful model outcome when the framework omits status.

Also finish two UI corrections: anchor completed landing/home responses to the question with space for the sticky input, and change session JavaScript's inline username display to inline-block.

Validation: focused provider-error, model-timing and completion/recovery tests pass. Earlier full internal/app suite passed for the question anchor change. No live model requests or visual browser validation. Old discarded error details cannot be recovered by this change.