### PR TITLE
Expose startup timings, fix logging and simplify public pages

### DIFF
--- a/admin/server.go
+++ b/admin/server.go
@@ -19,7 +19,9 @@ import (
 	"fmt"
 	"html"
 	"net/http"
+	"sort"
 	"strings"
+	"time"
 
 	"mu/internal/app"
 	"mu/internal/auth"
@@ -36,7 +38,7 @@ func ServerHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	content := back() + app.RenderInternalStatusHTML() + storesTable()
+	content := back() + app.RenderInternalStatusHTML() + startupTable() + storesTable()
 
 	app.Respond(w, r, app.Response{Title: "Server", Description: "What this process is doing and what it is sitting on", HTML: content})
 }
@@ -89,5 +91,21 @@ func storesTable() string {
 	b.WriteString(fmt.Sprintf(`<p class="text-muted text-sm">%s in the data directory. `+
 		`Each of these is rewritten whole when it changes, except where marked. `+
 		`Search index: %s.</p>`, app.Bytes(total), html.EscapeString(data.SearchBackend())))
+	return b.String()
+}
+
+// Keep these on the authenticated server page: component names are internal.
+func startupTable() string {
+	steps, total := app.StartupTimings()
+	if len(steps) == 0 {
+		return `<section class="page-section"><h3>Startup</h3><p>No startup timings recorded for this process.</p></section>`
+	}
+	sort.SliceStable(steps, func(i, j int) bool { return steps[i].Duration > steps[j].Duration })
+	var b strings.Builder
+	b.WriteString(fmt.Sprintf(`<section class="page-section"><h3>Startup</h3><p>Initialization: <strong>%s</strong>. Current process, slowest loaders first. Timings cover service loading through route registration.</p><table class="stats-table"><thead><tr><th>Component</th><th>Time</th></tr></thead><tbody>`, total.Round(time.Millisecond)))
+	for _, step := range steps {
+		b.WriteString(fmt.Sprintf(`<tr><td>%s</td><td>%.1f ms</td></tr>`, html.EscapeString(step.Component), float64(step.Duration)/float64(time.Millisecond)))
+	}
+	b.WriteString(`</tbody></table><p class="text-muted text-sm">Loader start and completion events are also recorded in the server log.</p></section>`)
 	return b.String()
 }

--- a/home/about.go
+++ b/home/about.go
@@ -34,7 +34,9 @@ func AboutHandler(w http.ResponseWriter, r *http.Request) {
 		`<a href="https://github.com/micro/mu">The Mu source</a>` +
 		`</p></div>`)
 
