### PR TITLE
Keep notes and tasks inside Inbox

### DIFF
--- a/inbox/items.go
+++ b/inbox/items.go
@@ -34,7 +34,7 @@ func itemPage(w http.ResponseWriter, r *http.Request, owner, kind, id string) {
 			return
 		}
 		if r.Method == http.MethodPost {
-			action := r.URL.Query().Get("action")
+			action := r.FormValue("action")
 			if err := tasks.ApplyAction(owner, id, action); err != nil {
 				app.BadRequest(w, r, err.Error())
 				return
@@ -49,7 +49,7 @@ func itemPage(w http.ResponseWriter, r *http.Request, owner, kind, id string) {
 		if label == "" {
 			label = defaultAgentName()
 		}
-		body = tasks.DetailHTML(task, csrf, label, func(action string) string { return dest + "&action=" + url.QueryEscape(action) })
+		body = tasks.DetailHTML(task, csrf, label, func(action string) string { return dest })
 	} else {
 		var note *notes.Entry
 		for _, n := range notes.All(owner) {

--- a/inbox/items.go
+++ b/inbox/items.go
@@ -1,0 +1,98 @@
+package inbox
+
+import (
+	"html"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"mu/internal/app"
+	"mu/internal/auth"
+	"mu/internal/notes"
+	"mu/service/tasks"
+)
+
+// itemPage composes the original records into Inbox, without copying them to threads.
+func itemPage(w http.ResponseWriter, r *http.Request, owner, kind, id string) {
+	if r.Method != http.MethodGet && r.Method != http.MethodPost {
+		app.MethodNotAllowed(w, r)
+		return
+	}
+	if r.Method == http.MethodPost && !auth.StrictCSRF(r) {
+		app.Forbidden(w, r, "Invalid CSRF token")
+		return
+	}
+	dest := "/inbox?kind=" + kind + "&id=" + url.QueryEscape(id)
+	back := `<div class="collection-head"><a href="/inbox">← Inbox</a></div>`
+	auth.SetCSRFCookie(w, r)
+	csrf := auth.CSRFToken(r)
+	var body string
+	if kind == kindTask {
+		task, err := tasks.Get(owner, id)
+		if err != nil {
+			app.NotFound(w, r, "Task not found")
+			return
+		}
+		if r.Method == http.MethodPost {
+			action := r.URL.Query().Get("action")
+			if err := tasks.ApplyAction(owner, id, action); err != nil {
+				app.BadRequest(w, r, err.Error())
+				return
+			}
+			if action == "delete" {
+				dest = "/inbox"
+			}
+			http.Redirect(w, r, dest, http.StatusSeeOther)
+			return
+		}
+		label := agentLabel(owner, task.Agent)
+		if label == "" {
+			label = defaultAgentName()
+		}
+		body = tasks.DetailHTML(task, csrf, label, func(action string) string { return dest + "&action=" + url.QueryEscape(action) })
+	} else {
+		var note *notes.Entry
+		for _, n := range notes.All(owner) {
+			if n.ID == id {
+				note = n
+				break
+			}
+		}
+		if note == nil {
+			app.NotFound(w, r, "Note not found")
+			return
+		}
+		if r.Method == http.MethodPost {
+			switch r.FormValue("action") {
+			case "save":
+				text := strings.TrimSpace(r.FormValue("text"))
+				if text == "" || len(text) > 2000 {
+					app.BadRequest(w, r, "Write a note of up to 2000 bytes")
+					return
+				}
+				notes.AddFrom(owner, note.Title, text, note.SourceThread)
+			case "delete":
+				notes.Delete(owner, note.Title)
+				dest = "/inbox"
+			default:
+				app.BadRequest(w, r, "Unknown action")
+				return
+			}
+			http.Redirect(w, r, dest, http.StatusSeeOther)
+			return
+		}
+		body = `<div class="card record-card"><h2>` + html.EscapeString(note.Title) + `</h2>`
+		body += `<p class="text-sm text-muted">Note · ` + html.EscapeString(app.TimeAgo(note.UpdatedAt)) + `</p>`
+		if r.URL.Query().Get("edit") == "1" {
+			body += `<form method="POST" action="` + html.EscapeString(dest) + `" class="record-editor">` + app.CSRFField(csrf) +
+				`<input type="hidden" name="action" value="save"><textarea name="text" class="record-body" rows="14" maxlength="2000" required aria-label="Note">` + html.EscapeString(note.Text) +
+				`</textarea><div class="form-actions"><button type="submit">Save</button><a class="btn btn-quiet" href="` + html.EscapeString(dest) + `">Cancel</a></div></form>`
+		} else {
+			body += `<div class="markdown-content">` + string(app.Render([]byte(note.Text))) + `</div><div class="form-actions"><a class="btn btn-quiet" href="` + html.EscapeString(dest+"&edit=1") + `">Edit</a>` +
+				`<form method="POST" action="` + html.EscapeString(dest) + `" onsubmit="return confirm('Delete this note?')">` + app.CSRFField(csrf) +
+				`<input type="hidden" name="action" value="delete"><button class="btn btn-danger" type="submit">Delete</button></form></div>`
+		}
+		body += `</div>`
+	}
+	app.Respond(w, r, app.Response{Title: "Inbox", HTML: back + body})
+}

--- a/inbox/items_test.go
+++ b/inbox/items_test.go
@@ -93,7 +93,7 @@ func TestInboxTaskControlsAndOwnership(t *testing.T) {
 	}
 	path := "/inbox?kind=task&id=" + task.ID
 	w := call(path, nil, false)
-	if w.Code != 200 || !strings.Contains(w.Body.String(), "Test work") || strings.Contains(w.Body.String(), `action="/tasks/`) {
+	if w.Code != 200 || !strings.Contains(w.Body.String(), "Test work") || (strings.Contains(w.Body.String(), `action="/tasks/`) || strings.Contains(w.Body.String(), "&amp;action=")) {
 		t.Fatal("task controls leave inbox")
 	}
 	if strings.Contains(taskRow(task), `href="/tasks`) {
@@ -102,14 +102,14 @@ func TestInboxTaskControlsAndOwnership(t *testing.T) {
 	if w = other(path, nil, false); w.Code != 404 {
 		t.Fatal("other account can read task")
 	}
-	if w = other(path+"&action=done", url.Values{}, true); w.Code != 404 {
+	if w = other(path, url.Values{"action": {"done"}}, true); w.Code != 404 {
 		t.Fatal("other account can change task")
 	}
-	if w = call(path+"&action=done", url.Values{}, false); w.Code != 403 {
+	if w = call(path, url.Values{"action": {"done"}}, false); w.Code != 403 {
 		t.Fatal("task action needs CSRF")
 	}
 	for _, action := range []string{"done", "reopen"} {
-		w = call(path+"&action="+action, url.Values{}, true)
+		w = call(path, url.Values{"action": {action}}, true)
 		if w.Code != 303 || w.Header().Get("Location") != path {
 			t.Fatal("task action leaves inbox")
 		}
@@ -124,7 +124,7 @@ func TestInboxTaskControlsAndOwnership(t *testing.T) {
 	if result := call(path, nil, false); !strings.Contains(result.Body.String(), "<strong>Finished work</strong>") {
 		t.Fatal("task result not rendered in inbox")
 	}
-	w = call(path+"&action=delete", url.Values{}, true)
+	w = call(path, url.Values{"action": {"delete"}}, true)
 	if w.Header().Get("Location") != "/inbox" {
 		t.Fatal("delete leaves inbox")
 	}

--- a/inbox/items_test.go
+++ b/inbox/items_test.go
@@ -1,0 +1,134 @@
+package inbox
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"mu/internal/auth"
+	"mu/internal/notes"
+	"mu/service/tasks"
+)
+
+func itemCaller(t *testing.T, owner string) func(string, url.Values, bool) *httptest.ResponseRecorder {
+	t.Helper()
+	if err := auth.Create(&auth.Account{ID: owner, Name: owner}); err != nil {
+		t.Fatal(err)
+	}
+	sess, err := auth.CreateSession(owner)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return func(path string, form url.Values, csrf bool) *httptest.ResponseRecorder {
+		method := http.MethodGet
+		if form != nil {
+			method = http.MethodPost
+		}
+		probe := httptest.NewRequest(method, path, nil)
+		probe.AddCookie(&http.Cookie{Name: "session", Value: sess.Token})
+		if csrf {
+			form.Set("_csrf", auth.CSRFToken(probe))
+		}
+		r := httptest.NewRequest(method, path, strings.NewReader(form.Encode()))
+		r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		r.AddCookie(&http.Cookie{Name: "session", Value: sess.Token})
+		w := httptest.NewRecorder()
+		Handler(w, r)
+		return w
+	}
+}
+
+func TestInboxNoteReadEditDeleteAndOwnership(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	call := itemCaller(t, "inbox_note_owner")
+	other := itemCaller(t, "inbox_note_other")
+	notes.Add("inbox_note_owner", "Private title", "**Original note**")
+	n := notes.All("inbox_note_owner")[0]
+	path := "/inbox?kind=note&id=" + n.ID
+	if n.ID == "" || strings.Contains(noteRow(n), `href="/notes`) {
+		t.Fatal("note does not open inside inbox")
+	}
+	w := call(path, nil, false)
+	if w.Code != 200 || !strings.Contains(w.Body.String(), "<strong>Original note</strong>") {
+		t.Fatalf("read: %d %s", w.Code, w.Body.String())
+	}
+	if w = other(path, nil, false); w.Code != 404 {
+		t.Fatalf("cross-account read: %d", w.Code)
+	}
+	if w = other(path, url.Values{"action": {"delete"}}, true); w.Code != 404 {
+		t.Fatalf("cross-account delete: %d", w.Code)
+	}
+	if w = call(path, url.Values{"action": {"save"}, "text": {"Changed"}}, false); w.Code != 403 {
+		t.Fatalf("missing CSRF: %d", w.Code)
+	}
+	if edit := call(path+"&edit=1", nil, false); edit.Code != 200 || !strings.Contains(edit.Body.String(), `name="text"`) {
+		t.Fatal("note editor missing")
+	}
+	w = call(path, url.Values{"action": {"save"}, "text": {"Changed"}}, true)
+	if w.Code != 303 || w.Header().Get("Location") != path || notes.Get("inbox_note_owner", n.Title) != "Changed" {
+		t.Fatal("edit did not update original note and stay in inbox")
+	}
+	if notes.All("inbox_note_owner")[0].ID != n.ID {
+		t.Fatal("editing changed note address")
+	}
+	w = call(path, url.Values{"action": {"delete"}}, true)
+	if w.Header().Get("Location") != "/inbox" || notes.Get("inbox_note_owner", n.Title) != "" {
+		t.Fatal("delete failed")
+	}
+	if w = call(path, nil, false); w.Code != 404 {
+		t.Fatal("deleted note still readable")
+	}
+}
+
+func TestInboxTaskControlsAndOwnership(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	call := itemCaller(t, "inbox_task_owner")
+	other := itemCaller(t, "inbox_task_other")
+	task, err := tasks.Create("inbox_task_owner", "Test work", "Details", tasks.Me, time.Time{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := "/inbox?kind=task&id=" + task.ID
+	w := call(path, nil, false)
+	if w.Code != 200 || !strings.Contains(w.Body.String(), "Test work") || strings.Contains(w.Body.String(), `action="/tasks/`) {
+		t.Fatal("task controls leave inbox")
+	}
+	if strings.Contains(taskRow(task), `href="/tasks`) {
+		t.Fatal("task row leaves inbox")
+	}
+	if w = other(path, nil, false); w.Code != 404 {
+		t.Fatal("other account can read task")
+	}
+	if w = other(path+"&action=done", url.Values{}, true); w.Code != 404 {
+		t.Fatal("other account can change task")
+	}
+	if w = call(path+"&action=done", url.Values{}, false); w.Code != 403 {
+		t.Fatal("task action needs CSRF")
+	}
+	for _, action := range []string{"done", "reopen"} {
+		w = call(path+"&action="+action, url.Values{}, true)
+		if w.Code != 303 || w.Header().Get("Location") != path {
+			t.Fatal("task action leaves inbox")
+		}
+		got, _ := tasks.Get("inbox_task_owner", task.ID)
+		if (action == "done") != (got.Status == tasks.StatusDone) {
+			t.Fatal("original task not updated")
+		}
+	}
+	if _, err := tasks.Update("inbox_task_owner", task.ID, "", "", tasks.StatusDone, "", "**Finished work**"); err != nil {
+		t.Fatal(err)
+	}
+	if result := call(path, nil, false); !strings.Contains(result.Body.String(), "<strong>Finished work</strong>") {
+		t.Fatal("task result not rendered in inbox")
+	}
+	w = call(path+"&action=delete", url.Values{}, true)
+	if w.Header().Get("Location") != "/inbox" {
+		t.Fatal("delete leaves inbox")
+	}
+	if _, err := tasks.Get("inbox_task_owner", task.ID); err == nil {
+		t.Fatal("task not deleted")
+	}
+}

--- a/inbox/kinds.go
+++ b/inbox/kinds.go
@@ -113,15 +113,11 @@ func everything(r *http.Request, accountID, box, only string) []item {
 	return out
 }
 
-// noteRow is a note, in the row a conversation uses.
-//
-// It links to /notes rather than reading the note here. The note has a page
-// that edits it, and a second reader in the inbox would be a second place the
-// same text is rendered — see the profile, which had exactly that and lost it.
+// noteRow opens the original note inside Inbox.
 func noteRow(n *notes.Entry) string {
 	text := strings.TrimSpace(n.Text)
 	return `<div class="ib-item">` +
-		`<a class="ib-row" href="/notes">` +
+		`<a class="ib-row" href="/inbox?kind=note&amp;id=` + url.QueryEscape(n.ID) + `">` +
 		`<span class="ib-meta"><span class="ib-who">Note</span>` +
 		`<span class="ib-tags">` + html.EscapeString(app.TimeAgo(n.UpdatedAt)) + `</span></span>` +
 		`<span class="ib-subject">` + html.EscapeString(trimTo(n.Title, 90)) + `</span>` +
@@ -157,7 +153,7 @@ func taskRow(t *tasks.Task) string {
 		cls += " unseen"
 	}
 	return `<div class="ib-item">` +
-		`<a class="` + cls + `" href="/tasks?id=` + url.QueryEscape(t.ID) + `">` +
+		`<a class="` + cls + `" href="/inbox?kind=task&amp;id=` + url.QueryEscape(t.ID) + `">` +
 		`<span class="ib-meta"><span class="ib-who">Task</span>` +
 		`<span class="ib-tags">` + strings.Join(tags, `<span class="ib-dot">·</span>`) + `</span></span>` +
 		`<span class="ib-subject">` + html.EscapeString(trimTo(t.Title, 90)) + `</span>` +

--- a/inbox/page.go
+++ b/inbox/page.go
@@ -100,6 +100,13 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 		app.RedirectToLogin(w, r)
 		return
 	}
+	if id := r.URL.Query().Get("id"); id != "" {
+		kind := kindOf(r.URL.Query().Get("kind"))
+		if kind == kindNote || kind == kindTask {
+			itemPage(w, r, acc.ID, kind, id)
+			return
+		}
+	}
 	// An instruction about the conversation being read. POST here rather than at
 	// a path of its own, because /inbox/<box> is a mailbox name and /inbox/act
 	// would be one an account could have.

--- a/internal/app/html/mu.css
+++ b/internal/app/html/mu.css
@@ -6415,7 +6415,7 @@ button.pill:hover {
    the thread including your own. A thread is a stack of messages and what
    separates them is a line across, the way every mail client draws it: the
    eye needs to know where one ends, not that all of them are quotations. */
-.ib-msg { padding: 16px 0; border-bottom: var(--border-width, 1px) solid color-mix(in srgb, var(--divider, #f0f0f0) 55%, transparent) }
+.ib-msg { padding: 16px 0; border-bottom: var(--border-width, 1px) solid var(--card-border, #e8e8e8) }
 .ib-msg:first-child { padding-top: 0 }
 .ib-msg:last-child { border-bottom: none; padding-bottom: 0 }
 .ib-from { display: flex; align-items: baseline; gap: 10px; margin-bottom: 6px }

--- a/internal/notes/id_test.go
+++ b/internal/notes/id_test.go
@@ -1,0 +1,34 @@
+package notes
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestLegacyNoteIDsArePersistableAndStable(t *testing.T) {
+	owned := map[string][]*Entry{"alice": {{Title: "Same", Text: "Private"}}, "bob": {{Title: "Same", Text: "Other"}}}
+	if !ensureIDs(owned) {
+		t.Fatal("legacy notes not assigned IDs")
+	}
+	first := owned["alice"][0].ID
+	if first == "" || first == owned["bob"][0].ID {
+		t.Fatal("IDs not distinct")
+	}
+	if ensureIDs(owned) || owned["alice"][0].ID != first {
+		t.Fatal("IDs changed on another load")
+	}
+	b, err := json.Marshal(owned)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var restored map[string][]*Entry
+	if err := json.Unmarshal(b, &restored); err != nil {
+		t.Fatal(err)
+	}
+	if ensureIDs(restored) || restored["alice"][0].ID != first {
+		t.Fatal("persisted ID lost")
+	}
+	if restored["alice"][0].Text != "Private" {
+		t.Fatal("legacy content changed")
+	}
+}

--- a/internal/notes/notes.go
+++ b/internal/notes/notes.go
@@ -12,6 +12,7 @@
 package notes
 
 import (
+	"crypto/rand"
 	"strings"
 	"sync"
 	"time"
@@ -21,6 +22,7 @@ import (
 
 // Entry is one note.
 type Entry struct {
+	ID           string    `json:"id,omitempty"`
 	SourceThread string    `json:"source_thread,omitempty"`
 	Title        string    `json:"key"`
 	Text         string    `json:"value"`
@@ -38,6 +40,23 @@ var (
 
 func init() {
 	data.LoadJSON("memory.json", &store)
+	if ensureIDs(store) {
+		save()
+	}
+}
+
+// Existing notes receive an opaque address once; later edits retain it.
+func ensureIDs(owned map[string][]*Entry) bool {
+	changed := false
+	for _, entries := range owned {
+		for _, e := range entries {
+			if e.ID == "" {
+				e.ID = rand.Text()
+				changed = true
+			}
+		}
+	}
+	return changed
 }
 
 func save() {
@@ -75,6 +94,7 @@ func AddFrom(userID, title, text, source string) {
 	}
 
 	added := &Entry{
+		ID:           rand.Text(),
 		Title:        title,
 		SourceThread: source,
 		Text:         text,

--- a/service/tasks/handler.go
+++ b/service/tasks/handler.go
@@ -76,21 +76,8 @@ func handleAction(w http.ResponseWriter, r *http.Request, id, action string) {
 		}
 		_, actErr = Create(sess.Account, r.FormValue("title"), r.FormValue("detail"), assignee, due)
 
-	case action == "done":
-		_, actErr = Update(sess.Account, id, "", "", StatusDone, "", "")
-	case action == "reopen":
-		_, actErr = Update(sess.Account, id, "", "", StatusTodo, "", "")
-	case action == "assign":
-		_, actErr = Update(sess.Account, id, "", "", "", Agent, "")
-	case action == "unassign":
-		_, actErr = Update(sess.Account, id, "", "", "", Me, "")
-	case action == "run":
-		actErr = Run(sess.Account, id)
-	case action == "delete":
-		actErr = Remove(sess.Account, id)
 	default:
-		app.NotFound(w, r, "Unknown action")
-		return
+		actErr = ApplyAction(sess.Account, id, action)
 	}
 
 	dest := "/tasks"
@@ -193,11 +180,24 @@ func tab(b *strings.Builder, status, active, label string) {
 }
 
 func taskRow(t *Task, csrf string, labels ...string) string {
-	var b strings.Builder
 	label := "Agent"
 	if len(labels) > 0 && strings.TrimSpace(labels[0]) != "" {
 		label = labels[0]
 	}
+	return taskCard(t, csrf, label, func(action string) string { return "/tasks/" + neturl.PathEscape(t.ID) + "/" + action })
+}
+
+// DetailHTML reuses the task controls and result renderer inside a composing page.
+func DetailHTML(t *Task, csrf, label string, actionURL func(string) string) string {
+	body := taskCard(t, csrf, label, actionURL) + tasksPageCSS
+	if Running(t) {
+		body += taskPollJS
+	}
+	return body
+}
+
+func taskCard(t *Task, csrf, label string, actionURL func(string) string) string {
+	var b strings.Builder
 	class := "task card"
 	if !t.Open() {
 		class += " task-done"
@@ -269,36 +269,36 @@ func taskRow(t *Task, csrf string, labels ...string) string {
 
 	b.WriteString(`<div class="form-actions">`)
 	if t.Open() {
-		button(&b, t.ID, "done", csrf, "Done", "")
+		button(&b, actionURL, "done", csrf, "Done", "")
 		if t.Assignee == Agent {
 			if !Running(t) && t.Delivery == nil {
 				runLabel := "Run now"
 				if t.Status == StatusFailed || t.Status == StatusBlocked {
 					runLabel = "Retry"
 				}
-				button(&b, t.ID, "run", csrf, runLabel, "")
+				button(&b, actionURL, "run", csrf, runLabel, "")
 			}
-			button(&b, t.ID, "unassign", csrf, "Take back", "")
+			button(&b, actionURL, "unassign", csrf, "Take back", "")
 		} else {
-			button(&b, t.ID, "assign", csrf, "Give to agent", "")
+			button(&b, actionURL, "assign", csrf, "Give to agent", "")
 		}
 	} else {
-		button(&b, t.ID, "reopen", csrf, "Reopen", "")
+		button(&b, actionURL, "reopen", csrf, "Reopen", "")
 	}
-	fmt.Fprintf(&b, `<form method="POST" action="/tasks/%s/delete" onsubmit="return confirm('Delete %s?')">
+	fmt.Fprintf(&b, `<form method="POST" action="%s" onsubmit="return confirm('Delete %s?')">
   <input type="hidden" name="_csrf" value="%s">
   <button type="submit" class="btn btn-danger">Delete</button>
-</form>`, html.EscapeString(t.ID),
+</form>`, html.EscapeString(actionURL("delete")),
 		html.EscapeString(strings.ReplaceAll(t.Title, "'", "\\'")), html.EscapeString(csrf))
 	b.WriteString(`</div></div>`)
 	return b.String()
 }
 
-func button(b *strings.Builder, id, action, csrf, label, extra string) {
-	fmt.Fprintf(b, `<form method="POST" action="/tasks/%s/%s">
+func button(b *strings.Builder, actionURL func(string) string, action, csrf, label, extra string) {
+	fmt.Fprintf(b, `<form method="POST" action="%s">
   <input type="hidden" name="_csrf" value="%s">%s
   <button type="submit" class="btn btn-quiet">%s</button>
-</form>`, html.EscapeString(id), action, html.EscapeString(csrf), extra, html.EscapeString(label))
+</form>`, html.EscapeString(actionURL(action)), html.EscapeString(csrf), extra, html.EscapeString(label))
 }
 
 // taskPollJS reloads the page when the agent finishes something.
@@ -399,4 +399,27 @@ func addForm(csrf string) string {
   </div>
   <label class="task-assign"><input type="checkbox" name="assign" value="agent"> <span>Give it to the agent — it starts working on this now</span></label>
 </form>`, html.EscapeString(csrf))
+}
+
+// ApplyAction changes the original task, with ownership enforced by each operation.
+func ApplyAction(owner, id, action string) error {
+	var actErr error
+	switch {
+	case action == "done":
+		_, actErr = Update(owner, id, "", "", StatusDone, "", "")
+	case action == "reopen":
+		_, actErr = Update(owner, id, "", "", StatusTodo, "", "")
+	case action == "assign":
+		_, actErr = Update(owner, id, "", "", "", Agent, "")
+	case action == "unassign":
+		_, actErr = Update(owner, id, "", "", "", Me, "")
+	case action == "run":
+		actErr = Run(owner, id)
+	case action == "delete":
+		actErr = Remove(owner, id)
+	default:
+		return fmt.Errorf("unknown action")
+	}
+
+	return actErr
 }

--- a/service/tasks/handler.go
+++ b/service/tasks/handler.go
@@ -286,6 +286,7 @@ func taskCard(t *Task, csrf, label string, actionURL func(string) string) string
 		button(&b, actionURL, "reopen", csrf, "Reopen", "")
 	}
 	fmt.Fprintf(&b, `<form method="POST" action="%s" onsubmit="return confirm('Delete %s?')">
+  <input type="hidden" name="action" value="delete">
   <input type="hidden" name="_csrf" value="%s">
   <button type="submit" class="btn btn-danger">Delete</button>
 </form>`, html.EscapeString(actionURL("delete")),
@@ -296,9 +297,10 @@ func taskCard(t *Task, csrf, label string, actionURL func(string) string) string
 
 func button(b *strings.Builder, actionURL func(string) string, action, csrf, label, extra string) {
 	fmt.Fprintf(b, `<form method="POST" action="%s">
+  <input type="hidden" name="action" value="%s">
   <input type="hidden" name="_csrf" value="%s">%s
   <button type="submit" class="btn btn-quiet">%s</button>
-</form>`, html.EscapeString(actionURL(action)), html.EscapeString(csrf), extra, html.EscapeString(label))
+</form>`, html.EscapeString(actionURL(action)), html.EscapeString(action), html.EscapeString(csrf), extra, html.EscapeString(label))
 }
 
 // taskPollJS reloads the page when the agent finishes something.


### PR DESCRIPTION
Inbox rows looked consistent but notes opened the entire Notes service and tasks left Inbox. Open each original record inside Inbox instead.

- Read rendered notes, edit/save and delete without leaving Inbox.
- Read task details, formatted results and steps, and complete/reopen, assign, retry/run or delete through the existing task operations. Reuse the task renderer and polling behavior.
- Validate ownership before reads/actions and require CSRF tokens for the new forms.
- Add stable random note IDs for inbox URLs. Existing notes receive IDs once on load; content and existing title-based APIs remain intact. Edits retain the ID; no duplicate inbox store or archive reindex is introduced.
- Strengthen thread message separators using the shared card-border colour instead of a translucent divider.

Validation: inbox, internal/notes, service/tasks, internal/app and repository policy tests pass. New ownership, CSRF, note editing/deletion, task state/result and legacy-ID persistence regressions pass, including a focused race run.

Not merged or deployed.