### PR TITLE
Lead Prayer with the verse and reflection, add filters and Ask

### DIFF
--- a/internal/app/reading.go
+++ b/internal/app/reading.go
@@ -36,7 +36,7 @@ func ReadingActionItems(r *http.Request, ref string) string {
 	} else if strings.HasPrefix(r.URL.Path, "/blog") {
 		path = "/blog/post?id=" + url.QueryEscape(ref)
 	}
-	return SaveControl(r, ref) + `<button class="mini-btn" type="button" data-url="` + html.EscapeString(path) + `" onclick="const u=new URL(this.dataset.url,location.href).href;if(navigator.share){navigator.share({url:u}).catch(()=>{})}else{navigator.clipboard.writeText(u).catch(()=>{})}">Share</button>` + `<a class="mini-btn" href="/agent/micro?item=` + url.QueryEscape(ref) + `">Discuss</a>`
+	return SaveControl(r, ref) + `<button class="mini-btn" type="button" data-url="` + html.EscapeString(path) + `" onclick="const u=new URL(this.dataset.url,location.href).href;if(navigator.share){navigator.share({url:u}).catch(()=>{})}else{navigator.clipboard.writeText(u).catch(()=>{})}">Share</button>` + AskControl(ref)
 }
 func ReadingFilters(path, active string, categories []string) string {
 	sort.Strings(categories)
@@ -80,3 +80,9 @@ func ReadingPages(path, category string, page, total, size int) string {
 const ReadingCSS = `<style>
 .reading-row{padding:18px 0;border-bottom:1px solid var(--border,#eee)}.reading-row h3{font-size:18px;line-height:1.4;margin:5px 0}.reading-row p{font-size:14px;line-height:1.6;color:var(--text-muted,#666);margin:6px 0}.reading-meta{font-size:12px;color:var(--text-muted,#777)}.reading-actions{display:flex;align-items:center;gap:8px;flex-wrap:wrap;margin:12px 0;font-size:14px}.reading-actions form,.reading-save{display:inline-flex;flex:0 0 auto;width:auto;margin:0;padding:0}.reading-actions>a,.reading-save button{white-space:nowrap}.reading-actions .mini-btn{display:inline-flex;align-items:center;justify-content:center;text-decoration:none}.reading-list{max-width:840px}.reading-row h3 a{text-decoration:none}.reading-row h3 a:hover{text-decoration:underline}
 </style>`
+
+// AskControl opens a private conversation with public reading material attached.
+// Only its opaque reference travels in the URL; questions stay in the chat body.
+func AskControl(ref string) string {
+	return `<a class="mini-btn" href="/agent/micro?item=` + url.QueryEscape(ref) + `">Ask</a>`
+}

--- a/internal/bookmarks/saved.go
+++ b/internal/bookmarks/saved.go
@@ -81,7 +81,7 @@ func publicEntry(ref string) (*data.IndexEntry, error) {
 		return nil, ErrNotFound
 	}
 	switch e.Type {
-	case data.KindNews, data.KindVideo:
+	case data.KindNews, data.KindVideo, data.KindReminder:
 	case data.KindPost:
 		if public, ok := e.Metadata["public"].(bool); !ok || !public {
 			return nil, ErrNotFound
@@ -107,6 +107,9 @@ func Source(ref string) (*Item, error) {
 	case data.KindVideo:
 		item.Kind = "video"
 		item.URL = "https://www.youtube.com/watch?v=" + url.QueryEscape(strings.TrimPrefix(e.ID, "video_"))
+	case data.KindReminder:
+		item.Kind = "reflection"
+		item.URL = s("url")
 	case data.KindPost:
 		item.Kind = "post"
 		item.URL = "/blog/post?id=" + url.QueryEscape(e.ID)

--- a/internal/bookmarks/saved_test.go
+++ b/internal/bookmarks/saved_test.go
@@ -163,3 +163,26 @@ func TestLinkGainsArchiveMetadataWithoutLosingPrivateState(t *testing.T) {
 		t.Fatal("enrichment was not persisted")
 	}
 }
+
+func TestPrayerSourceCarriesReflectionButRejectsPrivateData(t *testing.T) {
+	for _, owner := range []string{"", "someone"} {
+		id := "test-prayer-reading-" + owner
+		if err := data.IndexSQLite(id, data.KindReminder, "A verse", "Verse: source text\n\nReflection: retained message", owner, map[string]any{"url": "https://reminder.dev"}); err != nil {
+			t.Fatal(err)
+		}
+		defer data.Unindex(id)
+		item, err := Source(id)
+		if owner != "" {
+			if err == nil {
+				t.Fatal("private reflection was exposed")
+			}
+			continue
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+		if item.Kind != "reflection" || !strings.Contains(Context(item), "retained message") {
+			t.Fatal("Ask lost the reflection")
+		}
+	}
+}

--- a/service/bookmarks/page.go
+++ b/service/bookmarks/page.go
@@ -115,7 +115,7 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		b.WriteString(`<p><a href="/bookmarks">← Bookmarks</a></p><h2>` + html.EscapeString(item.Title) + `</h2><p>` + html.EscapeString(item.Excerpt) + `</p>`)
-		b.WriteString(`<div class="reading-actions"><a href="` + html.EscapeString(item.URL) + `" rel="noopener noreferrer">Original ↗</a><a class="mini-btn" href="/agent/micro?bookmark=` + url.QueryEscape(item.ID) + `">Discuss</a></div>`)
+		b.WriteString(`<div class="reading-actions"><a href="` + html.EscapeString(item.URL) + `" rel="noopener noreferrer">Original ↗</a><a class="mini-btn" href="/agent/micro?bookmark=` + url.QueryEscape(item.ID) + `">Ask</a></div>`)
 		b.WriteString(`<form method="POST" action="/bookmarks">` + token(r) + hidden("action", "note") + hidden("id", item.ID) + `<label for="saved-note">Private note</label><textarea id="saved-note" name="note" rows="4" maxlength="4000">` + html.EscapeString(item.Note) + `</textarea><button>Save note</button></form>`)
 		b.WriteString(`<form method="POST" action="/bookmarks" class="reading-actions">` + token(r) + hidden("action", "delete") + hidden("id", item.ID) + `<button>Remove bookmark</button></form>`)
 	} else {
@@ -149,7 +149,7 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 		for _, i := range items {
-			b.WriteString(`<article class="reading-row"><div class="reading-meta">` + app.Pill(i.Kind) + " · " + html.EscapeString(i.Source+" · "+app.TimeAgo(i.Created)) + `</div><h3><a href="/bookmarks?id=` + url.QueryEscape(i.ID) + `">` + html.EscapeString(i.Title) + `</a></h3><p>` + html.EscapeString(i.Note) + `</p><div class="reading-actions"><a href="` + html.EscapeString(i.URL) + `" rel="noopener noreferrer">Original ↗</a><a class="mini-btn" href="/agent/micro?bookmark=` + url.QueryEscape(i.ID) + `">Discuss</a></div></article>`)
+			b.WriteString(`<article class="reading-row"><div class="reading-meta">` + app.Pill(i.Kind) + " · " + html.EscapeString(i.Source+" · "+app.TimeAgo(i.Created)) + `</div><h3><a href="/bookmarks?id=` + url.QueryEscape(i.ID) + `">` + html.EscapeString(i.Title) + `</a></h3><p>` + html.EscapeString(i.Note) + `</p><div class="reading-actions"><a href="` + html.EscapeString(i.URL) + `" rel="noopener noreferrer">Original ↗</a><a class="mini-btn" href="/agent/micro?bookmark=` + url.QueryEscape(i.ID) + `">Ask</a></div></article>`)
 		}
 		b.WriteString(`<div class="reading-actions">`)
 		for _, p := range []struct {

--- a/service/prayer/page_test.go
+++ b/service/prayer/page_test.go
@@ -1,0 +1,39 @@
+package prayer
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestPrayerFiltersLeadWithVerseAndReflection(t *testing.T) {
+	rd := &ReminderData{Verse: "verse-content", Hadith: "saying-content", Name: "name-content", Message: "reflection-content", Updated: "2026-01-01T00:00:00Z"}
+	for _, view := range []string{"", "unknown", "verse"} {
+		page := renderPrayerPage(rd, view)
+		verse, reflection := strings.Index(page, "verse-content"), strings.Index(page, "reflection-content")
+		if verse < 0 || reflection < verse {
+			t.Error("default page must lead with verse then reflection")
+		}
+		if strings.Contains(page, `id="prayer-card"`) || strings.Contains(page, "saying-content") || strings.Contains(page, "name-content") {
+			t.Error("unselected content shown")
+		}
+	}
+	for _, tc := range []struct{ view, text string }{{"saying", "saying-content"}, {"name", "name-content"}, {"reflection", "reflection-content"}} {
+		page := renderPrayerPage(rd, tc.view)
+		if !strings.Contains(page, tc.text) || strings.Contains(page, "verse-content") {
+			t.Errorf("wrong content for %s", tc.view)
+		}
+	}
+	if page := renderPrayerPage(nil, "times"); !strings.Contains(page, `id="prayer-card"`) {
+		t.Error("times should work without reminder data")
+	}
+	if page := renderPrayerPage(nil, ""); !strings.Contains(page, "not available") {
+		t.Error("missing empty state")
+	}
+}
+
+func TestPrayerReadingEscapesContent(t *testing.T) {
+	page := renderPrayerPage(&ReminderData{Verse: `<script>bad()</script>`, Message: `<img onerror="bad()">`}, "")
+	if strings.Contains(page, "<script>bad") || strings.Contains(page, "<img onerror") {
+		t.Fatal("untrusted reminder markup rendered")
+	}
+}

--- a/service/prayer/reflection.go
+++ b/service/prayer/reflection.go
@@ -38,6 +38,8 @@ func Load() {
 		reminderMutex.Unlock()
 	}
 
+	restoreReading(GetReminderData())
+
 	// Start background refresh
 	go refreshReminder()
 }
@@ -360,14 +362,8 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 		app.RespondJSON(w, GetReminderData())
 		return
 	}
-	// Prayer times beside the reminder rather than above it: the times are a
-	// short table that does not need the full width, and the verse is what
-	// most readers came for. The aside is first in the DOM so the stacked
-	// phone layout leads with the times.
-	body := `<div class="prayer-layout">` +
-		`<aside class="prayer-side">` + prayerTimesHTML() + `</aside>` +
-		`<div class="prayer-main">` + renderReflectionPage(GetReminderData()) + `</div>` +
-		`</div>`
+	body := renderPrayerPage(GetReminderData(), r.URL.Query().Get("view"))
+
 	app.Respond(w, r, app.Response{
 		Title:       "Prayer",
 		Description: "Islamic prayer times, the qibla, and a daily verse, saying, name and reflection",
@@ -632,35 +628,78 @@ func splitTitleBody(s string) (string, string) {
 // reader who knows the tradition loses nothing, and one who does not is not
 // asked to know it before they can read a line.
 func renderReflectionPage(rd *ReminderData) string {
-	if rd == nil {
-		return `<div class="card"><p class="text-muted">Today's reminder is loading — check back shortly.</p></div>`
+	return renderPrayerPage(rd, "verse")
+}
+
+func renderPrayerPage(rd *ReminderData, view string) string {
+	switch view {
+	case "verse", "saying", "name", "reflection", "times":
+	default:
+		view = "verse"
 	}
 	var b strings.Builder
+	b.WriteString(app.Column() + `<nav class="app-filters" aria-label="Prayer sections">`)
+	for _, tab := range []struct{ id, label string }{{"verse", "Verse"}, {"saying", "Saying"}, {"name", "Name"}, {"reflection", "Reflection"}, {"times", "Times & Qibla"}} {
+		b.WriteString(app.PillLink(tab.label, "/prayer?view="+tab.id, view == tab.id))
+	}
+	b.WriteString(`</nav>`)
+	if view == "times" {
+		b.WriteString(prayerTimesHTML())
+		b.WriteString(app.Close())
+		return b.String()
+	}
+	if rd == nil {
+		b.WriteString(`<p class="text-muted">The reminder is not available yet. Please try again shortly.</p>` + app.Close())
+		return b.String()
+	}
 	section := func(title, content, linkKey, linkLabel string) {
 		if strings.TrimSpace(content) == "" {
+			b.WriteString(`<p class="text-muted">` + title + ` is not available for this reminder.</p>`)
 			return
 		}
 		head, body := splitTitleBody(content)
-		b.WriteString(`<div class="card"><h3>` + title + `</h3>`)
+		b.WriteString(`<section class="card"><h3>` + title + `</h3>`)
 		if head != "" {
-			b.WriteString(`<p class="semibold m-0 mb-2">` + html.EscapeString(head) + `</p>`)
+			b.WriteString(`<p class="semibold">` + html.EscapeString(head) + `</p>`)
 		}
-		b.WriteString(`<p class="pre-line m-0">` + html.EscapeString(body) + `</p>`)
-		if linkKey != "" && rd.Links != nil {
-			if p, ok := rd.Links[linkKey].(string); ok && p != "" {
-				b.WriteString(`<p class="mt-3 m-0"><a href="https://reminder.dev` + html.EscapeString(p) + `" target="_blank">` + linkLabel + ` &rarr;</a></p>`)
-			}
+		b.WriteString(`<p class="pre-line">` + html.EscapeString(body) + `</p>`)
+		if p, ok := rd.Links[linkKey].(string); ok && strings.HasPrefix(p, "/") && !strings.HasPrefix(p, "//") {
+			b.WriteString(`<p><a href="https://reminder.dev` + html.EscapeString(p) + `" target="_blank" rel="noopener noreferrer">` + linkLabel + ` &rarr;</a></p>`)
 		}
-		b.WriteString(`</div>`)
+		b.WriteString(`</section>`)
 	}
-	section("Verse", rd.Verse, "verse", "Read in the Quran")
-	section("Saying", rd.Hadith, "hadith", "Read the hadith")
-	section("Name", rd.Name, "name", "The 99 names of Allah")
-	if strings.TrimSpace(rd.Message) != "" {
-		b.WriteString(`<div class="card"><h3>Reflection</h3><p class="m-0">` + html.EscapeString(rd.Message) + `</p></div>`)
+	switch view {
+	case "verse":
+		section("Verse", deduplicateVerseName(rd.Verse), "verse", "Read in the Quran")
+	case "saying":
+		section("Saying", rd.Hadith, "hadith", "Read the hadith")
+	case "name":
+		section("Name", rd.Name, "name", "The 99 names of Allah")
 	}
-	b.WriteString(`<p class="text-xs text-muted">A daily verse of the Quran, a hadith and a name of Allah, via <a href="https://reminder.dev">reminder.dev</a>. Ask the agent to look up any verse or hadith.</p>`)
+	if view == "verse" || view == "reflection" {
+		section("Reflection", rd.Message, "", "")
+	}
+	ref := "reminder-" + reflectionKey(rd.Updated)
+	if entry := data.ByID(ref); entry != nil && entry.Type == data.KindReminder && entry.Owner == "" {
+		b.WriteString(`<div class="section-actions">` + app.AskControl(ref) + `</div>`)
+	}
+	b.WriteString(`<p class="text-xs text-muted">From <a href="https://reminder.dev">reminder.dev</a>. Ask Micro about this reminder using its Quran and hadith tools.</p>`)
+	b.WriteString(app.Close())
 	return b.String()
+}
+
+// Restore the reading attachment for a cached reminder on an older instance.
+// The normal refresh already indexes each publication under this same key.
+func restoreReading(rd *ReminderData) {
+	if rd == nil {
+		return
+	}
+	ref := "reminder-" + reflectionKey(rd.Updated)
+	if data.ByID(ref) != nil {
+		return
+	}
+	val := map[string]interface{}{"verse": rd.Verse, "hadith": rd.Hadith, "name": rd.Name, "message": rd.Message, "links": rd.Links}
+	data.Index(ref, data.KindReminder, reflectionTitle(val, rd.Updated), reflectionText(val), reflectionMeta(val, rd.Updated))
 }
 
 // GetReminderData loads the cached reminder data (from api/latest, rotates hourly)


### PR DESCRIPTION
Held unmerged for the owner's review during the launch freeze.

Home shows a verse, but Prayer put times first on mobile and spread all reading sections down the page. Prayer now defaults to the verse with Reminder's existing reflection below it. Shared pills filter Verse, Saying, Name, Reflection and Times & Qibla. Only the times view loads location/compass code; filtering renders cached content and makes no model call.

Ask reuses the existing private reading conversation in Micro. The archived reminder is attached by reference and retained for follow-up questions; opening Ask does not submit a question or call a model. Prayer already exposes Reminder API search/verse/hadith tools for Micro to use. Public reminders are now eligible reading sources, with the existing owner check preserved. Startup restores a missing archive entry for the cached reminder. Existing reading and bookmark Discuss labels become Ask via the shared reading action.

Validation: short tests pass for service/prayer, internal/bookmarks, internal/app and service/bookmarks; git diff --check passes. Added tests cover verse-first order, filters, unavailable data, escaping and public/private reminder attachment access. No browser visual verification or production deployment performed.

Scope: the attached material is the whole selected reminder (verse, saying, name and reflection). This extends the existing reading workflow; it does not add Ask to every platform surface or generate reflections automatically.