### PR TITLE
Show observed capability health on public Status

### DIFF
--- a/internal/app/public_status.go
+++ b/internal/app/public_status.go
@@ -1,0 +1,96 @@
+package app
+
+import (
+	"fmt"
+	"html"
+	"sort"
+	"strings"
+	"time"
+)
+
+// Public status exposes aggregate observations, never provider errors or user data.
+type CapabilityHealth struct {
+	Name    string `json:"name"`
+	State   string `json:"state"`
+	Details string `json:"details"`
+}
+
+type PublicStatusResponse struct {
+	State        string             `json:"state"`
+	CheckedAt    time.Time          `json:"checked_at"`
+	Capabilities []CapabilityHealth `json:"capabilities"`
+}
+
+func checkPublicStatus() PublicStatusResponse {
+	return publicStatusAt(time.Now(), APILog())
+}
+
+func publicStatusAt(now time.Time, entries []*APILogEntry) PublicStatusResponse {
+	model := CapabilityHealth{"Assistant models", "unknown", "No recent completed model calls."}
+	var durations []time.Duration
+	failed := 0
+	for _, e := range entries {
+		if e == nil || e.Kind != "model" || e.Time.Before(now.Add(-15*time.Minute)) || e.Time.After(now) {
+			continue
+		}
+		bad := e.Error != "" || e.ErrorKind != "" || e.Status >= 400
+		if !bad && e.Outcome != "done" && e.Outcome != "completed" && e.Outcome != "success" {
+			continue // A started or unfinished call is not a successful response.
+		}
+		if bad {
+			failed++
+		}
+		durations = append(durations, e.Duration)
+	}
+	state := "unknown"
+	if n := len(durations); n > 0 {
+		sort.Slice(durations, func(i, j int) bool { return durations[i] < durations[j] })
+		median := durations[n/2]
+		model.State = "operational"
+		if failed > 0 || median >= 10*time.Second {
+			model.State = "degraded"
+		}
+		if failed == n {
+			model.State = "unavailable"
+		}
+		model.Details = fmt.Sprintf("%d of %d recent model calls succeeded. Median call time: %.1fs.", n-failed, n, median.Seconds())
+		// Delivery and scheduled execution do not yet have end-to-end monitoring.
+		if model.State != "operational" {
+			state = "degraded"
+		}
+	}
+	return PublicStatusResponse{State: state, CheckedAt: now.UTC(), Capabilities: []CapabilityHealth{
+		{"Website", "operational", "This status page is reachable. Other pages are not independently checked."},
+		model,
+		{"Mail delivery", "unknown", "Delivery is not currently monitored here."},
+		{"Scheduled tasks", "unknown", "Scheduled execution is not currently monitored here."},
+	}}
+}
+
+func renderPublicStatusHTML(status PublicStatusResponse) string {
+	var sb strings.Builder
+	title := "Monitoring is partial"
+	if status.State == "degraded" {
+		title = "Some features are experiencing issues"
+	}
+	sb.WriteString(Column())
+	sb.WriteString(`<div class="page-stack"><section class="page-section"><h2>` + title + `</h2><p class="status-details">Updated ` + html.EscapeString(status.CheckedAt.Format("15:04 UTC")) + `</p></section><section class="page-section">`)
+	for _, c := range status.Capabilities {
+		label, class := "Not monitored", "status-details"
+		switch c.State {
+		case "operational":
+			label, class = "Operational", "status-ok"
+		case "degraded":
+			label, class = "Degraded", "status-warn"
+		case "unavailable":
+			label, class = "Unavailable", "status-error"
+		}
+		if c.Name == "Assistant models" && c.State == "unknown" {
+			label = "No recent data"
+		}
+		fmt.Fprintf(&sb, `<div class="status-item"><div><span class="status-name">%s</span><p class="status-details">%s</p></div><span class="%s">%s</span></div>`, html.EscapeString(c.Name), html.EscapeString(c.Details), class, label)
+	}
+	sb.WriteString(`</section><section class="page-section"><h3>Recent reliability</h3><p class="status-details">Model measurements cover calls recorded in the last 15 minutes, within the latest 500 external calls. They include retries and background work; they are not total answer times or an uptime percentage.</p><p class="status-details">Incident history is not yet available. This page runs on the same server as Micro and may be unreachable during an outage.</p></section></div>`)
+	sb.WriteString(Close())
+	return sb.String()
+}