-	app.Respond(w, r, app.Response{
+	b.WriteString(app.Close())
+
+	app.RespondPublic(w, r, app.Response{
 		Title:       "About Micro",
 		Description: "Micro is a personal assistant powered by the open source Mu runtime.",
 		HTML:        b.String(),

--- a/home/collapsed_test.go
+++ b/home/collapsed_test.go
@@ -57,29 +57,6 @@ func TestProseCentresWhenTheRailIsGone(t *testing.T) {
 	}
 }
 
-// The corner says who you are only when the rail is not already saying it.
-//
-// The rail's foot carries "Signed in as @you" with Account under it, and the
-// corner carries @you linking to the same page. Collapsed, the rail is not on
-// screen and the corner is the only answer — which is why it exists. Open, both
-// were on screen at once, in two styles, one above the other.
-func TestTheCornerDoesNotRepeatTheRail(t *testing.T) {
-	css := styles(t)
-	if !regexp.MustCompile(`body:not\(\.nav-collapsed\)\s+#head-me\s*\{[^}]*display:\s*none`).MatchString(css) {
-		t.Error("the corner names the account while the rail is open and naming it too")
-	}
-	// And only on a desktop, where the rail is a column beside the corner.
-	// Below 901px it is an overlay and there is nothing on screen to repeat, so
-	// a rule that was not scoped to that width would take the name away on a
-	// phone as well — where the rail is a tap away rather than a glance.
-	desktop := strings.Index(css, "min-width: 901px")
-	scoped := strings.Index(css, "body:not(.nav-collapsed) #head-me")
-	if desktop < 0 || scoped < desktop {
-		t.Error("the corner's name is hidden outside the desktop rule, where the rail " +
-			"is an overlay and repeats nothing")
-	}
-}
-
 // Headlines form one readable column with their descriptions.
 func TestTheNewsCardIsAGlance(t *testing.T) {
 	css := styles(t)

--- a/home/contact.go
+++ b/home/contact.go
@@ -53,7 +53,7 @@ func ContactHandler(w http.ResponseWriter, r *http.Request) {
 	if _, a := auth.TrySession(r); a != nil {
 		acc = a
 	}
-	app.Respond(w, r, app.Response{
+	app.RespondPublic(w, r, app.Response{
 		Title:       "Contact",
 		Description: "Every way to reach this instance's assistant — the web, a text, WhatsApp, mail, or a program.",
 		HTML:        contactBody(acc),

--- a/home/pricing.go
+++ b/home/pricing.go
@@ -23,6 +23,7 @@ package home
 // numbers that will never be applied to anybody. It says so instead.
 
 import (
+	"html"
 	"net/http"
 	"strconv"
 	"strings"
@@ -48,7 +49,8 @@ func PricingHandler(w http.ResponseWriter, r *http.Request) {
 			`makes.</p>` +
 			`<p class="text-sm"><a href="/install">Run your own &rarr;</a> · ` +
 			`<a href="/about">What this is</a></p></div>`)
-		app.Respond(w, r, app.Response{
+		b.WriteString(app.Close())
+		app.RespondPublic(w, r, app.Response{
 			Title:       "Pricing",
 			Description: "This instance does not charge for anything.",
 			HTML:        b.String(),
@@ -70,6 +72,8 @@ func PricingHandler(w http.ResponseWriter, r *http.Request) {
 		`model call, a search is a search company's, a text message is a carrier's. ` +
 		`Anything that only touches this server — reading the news, your mail, your ` +
 		`notes, the archive — is free, because serving it costs nothing.</p>` +
+		`<p>Paid tools used to answer a question are charged separately at the rates below. ` +
+		`Cached results that do not call a paid provider are not charged.</p>` +
 		account.PricingTableHTML() +
 		`</div>`)
 
@@ -78,14 +82,14 @@ func PricingHandler(w http.ResponseWriter, r *http.Request) {
 	// credit is. The table above answers neither.
 	start := `<div class="card"><h3>Starting</h3>` +
 		`<p>A new account gets ` + creditsInWords() + ` to find out whether this is ` +
-		`useful — about thirty questions. Nothing is asked for up front and there is ` +
-		`no card to leave.</p>`
+		`useful. This is a one-time welcome balance of ` + strconv.Itoa(account.WelcomeCredits) +
+		` credits, not a daily allowance. No card is required to start.</p>`
 	if account.TopUpConfigured() {
 		start += `<p>After that you top up: $5, $10, $25 or $50, or any amount you type. ` +
 			`A credit is a cent, and it is spent on what you use rather than on a plan — ` +
 			`there is no subscription, and an account that sits idle is charged nothing.</p>` +
-			`<p class="text-sm"><a href="/signup" class="btn">Sign up</a> ` +
-			`<a href="/account/topup" class="btn btn-secondary">Top up</a></p>`
+			`<div class="form-actions"><a href="/signup" class="btn">Sign up</a> ` +
+			`<a href="/account/topup" class="btn btn-secondary">Top up</a></div>`
 	} else {
 		// Metered but with no card route configured — x402 only. Real, and the
 		// page must not offer a top-up form that is not there.
@@ -96,13 +100,16 @@ func PricingHandler(w http.ResponseWriter, r *http.Request) {
 	b.WriteString(start)
 
 	b.WriteString(`<div class="card"><h3>Running it yourself</h3>` +
-		`<p>The software is the same either way, and an instance you run has no meter ` +
-		`in it: you hold the API keys and pay the providers directly.</p>` +
+		`<p>Run your own instance with your API keys and pay the providers directly. ` +
+		`Without payments configured, the instance does not charge its users.</p>` +
 		`<p class="text-sm"><a href="/install">How to run it</a> · ` +
 		`<a href="/about">What this is</a> · ` +
 		`<a href="https://github.com/micro/mu">The source</a></p></div>`)
 
-	app.Respond(w, r, app.Response{
+	b.WriteString(dailyLimitsHTML())
+	b.WriteString(app.Close())
+
+	app.RespondPublic(w, r, app.Response{
 		Title:       "Pricing",
 		Description: "What this instance costs: a dollar of credit to start, then a credit is a cent.",
 		HTML:        b.String(),
@@ -121,4 +128,19 @@ func creditsInWords() string {
 		return "$" + strconv.Itoa(c/100) + " of credit"
 	}
 	return strconv.Itoa(c) + " credits"
+}
+
+func dailyLimitsHTML() string {
+	var b strings.Builder
+	for _, p := range quota.Prices() {
+		limit := quota.DailyLimit(p.Op)
+		if limit == quota.NoLimit {
+			continue
+		}
+		b.WriteString("<tr><td>" + html.EscapeString(p.Label) + "</td><td>" + strconv.Itoa(limit) + "</td></tr>")
+	}
+	if b.Len() == 0 {
+		return ""
+	}
+	return `<section class="card"><h3>Daily limits</h3><p>These are limits on calls, separate from your credit balance. They reset at midnight UTC. Account-specific limits may differ.</p><table><thead><tr><th>Operation</th><th>Calls per day</th></tr></thead><tbody>` + b.String() + `</tbody></table></section>`
 }

--- a/home/privacy.go
+++ b/home/privacy.go
@@ -88,5 +88,5 @@ func PrivacyHandler(w http.ResponseWriter, r *http.Request) {
 
 	b.WriteString(`</div>`)
 
-	app.Respond(w, r, app.Response{Title: "Privacy", Description: "What this instance stores, why, and what it never does", HTML: b.String()})
+	app.RespondPublic(w, r, app.Response{Title: "Privacy", Description: "What this instance stores, why, and what it never does", HTML: b.String()})
 }

--- a/home/public_test.go
+++ b/home/public_test.go
@@ -1,0 +1,54 @@
+package home
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"mu/internal/app"
+)
+
+func TestPublicPagesUseLandingShell(t *testing.T) {
+	for _, tc := range []struct {
+		path    string
+		handler http.HandlerFunc
+	}{
+		{"/about", AboutHandler}, {"/contact", ContactHandler},
+		{"/pricing", PricingHandler}, {"/privacy", PrivacyHandler}, {"/status", app.StatusHandler},
+	} {
+		t.Run(tc.path, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			tc.handler(w, httptest.NewRequest("GET", tc.path, nil))
+			body := w.Body.String()
+			if w.Code != 200 || !strings.Contains(body, `<article class="public-page"><h1>`) {
+				t.Fatal("missing public page")
+			}
+			for _, marker := range []string{`id="nav"`, `id="footer"`, `/mu.css?`} {
+				if strings.Contains(body, marker) {
+					t.Errorf("app shell leaked into public page: %s", marker)
+				}
+			}
+			hasFooter := strings.Contains(body, `<div class="footer">`)
+			if hasFooter != (tc.path != "/about") {
+				t.Error("wrong footer visibility")
+			}
+			if !strings.Contains(w.Header().Get("Cache-Control"), "private") {
+				t.Error("contact response must not be shared between accounts")
+			}
+		})
+	}
+}
+
+func TestPricingExplainsWelcomeBalance(t *testing.T) {
+	takesPayment(t)
+	body := pricingPage(t)
+	for _, want := range []string{"one-time welcome balance", "not a daily allowance", "Daily limits", "midnight UTC"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("missing %q", want)
+		}
+	}
+	if strings.Contains(body, "thirty questions") {
+		t.Error("hardcoded question estimate")
+	}
+}

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -1410,29 +1410,12 @@ func navPinned(acc *auth.Account) string {
 //
 // nav-username is a label mu.js corrects from the session: a page cached for
 // one viewer and served to another would otherwise greet them by the wrong name.
-// headCorner shows the signed-in account. Guests sign in through the sidebar.
+// headCorner holds the balance; account identity belongs in the sidebar.
 func headCorner(acc *auth.Account, here string) string {
 	if acc == nil {
 		return ""
 	}
-
-	// And who you are, which is the other half of the same answer.
-	//
-	// The corner held only Admin and the balance, and both are conditional —
-	// an ordinary account on an unmetered instance got an empty corner. That
-	// was survivable while the front door drew its own "Home · Log out" and the
-	// sidebar was always open; with one corner on every page and the rail
-	// collapsed, it meant signed out said "Sign up · Log in" and signed in said
-	// nothing at all. The one thing this corner exists to answer went
-	// unanswered in exactly the state you would check it in.
-	//
-	// The name, not Log out. Log out is in the rail under "Signed in as", which
-	// is where somebody goes to leave; the corner's job is to say which account
-	// this browser is, and on a shared or long-lived one that is a real
-	// question. It links to /account, which is where the answer leads.
-	return headBalance(acc) +
-		`<a id="head-me" href="/account" title="Your account"><span class="label">@` +
-		htmlpkg.EscapeString(acc.ID) + `</span></a>`
+	return headBalance(acc)
 }
 
 func loginBack(here string) string {

--- a/internal/app/corner_test.go
+++ b/internal/app/corner_test.go
@@ -22,32 +22,14 @@ func TestGuestsSignInThroughTheSidebar(t *testing.T) {
 	}
 }
 
-// Signed in, the corner says which account this browser is.
-//
-// It held only Admin and the balance, both conditional, so an ordinary account
-// on an unmetered instance got an empty corner — signed out it said "Sign up ·
-// Log in" and signed in it said nothing at all, which is the one question the
-// corner exists to answer going unanswered in exactly the state you would check
-// it in. That was invisible while the front door drew a corner of its own.
-func TestSignedInTheCornerSaysWhoYouAre(t *testing.T) {
-	got := headCorner(&auth.Account{ID: "tester"}, "")
-	if !strings.Contains(got, "@tester") {
-		t.Errorf("the corner does not name the account: %q", got)
+func TestAccountIdentityStaysInSidebar(t *testing.T) {
+	acc := &auth.Account{ID: "tester"}
+	got := headCorner(acc, "")
+	if strings.Contains(got, "@tester") || strings.Contains(got, `id="head-me"`) {
+		t.Errorf("header duplicates account identity: %q", got)
 	}
-	if !strings.Contains(got, `href="/account"`) {
-		t.Errorf("the name does not lead anywhere: %q", got)
-	}
-	// And it is not the signed-out pair.
-	if strings.Contains(got, `href="/login"`) || strings.Contains(got, `href="/signup"`) {
-		t.Errorf("signed in, the corner still offers a way in: %q", got)
-	}
-}
-
-// A username is somebody's own text and lands in markup.
-func TestTheNameInTheCornerIsEscaped(t *testing.T) {
-	got := headCorner(&auth.Account{ID: `<script>x</script>`}, "")
-	if strings.Contains(got, "<script>") {
-		t.Errorf("an account id went into the corner as markup: %q", got)
+	if got := navBottom(acc, ""); !strings.Contains(got, "tester") {
+		t.Errorf("sidebar lost account identity: %q", got)
 	}
 }
 

--- a/internal/app/html/composition.css
+++ b/internal/app/html/composition.css
@@ -80,7 +80,7 @@
    presets, the wallet's sign-up button, two on the blog.
    Marking the background important as well would have hidden the cause and
    left the next property to do the same thing. Order is the cause. */
-a.btn-secondary, .btn-secondary {
+a.btn-secondary, a.btn-secondary:visited, .btn-secondary {
   background: var(--hover-background, #eee);
   color: var(--text-primary, #333);
   border-color: var(--border-color, #ddd);

--- a/internal/app/html/mu.css
+++ b/internal/app/html/mu.css
@@ -760,44 +760,6 @@ td {
    would lose to the one it is meant to override. */
 #head-out a#head-signup { color: #111; font-weight: 700; }
 
-/* Who this browser is signed in as. The same face as the signed-out pair
-   opposite it, because they are the two answers to one question. */
-#head-me {
-  color: #555;
-  text-decoration: none;
-  font-size: 14px;
-  font-weight: 600;
-  line-height: 20px;
-  white-space: nowrap;
-  max-width: 14ch;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-#head-me:hover { color: #111; }
-/* At phone width #head-right is beside a centred brand and the two fight for
-   the middle, which is why Admin drops its label here too. The rail says
-   "Signed in as @you" a tap away. */
-@media only screen and (max-width: 600px) {
-  #head-me { display: none; }
-}
-
-/* And on a desktop with the rail open, because the rail is already saying it.
-   
-   The corner answers "which account is this browser", and it was added because
-   the rail is collapsed by default: signed out the corner offered a way in and
-   signed in it said nothing at all, which is the one question it exists for
-   going unanswered in the state you would check it in. Open, the foot of the
-   rail says "Signed in as @you" with Account under it — so the name was on
-   screen twice, in two styles, both linking to /account.
-   
-   Only here. Below 901px the rail is an overlay rather than a column, so it is
-   not on screen beside the corner and there is nothing to duplicate. And only
-   the name: Admin has no other home — see the note above headAdmin, which is
-   why it is in the corner rather than in the rail. */
-@media only screen and (min-width: 901px) {
-  body:not(.nav-collapsed) #head-me { display: none; }
-}
-
 /* Credit balance in the top bar, beside Tools. The only place it appears: it
    was in the sidebar too for a moment, and the same number twice on one screen
    reads as a mistake. The top bar is fixed, always visible, and the same on

--- a/internal/app/index.go
+++ b/internal/app/index.go
@@ -152,8 +152,28 @@ body{font-family:'Nunito Sans',sans-serif;background:#fff;color:#111;min-height:
 /* No extra margin: FooterLinks already spaces the links with separators,
    so adding margin here made the same six links wrap where the app shell fits
    them on one line. */
-.footer a{color:#555;text-decoration:none}
+.footer a{color:#555;text-decoration:none;font-weight:400}
 .footer a:hover{text-decoration:underline}
+.index-body:has(>.public-page){justify-content:flex-start;padding:32px 0 0}
+.public-page{width:100%;max-width:760px;margin:40px auto 0;line-height:1.65}
+.public-page h1{text-align:center;font-size:28px;margin-bottom:32px}
+.public-page .page-col{width:100%;max-width:none}
+.public-page .card{margin-bottom:24px}
+.public-page h3{font-size:18px;margin-bottom:8px}
+.public-page p{margin-bottom:16px}
+.public-page a:not(.btn){color:#555;text-decoration:none;font-weight:700}
+.public-page table{width:100%;border-collapse:collapse;margin-bottom:16px;text-align:left;font-size:14px}
+.public-page td,.public-page th{padding:8px;border-bottom:1px solid #eee;vertical-align:top}
+.public-page td:last-child{white-space:nowrap}
+.public-page .text-sm{font-size:13px}
+.public-page .text-muted{color:#777}
+.public-page .status-header,.public-page .status-value{display:flex;align-items:center;gap:8px}
+.public-page .status-header{margin-bottom:24px}
+.public-page .status-item{display:flex;justify-content:space-between;padding:8px 0;border-bottom:1px solid #eee}
+.public-page .status-ok{color:#238636}
+.public-page .status-error{color:#c62828}
+.public-page .status-details{color:#777;font-size:13px}
+
 /* 14vh of air above the wordmark is right on a tall window and is a fifth of a
    short one — a 1280x600 laptop spent 84px on padding and then scrolled by 23.
    Height is the axis that decides here, so the query is on height. */

--- a/internal/app/logfile.go
+++ b/internal/app/logfile.go
@@ -29,6 +29,7 @@ package app
 import (
 	"fmt"
 	"io"
+	"log"
 	"log/slog"
 	"mu/internal/dir"
 	"os"
@@ -89,6 +90,7 @@ func OpenLog() {
 		logToStdio = true
 		return
 	}
+	log.SetOutput(f)
 	logWriter = f
 	logPath = path
 

--- a/internal/app/public.go
+++ b/internal/app/public.go
@@ -1,0 +1,27 @@
+package app
+
+import (
+	"html"
+	"net/http"
+)
+
+// RespondPublic uses the landing shell for informational pages.
+func RespondPublic(w http.ResponseWriter, r *http.Request, resp Response) {
+	if WantsJSON(r) {
+		Respond(w, r, resp)
+		return
+	}
+	footer := FooterLinks()
+	if r.URL.Path == "/about" {
+		footer = ""
+	}
+	page := RenderIndex(Index{
+		Title: html.EscapeString(resp.Title), Description: html.EscapeString(resp.Description),
+		TopRight: `<a href="/">Micro</a>`,
+		Body:     `<article class="public-page"><h1>` + html.EscapeString(resp.Title) + `</h1>` + resp.HTML + `</article>`,
+		Footer:   footer,
+	})
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.Header().Set("Cache-Control", "no-cache, private")
+	w.Write([]byte(page)) //nolint:errcheck
+}

--- a/internal/app/startup.go
+++ b/internal/app/startup.go
@@ -1,0 +1,36 @@
+package app
+
+import (
+	"sync"
+	"time"
+)
+
+// StartupTiming describes initialization of this process, not a previous run.
+type StartupTiming struct {
+	Component string
+	Duration  time.Duration
+}
+
+var startupTimings struct {
+	sync.RWMutex
+	steps []StartupTiming
+	total time.Duration
+}
+
+func RecordStartup(component string, elapsed time.Duration) {
+	startupTimings.Lock()
+	defer startupTimings.Unlock()
+	startupTimings.steps = append(startupTimings.steps, StartupTiming{component, elapsed})
+}
+
+func CompleteStartup(elapsed time.Duration) {
+	startupTimings.Lock()
+	defer startupTimings.Unlock()
+	startupTimings.total = elapsed
+}
+
+func StartupTimings() ([]StartupTiming, time.Duration) {
+	startupTimings.RLock()
+	defer startupTimings.RUnlock()
+	return append([]StartupTiming(nil), startupTimings.steps...), startupTimings.total
+}

--- a/internal/app/startup_test.go
+++ b/internal/app/startup_test.go
@@ -1,0 +1,29 @@
+package app
+
+import (
+	"testing"
+	"time"
+)
+
+func TestStartupTimingsSnapshot(t *testing.T) {
+	startupTimings.Lock()
+	oldSteps, oldTotal := startupTimings.steps, startupTimings.total
+	startupTimings.steps, startupTimings.total = nil, 0
+	startupTimings.Unlock()
+	t.Cleanup(func() {
+		startupTimings.Lock()
+		defer startupTimings.Unlock()
+		startupTimings.steps, startupTimings.total = oldSteps, oldTotal
+	})
+	RecordStartup("data.Load", 6*time.Second)
+	CompleteStartup(42 * time.Second)
+	steps, total := StartupTimings()
+	if len(steps) != 1 || total != 42*time.Second || steps[0].Duration != 6*time.Second {
+		t.Fatal("startup timing was lost")
+	}
+	steps[0].Component = "changed"
+	again, _ := StartupTimings()
+	if again[0].Component != "data.Load" {
+		t.Fatal("reader can mutate recorded timings")
+	}
+}

--- a/internal/app/status.go
+++ b/internal/app/status.go
@@ -104,7 +104,7 @@ func StatusHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	Respond(w, r, Response{Title: "Status", Description: "Service status",
+	RespondPublic(w, r, Response{Title: "Status", Description: "Service status",
 		HTML: renderPublicStatusHTML(status)})
 }
 

--- a/internal/data/data.go
+++ b/internal/data/data.go
@@ -3,6 +3,7 @@ package data
 import (
 	"encoding/json"
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"sort"
@@ -420,7 +421,7 @@ func IndexOwned(id, entryType, title, content, owner string, metadata map[string
 	// Use SQLite backend if enabled
 	if UseSQLite {
 		if err := IndexSQLite(id, entryType, title, content, owner, metadata); err != nil {
-			fmt.Printf("[data] SQLite index error: %v\n", err)
+			log.Printf("[data] SQLite index error: %v\n", err)
 		}
 		return
 	}
@@ -539,7 +540,7 @@ func ByID(id string) *IndexEntry {
 	if UseSQLite {
 		entry, err := ByIDSQLite(id)
 		if err != nil {
-			fmt.Printf("[data] SQLite ByID error: %v\n", err)
+			log.Printf("[data] SQLite ByID error: %v\n", err)
 			return nil
 		}
 		return entry
@@ -581,7 +582,7 @@ func UnindexOwned(owner string) {
 		return
 	}
 	if err := UnindexOwnedSQLite(owner); err != nil {
-		fmt.Printf("unindex owner %s: %v\n", owner, err)
+		log.Printf("unindex owner %s: %v\n", owner, err)
 	}
 }
 
@@ -589,7 +590,7 @@ func Search(query string, limit int, opts ...SearchOption) []*IndexEntry {
 	if UseSQLite {
 		results, err := SearchSQLite(query, limit, opts...)
 		if err != nil {
-			fmt.Printf("[data] SQLite Search error: %v\n", err)
+			log.Printf("[data] SQLite Search error: %v\n", err)
 			return nil
 		}
 		return results
@@ -662,7 +663,7 @@ func ByType(entryType string, limit int) []*IndexEntry {
 	if UseSQLite {
 		results, err := ByTypeSQLite(entryType, limit)
 		if err != nil {
-			fmt.Printf("[data] SQLite ByType error: %v\n", err)
+			log.Printf("[data] SQLite ByType error: %v\n", err)
 			return nil
 		}
 		return results
@@ -762,7 +763,7 @@ func saveIndex() {
 
 	if err == nil {
 		if err := persistIndex(file); err != nil {
-			fmt.Printf("[data] Saving index: %v\n", err)
+			log.Printf("[data] Saving index: %v\n", err)
 		}
 	}
 
@@ -789,9 +790,9 @@ func persistIndex(file string) error {
 func Load() {
 	// If SQLite is enabled, migrate from JSON and use SQLite
 	if UseSQLite {
-		fmt.Println("[data] SQLite backend enabled")
+		log.Println("[data] SQLite backend enabled")
 		if err := MigrateFromJSON(); err != nil {
-			fmt.Printf("[data] Migration error: %v\n", err)
+			log.Printf("[data] Migration error: %v\n", err)
 		}
 		EnsureFTS()
 
@@ -810,16 +811,16 @@ func Load() {
 		// is true it is true at boot, and a fact that safe does not need a
 		// person to confirm it.
 		if removed, freed, err := RemoveSuperseded(); err != nil {
-			fmt.Printf("[data] Could not remove migrated stores: %v\n", err)
+			log.Printf("[data] Could not remove migrated stores: %v\n", err)
 		} else if len(removed) > 0 {
-			fmt.Printf("[data] Removed %s left by the migration, freeing %d bytes\n",
+			log.Printf("[data] Removed %s left by the migration, freeing %d bytes\n",
 				strings.Join(removed, " and "), freed)
 		}
 
 		// Get stats
 		entries, embCount, err := IndexStats()
 		if err == nil {
-			fmt.Printf("[data] SQLite index: %d entries, %d embeddings\n", entries, embCount)
+			log.Printf("[data] SQLite index: %d entries, %d embeddings\n", entries, embCount)
 		}
 		return
 	}
@@ -830,7 +831,7 @@ func Load() {
 		indexMutex.Lock()
 		json.Unmarshal(b, &index)
 		indexMutex.Unlock()
-		fmt.Printf("[data] Loaded %d index entries from disk\n", len(index))
+		log.Printf("[data] Loaded %d index entries from disk\n", len(index))
 	}
 }
 

--- a/internal/data/sqlite.go
+++ b/internal/data/sqlite.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"sort"
@@ -95,7 +96,7 @@ func initDB() error {
 			return
 		}
 
-		fmt.Println("[data] SQLite database initialized at", dbPath)
+		log.Println("[data] SQLite database initialized at", dbPath)
 	})
 	return initErr
 }
@@ -437,7 +438,7 @@ func scoreMatch(entry *IndexEntry, words []string) float64 {
 		// Exact word boundary match in title (highest value)
 		if matchesWordBoundary(titleLower, word) {
 			score += 10.0
-			fmt.Printf("[SCORE] Title word-boundary match '%s' in '%s' -> +10\n", word, entry.Title[:min(50, len(entry.Title))])
+			log.Printf("[SCORE] Title word-boundary match '%s' in '%s' -> +10\n", word, entry.Title[:min(50, len(entry.Title))])
 		} else if strings.Contains(titleLower, word) {
 			// Substring match in title
 			score += 3.0
@@ -601,14 +602,14 @@ func MigrateFromJSON() error {
 	var indexCount int
 	db.QueryRow(`SELECT COUNT(*) FROM index_entries`).Scan(&indexCount)
 	if indexCount > 0 {
-		fmt.Printf("[data] SQLite already has %d entries, skipping migration\n", indexCount)
+		log.Printf("[data] SQLite already has %d entries, skipping migration\n", indexCount)
 		return nil
 	}
 
 	// Load existing index.json
 	b, err := LoadFile("index.json")
 	if err != nil {
-		fmt.Println("[data] No index.json to migrate")
+		log.Println("[data] No index.json to migrate")
 		return nil
 	}
 
@@ -635,7 +636,7 @@ func MigrateFromJSON() error {
 		return fmt.Errorf("failed to parse index.json: %w", err)
 	}
 
-	fmt.Printf("[data] Migrating %d index entries...\n", len(oldIndex))
+	log.Printf("[data] Migrating %d index entries...\n", len(oldIndex))
 
 	tx, err := db.Begin()
 	if err != nil {
@@ -663,13 +664,13 @@ func MigrateFromJSON() error {
 		// an empty string means here and everywhere else.
 		_, err := stmt.Exec(id, entry.Type, entry.Title, entry.Content, entry.Owner, string(metadataJSON), entry.IndexedAt)
 		if err != nil {
-			fmt.Printf("[data] Failed to migrate entry %s: %v\n", id, err)
+			log.Printf("[data] Failed to migrate entry %s: %v\n", id, err)
 			continue
 		}
 		migrated++
 
 		if migrated%1000 == 0 {
-			fmt.Printf("[data] Migrated %d entries...\n", migrated)
+			log.Printf("[data] Migrated %d entries...\n", migrated)
 		}
 	}
 
@@ -677,10 +678,10 @@ func MigrateFromJSON() error {
 		return fmt.Errorf("failed to commit migration: %w", err)
 	}
 
-	fmt.Printf("[data] Migrated %d index entries\n", migrated)
+	log.Printf("[data] Migrated %d index entries\n", migrated)
 
 	rebuildFTS()
-	fmt.Println("[data] Migration complete!")
+	log.Println("[data] Migration complete!")
 
 	return nil
 }
@@ -706,15 +707,13 @@ func rebuildFTS() {
 	if err != nil {
 		return
 	}
-	fmt.Println("[data] Rebuilding FTS index...")
-	db.Exec(`DELETE FROM index_fts`)
-	result, err := db.Exec(`INSERT INTO index_fts(rowid, title, content) SELECT rowid, title, content FROM index_entries`)
+	log.Println("[data] Rebuilding FTS index...")
+	_, err = db.Exec(`INSERT INTO index_fts(index_fts) VALUES('rebuild')`)
 	if err != nil {
-		fmt.Printf("[data] FTS rebuild error: %v\n", err)
+		log.Printf("[data] FTS rebuild error: %v\n", err)
 		return
 	}
-	count, _ := result.RowsAffected()
-	fmt.Printf("[data] FTS index rebuilt with %d entries\n", count)
+	log.Println("[data] FTS index rebuilt")
 }
 
 // EnsureFTS checks if FTS index needs rebuilding on startup
@@ -723,10 +722,22 @@ func EnsureFTS() {
 	if err != nil {
 		return
 	}
-	var ftsCount, entryCount int
-	db.QueryRow(`SELECT COUNT(*) FROM index_fts`).Scan(&ftsCount)
-	db.QueryRow(`SELECT COUNT(*) FROM index_entries`).Scan(&entryCount)
-	if entryCount > 0 && ftsCount == 0 {
+	// A scan of this external-content virtual table reads index_entries,
+	// even when the search index is empty. Its default docsize backing table
+	// records the documents actually indexed. Only read it; FTS owns writes.
+	var hasFTS, hasEntries bool
+	if err := db.QueryRow(`SELECT EXISTS(SELECT 1 FROM index_fts_docsize LIMIT 1)`).Scan(&hasFTS); err != nil {
+		log.Printf("[data] FTS startup check: %v", err)
+		return
+	}
+	if hasFTS {
+		return
+	}
+	if err := db.QueryRow(`SELECT EXISTS(SELECT 1 FROM index_entries LIMIT 1)`).Scan(&hasEntries); err != nil {
+		log.Printf("[data] Index startup check: %v", err)
+		return
+	}
+	if hasEntries {
 		rebuildFTS()
 	}
 }

--- a/internal/data/sqlite_test.go
+++ b/internal/data/sqlite_test.go
@@ -244,3 +244,36 @@ func TestFTS5Search(t *testing.T) {
 		t.Error("Expected FTS results for 'ethereum upgrade'")
 	}
 }
+
+func TestEnsureFTS(t *testing.T) {
+	resetSQLiteTestDB(t)
+	d, err := getDB()
+	if err != nil {
+		t.Fatal(err)
+	}
+	EnsureFTS() // An empty database is valid.
+	if err := IndexSQLite("one", "news", "Original", "Content", "", nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := d.Exec(`UPDATE index_fts SET title = 'Existing'`); err != nil {
+		t.Fatal(err)
+	}
+	EnsureFTS()
+	var count int
+	if err := d.QueryRow(`SELECT count(*) FROM index_fts WHERE index_fts MATCH 'Existing'`).Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if count != 1 {
+		t.Fatal("populated FTS was rebuilt")
+	}
+	if _, err := d.Exec(`INSERT INTO index_fts(index_fts) VALUES('delete-all')`); err != nil {
+		t.Fatal(err)
+	}
+	EnsureFTS()
+	if err := d.QueryRow(`SELECT count(*) FROM index_fts WHERE index_fts MATCH 'Original'`).Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if count != 1 {
+		t.Fatal("empty FTS was not restored")
+	}
+}

--- a/internal/server/boot.go
+++ b/internal/server/boot.go
@@ -54,98 +54,98 @@ import (
 
 // boot starts the runtime core and loads every service.
 func boot() {
-	service.Init()
+	startupStep("service.Init", service.Init)
 
 	// load settings first so other packages can use them
-	settings.Load()
+	startupStep("settings.Load", settings.Load)
 
 	// load the data index
-	data.Load()
+	startupStep("data.Load", data.Load)
 
 	// Subscribe before services start publishing their first refresh.
-	stream.Load()
+	startupStep("stream.Load", stream.Load)
 
 	// load admin/flags
-	admin.Load()
+	startupStep("admin.Load", admin.Load)
 
 	// load the chat
-	chat.Load()
+	startupStep("chat.Load", chat.Load)
 
 	// load the news
-	news.Load()
-	news.StartSentimentLoop()
+	startupStep("news.Load", news.Load)
+	startupStep("news.StartSentimentLoop", news.StartSentimentLoop)
 
 	// load the videos
-	video.Load()
+	startupStep("video.Load", video.Load)
 
 	// load the blog
-	blog.Load()
+	startupStep("blog.Load", blog.Load)
 
 	// load the mail (also configures SMTP and DKIM)
-	mail.Load()
+	startupStep("mail.Load", mail.Load)
 
 	// load places
-	places.Load()
+	startupStep("places.Load", places.Load)
 
 	// load weather
-	weather.Load()
+	startupStep("weather.Load", weather.Load)
 
 	// load markets, reminder, wallet
-	markets.Load()
-	prayer.Load()
+	startupStep("markets.Load", markets.Load)
+	startupStep("prayer.Load", prayer.Load)
 	// Going looking in your own past on purpose — the read over internal/thread
 	// that every client writes to. See service/recall.
-	recall.Load()
-	bookmarks.Load()
+	startupStep("recall.Load", recall.Load)
+	startupStep("bookmarks.Load", bookmarks.Load)
 	// One search across everything this instance has collected. Six services
 	// write to that index and every reader over it was filtered to one type.
-	archive.Load()
-	browser.Load()
-	shell.Load()
+	startupStep("archive.Load", archive.Load)
+	startupStep("browser.Load", browser.Load)
+	startupStep("shell.Load", shell.Load)
 
 	// And the SSH door onto it, when an operator has named a port. Off
 	// otherwise — see service/sandbox/ssh.go for why the port is a decision
 	// rather than a default.
-	shell.LoadSSH()
-	web.Load()
-	text.Load()
-	food.Load()
-	transit.Load()
-	hazards.Load()
-	maps.Load()
-	wallet.Load()
-	stream.LoadService()
-	chat.LoadService()
-	docs.LoadService()
-	notes.LoadService()
-	notify.LoadService()
-	sms.LoadService()
-	images.Load()
+	startupStep("shell.LoadSSH", shell.LoadSSH)
+	startupStep("web.Load", web.Load)
+	startupStep("text.Load", text.Load)
+	startupStep("food.Load", food.Load)
+	startupStep("transit.Load", transit.Load)
+	startupStep("hazards.Load", hazards.Load)
+	startupStep("maps.Load", maps.Load)
+	startupStep("wallet.Load", wallet.Load)
+	startupStep("stream.LoadService", stream.LoadService)
+	startupStep("chat.LoadService", chat.LoadService)
+	startupStep("docs.LoadService", docs.LoadService)
+	startupStep("notes.LoadService", notes.LoadService)
+	startupStep("notify.LoadService", notify.LoadService)
+	startupStep("sms.LoadService", sms.LoadService)
+	startupStep("images.Load", images.Load)
 	// The cache behind /img, which serves article images from here instead of
 	// from four publisher CDNs. See internal/imageproxy.
-	imageproxy.Load()
+	startupStep("imageproxy.Load", imageproxy.Load)
 	// Counters behind /admin/traffic: what this instance is being asked to do.
-	usage.Load()
-	files.Load()
+	startupStep("usage.Load", usage.Load)
+	startupStep("files.Load", files.Load)
 
 	// load flights
-	flights.Load()
-	routes.Load()
-	contacts.Load()
-	users.Load()
+	startupStep("flights.Load", flights.Load)
+	startupStep("routes.Load", routes.Load)
+	startupStep("contacts.Load", contacts.Load)
+	startupStep("users.Load", users.Load)
 	// Who is here: the presence broadcaster behind /presence. It was started
 	// from wireHooks, which is for breaking cycles rather than standing things
 	// up, and it never needed one.
-	user.Load()
+	startupStep("user.Load", user.Load)
 
 	// These three loaded from wireHooks, which is for breaking cycles rather
 	// than for standing services up. Nothing about them needed a hook first —
 	// they were simply written where somebody was working — and the cost was
 	// invisible until a test asked which Specs exist after boot and got an
 	// answer three short. Loading is boot's job.
-	apps.Load()
-	social.Load()
-	account.Load()
-	tasks.Load()
-	events.Load()
+	startupStep("apps.Load", apps.Load)
+	startupStep("social.Load", social.Load)
+	startupStep("account.Load", account.Load)
+	startupStep("tasks.Load", tasks.Load)
+	startupStep("events.Load", events.Load)
 }

--- a/internal/server/hooks.go
+++ b/internal/server/hooks.go
@@ -88,7 +88,7 @@ func wireHooks() {
 	// knows nothing about Google; this is the only place the two meet, and it
 	// stays unset on an instance with no Google credentials — one calendar
 	// instead of two, rather than a broken second one.
-	google.Load()
+	startupStep("google.Load", google.Load)
 	if google.Configured() {
 		events.ExternalConnected = func(owner string) bool {
 			return google.HasScope(owner, google.CalendarScope)
@@ -171,11 +171,11 @@ func wireHooks() {
 	// that stays up can do where a stdio MCP process cannot: "every morning,
 	// brief me and mail it" has nowhere to live in a process that only exists
 	// while a client is attached.
-	work.Load()
+	startupStep("work.Load", work.Load)
 
 	// Mail is a client like another client: it speaks its own protocol and
 	// hands what arrives to the agent. See agent/mail.
-	mailagent.Load()
+	startupStep("mailagent.Load", mailagent.Load)
 
 	// And IMAP is a client of the record rather than of the mail store.
 	//
@@ -194,24 +194,24 @@ func wireHooks() {
 	// whether the agent was named; this is what answers when it was. It used to
 	// be a hundred and ninety lines inside the service composing replies with
 	// its own RAG and its own web search — see agent/chat.
-	chatagent.Load()
+	startupStep("chatagent.Load", chatagent.Load)
 
 	// And a phone number is a client too. A text from a number the account has
 	// verified wakes the agent the same way mail does; service/sms decides
 	// whose it is and whether it proved that, and this is what answers.
-	smsagent.Load()
+	startupStep("smsagent.Load", smsagent.Load)
 
 	// And every text goes in the record, whoever sent it — which is a separate
 	// job from answering one, the way agent/mail splits recording from
 	// answering. Without it a text from a number nobody here knows was dropped
 	// with a log line, because the only path into the record was the side
 	// effect of an agent replying.
-	smsagent.LoadRecord()
+	startupStep("smsagent.LoadRecord", smsagent.LoadRecord)
 
 	// Whether an arrival from a stranger should be let in at all. One judge for
 	// every channel, because a text from an unknown number and a federated chat
 	// from an unknown address are one question. See agent/gate.
-	gate.Load()
+	startupStep("gate.Load", gate.Load)
 
 	// And the agent introduces itself to a new account, in that account's
 	// inbox. Onboarding as a message rather than a page: the claim is that you
@@ -223,7 +223,7 @@ func wireHooks() {
 	// agent — it was a function variable inside internal/flag that service/chat
 	// filled in, which put content moderation for the whole instance behind an
 	// unrelated service loading. See agent/moderate.
-	moderate.Load()
+	startupStep("moderate.Load", moderate.Load)
 
 	// Telling the operator when something is worth knowing. After the mail
 	// agent, because it delivers to an inbox here. See admin/alert.go.
@@ -407,10 +407,10 @@ func wireHooks() {
 		return agent.Path("", a.ID), a.Examples
 	}
 
-	home.Load()
+	startupStep("home.Load", home.Load)
 
 	// load agent
-	agent.Load()
+	startupStep("agent.Load", agent.Load)
 
 	// Wire user context into the agent — personalises responses.
 	// What an agent knows about you before you have said anything.
@@ -483,18 +483,18 @@ func wireHooks() {
 	// restart. See agent.ForgetConversation.
 	thread.Deleted = agent.ForgetConversation
 
-	digest.Load()
+	startupStep("digest.Load", digest.Load)
 
 	// The line at the top of Home. Same shape as the digest and a tenth of the
 	// output: one cheap call an hour, so the front page can say what happened
 	// without every page load paying for a model.
-	brief.Load()
+	startupStep("brief.Load", brief.Load)
 
 	// load search
-	web.Load()
+	startupStep("web.Load", web.Load)
 
 	// load docs
-	help.Load()
+	startupStep("help.Load", help.Load)
 
 	// Keep copies of the data directory. It takes one at startup, because the
 	// most useful snapshot is the one from before whatever is about to go
@@ -502,7 +502,7 @@ func wireHooks() {
 	// copy — nothing reindexes what is already there, so losing it is not a
 	// rebuild, it is a loss.
 	backup.IndexSnapshot = data.SnapshotInto
-	backup.Load()
+	startupStep("backup.Load", backup.Load)
 
 	// Optionally run go-micro's MCP gateway alongside mu's existing /mcp, on a
 	// separate port. It auto-exposes every registered service as an MCP tool.

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -86,6 +86,7 @@ func Run(addr string) {
 	app.Log("main", "boot: routes in %s, ready in %s",
 		time.Since(phase).Round(time.Millisecond), time.Since(started).Round(time.Millisecond))
 
+	app.CompleteStartup(time.Since(started))
 	serve(addr)
 }
 

--- a/internal/server/startup.go
+++ b/internal/server/startup.go
@@ -1,0 +1,14 @@
+package server
+
+import (
+	"mu/internal/app"
+	"time"
+)
+
+// Record both boundaries so the last start identifies a component still loading.
+func startupStep(name string, load func()) {
+	start := time.Now()
+	app.Log("startup", "component=%s state=starting", name)
+	load()
+	app.Log("startup", "component=%s state=ready duration_ms=%.3f", name, float64(time.Since(start))/float64(time.Millisecond))
+}

--- a/internal/server/startup.go
+++ b/internal/server/startup.go
@@ -10,5 +10,7 @@ func startupStep(name string, load func()) {
 	start := time.Now()
 	app.Log("startup", "component=%s state=starting", name)
 	load()
-	app.Log("startup", "component=%s state=ready duration_ms=%.3f", name, float64(time.Since(start))/float64(time.Millisecond))
+	elapsed := time.Since(start)
+	app.RecordStartup(name, elapsed)
+	app.Log("startup", "component=%s state=ready duration_ms=%.3f", name, float64(elapsed)/float64(time.Millisecond))
 }


### PR DESCRIPTION
Do not merge or deploy: held for the owner's review during the Hacker News launch.

Startup logs show roughly 42 seconds between process launch and the HTTP serving announcement. The server waits for boot, hooks, catalogue and routes before accepting HTTP requests. This PR records loader start/completion and duration in the log, and shows total initialization time plus slowest loaders first under Admin → Server. The breakdown is kept in memory for the current process and is only rendered behind the existing admin gate.

Data and SCORE messages now use logging routed to mu.log. The FTS startup check uses existence probes against the actual indexed-document table instead of counting the external-content table; empty indexes are rebuilt using SQLite's rebuild command. Removes the header @username and obsolete styles/tests; identity remains in the sidebar.

About, Contact, Pricing, Privacy and public Status use the landing shell with a centered title and simple prose layout. About has no footer; the others use the landing footer. Secondary buttons keep dark text including visited links. Pricing explicitly describes the 100-credit welcome balance as one-time, removes the fixed question estimate, explains separate paid-tool charges and lists configured daily operation limits. Prices and limits come from the live quota catalogue. Self-hosting copy reflects whether payments are configured.

Validation: internal/data, internal/app, internal/server and admin short tests passed; focused Home public-page, pricing and contact tests passed; git diff --check passed. New tests cover FTS preservation/recovery, sidebar identity, startup snapshot isolation, public page shells and welcome-credit wording. Full Home tests also report the pre-existing TestTheNameIsTheSameOnEverySurface branding mismatch. Browser visual verification was unavailable in this workspace.

Limits: this does not yet move loaders off the serving path, prove the cause of the entire startup delay or diagnose production CPU consumption. No production restart, deployment or merge was performed.