### PR TITLE
Soften inbox thread dividers

### DIFF
--- a/internal/app/html/mu.css
+++ b/internal/app/html/mu.css
@@ -6452,7 +6452,7 @@ button.pill:hover {
    the thread including your own. A thread is a stack of messages and what
    separates them is a line across, the way every mail client draws it: the
    eye needs to know where one ends, not that all of them are quotations. */
-.ib-msg { padding: 16px 0; border-bottom: var(--border-width, 1px) solid var(--divider, #f0f0f0) }
+.ib-msg { padding: 16px 0; border-bottom: var(--border-width, 1px) solid color-mix(in srgb, var(--divider, #f0f0f0) 55%, transparent) }
 .ib-msg:first-child { padding-top: 0 }
 .ib-msg:last-child { border-bottom: none; padding-bottom: 0 }
 .ib-from { display: flex; align-items: baseline; gap: 10px; margin-bottom: 6px }


### PR DESCRIPTION
Reduce inbox message divider contrast to 55% of the existing theme divider colour. Keep bottom placement and omit the final divider.

Inspected the shared styles and message markup. One CSS declaration changed; no live visual validation.