### PR TITLE
Treat failed fetches as unavailable sources instead of answers

### DIFF
--- a/agent/answer_guard.go
+++ b/agent/answer_guard.go
@@ -1269,7 +1269,12 @@ func isProgressOnlyAnswer(answer string) bool {
 	return false
 }
 
+var rawHTTPFailure = regexp.MustCompile(`(?i)^HTTP\s+[45][0-9]{2}(?:\s+[45][0-9]{2})?(?:\s+[a-z ]+)?[.!]?$`)
+
 func isRawToolPayloadAnswer(answer string) bool {
+	if rawHTTPFailure.MatchString(strings.TrimSpace(answer)) {
+		return true
+	}
 	if answer == "" {
 		return false
 	}

--- a/agent/native.go
+++ b/agent/native.go
@@ -944,6 +944,16 @@ func (r *nativeToolRecorder) wrap(next gmai.ToolHandler) gmai.ToolHandler {
 		res := next(ctx, call)
 		title := nativeToolTitle(call.Name)
 
+		if message := toolResultError(res); message != "" {
+			r.add("### " + title + "\n" + unavailableToolMessage(NativeToolName(call.Name)))
+			if NativeToolName(call.Name) == "web_fetch" {
+				payload := map[string]string{"error": message, "guidance": "This page was not read. Try another relevant accessible source using the available read/search tools. Do not bypass access restrictions or claim to have read this page. If only search snippets are available, label them as snippets; if no sources are readable, explain the limitation."}
+				encoded, _ := json.Marshal(payload)
+				res.Value, res.Content = payload, string(encoded)
+			}
+			return res
+		}
+
 		// A source that could not answer is recorded as unavailable rather than
 		// skipped. The answer guard collects these and names them — "Unavailable
 		// right now: news" — which is the difference between an answer that is
@@ -1193,4 +1203,26 @@ func Status() (string, bool) {
 		return "Not configured — the agent cannot answer until a provider key is set", false
 	}
 	return provider + "/" + model, true
+}
+
+// RPC failures are error envelopes, not successful source text. Providers consume
+// either Value or Content, so recognise both representations.
+func toolResultError(res gmai.ToolResult) string {
+	switch v := res.Value.(type) {
+	case map[string]string:
+		if v["error"] != "" {
+			return v["error"]
+		}
+	case map[string]any:
+		if e, ok := v["error"].(string); ok && e != "" {
+			return e
+		}
+	}
+	var payload struct {
+		Error string `json:"error"`
+	}
+	if json.Unmarshal([]byte(res.Content), &payload) == nil {
+		return payload.Error
+	}
+	return ""
 }

--- a/agent/tool_failure_test.go
+++ b/agent/tool_failure_test.go
@@ -1,0 +1,38 @@
+package agent
+
+import (
+	"context"
+	gmai "go-micro.dev/v6/ai"
+	"strings"
+	"testing"
+)
+
+func TestFailedFetchIsNotSourceContent(t *testing.T) {
+	for _, res := range []gmai.ToolResult{
+		{Content: `{"error":"HTTP 403 403 Forbidden"}`},
+		{Value: map[string]string{"error": "HTTP 403 403 Forbidden"}},
+		{Value: map[string]any{"error": "HTTP 403 403 Forbidden"}},
+	} {
+		recorder := newNativeToolRecorder()
+		handler := recorder.wrap(func(context.Context, gmai.ToolCall) gmai.ToolResult { return res })
+		got := handler(context.Background(), gmai.ToolCall{Name: "web_Server_Fetch", ID: "blocked"})
+		if !strings.Contains(got.Content, "This page was not read") {
+			t.Fatal("model not told fetch failed")
+		}
+		for _, custom := range []bool{false, true} {
+			answer := completeToolAnswerFor("HTTP 403 403 Forbidden", recorder.ragParts(), custom)
+			if strings.Contains(answer, "403") || !strings.Contains(answer, "unavailable") {
+				t.Fatalf("raw failure escaped: %s", answer)
+			}
+		}
+	}
+}
+
+func TestHTTPDiscussionIsNotRawFailure(t *testing.T) {
+	if isRawToolPayloadAnswer("HTTP 403 means the server refused access. You can read the other source.") {
+		t.Fatal("explanation mistaken for raw failure")
+	}
+	if toolResultError(gmai.ToolResult{Content: `{"content":"An article about HTTP 403 errors"}`}) != "" {
+		t.Fatal("article mistaken for failure")
+	}
+}

--- a/service/web/fetch.go
+++ b/service/web/fetch.go
@@ -166,7 +166,7 @@ func FetchAndExtract(rawURL string) (string, string, error) {
 
 	if resp.StatusCode != http.StatusOK {
 		app.RecordAPICall("fetch", "GET", rawURL, resp.StatusCode, duration, fmt.Errorf("HTTP %d", resp.StatusCode), "", "")
-		return "", "", fmt.Errorf("HTTP %d %s", resp.StatusCode, resp.Status)
+		return "", "", fetchStatusError(resp.StatusCode)
 	}
 
 	// Limit read to 2MB to prevent abuse
@@ -233,7 +233,7 @@ func fetchAndSanitize(rawURL string, proxy bool) (string, string, error) {
 
 	if resp.StatusCode != http.StatusOK {
 		app.RecordAPICall("fetch", "GET", rawURL, resp.StatusCode, duration, fmt.Errorf("HTTP %d", resp.StatusCode), "", "")
-		return "", "", fmt.Errorf("HTTP %d %s", resp.StatusCode, resp.Status)
+		return "", "", fetchStatusError(resp.StatusCode)
 	}
 
 	limited := io.LimitReader(resp.Body, 2*1024*1024)
@@ -556,3 +556,10 @@ func validateFetchURL(parsed *url.URL) error { return hosts.Fetchable(parsed) }
 func isPrivateHost(host string) bool { return hosts.Private(host) }
 
 func isPrivateIP(ip net.IP) bool { return hosts.PrivateIP(ip) }
+
+func fetchStatusError(code int) error {
+	if code == http.StatusForbidden {
+		return fmt.Errorf("the website refused access (HTTP 403 Forbidden); its page content could not be read")
+	}
+	return fmt.Errorf("the website returned HTTP %d %s; its page content could not be read", code, http.StatusText(code))
+}


### PR DESCRIPTION
Held unmerged for review.

A failed web fetch can return HTTP 403 403 Forbidden as the entire answer. The web fetcher duplicated the status code, and the native tool recorder treated structured RPC error envelopes as successful source content because Refused was empty.

Recognise error envelopes in both structured Value and JSON Content, record them as unavailable, and pass web-fetch failures back to the model with guidance to try accessible sources without bypassing restrictions or claiming the failed page was read. The answer guard also recognises a bare HTTP error as an incomplete response and uses available tool results or an unavailable-source explanation. Fetch errors now clearly identify a website access failure.

Validation: focused agent error/recorder tests and service/web short tests pass; git diff --check passes. Tests cover both error representations, default/custom agent guards and legitimate discussion of HTTP errors.

This does not make blocked sites accessible, guarantee a model will choose a replacement source, fix Gemini's separate follow-up API error handling, or implement local-news prefetch. No live Gemini request was performed. Investigation also found that initial news context contains titles without IDs/URLs and archive indexing may replace feed content with a summary; those retention/retrieval changes are separate work.