--- a/internal/app/public_status_test.go
+++ b/internal/app/public_status_test.go
@@ -1,0 +1,47 @@
+package app
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestPublicStatusUsesRecentOutcomes(t *testing.T) {
+	now := time.Now()
+	for _, tc := range []struct {
+		name    string
+		entries []*APILogEntry
+		want    string
+	}{
+		{"idle", nil, "unknown"},
+		{"old failure", []*APILogEntry{{Kind: "model", Time: now.Add(-time.Hour), Error: "failed"}}, "unknown"},
+		{"in flight", []*APILogEntry{{Kind: "model", Time: now, Outcome: "running"}}, "unknown"},
+		{"success", []*APILogEntry{{Kind: "model", Time: now, Outcome: "done", Duration: time.Second}}, "operational"},
+		{"slow", []*APILogEntry{{Kind: "model", Time: now, Outcome: "done", Duration: 30 * time.Second}}, "degraded"},
+		{"failed", []*APILogEntry{{Kind: "model", Time: now, Error: "private provider error"}}, "unavailable"},
+		{"mixed", []*APILogEntry{{Kind: "model", Time: now, Error: "failed"}, {Kind: "model", Time: now, Outcome: "done"}}, "degraded"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s := publicStatusAt(now, tc.entries)
+			if s.Capabilities[1].State != tc.want {
+				t.Fatalf("got %s, want %s", s.Capabilities[1].State, tc.want)
+			}
+			if s.State == "operational" {
+				t.Fatal("unmonitored capabilities must not produce an all-clear")
+			}
+		})
+	}
+}
+
+func TestPublicStatusDoesNotExposeDiagnosticsOrProbeServices(t *testing.T) {
+	now := time.Now()
+	s := publicStatusAt(now, []*APILogEntry{{Kind: "model", Time: now, Error: "secret-token", URL: "private-url", Model: "private-model", RequestBody: "private-prompt"}})
+	b, _ := json.Marshal(s)
+	page := renderPublicStatusHTML(s)
+	for _, forbidden := range []string{"secret-token", "private-url", "private-model", "private-prompt", "fetch(", "data-path", "All systems operational"} {
+		if strings.Contains(string(b)+page, forbidden) {
+			t.Errorf("public status contains %q", forbidden)
+		}
+	}
+}

--- a/internal/app/status.go
+++ b/internal/app/status.go
@@ -85,12 +85,6 @@ type ServiceHealth struct {
 	Path   string `json:"path,omitempty"`
 }
 
-// PublicStatusResponse is the public status page response
-type PublicStatusResponse struct {
-	Healthy  bool            `json:"healthy"`
-	Services []ServiceHealth `json:"services"`
-}
-
 // HealthCheckFunc is set by main to run service health checks (avoids import cycles)
 var HealthCheckFunc func() []ServiceHealth
 
@@ -104,89 +98,8 @@ func StatusHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	RespondPublic(w, r, Response{Title: "Status", Description: "Service status",
+	RespondPublic(w, r, Response{Title: "Status", Description: "Micro availability",
 		HTML: renderPublicStatusHTML(status)})
-}
-
-func checkPublicStatus() PublicStatusResponse {
-	var services []ServiceHealth
-	if HealthCheckFunc != nil {
-		services = HealthCheckFunc()
-	}
-	healthy := true
-	for _, s := range services {
-		if !s.Status {
-			healthy = false
-			break
-		}
-	}
-	return PublicStatusResponse{
-		Healthy:  healthy,
-		Services: services,
-	}
-}
-
-func renderPublicStatusHTML(status PublicStatusResponse) string {
-	var sb strings.Builder
-
-	statusText := "All systems operational"
-	statusClass := "status-ok"
-	if !status.Healthy {
-		statusText = "Some services are experiencing issues"
-		statusClass = "status-error"
-	}
-
-	// In the column the other public pages use. It had a 600px cap of its own,
-	// which made it the fourth width among four pages a stranger reads in one
-	// sitting. See Column.
-	sb.WriteString(Column())
-	sb.WriteString(`<div class="status-page">`)
-
-	// Header
-	sb.WriteString(fmt.Sprintf(`<div class="status-header">
-<span class="status-icon %s text-24">●</span>
-<span class="text-18">%s</span>
-</div>`, statusClass, statusText))
-
-	// Services
-	sb.WriteString(`<div class="status-section">`)
-	for _, svc := range status.Services {
-		icon := "●"
-		class := "status-ok"
-		if !svc.Status {
-			class = "status-error"
-		}
-		pathAttr := ""
-		if svc.Path != "" {
-			pathAttr = fmt.Sprintf(` data-path="%s"`, svc.Path)
-		}
-		sb.WriteString(fmt.Sprintf(`<div class="status-item"%s>
-<span class="status-name">%s</span>
-<span class="status-value"><span class="status-latency"></span><span class="status-icon %s">%s</span></span>
-</div>`, pathAttr, svc.Name, class, icon))
-	}
-	sb.WriteString(`</div>`)
-
-	// Client-side latency checks
-	sb.WriteString(`<script>
-document.querySelectorAll('.status-item[data-path]').forEach(function(el) {
-  var path = el.getAttribute('data-path');
-  var span = el.querySelector('.status-latency');
-  var start = performance.now();
-  fetch(path, {method:'HEAD',cache:'no-store'}).then(function() {
-    var ms = Math.round(performance.now() - start);
-    span.textContent = ms + 'ms';
-    span.className = 'status-latency status-details';
-  }).catch(function() {
-    span.textContent = 'error';
-    span.className = 'status-latency status-details';
-  });
-});
-</script>`)
-
-	sb.WriteString(`</div>`)
-	sb.WriteString(Close())
-	return sb.String()
 }
 
 // RenderInternalStatusHTML returns the internal status HTML for embedding in the admin server page


### PR DESCRIPTION
The footer Status page reports registered services as healthy and measures page HEAD requests, even when model requests fail. Replace the catalogue with website reachability, recent model-call outcomes and explicit unknown states for mail delivery and scheduled execution.

Show degraded/failed model observations and median call duration from the recent bounded log. Explain that measurements include background calls and retries, are not end-to-end response times, and that incident history and independent outage monitoring are not yet available. Keep raw errors, provider details and account data private. Admin diagnostics remain available.

Validation: go test ./internal/app passes, including idle/stale/in-flight, failed, mixed and slow call cases and public-output privacy checks.

Not merged or deployed.