### PR TITLE
Keep internal web search guidance out of fallback answers

### DIFF
--- a/agent/answer_guard.go
+++ b/agent/answer_guard.go
@@ -69,7 +69,7 @@ func completeToolAnswerFor(answer string, ragParts []string, custom bool) string
 		return answer
 	}
 	// A custom agent with something substantive to say keeps it.
-	if custom && trimmed != "" && !isProgressOnlyAnswer(trimmed) && !isRawToolPayloadAnswer(trimmed) {
+	if custom && trimmed != "" && !isProgressOnlyAnswer(trimmed) && !isRawToolPayloadAnswer(trimmed) && !hasOperationalFallbackLead(trimmed) {
 		if caveat := staleNewsFreshnessCaveat(ragParts); caveat != "" {
 			guarded := labelStaleNewsAnswerStories(trimmed)
 			if guarded == "" {
@@ -724,6 +724,19 @@ func meaningfulLines(body string, limit int) []string {
 			// answer to save the reader from the braces around it. Unwrap what
 			// can be unwrapped; drop what cannot.
 			line = readableFromPayload(line)
+			if line != "" {
+				// Decode before splitting and filtering: a text field can hold
+				// a whole search response, including model-only instructions.
+				decoded := meaningfulLines(line, limit)
+				for _, item := range decoded {
+					if isFallbackSecondaryContextLine(item) {
+						context = append(context, item)
+					} else {
+						primary = append(primary, item)
+					}
+				}
+			}
+			continue
 		}
 		if line == "" {
 			continue

--- a/agent/web_envelope_test.go
+++ b/agent/web_envelope_test.go
@@ -1,0 +1,29 @@
+package agent
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestWebFallbackFiltersMetadataInsideJSONEnvelope(t *testing.T) {
+	text := `Web results for "Meta Muse":
+Query intent: answer the user's original query "Meta Muse"; do not replace it with a broader meaning.
+Confidence: high — synthesize only what the listed sources support.
+Sources:
+1. Meta introduces Muse — Muse is a personal AI agent that helps with everyday tasks. (https://example.com/muse)
+2. How Muse works — The assistant connects to tools to carry out user requests. (https://example.com/how)`
+	body, _ := json.Marshal(map[string]any{"text": text, "items": []map[string]string{{"title": "Meta introduces Muse", "url": "https://example.com/muse"}}})
+	rag := []string{"### web_search\n" + string(body)}
+	for _, custom := range []bool{false, true} {
+		got := completeToolAnswerFor("Web results for Meta Muse: Query intent: answer the query", rag, custom)
+		for _, internal := range []string{"Query intent:", "Confidence:", "Sources:", "Web results for", "synthesize only"} {
+			if strings.Contains(got, internal) {
+				t.Fatalf("internal guidance leaked: %s", got)
+			}
+		}
+		if !strings.Contains(got, "personal AI agent") || !strings.Contains(got, "https://example.com/muse") {
+			t.Fatalf("source evidence lost: %s", got)
+		}
+	}
+}


### PR DESCRIPTION
When a model failed to provide a substantive answer, the fallback decoded the web tool's JSON text field after filtering metadata. It then truncated the entire multiline text into one bullet, leaking Query intent and Confidence while losing the actual source snippets.

Process decoded text through line splitting and metadata filtering before truncation. Apply the operational-output guard to custom agents too, while retaining their substantive answers. Regression test covers the web response envelope with both items and text, default/custom agents, preserved source descriptions and URLs, and removed internal guidance.

Validation: focused web-envelope, CompleteToolAnswer and payload tests pass. No live provider calls.