### PR TITLE
Align application pages to one shared layout

### DIFF
--- a/home/collapsed_test.go
+++ b/home/collapsed_test.go
@@ -43,17 +43,14 @@ func TestClosingTheSidebarDoesNotNarrowThePage(t *testing.T) {
 	}
 }
 
-// And a column of prose centres when there is no rail to align to.
-//
-// This is what the cap was for, and it is the only thing that actually needed
-// fixing: a page that sets .page-col has said its content is one 760px column,
-// and with the rail gone that column sat against the left of a wide window.
-// Nothing else is narrowed to solve it.
-func TestProseCentresWhenTheRailIsGone(t *testing.T) {
+// A page column inherits the shell width whether the sidebar is open or closed.
+func TestPageColumnsUseTheSharedFrame(t *testing.T) {
 	css := styles(t)
-	if !regexp.MustCompile(`body\.nav-collapsed\s+\.page-col\s*\{[^}]*margin-inline:\s*auto`).MatchString(css) {
-		t.Error("a one-column page does not centre with the sidebar closed, so it " +
-			"is left hanging off the edge it was aligned to")
+	if !regexp.MustCompile(`\.page-col\s*\{[^}]*max-width:\s*var\(--page-width\)`).MatchString(css) {
+		t.Error("page columns do not use the shared page width")
+	}
+	if strings.Contains(css, "#content:has(.page-col) #page-title") {
+		t.Error("a page type independently moves its title")
 	}
 }
 

--- a/inbox/items.go
+++ b/inbox/items.go
@@ -34,7 +34,7 @@ func itemPage(w http.ResponseWriter, r *http.Request, owner, kind, id string) {
 			return
 		}
 		if r.Method == http.MethodPost {
-			action := r.URL.Query().Get("action")
+			action := r.FormValue("action")
 			if err := tasks.ApplyAction(owner, id, action); err != nil {
 				app.BadRequest(w, r, err.Error())
 				return
@@ -49,7 +49,7 @@ func itemPage(w http.ResponseWriter, r *http.Request, owner, kind, id string) {
 		if label == "" {
 			label = defaultAgentName()
 		}
-		body = tasks.DetailHTML(task, csrf, label, func(action string) string { return dest + "&action=" + url.QueryEscape(action) })
+		body = tasks.DetailHTML(task, csrf, label, func(action string) string { return dest })
 	} else {
 		var note *notes.Entry
 		for _, n := range notes.All(owner) {

--- a/inbox/items.go
+++ b/inbox/items.go
@@ -1,0 +1,98 @@
+package inbox
+
+import (
+	"html"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"mu/internal/app"
+	"mu/internal/auth"
+	"mu/internal/notes"
+	"mu/service/tasks"
+)
+
+// itemPage composes the original records into Inbox, without copying them to threads.
+func itemPage(w http.ResponseWriter, r *http.Request, owner, kind, id string) {
+	if r.Method != http.MethodGet && r.Method != http.MethodPost {
+		app.MethodNotAllowed(w, r)
+		return
+	}
+	if r.Method == http.MethodPost && !auth.StrictCSRF(r) {
+		app.Forbidden(w, r, "Invalid CSRF token")
+		return
+	}
+	dest := "/inbox?kind=" + kind + "&id=" + url.QueryEscape(id)
+	back := `<div class="collection-head"><a href="/inbox">← Inbox</a></div>`
+	auth.SetCSRFCookie(w, r)
+	csrf := auth.CSRFToken(r)
+	var body string
+	if kind == kindTask {
+		task, err := tasks.Get(owner, id)
+		if err != nil {
+			app.NotFound(w, r, "Task not found")
+			return
+		}
+		if r.Method == http.MethodPost {
+			action := r.URL.Query().Get("action")
+			if err := tasks.ApplyAction(owner, id, action); err != nil {
+				app.BadRequest(w, r, err.Error())
+				return
+			}
+			if action == "delete" {
+				dest = "/inbox"
+			}
+			http.Redirect(w, r, dest, http.StatusSeeOther)
+			return
+		}
+		label := agentLabel(owner, task.Agent)
+		if label == "" {
+			label = defaultAgentName()
+		}
+		body = tasks.DetailHTML(task, csrf, label, func(action string) string { return dest + "&action=" + url.QueryEscape(action) })
+	} else {
+		var note *notes.Entry
+		for _, n := range notes.All(owner) {
+			if n.ID == id {
+				note = n
+				break
+			}
+		}
+		if note == nil {
+			app.NotFound(w, r, "Note not found")
+			return
+		}
+		if r.Method == http.MethodPost {
+			switch r.FormValue("action") {
+			case "save":
+				text := strings.TrimSpace(r.FormValue("text"))
+				if text == "" || len(text) > 2000 {
+					app.BadRequest(w, r, "Write a note of up to 2000 bytes")
+					return
+				}
+				notes.AddFrom(owner, note.Title, text, note.SourceThread)
+			case "delete":
+				notes.Delete(owner, note.Title)
+				dest = "/inbox"
+			default:
+				app.BadRequest(w, r, "Unknown action")
+				return
+			}
+			http.Redirect(w, r, dest, http.StatusSeeOther)
+			return
+		}
+		body = `<div class="card record-card"><h2>` + html.EscapeString(note.Title) + `</h2>`
+		body += `<p class="text-sm text-muted">Note · ` + html.EscapeString(app.TimeAgo(note.UpdatedAt)) + `</p>`
+		if r.URL.Query().Get("edit") == "1" {
+			body += `<form method="POST" action="` + html.EscapeString(dest) + `" class="record-editor">` + app.CSRFField(csrf) +
+				`<input type="hidden" name="action" value="save"><textarea name="text" class="record-body" rows="14" maxlength="2000" required aria-label="Note">` + html.EscapeString(note.Text) +
+				`</textarea><div class="form-actions"><button type="submit">Save</button><a class="btn btn-quiet" href="` + html.EscapeString(dest) + `">Cancel</a></div></form>`
+		} else {
+			body += `<div class="markdown-content">` + string(app.Render([]byte(note.Text))) + `</div><div class="form-actions"><a class="btn btn-quiet" href="` + html.EscapeString(dest+"&edit=1") + `">Edit</a>` +
+				`<form method="POST" action="` + html.EscapeString(dest) + `" onsubmit="return confirm('Delete this note?')">` + app.CSRFField(csrf) +
+				`<input type="hidden" name="action" value="delete"><button class="btn btn-danger" type="submit">Delete</button></form></div>`
+		}
+		body += `</div>`
+	}
+	app.Respond(w, r, app.Response{Title: "Inbox", HTML: back + body})
+}

--- a/inbox/items_test.go
+++ b/inbox/items_test.go
@@ -93,7 +93,7 @@ func TestInboxTaskControlsAndOwnership(t *testing.T) {
 	}
 	path := "/inbox?kind=task&id=" + task.ID
 	w := call(path, nil, false)
-	if w.Code != 200 || !strings.Contains(w.Body.String(), "Test work") || strings.Contains(w.Body.String(), `action="/tasks/`) {
+	if w.Code != 200 || !strings.Contains(w.Body.String(), "Test work") || (strings.Contains(w.Body.String(), `action="/tasks/`) || strings.Contains(w.Body.String(), "&amp;action=")) {
 		t.Fatal("task controls leave inbox")
 	}
 	if strings.Contains(taskRow(task), `href="/tasks`) {
@@ -102,14 +102,14 @@ func TestInboxTaskControlsAndOwnership(t *testing.T) {
 	if w = other(path, nil, false); w.Code != 404 {
 		t.Fatal("other account can read task")
 	}
-	if w = other(path+"&action=done", url.Values{}, true); w.Code != 404 {
+	if w = other(path, url.Values{"action": {"done"}}, true); w.Code != 404 {
 		t.Fatal("other account can change task")
 	}
-	if w = call(path+"&action=done", url.Values{}, false); w.Code != 403 {
+	if w = call(path, url.Values{"action": {"done"}}, false); w.Code != 403 {
 		t.Fatal("task action needs CSRF")
 	}
 	for _, action := range []string{"done", "reopen"} {
-		w = call(path+"&action="+action, url.Values{}, true)
+		w = call(path, url.Values{"action": {action}}, true)
 		if w.Code != 303 || w.Header().Get("Location") != path {
 			t.Fatal("task action leaves inbox")
 		}
@@ -124,7 +124,7 @@ func TestInboxTaskControlsAndOwnership(t *testing.T) {
 	if result := call(path, nil, false); !strings.Contains(result.Body.String(), "<strong>Finished work</strong>") {
 		t.Fatal("task result not rendered in inbox")
 	}
-	w = call(path+"&action=delete", url.Values{}, true)
+	w = call(path, url.Values{"action": {"delete"}}, true)
 	if w.Header().Get("Location") != "/inbox" {
 		t.Fatal("delete leaves inbox")
 	}

--- a/inbox/items_test.go
+++ b/inbox/items_test.go
@@ -1,0 +1,134 @@
+package inbox
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"mu/internal/auth"
+	"mu/internal/notes"
+	"mu/service/tasks"
+)
+
+func itemCaller(t *testing.T, owner string) func(string, url.Values, bool) *httptest.ResponseRecorder {
+	t.Helper()
+	if err := auth.Create(&auth.Account{ID: owner, Name: owner}); err != nil {
+		t.Fatal(err)
+	}
+	sess, err := auth.CreateSession(owner)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return func(path string, form url.Values, csrf bool) *httptest.ResponseRecorder {
+		method := http.MethodGet
+		if form != nil {
+			method = http.MethodPost
+		}
+		probe := httptest.NewRequest(method, path, nil)
+		probe.AddCookie(&http.Cookie{Name: "session", Value: sess.Token})
+		if csrf {
+			form.Set("_csrf", auth.CSRFToken(probe))
+		}
+		r := httptest.NewRequest(method, path, strings.NewReader(form.Encode()))
+		r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		r.AddCookie(&http.Cookie{Name: "session", Value: sess.Token})
+		w := httptest.NewRecorder()
+		Handler(w, r)
+		return w
+	}
+}
+
+func TestInboxNoteReadEditDeleteAndOwnership(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	call := itemCaller(t, "inbox_note_owner")
+	other := itemCaller(t, "inbox_note_other")
+	notes.Add("inbox_note_owner", "Private title", "**Original note**")
+	n := notes.All("inbox_note_owner")[0]
+	path := "/inbox?kind=note&id=" + n.ID
+	if n.ID == "" || strings.Contains(noteRow(n), `href="/notes`) {
+		t.Fatal("note does not open inside inbox")
+	}
+	w := call(path, nil, false)
+	if w.Code != 200 || !strings.Contains(w.Body.String(), "<strong>Original note</strong>") {
+		t.Fatalf("read: %d %s", w.Code, w.Body.String())
+	}
+	if w = other(path, nil, false); w.Code != 404 {
+		t.Fatalf("cross-account read: %d", w.Code)
+	}
+	if w = other(path, url.Values{"action": {"delete"}}, true); w.Code != 404 {
+		t.Fatalf("cross-account delete: %d", w.Code)
+	}
+	if w = call(path, url.Values{"action": {"save"}, "text": {"Changed"}}, false); w.Code != 403 {
+		t.Fatalf("missing CSRF: %d", w.Code)
+	}
+	if edit := call(path+"&edit=1", nil, false); edit.Code != 200 || !strings.Contains(edit.Body.String(), `name="text"`) {
+		t.Fatal("note editor missing")
+	}
+	w = call(path, url.Values{"action": {"save"}, "text": {"Changed"}}, true)
+	if w.Code != 303 || w.Header().Get("Location") != path || notes.Get("inbox_note_owner", n.Title) != "Changed" {
+		t.Fatal("edit did not update original note and stay in inbox")
+	}
+	if notes.All("inbox_note_owner")[0].ID != n.ID {
+		t.Fatal("editing changed note address")
+	}
+	w = call(path, url.Values{"action": {"delete"}}, true)
+	if w.Header().Get("Location") != "/inbox" || notes.Get("inbox_note_owner", n.Title) != "" {
+		t.Fatal("delete failed")
+	}
+	if w = call(path, nil, false); w.Code != 404 {
+		t.Fatal("deleted note still readable")
+	}
+}
+
+func TestInboxTaskControlsAndOwnership(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	call := itemCaller(t, "inbox_task_owner")
+	other := itemCaller(t, "inbox_task_other")
+	task, err := tasks.Create("inbox_task_owner", "Test work", "Details", tasks.Me, time.Time{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := "/inbox?kind=task&id=" + task.ID
+	w := call(path, nil, false)
+	if w.Code != 200 || !strings.Contains(w.Body.String(), "Test work") || strings.Contains(w.Body.String(), `action="/tasks/`) {
+		t.Fatal("task controls leave inbox")
+	}
+	if strings.Contains(taskRow(task), `href="/tasks`) {
+		t.Fatal("task row leaves inbox")
+	}
+	if w = other(path, nil, false); w.Code != 404 {
+		t.Fatal("other account can read task")
+	}
+	if w = other(path+"&action=done", url.Values{}, true); w.Code != 404 {
+		t.Fatal("other account can change task")
+	}
+	if w = call(path+"&action=done", url.Values{}, false); w.Code != 403 {
+		t.Fatal("task action needs CSRF")
+	}
+	for _, action := range []string{"done", "reopen"} {
+		w = call(path+"&action="+action, url.Values{}, true)
+		if w.Code != 303 || w.Header().Get("Location") != path {
+			t.Fatal("task action leaves inbox")
+		}
+		got, _ := tasks.Get("inbox_task_owner", task.ID)
+		if (action == "done") != (got.Status == tasks.StatusDone) {
+			t.Fatal("original task not updated")
+		}
+	}
+	if _, err := tasks.Update("inbox_task_owner", task.ID, "", "", tasks.StatusDone, "", "**Finished work**"); err != nil {
+		t.Fatal(err)
+	}
+	if result := call(path, nil, false); !strings.Contains(result.Body.String(), "<strong>Finished work</strong>") {
+		t.Fatal("task result not rendered in inbox")
+	}
+	w = call(path+"&action=delete", url.Values{}, true)
+	if w.Header().Get("Location") != "/inbox" {
+		t.Fatal("delete leaves inbox")
+	}
+	if _, err := tasks.Get("inbox_task_owner", task.ID); err == nil {
+		t.Fatal("task not deleted")
+	}
+}

--- a/inbox/kinds.go
+++ b/inbox/kinds.go
@@ -113,15 +113,11 @@ func everything(r *http.Request, accountID, box, only string) []item {
 	return out
 }
 
-// noteRow is a note, in the row a conversation uses.
-//
-// It links to /notes rather than reading the note here. The note has a page
-// that edits it, and a second reader in the inbox would be a second place the
-// same text is rendered — see the profile, which had exactly that and lost it.
+// noteRow opens the original note inside Inbox.
 func noteRow(n *notes.Entry) string {
 	text := strings.TrimSpace(n.Text)
 	return `<div class="ib-item">` +
-		`<a class="ib-row" href="/notes">` +
+		`<a class="ib-row" href="/inbox?kind=note&amp;id=` + url.QueryEscape(n.ID) + `">` +
 		`<span class="ib-meta"><span class="ib-who">Note</span>` +
 		`<span class="ib-tags">` + html.EscapeString(app.TimeAgo(n.UpdatedAt)) + `</span></span>` +
 		`<span class="ib-subject">` + html.EscapeString(trimTo(n.Title, 90)) + `</span>` +
@@ -157,7 +153,7 @@ func taskRow(t *tasks.Task) string {
 		cls += " unseen"
 	}
 	return `<div class="ib-item">` +
-		`<a class="` + cls + `" href="/tasks?id=` + url.QueryEscape(t.ID) + `">` +
+		`<a class="` + cls + `" href="/inbox?kind=task&amp;id=` + url.QueryEscape(t.ID) + `">` +
 		`<span class="ib-meta"><span class="ib-who">Task</span>` +
 		`<span class="ib-tags">` + strings.Join(tags, `<span class="ib-dot">·</span>`) + `</span></span>` +
 		`<span class="ib-subject">` + html.EscapeString(trimTo(t.Title, 90)) + `</span>` +

--- a/inbox/page.go
+++ b/inbox/page.go
@@ -100,6 +100,13 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 		app.RedirectToLogin(w, r)
 		return
 	}
+	if id := r.URL.Query().Get("id"); id != "" {
+		kind := kindOf(r.URL.Query().Get("kind"))
+		if kind == kindNote || kind == kindTask {
+			itemPage(w, r, acc.ID, kind, id)
+			return
+		}
+	}
 	// An instruction about the conversation being read. POST here rather than at
 	// a path of its own, because /inbox/<box> is a mailbox name and /inbox/act
 	// would be one an account could have.

--- a/internal/app/html/mu.css
+++ b/internal/app/html/mu.css
@@ -6415,7 +6415,7 @@ button.pill:hover {
    the thread including your own. A thread is a stack of messages and what
    separates them is a line across, the way every mail client draws it: the
    eye needs to know where one ends, not that all of them are quotations. */
-.ib-msg { padding: 16px 0; border-bottom: var(--border-width, 1px) solid color-mix(in srgb, var(--divider, #f0f0f0) 55%, transparent) }
+.ib-msg { padding: 16px 0; border-bottom: var(--border-width, 1px) solid var(--card-border, #e8e8e8) }
 .ib-msg:first-child { padding-top: 0 }
 .ib-msg:last-child { border-bottom: none; padding-bottom: 0 }
 .ib-from { display: flex; align-items: baseline; gap: 10px; margin-bottom: 6px }

--- a/internal/app/html/mu.css
+++ b/internal/app/html/mu.css
@@ -16,24 +16,10 @@
    rules have to agree about, and they did not. See navTabs. */
 :root {
   --tabbar: 0px;
-  /* One measure for a page of prose, a form or a list.
-   *
-   * There were ten. .max-w-xl was 750, .w-760 was 760, .col-feed 800, .w-820
-   * 820, .browser-page 860, .page-col 720, and the archive, weather and markets
-   * pages each shipped their own number in their own <style> block. Nothing was
-   * wrong with any one of them and the result was that walking the row of
-   * services under the search box — Archive, News, Video, Social, Markets,
-   * Weather, Places, Web — moved the content sideways on every click, and put
-   * the search box on one page at a different width from the results under it.
-   *
-   * 760 because it was already the most common, so the fewest pages move.
-   *
-   * Not every page: a grid of cards wants the width it can get, and those use
-   * the shell's own 1400 by having no wrapper at all. The rule is the shape of
-   * the content — one column reads at --measure, a grid fills the shell — and
-   * it is a decision each page makes once rather than a number each page
-   * invents. */
-  --measure: 760px;
+  /* Every application page uses the same frame. Content components may size
+     their own controls or media, but must not narrow the page around them. */
+  --page-width: 1400px;
+  --page-gutter: 40px;
   /* This product is light. Say so, rather than letting a browser guess.
    *
    * Reported as "topup amounts have black text on black background", followed
@@ -833,9 +819,9 @@ td {
 
 #content {
   flex: 1;
-  max-width: 1400px;
+  max-width: var(--page-width);
   margin: 0 auto;
-  padding: 20px 40px;
+  padding: 20px var(--page-gutter);
   text-align: left;
   width: 100%;
   box-sizing: border-box;
@@ -901,11 +887,6 @@ a.btn-plain:hover {
 /* ========================================
    HOME PAGE
    ======================================== */
-
-/* Hide the customize-link on the home page but keep the title */
-body.page-home #page-title ~ #customize-link {
-  display: none;
-}
 
 #home-date {
   color: #888;
@@ -999,13 +980,6 @@ body.page-home #page-title ~ #customize-link {
    leaves 744px, which is a 320px rail and a 400px column of cards. Below it the
    rail would be half the page. */
 @media only screen and (min-width: 1024px) {
-  /* Home earns a wider page than the reading pages do. 1400px is a measure for
-     a column of prose; this is a dashboard, and at 1400 a 2560px monitor spends
-     a third of itself on margins while the cards queue up two abreast. */
-  body.page-home #content {
-    max-width: 1700px;
-  }
-
   #home-cards {
     display: grid;
     grid-template-columns: 320px minmax(0, 1fr);
@@ -1926,14 +1900,6 @@ body:has(#messages) #chat-back-link {
 /* ========================================
    BLOG PAGE
    ======================================== */
-/* Reading width for the /blog page. Scoped away from .card because the home
-   card reuses this id — an id beats .home-left .card on specificity, so
-   without :not(.card) the card sits narrower than its neighbours. The
-   equivalent #news and #video caps were deleted outright: those pages have no
-   element with that id, so the rules only ever hit the home cards. */
-#blog:not(.card) {
-  max-width: 900px;
-}
 
 #blog {
   position: relative;
@@ -2769,54 +2735,10 @@ a.highlight {
     transform: translateX(-100%);
   }
   body.nav-collapsed #nav-container ~ #content {
-    padding-left: 40px;
+    padding-left: var(--page-gutter);
   }
 
-  /* With no rail, the page does not hug the edge it was aligned to.
 
-     Everything here is left-aligned against the sidebar, which is what a
-     sidebar is for. Collapsed, that leaves a 760px column against the left of a
-     wide window with half the screen empty beside it — the page still laid out
-     around something that is not there.
-
-     That was answered by capping this box at 1080px so it narrowed and centred,
-     on the reasoning that a page which is genuinely wide "still gets 1000px,
-     which is more than any of them use". Home uses more. Measured at 1728: with
-     the rail open the news card is 692px wide, and closing the rail took it to
-     272 — the content box went from 1700 to 1080 while the fixed 320px
-     right-hand track kept its width, so the whole loss landed on the column
-     beside it. Closing a sidebar has to give a page more room than opening it,
-     and this took away up to 620px of it, on every page, at any width past
-     about 1300.
-
-     So the box keeps whatever cap its page already has — 1400, or Home's 1700 —
-     and only the gutter changes: 240px of rail becomes 40px of margin. It
-     already centres, from the margin:0 auto on #content.
-
-     The stranded column is answered where it lives, below: a page that sets
-     .page-col has said its content is one column of prose, and that is the only
-     thing a missing rail leaves floating. Nothing else is narrowed to fix it. */
-  body.nav-collapsed .page-col {
-    margin-inline: auto;
-  }
-
-  /* And the title moves with it.
-   *
-   * The rule above centres a page's column and left the heading where it was,
-   * against the left of the content box — so on a wide screen with the rail
-   * closed, "About" sat 220px to the left of the paragraph under it. The
-   * comment on the cap this replaced said exactly that would happen: "the
-   * title and what is under it keep the single edge they share, which is the
-   * thing that goes wrong if you centre the column and leave the heading
-   * behind". It was right and I removed it along with the cap.
-   *
-   * :has, so only the pages with a column are affected — a grid or a two-pane
-   * page fills the box and its title belongs at the edge of it. The selector
-   * is already used twice in this file for the same reason. */
-  body.nav-collapsed #content:has(.page-col) #page-title {
-    max-width: var(--measure);
-    margin-inline: auto;
-  }
 }
 
 /* Respect a user who has asked for less motion. */
@@ -2981,7 +2903,6 @@ a.highlight {
   #content {
     margin-left: 0;
     padding: 15px 15px calc(15px + var(--tabbar));
-    max-width: 100%;
   }
   
   #page-title {
@@ -3373,7 +3294,7 @@ a.highlight {
 .whitespace-pre-wrap { white-space: pre-wrap; }
 /* Width */
 .w-full { width: 100%; }
-.max-w-xl { max-width: var(--measure); }
+.max-w-xl { max-width: var(--page-width); }
 
 /* Margins */
 /* The shapes pages were writing by hand.
@@ -3548,7 +3469,7 @@ a.highlight {
 .w-160 { width: 160px; }
 .w-260 { width: 260px; }
 .w-640 { max-width: 640px; }
-.w-760 { max-width: var(--measure); }
+.w-760 { max-width: var(--page-width); }
 
 /* A row separated from the next by a hairline and nothing else. .feed-row is
    the roomier version; this is for a dense list. */
@@ -3760,7 +3681,7 @@ a.highlight {
 .fill { height: 100%; width: 100%; }
 .w-320 { max-width: 320px; }
 .w-440 { max-width: 440px; }
-.w-820 { max-width: var(--measure); }
+.w-820 { max-width: var(--page-width); }
 .centered { margin: 0 auto; }
 .mt-half { margin-top: 6px; }
 .mt-14 { margin-top: 14px; }
@@ -3975,7 +3896,7 @@ button.btn-plain { padding: 6px 12px; font: inherit; cursor: pointer; color: var
 /* A feed is read, not filled in, so it gets more room than a form does.
    Its own width rather than a wider .col-narrow, which apps and agents also
    use — they are forms and lists and want the narrower measure. */
-.col-feed { max-width: var(--measure); }
+.col-feed { max-width: var(--page-width); }
 
 /* A textarea for prose you type: full width, growable, in the page's own face
    rather than the browser's monospace default. */
@@ -4523,11 +4444,8 @@ a.btn-primary:hover, .btn-primary:hover {
 
 /* Base card */
 .card {
-  /* The same measure every page column uses — see --measure. It was 750, one
-     of eleven numbers in this file meaning "a readable width", and it is what
-     put the form on /places and /tasks at 716 while the one on /news ran to
-     1000. */
-  max-width: var(--measure);
+  /* Cards fill the shared page or the grid track containing them. */
+  max-width: var(--page-width);
   box-sizing: border-box;
   display: block;
   position: relative;
@@ -5339,7 +5257,7 @@ a.card-hover:hover {
    MARKETS PAGE
    ======================================== */
 .markets-page {
-  max-width: var(--measure);
+  max-width: var(--page-width);
 }
 
 .markets-page .description {
@@ -5861,7 +5779,6 @@ body.display-mode .card h4 {
 /* Endpoint reference with a sticky index rail (/mcp, /api). On desktop the
    index sits to the left and follows the scroll; on mobile it is hidden and the
    cards stack normally. */
-#content:has(.ep-layout) { max-width: none; }
 #content:has(.ep-layout) .card { max-width: none; }
 
 .ep-layout { display: flex; gap: 32px; align-items: flex-start; }
@@ -5893,7 +5810,6 @@ body.display-mode .card h4 {
 .tool-price b { color: #111; font-weight: 600; }
 .tool-price span { color: #9ca3af; }
 /* Agent page: match the standard content width so it's as wide as every other page. */
-#content:has(.chat-layout) { max-width: 1400px; }
 
 @media (max-width: 900px) {
   .ep-layout { display: block; }
@@ -6811,7 +6727,7 @@ textarea.ib-field { resize: vertical; line-height: var(--line-height, 1.6) }
 @media only screen and (max-width: 600px) { .ib-held-when { margin-left: 0 } }
 
 /* Putting an app on somebody else's page. See service/apps/embed.go. */
-.embed-page { max-width: var(--measure) }
+.embed-page { max-width: var(--page-width) }
 .embed-title { font-size: 20px; margin: 0 0 6px }
 .embed-lead { font-size: 14px; color: var(--text-secondary, #555); margin: 0 0 var(--spacing-lg, 24px); line-height: var(--line-height, 1.6) }
 .embed-empty { font-size: 14px; color: var(--text-muted, #888) }
@@ -7018,7 +6934,7 @@ textarea.ib-field { resize: vertical; line-height: var(--line-height, 1.6) }
 .home-brief a:hover { text-decoration: underline }
 
 /* A real browser, at /browser. See service/browser/page.go. */
-.browser-page { max-width: var(--measure) }
+.browser-page { max-width: var(--page-width) }
 
 .browser-form { display: flex; flex-wrap: wrap; align-items: center; gap: 8px; margin: 0 0 var(--spacing-md, 16px) }
 
@@ -7170,7 +7086,7 @@ textarea.ib-field { resize: vertical; line-height: var(--line-height, 1.6) }
 .pf-write { display: flex; align-items: center; gap: 12px; flex-wrap: wrap; margin: 16px 0 0 }
 
 /* One tool, at an address of its own. See internal/api/tool_page.go. */
-.tool-page { max-width: var(--measure) }
+.tool-page { max-width: var(--page-width) }
 .tool-name { font-size: 24px; margin: 0 0 6px; font-family: ui-monospace, SFMono-Regular, Menlo, monospace }
 .tool-lead { font-size: 15px; color: var(--text-secondary, #555); margin: 0 0 var(--spacing-md, 16px); line-height: var(--line-height, 1.6) }
 .tool-cost, .tool-from { font-size: 13px; color: var(--text-secondary, #555); margin: 0 0 8px }
@@ -7193,7 +7109,7 @@ textarea.ib-field { resize: vertical; line-height: var(--line-height, 1.6) }
 }
 
 /* A service, derived from its Spec. See internal/api/service_page.go. */
-.svc-page { max-width: var(--measure) }
+.svc-page { max-width: var(--page-width) }
 .svc-lead { font-size: 15px; color: var(--text-secondary, #555); margin: 0 0 var(--spacing-md, 16px); line-height: var(--line-height, 1.6) }
 
 /* The card, at the size the page has room for. It is the answer somebody came
@@ -7472,7 +7388,7 @@ select.field-wide { max-width: 100%; width: 100%; }
    on the grounds that "a pannable map means a JavaScript dependency and this
    page is the demonstration rather than the product". A page you cannot use is
    a screenshot, and a slippy map is a hundred lines of plain JavaScript. */
-.maps-page { max-width: var(--measure) }
+.maps-page { max-width: var(--page-width) }
 .maps-styles { display: flex; flex-wrap: wrap; gap: 6px; margin: 0 0 14px }
 
 .map-wrap { position: relative; margin: 0 0 var(--spacing-lg, 24px) }
@@ -7593,7 +7509,7 @@ a.ib-addr-write:hover { text-decoration: underline }
    Pages chose their own — 600, 640, 680, 700, 720, 760, 820 — so the text
    changed width as you walked between them, and /privacy centred itself on top
    of that, which moved it sideways as well. */
-.page-col { max-width: var(--measure) }
+.page-col { max-width: var(--page-width) }
 
 /* A date or time input carries its own intrinsic sizing, which is why it came
  * out 32px in a row of 30px controls: the browser lays out its internal

--- a/internal/app/html/mu.js
+++ b/internal/app/html/mu.js
@@ -516,10 +516,7 @@ function setSession() {
       // Show the wallet link and badge its credit balance for logged-in users.
       document.body.classList.add('signed-in');
       // How many conversations are waiting, for the envelope in the header.
-      // Initialize card customization for home page
-      if (window.location.pathname === '/home') {
-        initCardCustomization();
-      }
+
     } else {
       isAuthenticated = false;
       if (navAdmin) navAdmin.style.display = 'none';
@@ -1313,105 +1310,8 @@ if (window.location.pathname === '/home' || window.location.pathname === '/') {
     // Small delay to let session check complete first
     setTimeout(connectPresence, 500);
     
-    // Apply hidden cards immediately (from localStorage)
-    applyHiddenCards();
+
   });
-}
-
-// ============================================
-// CARD CUSTOMIZATION
-// ============================================
-
-function applyHiddenCards() {
-  // Apply hidden cards from localStorage
-  const hidden = JSON.parse(localStorage.getItem('mu_hidden_cards') || '[]');
-  hidden.forEach(id => {
-    const card = document.getElementById(id);
-    if (card) card.style.display = 'none';
-  });
-}
-
-// Available cards that can be shown/hidden
-const availableCards = [
-  { id: 'news', title: 'News' },
-  { id: 'reminder', title: 'Reminder' },
-  { id: 'markets', title: 'Markets' },
-  { id: 'blog', title: 'Blog' },
-  { id: 'video', title: 'Video' }
-];
-
-function initCardCustomization() {
-  if (document.getElementById('customize-link')) return;
-  
-  const pageTitle = document.getElementById('page-title');
-  if (!pageTitle || pageTitle.textContent !== 'Home') return;
-  
-  const link = document.createElement('a');
-  link.id = 'customize-link';
-  link.href = '#';
-  link.textContent = 'Customize';
-  link.style.cssText = 'font-size: 12px; color: var(--text-muted); position: absolute; right: 0; top: 50%; transform: translateY(-50%);';
-  link.onclick = (e) => { e.preventDefault(); showCardModal(); };
-  
-  // Wrap title in relative container for absolute positioning
-  const wrapper = document.createElement('div');
-  wrapper.style.cssText = 'position: relative;';
-  pageTitle.parentNode.insertBefore(wrapper, pageTitle);
-  wrapper.appendChild(pageTitle);
-  wrapper.appendChild(link);
-}
-
-function showCardModal() {
-  const hidden = JSON.parse(localStorage.getItem('mu_hidden_cards') || '[]');
-  
-  // Build checkbox list from available cards
-  let checkboxes = '';
-  availableCards.forEach(card => {
-    const checked = !hidden.includes(card.id) ? 'checked' : '';
-    checkboxes += `<label style="display: block; margin: 12px 0; cursor: pointer;"><input type="checkbox" ${checked} data-card-id="${card.id}" style="width: auto; margin-right: 8px;"> ${card.title}</label>`;
-  });
-  
-  // Create modal
-  const modal = document.createElement('div');
-  modal.id = 'card-customize-modal';
-  modal.innerHTML = `
-    <div style="position: fixed; top: 0; left: 0; right: 0; bottom: 0; background: rgba(0,0,0,0.5); z-index: 1000; display: flex; align-items: center; justify-content: center;">
-      <div style="background: white; padding: 20px; border-radius: 8px; max-width: 400px; width: 90%; max-height: 80vh; overflow-y: auto;">
-        <h3 style="margin-top: 0;">Customize Home Cards</h3>
-        <p style="color: var(--text-muted); font-size: 14px;">Choose which cards to show:</p>
-        <div id="card-checkboxes">${checkboxes}</div>
-        <div style="margin-top: 20px; display: flex; gap: 10px;">
-          <button onclick="saveCardPrefs()" style="flex: 1;">Save</button>
-          <button onclick="closeCardModal()" style="flex: 1; background: #666;">Cancel</button>
-        </div>
-      </div>
-    </div>
-  `;
-  document.body.appendChild(modal);
-}
-
-function closeCardModal() {
-  const modal = document.getElementById('card-customize-modal');
-  if (modal) modal.remove();
-}
-
-function saveCardPrefs() {
-  const checkboxes = document.querySelectorAll('#card-checkboxes input[type="checkbox"]');
-  const hidden = [];
-  
-  checkboxes.forEach(cb => {
-    const cardId = cb.dataset.cardId;
-    const card = document.getElementById(cardId);
-    if (!cb.checked) {
-      hidden.push(cardId);
-      if (card) card.style.display = 'none';
-    } else {
-      if (card) card.style.display = '';
-    }
-  });
-  
-  localStorage.setItem('mu_hidden_cards', JSON.stringify(hidden));
-  closeCardModal();
 }
 
 // ============================================

--- a/internal/app/page_frame_test.go
+++ b/internal/app/page_frame_test.go
@@ -1,0 +1,51 @@
+package app
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+)
+
+func TestApplicationPagesShareOneFrame(t *testing.T) {
+	b, err := htmlFiles.ReadFile("html/mu.css")
+	if err != nil {
+		t.Fatal(err)
+	}
+	css := regexp.MustCompile(`(?s)/\*.*?\*/`).ReplaceAllString(string(b), "")
+	if strings.Count(css, "--page-width:") != 1 {
+		t.Fatal("page width must be defined once")
+	}
+	for _, rule := range regexp.MustCompile(`[^{}]+\{[^{}]*\}`).FindAllString(css, -1) {
+		selector, body, _ := strings.Cut(rule, "{")
+		// Kiosk mode explicitly removes the navigation shell.
+		if strings.TrimSpace(selector) == "body.display-mode #content" {
+			continue
+		}
+		if strings.Contains(selector, "#content") && strings.Contains(body, "max-width:") && !strings.Contains(selector, ".card") {
+			if strings.TrimSpace(selector) != "#content" || !strings.Contains(body, "max-width: var(--page-width)") {
+				t.Errorf("page-specific shell width: %s", rule)
+			}
+		}
+	}
+	for _, selector := range []string{".page-col", ".card", ".col-feed", ".markets-page", ".browser-page", ".maps-page"} {
+		pattern := regexp.MustCompile(regexp.QuoteMeta(selector) + `\s*\{[^}]*max-width:\s*var\(--page-width\)`)
+		if !pattern.MatchString(css) {
+			t.Errorf("%s does not use the shared width", selector)
+		}
+	}
+	if strings.Contains(css, "#content:has(.page-col) #page-title") {
+		t.Fatal("page type moves title independently")
+	}
+}
+
+func TestHomeSessionCannotInjectLegacyLayout(t *testing.T) {
+	b, err := htmlFiles.ReadFile("html/mu.js")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, old := range []string{"initCardCustomization", "customize-link", "mu_hidden_cards", "pageTitle.parentNode.insertBefore"} {
+		if strings.Contains(string(b), old) {
+			t.Errorf("legacy home DOM mutation remains: %s", old)
+		}
+	}
+}

--- a/internal/app/ui.go
+++ b/internal/app/ui.go
@@ -141,17 +141,9 @@ func Page(opts PageOpts) string {
 
 // Column opens the page's text column.
 //
-// One width, everywhere. Pages picked their own — 600, 640, 680, 700, 720, 760,
-// 820 — so the text changed width as you walked between them, and /privacy also
-// centred itself, which moved it sideways as well. None of that was decided;
-// each page picked a number the day it was written.
-//
-// 720 because it is what the two widest text pages already used and it is about
-// 90 characters at the body size, which is the top of the readable range.
-//
-// A function rather than a class, because the pages that need it are building
-// strings and a helper is one call rather than a div somebody has to remember
-// to close in the right place — Close is its pair.
+// Column groups page content within the shared shell width.
+// It does not choose a separate reading width or alignment.
+// Close is its pair.
 func Column() string { return `<div class="page-col">` }
 
 // Close closes what Column opened.

--- a/internal/notes/id_test.go
+++ b/internal/notes/id_test.go
@@ -1,0 +1,34 @@
+package notes
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestLegacyNoteIDsArePersistableAndStable(t *testing.T) {
+	owned := map[string][]*Entry{"alice": {{Title: "Same", Text: "Private"}}, "bob": {{Title: "Same", Text: "Other"}}}
+	if !ensureIDs(owned) {
+		t.Fatal("legacy notes not assigned IDs")
+	}
+	first := owned["alice"][0].ID
+	if first == "" || first == owned["bob"][0].ID {
+		t.Fatal("IDs not distinct")
+	}
+	if ensureIDs(owned) || owned["alice"][0].ID != first {
+		t.Fatal("IDs changed on another load")
+	}
+	b, err := json.Marshal(owned)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var restored map[string][]*Entry
+	if err := json.Unmarshal(b, &restored); err != nil {
+		t.Fatal(err)
+	}
+	if ensureIDs(restored) || restored["alice"][0].ID != first {
+		t.Fatal("persisted ID lost")
+	}
+	if restored["alice"][0].Text != "Private" {
+		t.Fatal("legacy content changed")
+	}
+}

--- a/internal/notes/notes.go
+++ b/internal/notes/notes.go
@@ -12,6 +12,7 @@
 package notes
 
 import (
+	"crypto/rand"
 	"strings"
 	"sync"
 	"time"
@@ -21,6 +22,7 @@ import (
 
 // Entry is one note.
 type Entry struct {
+	ID           string    `json:"id,omitempty"`
 	SourceThread string    `json:"source_thread,omitempty"`
 	Title        string    `json:"key"`
 	Text         string    `json:"value"`
@@ -38,6 +40,23 @@ var (
 
 func init() {
 	data.LoadJSON("memory.json", &store)
+	if ensureIDs(store) {
+		save()
+	}
+}
+
+// Existing notes receive an opaque address once; later edits retain it.
+func ensureIDs(owned map[string][]*Entry) bool {
+	changed := false
+	for _, entries := range owned {
+		for _, e := range entries {
+			if e.ID == "" {
+				e.ID = rand.Text()
+				changed = true
+			}
+		}
+	}
+	return changed
 }
 
 func save() {
@@ -75,6 +94,7 @@ func AddFrom(userID, title, text, source string) {
 	}
 
 	added := &Entry{
+		ID:           rand.Text(),
 		Title:        title,
 		SourceThread: source,
 		Text:         text,

--- a/service/archive/page.go
+++ b/service/archive/page.go
@@ -198,7 +198,7 @@ func kindChips(kinds []data.Kind, query, active string) string {
 }
 
 const pageCSS = `<style>
-.ar{max-width:var(--measure,760px)}
+.ar{max-width:var(--page-width)}
 .ar-empty{font-size:14px;color:#888;line-height:1.6}
 .ar-row{padding:12px 0;border-bottom:1px solid #f4f4f4}
 /* A kind and a time are two facts, and this had nothing between them — the pill

--- a/service/bookmarks/page.go
+++ b/service/bookmarks/page.go
@@ -163,7 +163,7 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 		}
 		b.WriteString(`</div><details><summary>Add a link</summary><form method="POST" action="/bookmarks" class="bookmarks-add">` + token(r) + hidden("action", "add") + `<input name="url" type="url" required maxlength="4096" placeholder="https://…" aria-label="Link"><input name="title" maxlength="1000" placeholder="Title" aria-label="Title"><button>Save link</button></form></details>`)
 	}
-	b.WriteString(`</div>` + app.ReadingCSS + `<style>.bookmarks-page{max-width:800px}.bookmarks-add{display:flex;gap:8px;flex-wrap:wrap;margin-bottom:20px}.bookmarks-page textarea{display:block;width:100%;box-sizing:border-box;margin:8px 0}.bookmarks-add{margin-top:12px}</style>`)
+	b.WriteString(`</div>` + app.ReadingCSS + `<style>.bookmarks-page{max-width:var(--page-width)}.bookmarks-add{display:flex;gap:8px;flex-wrap:wrap;margin-bottom:20px}.bookmarks-page textarea{display:block;width:100%;box-sizing:border-box;margin:8px 0}.bookmarks-add{margin-top:12px}</style>`)
 	app.Respond(w, r, app.Response{Title: "Bookmarks", Description: "Your private saved reading", HTML: b.String()})
 }
 func hidden(name, value string) string {

--- a/service/tasks/handler.go
+++ b/service/tasks/handler.go
@@ -76,21 +76,8 @@ func handleAction(w http.ResponseWriter, r *http.Request, id, action string) {
 		}
 		_, actErr = Create(sess.Account, r.FormValue("title"), r.FormValue("detail"), assignee, due)
 
-	case action == "done":
-		_, actErr = Update(sess.Account, id, "", "", StatusDone, "", "")
-	case action == "reopen":
-		_, actErr = Update(sess.Account, id, "", "", StatusTodo, "", "")
-	case action == "assign":
-		_, actErr = Update(sess.Account, id, "", "", "", Agent, "")
-	case action == "unassign":
-		_, actErr = Update(sess.Account, id, "", "", "", Me, "")
-	case action == "run":
-		actErr = Run(sess.Account, id)
-	case action == "delete":
-		actErr = Remove(sess.Account, id)
 	default:
-		app.NotFound(w, r, "Unknown action")
-		return
+		actErr = ApplyAction(sess.Account, id, action)
 	}
 
 	dest := "/tasks"
@@ -193,11 +180,24 @@ func tab(b *strings.Builder, status, active, label string) {
 }
 
 func taskRow(t *Task, csrf string, labels ...string) string {
-	var b strings.Builder
 	label := "Agent"
 	if len(labels) > 0 && strings.TrimSpace(labels[0]) != "" {
 		label = labels[0]
 	}
+	return taskCard(t, csrf, label, func(action string) string { return "/tasks/" + neturl.PathEscape(t.ID) + "/" + action })
+}
+
+// DetailHTML reuses the task controls and result renderer inside a composing page.
+func DetailHTML(t *Task, csrf, label string, actionURL func(string) string) string {
+	body := taskCard(t, csrf, label, actionURL) + tasksPageCSS
+	if Running(t) {
+		body += taskPollJS
+	}
+	return body
+}
+
+func taskCard(t *Task, csrf, label string, actionURL func(string) string) string {
+	var b strings.Builder
 	class := "task card"
 	if !t.Open() {
 		class += " task-done"
@@ -269,36 +269,36 @@ func taskRow(t *Task, csrf string, labels ...string) string {
 
 	b.WriteString(`<div class="form-actions">`)
 	if t.Open() {
-		button(&b, t.ID, "done", csrf, "Done", "")
+		button(&b, actionURL, "done", csrf, "Done", "")
 		if t.Assignee == Agent {
 			if !Running(t) && t.Delivery == nil {
 				runLabel := "Run now"
 				if t.Status == StatusFailed || t.Status == StatusBlocked {
 					runLabel = "Retry"
 				}
-				button(&b, t.ID, "run", csrf, runLabel, "")
+				button(&b, actionURL, "run", csrf, runLabel, "")
 			}
-			button(&b, t.ID, "unassign", csrf, "Take back", "")
+			button(&b, actionURL, "unassign", csrf, "Take back", "")
 		} else {
-			button(&b, t.ID, "assign", csrf, "Give to agent", "")
+			button(&b, actionURL, "assign", csrf, "Give to agent", "")
 		}
 	} else {
-		button(&b, t.ID, "reopen", csrf, "Reopen", "")
+		button(&b, actionURL, "reopen", csrf, "Reopen", "")
 	}
-	fmt.Fprintf(&b, `<form method="POST" action="/tasks/%s/delete" onsubmit="return confirm('Delete %s?')">
+	fmt.Fprintf(&b, `<form method="POST" action="%s" onsubmit="return confirm('Delete %s?')">
   <input type="hidden" name="_csrf" value="%s">
   <button type="submit" class="btn btn-danger">Delete</button>
-</form>`, html.EscapeString(t.ID),
+</form>`, html.EscapeString(actionURL("delete")),
 		html.EscapeString(strings.ReplaceAll(t.Title, "'", "\\'")), html.EscapeString(csrf))
 	b.WriteString(`</div></div>`)
 	return b.String()
 }
 
-func button(b *strings.Builder, id, action, csrf, label, extra string) {
-	fmt.Fprintf(b, `<form method="POST" action="/tasks/%s/%s">
+func button(b *strings.Builder, actionURL func(string) string, action, csrf, label, extra string) {
+	fmt.Fprintf(b, `<form method="POST" action="%s">
   <input type="hidden" name="_csrf" value="%s">%s
   <button type="submit" class="btn btn-quiet">%s</button>
-</form>`, html.EscapeString(id), action, html.EscapeString(csrf), extra, html.EscapeString(label))
+</form>`, html.EscapeString(actionURL(action)), html.EscapeString(csrf), extra, html.EscapeString(label))
 }
 
 // taskPollJS reloads the page when the agent finishes something.
@@ -399,4 +399,27 @@ func addForm(csrf string) string {
   </div>
   <label class="task-assign"><input type="checkbox" name="assign" value="agent"> <span>Give it to the agent — it starts working on this now</span></label>
 </form>`, html.EscapeString(csrf))
+}
+
+// ApplyAction changes the original task, with ownership enforced by each operation.
+func ApplyAction(owner, id, action string) error {
+	var actErr error
+	switch {
+	case action == "done":
+		_, actErr = Update(owner, id, "", "", StatusDone, "", "")
+	case action == "reopen":
+		_, actErr = Update(owner, id, "", "", StatusTodo, "", "")
+	case action == "assign":
+		_, actErr = Update(owner, id, "", "", "", Agent, "")
+	case action == "unassign":
+		_, actErr = Update(owner, id, "", "", "", Me, "")
+	case action == "run":
+		actErr = Run(owner, id)
+	case action == "delete":
+		actErr = Remove(owner, id)
+	default:
+		return fmt.Errorf("unknown action")
+	}
+
+	return actErr
 }

--- a/service/tasks/handler.go
+++ b/service/tasks/handler.go
@@ -286,6 +286,7 @@ func taskCard(t *Task, csrf, label string, actionURL func(string) string) string
 		button(&b, actionURL, "reopen", csrf, "Reopen", "")
 	}
 	fmt.Fprintf(&b, `<form method="POST" action="%s" onsubmit="return confirm('Delete %s?')">
+  <input type="hidden" name="action" value="delete">
   <input type="hidden" name="_csrf" value="%s">
   <button type="submit" class="btn btn-danger">Delete</button>
 </form>`, html.EscapeString(actionURL("delete")),
@@ -296,9 +297,10 @@ func taskCard(t *Task, csrf, label string, actionURL func(string) string) string
 
 func button(b *strings.Builder, actionURL func(string) string, action, csrf, label, extra string) {
 	fmt.Fprintf(b, `<form method="POST" action="%s">
+  <input type="hidden" name="action" value="%s">
   <input type="hidden" name="_csrf" value="%s">%s
   <button type="submit" class="btn btn-quiet">%s</button>
-</form>`, html.EscapeString(actionURL(action)), html.EscapeString(csrf), extra, html.EscapeString(label))
+</form>`, html.EscapeString(actionURL(action)), html.EscapeString(action), html.EscapeString(csrf), extra, html.EscapeString(label))
 }
 
 // taskPollJS reloads the page when the agent finishes something.

--- a/service/video/video.go
+++ b/service/video/video.go
@@ -1313,7 +1313,7 @@ func Handler(w http.ResponseWriter, r *http.Request) {
       }
     })();
     </script>
-</div><style>.watch-page{max-width:1000px}.watch-page .video-embed{position:relative;width:100%%;height:auto;aspect-ratio:16/9;background:#000}.watch-page .video-embed iframe{position:absolute;inset:0;width:100%%;height:100%%}.watch-page .video-bar{position:static;background:#111;padding:8px}</style>
+</div><style>.watch-page{max-width:var(--page-width)}.watch-page .video-embed{position:relative;width:100%%;height:auto;aspect-ratio:16/9;background:#000}.watch-page .video-embed iframe{position:absolute;inset:0;width:100%%;height:100%%}.watch-page .video-bar{position:static;background:#111;padding:8px}</style>
 `
 		title, channel := watchTitle(id)
 		body := fmt.Sprintf(tmpl, embedVideoWithAutoplay(id, autoplay))

--- a/service/weather/page.go
+++ b/service/weather/page.go
@@ -358,7 +358,7 @@ func airFor(lat, lon float64) *AirQuality {
 }
 
 const pageCSS = `<style>
-.wx-page{max-width:var(--measure,760px)}
+.wx-page{max-width:var(--page-width)}
 .wx-find{display:flex;gap:8px;margin:0 0 var(--spacing-lg,24px);flex-wrap:wrap}
 .wx-find .field{flex:1;min-width:0}
 .wx-note{color:var(--text-secondary,#555);line-height:1.6;margin:0}


### PR DESCRIPTION
Navigating between Home, Inbox, Agents, Account, Blog and Prayer changes the page width and alignment because the stylesheet combines 1700px, 1400px, 900px and 760px page caps. An obsolete session callback also injects a Customize link and wraps Home's title after loading.

- Use one shared --page-width (1400px) for the application shell, page columns and cards, with shared desktop gutters and the existing common mobile layout.
- Remove Home, Blog, editor/chat and collapsed-sidebar title overrides that choose independent page widths or alignment.
- Bring archive, weather, bookmarks and video page containers onto the shared width. Keep component sizing for controls/media and the explicit fullscreen kiosk mode.
- Remove the obsolete browser-only card-customization UI and hidden-card overrides, so full loads and soft navigation render the same server-owned Home layout.
- Add guards for the single page frame and against reintroducing the late Customize mutation.

Validation: Home, shared app, blog, prayer, bookmarks, video, archive, weather and repository policy tests pass; shared frame regressions and JavaScript syntax check pass. No visual browser verification was available.

Includes #1617 pending its merge; the layout commit is 4eae269a. Merge #1617 first.