### PR TITLE
Stop startup reindexing and align server status layout

### DIFF
--- a/internal/app/html/mu.css
+++ b/internal/app/html/mu.css
@@ -4111,6 +4111,7 @@ button.btn-plain { padding: 6px 12px; font: inherit; cursor: pointer; color: var
   font-size: 14px;
 }
 
+.stats-table th:last-child,
 .stats-table td:last-child {
   text-align: right;
 }
@@ -5051,7 +5052,7 @@ a.card-hover:hover {
    ============================================= */
 
 .status-page {
-  max-width: 600px;
+  width: 100%;
 }
 .status-header {
   display: flex;

--- a/service/blog/blog.go
+++ b/service/blog/blog.go
@@ -316,12 +316,15 @@ func Load() {
 	// Update cached HTML
 	updateCache()
 
-	// Reconcile visibility before serving. Read current posts under the lock,
-	// never snapshots that a later background write could republish.
+	// The archive is maintained when posts change, not rebuilt on every boot.
+	// Only withdraw explicitly private sources here, including records from
+	// older versions that may have indexed them publicly.
 	mutex.RLock()
 	for _, post := range posts {
-		if err := indexPost(*post); err != nil {
-			app.Log("blog", "Indexing existing post: %v", err)
+		if post.Private {
+			if err := data.Unindex(post.ID); err != nil {
+				app.Log("blog", "Withdrawing private post: %v", err)
+			}
 		}
 	}
 	mutex.RUnlock()

--- a/service/social/social.go
+++ b/service/social/social.go
@@ -100,7 +100,7 @@ func Load() {
 			messages = cached
 			updateCacheLocked()
 			mutex.Unlock()
-			indexMessages(cached)
+			// Existing archive entries are already on disk. New messages index on write.
 		}
 	}
 


### PR DESCRIPTION
Production startup takes 62.859s, with social.Load at 37.706s and blog.Load at 23.750s. Both loaders replay their saved records into the existing SQLite archive synchronously. With SQLite enabled, Index is synchronous despite its queue-oriented API/comment, and each entry rewrites its source row and FTS data.

Remove the social startup indexing pass and public-blog startup indexing pass entirely. The existing archive is reused; ordinary new/updated content continues to index through its existing write paths. Do not move a full rebuild into the background. Keep withdrawal of explicitly private blog posts before serving, preserving the visibility safety check for older stored entries.

Also remove the 600px status-content cap so Admin Server content matches its full-width startup table, and align stats-table numeric headers with their right-aligned values.

Validation: go test ./service/blog ./service/social ./internal/app passes. No archive data migration, deletion of public entries, or on-disk layout change. Actual production restart improvement must be measured after deployment; loader timings also include JSON loading and rendering, which remain.

Left unmerged.