### PR TITLE
Use /admin/status and simplify About actions

### DIFF
--- a/admin/admin.go
+++ b/admin/admin.go
@@ -29,7 +29,7 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 		<a href="/admin/alerts">Alerts</a>
 		<a href="/admin/backup">Backup</a>
 		<a href="/admin/config">Config</a>
-		<a href="/admin/diagnostics">Status</a>
+		<a href="/admin/status">Status</a>
 		<a href="/admin/log">Logs` + alertBadge() + `</a>
 		<a href="/admin/oauth">OAuth Clients</a>
 		<a href="/admin/moderate">Moderation</a>

--- a/admin/diagnostics.go
+++ b/admin/diagnostics.go
@@ -24,7 +24,7 @@ type healthCheck struct {
 	Fix    string // actionable suggestion
 }
 
-func DiagnosticsHandler(w http.ResponseWriter, r *http.Request) {
+func StatusHandler(w http.ResponseWriter, r *http.Request) {
 	_, _, err := auth.RequireAdmin(r)
 	if err != nil {
 		app.Forbidden(w, r, "Admin access required")
@@ -70,7 +70,7 @@ func DiagnosticsHandler(w http.ResponseWriter, r *http.Request) {
 			b.WriteString(fmt.Sprintf(`<div class="text-base">%s</div>`, app.RenderString(diagnosis)))
 			b.WriteString(`</div>`)
 		} else {
-			b.WriteString(`<div class="my-3"><a href="/admin/diagnostics?diagnose=1" class="btn">Run AI Diagnosis</a></div>`)
+			b.WriteString(`<div class="my-3"><a href="/admin/status?diagnose=1" class="btn">Run AI Diagnosis</a></div>`)
 		}
 	}
 
@@ -171,7 +171,7 @@ func checkFederation(test bool) healthCheck {
 			Status: "ok",
 			Detail: "Listening on 5269. Whether the handshake works is a different question",
 			Fix: "Not checked. " + app.Link("Dial "+federationPeer+" now",
-				"/admin/diagnostics?test=federation"),
+				"/admin/status?test=federation"),
 		}
 	}
 
@@ -391,7 +391,7 @@ func checkMarkets() healthCheck {
 // saying "if requested", which nothing did. That is a whole model generation on
 // the render path, and the one condition that triggers it is exactly the
 // condition an operator opens this page under. A page that costs a digest to
-// look at, and takes as long as one, is how /admin/diagnostics came to be
+// look at, and takes as long as one, is how /admin/status came to be
 // something you avoided loading.
 func checkDigest(test bool) healthCheck {
 	ok, details := digest.Status()
@@ -403,7 +403,7 @@ func checkDigest(test bool) healthCheck {
 		}
 	}
 
-	fix := "Check AI provider status. " + app.Link("Test the generator", "/admin/diagnostics?test=digest")
+	fix := "Check AI provider status. " + app.Link("Test the generator", "/admin/status?test=digest")
 	if test {
 		out, err := digest.TestGenerate()
 		switch {
@@ -471,4 +471,13 @@ Keep it to 3-5 sentences. Be specific and actionable.`,
 		return "Could not run AI diagnosis: " + err.Error()
 	}
 	return result
+}
+
+// DiagnosticsHandler preserves old bookmarks and diagnostic query parameters.
+func DiagnosticsHandler(w http.ResponseWriter, r *http.Request) {
+	target := "/admin/status"
+	if r.URL.RawQuery != "" {
+		target += "?" + r.URL.RawQuery
+	}
+	http.Redirect(w, r, target, http.StatusPermanentRedirect)
 }

--- a/admin/status_route_test.go
+++ b/admin/status_route_test.go
@@ -1,0 +1,22 @@
+package admin
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestDiagnosticsRedirectKeepsQuery(t *testing.T) {
+	w := httptest.NewRecorder()
+	DiagnosticsHandler(w, httptest.NewRequest("GET", "/admin/diagnostics?test=digest", nil))
+	if w.Code != http.StatusPermanentRedirect || w.Header().Get("Location") != "/admin/status?test=digest" {
+		t.Fatalf("%d %s", w.Code, w.Header().Get("Location"))
+	}
+}
+func TestStatusStillRequiresAdmin(t *testing.T) {
+	w := httptest.NewRecorder()
+	StatusHandler(w, httptest.NewRequest("GET", "/admin/status", nil))
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("unauthenticated status returned %d", w.Code)
+	}
+}

--- a/home/about.go
+++ b/home/about.go
@@ -27,12 +27,7 @@ func AboutHandler(w http.ResponseWriter, r *http.Request) {
 		`archive, inbox and agent system that make those capabilities available. You can ` +
 		`run Mu yourself and Micro remains the default agent and front door.</p>` +
 		`</div>`)
-	b.WriteString(`<div class="card"><h3>Where to go next</h3><p class="text-sm">` +
-		`<a href="/contact">Every way to reach Micro</a> · ` +
-		`<a href="/archive">What this server has read</a> · ` +
-		`<a href="/api">For programs</a> · ` +
-		`<a href="https://github.com/micro/mu">The Mu source</a>` +
-		`</p></div>`)
+	b.WriteString(`<div class="page-action"><a class="btn" href="/signup">Sign up</a> · <a href="https://github.com/micro/mu">Source</a></div>`)
 
 	b.WriteString(app.Close())
 

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -161,6 +161,7 @@ func authRequired() map[string]bool {
 		"/admin/usage":       true,
 		"/admin/delete":      true,
 		"/admin/diagnostics": true,
+		"/admin/status":      true,
 		"/admin/alerts":      true,
 		"/admin/backup":      true,
 		"/admin/invite":      true,
@@ -284,6 +285,7 @@ func registerRoutes() {
 	http.HandleFunc("/admin/delete", admin.DeleteHandler)
 
 	// admin console
+	http.HandleFunc("/admin/status", admin.StatusHandler)
 	http.HandleFunc("/admin/diagnostics", admin.DiagnosticsHandler)
 	// What this instance will wake you for. See admin/alert.go.
 	http.HandleFunc("/admin/alerts", admin.AlertsHandler)


### PR DESCRIPTION
The admin navigation said Status but still linked to /admin/diagnostics. Register /admin/status as the canonical protected page, update navigation and diagnostic action links, and permanently redirect the old URL while preserving query parameters.

Replace About's 'Where to go next' card and four destination links with Sign up and Source actions.

Validation: focused admin tests verify the redirect retains its query and the new handler rejects unauthenticated requests. Focused About/public home tests pass. No merge or deployment.