### PR TITLE
Fix responsive service forms and separate SMS conversations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -514,7 +514,10 @@ cost; rate limits stop bots.
 Use the shared components in `internal/app/form.go`, `internal/app/html/mu.css` and
 `internal/app/html/composition.css` (also loaded by the landing page).
 Forms use `.form`, labelled fields use `app.Field` or `.field-label`, and related
-controls use `.form-group`. Services All/Select uses `app.ServiceSelect` on every
+controls use `.form-group`. Use `.form-row` for related controls side by side
+(or `.form.form-inline` for a whole inline form); its fields wrap based on the
+container width before they can be squeezed by buttons. Do not replace its
+field basis with `flex: 1` or add service-specific row breakpoints. Services All/Select uses `app.ServiceSelect` on every
 page. Actions use `.form-actions`, `.page-action`, or `.section-actions`; searches
 use `.search-bar`. A `.page-stack` owns the gap between adjacent blocks and a
 `.page-section` separates sections. Use `.disclosure` for Manage/expand controls.

--- a/internal/app/html/composition.css
+++ b/internal/app/html/composition.css
@@ -67,10 +67,26 @@
 .disclosure > summary::after { content: '+'; }
 .disclosure[open] > summary::after { content: '\2212'; }
 .disclosure > :not(summary) { margin-top: var(--space-field); }
+/* Rows wrap according to their available space, including inside a card or
+   beside the sidebar. A nonzero basis moves fields to the next line before
+   buttons and selects can squeeze them away. It is a preferred size, not a
+   fixed minimum: a field still fits a container narrower than that size. */
+.form-row, .form-inline, .search-bar {
+ display: flex; flex-direction: row; flex-wrap: wrap;
+ align-items: center; gap: var(--space-control); min-width: 0;
+}
+:is(.form-row, .form-inline, .search-bar) > * { max-width: 100%; box-sizing: border-box; margin-block: 0; }
+:is(.form-row, .form-inline, .search-bar) > :is(input:not(:where([type=hidden], [type=checkbox], [type=radio], [type=submit], [type=button])), textarea, .field-label, .form-group) {
+ flex: 1 1 12rem; min-width: 0; width: 100%; max-width: 100%;
+}
+:is(.form-row, .form-inline, .search-bar) > select { flex: 0 1 auto; min-width: 0; width: auto; max-width: 100%; }
+:is(.form-row, .form-inline, .search-bar) > :is(button, .btn, .form-actions) { flex: 0 0 auto; }
+:is(.form-row, .form-inline, .search-bar) > [hidden],
+:is(.form-row, .form-inline, .search-bar) > input[type=hidden] { display: none; }
+:is(.form, .form-row, .form-group, .field-label) :is(input, select, textarea) { box-sizing: border-box; max-width: 100%; }
+:is(.form-row, .form-inline) > :is(.field-label, .form-group) > :is(input, select, textarea) { width: 100%; max-width: 100%; min-width: 0; }
 @media(max-width:900px) {
  .form:not(.form-inline) .field { width: 100%; max-width: 100%; }
- .form-inline { align-items: stretch; }
- .form-inline > input:not([type=hidden]) { flex: 1 1 180px; min-width: 0; }
 }
 /* The quiet button, after .btn rather than before it.
    It was declared 2,800 lines above .btn, and both are one class, so .btn won

--- a/internal/app/html/mu.css
+++ b/internal/app/html/mu.css
@@ -6936,7 +6936,6 @@ textarea.ib-field { resize: vertical; line-height: var(--line-height, 1.6) }
 /* A real browser, at /browser. See service/browser/page.go. */
 .browser-page { max-width: var(--page-width) }
 
-.browser-form { display: flex; flex-wrap: wrap; align-items: center; gap: 8px; margin: 0 0 var(--spacing-md, 16px) }
 
 .browser-url {
   flex: 1 1 auto;
@@ -7861,9 +7860,7 @@ a:hover, a:hover * { text-decoration: none !important; }
 .record-controls { position:sticky; top:50px; z-index:10; display:flex; flex-direction:column; gap:10px; padding:10px 0; background:var(--card-background,#fff); border-bottom:1px solid var(--border-color,#eee); }
 .record-controls .record-actions { justify-content:space-between; }
 .search-bar { width:100%; min-width:0; align-items:stretch; }
-.search-bar input:not([type=hidden]) { flex:1 1 0; min-width:0; margin:0; }
 .search-bar button { margin:0; }
-.search-bar select { width:auto; max-width:40%; flex:0 1 auto; }
 .collection-head > .search-bar { margin-bottom:0; }
 
 /* New is the first action under a page title; search-led pages keep its edge. */
@@ -7880,7 +7877,7 @@ a:hover, a:hover * { text-decoration: none !important; }
  body.chat-page #container { height:var(--visible-height,100dvh); min-height:0; overflow:hidden; }
  body.chat-page #content { flex:none; min-height:0; overflow:hidden; display:flex; flex-direction:column; padding-bottom:calc(8px + var(--tabbar)); }
  body.chat-page #footer { display:none; }
- body.chat-page .chat-layout { flex:1 1 0; height:auto; min-height:0; overflow:hidden; }
+ body.chat-page .chat-layout { flex:1 1 0; height:auto; min-height:0; overflow:hidden; align-items:stretch; }
  body.chat-page .chat-main { display:flex; flex-direction:column; flex:1 1 0; min-height:0; overflow:hidden; }
  body.chat-page .mu-chat-transcript { flex:1 1 0; min-height:0; overflow:hidden; }
  body.chat-page .mu-chat-transcript #mu-chat-conv { flex:1 1 0; max-height:none; min-height:0; }

--- a/internal/app/testdata/layout.cjs
+++ b/internal/app/testdata/layout.cjs
@@ -8,18 +8,42 @@ const {chromium}=require(process.env.MU_PLAYWRIGHT_MODULE||'playwright');
   const u=new URL(route.request().url());
   if(u.pathname==='/composition.css')return route.fulfill({contentType:'text/css',body:input.composition});
   if(u.pathname==='/mu.css')return route.fulfill({contentType:'text/css',body:input.css});
-  if(input.pages[u.pathname])return route.fulfill({contentType:'text/html; charset=utf-8',body:input.pages[u.pathname]});
+  const html=input.pages[u.pathname+u.search]||input.pages[u.pathname];
+  if(html)return route.fulfill({contentType:'text/html; charset=utf-8',body:html});
   if(u.pathname==='/viewport.js')return route.fulfill({body:fs.readFileSync('../internal/app/html/viewport.js'),contentType:'application/javascript'});
   if(/\.(png|svg)$/.test(u.pathname)){const p='../internal/app/html'+u.pathname;if(fs.existsSync(p))return route.fulfill({body:fs.readFileSync(p),contentType:u.pathname.endsWith('.svg')?'image/svg+xml':'image/png'});}
   return route.fulfill({status:200,body:'',contentType:'text/plain'});
  });
  const gap=async(a,b)=>page.evaluate(([a,b])=>document.querySelector(b).getBoundingClientRect().top-document.querySelector(a).getBoundingClientRect().bottom,[a,b]);
- for(const width of [360,390,1440])for(const collapsed of (width>900?[false,true]:[false])){
+ for(const width of [320,390,768,1024,1440])for(const collapsed of (width>900?[false,true]:[false])){
   await page.setViewportSize({width,height:900});
-  for(const path of Object.keys(input.pages)){
+  for(const path of Object.keys(input.pages).filter(p=>!process.env.MU_LAYOUT_PATHS||process.env.MU_LAYOUT_PATHS.split(',').includes(p.split('?')[0]))){
    await page.goto('https://mu.test'+path);
    await page.evaluate(c=>document.body.classList.toggle('nav-collapsed',c),collapsed);
    assert(await page.evaluate(()=>document.documentElement.scrollWidth<=innerWidth+1),`${path} overflows at ${width}`);
+   // Exercise collapsed and revealed forms. Measure actual controls, not CSS
+   // declarations, so a later rule or a surrounding grid cannot hide a regression.
+   for(const revealed of [false,true]) {
+    if(revealed) await page.locator('details').evaluateAll(es=>es.forEach(e=>e.open=true));
+    const bad=await page.evaluate(()=>Array.from(document.querySelectorAll('#content input, #content select, #content textarea')).flatMap(e=>{
+     if(['hidden','checkbox','radio','submit','button','range','color'].includes(e.type)||!e.getClientRects().length||e.closest('#chat-form,#mu-chat-form'))return [];
+     const r=e.getBoundingClientRect(),p=e.parentElement.getBoundingClientRect();
+     if(r.width<Math.min(e.tagName==='SELECT'?40:80,p.width-2)||r.right>innerWidth+1||r.left<0)return [{name:e.name||e.id,width:r.width,left:r.left,right:r.right}];
+     return [];
+    }));
+    assert(!bad.length,`${path} squeezed/overflowing controls at ${width}, sidebar=${!collapsed}, revealed=${revealed}: ${JSON.stringify(bad)}`);
+   }
+   // Reset disclosures before the interaction-specific checks below.
+   await page.locator('details').evaluateAll(es=>es.forEach(e=>e.open=false));
+   if(path==='/sms') {
+    assert(await page.locator('.sms-conversation').count()===2,'SMS and WhatsApp merged in list');
+    assert(await page.locator('input[name=text]').count()===0,'reply boxes leaked onto list');
+   }
+   if(path.startsWith('/sms?id=')) {
+    assert(await page.locator('input[name=channel]').inputValue()==='whatsapp','reply channel changed');
+    assert(await page.locator('input[name=text]').count()===1,'expected one conversation composer');
+    assert(!await page.locator('#content').textContent().then(t=>t.includes('Latest SMS message')),'other channel appeared in thread');
+   }
    if(path==='/home')assert(await page.evaluate(()=>!window.muActiveAgent),'Home inherited another page agent');
    if(path==='/'||path==='/home')assert(await page.locator('.shortcuts,[data-shortcut]').count()===0,'shortcut panels remain');
    if(path==='/agent/new'||path==='/token'){
@@ -53,7 +77,7 @@ const {chromium}=require(process.env.MU_PLAYWRIGHT_MODULE||'playwright');
     await page.waitForTimeout(100);
     const bottom=await page.locator(composer).evaluate(e=>e.getBoundingClientRect().bottom);
 
-    assert(bottom<=430&&bottom>=410,`${path} keyboard composer bottom ${bottom}`);
+    assert(bottom<=430&&bottom>=410,`${path} at ${width}: keyboard composer bottom ${bottom}`);
     assert(await page.evaluate(()=>scrollY===0),`${path} page scrolled with keyboard`);
    }
    if(path==='/tasks'){
@@ -63,7 +87,7 @@ const {chromium}=require(process.env.MU_PLAYWRIGHT_MODULE||'playwright');
     await page.locator('.disclosure summary').click();
     assert(await gap('.disclosure summary','.disclosure form')>=15);
    }
-   if(process.env.MU_LAYOUT_SHOTS){fs.mkdirSync(process.env.MU_LAYOUT_SHOTS,{recursive:true});await page.screenshot({path:process.env.MU_LAYOUT_SHOTS+'/'+(path.replaceAll('/','-')||'landing')+'-'+width+'-'+collapsed+'.png',fullPage:true});}
+   if(process.env.MU_LAYOUT_SHOTS){fs.mkdirSync(process.env.MU_LAYOUT_SHOTS,{recursive:true});await page.screenshot({path:process.env.MU_LAYOUT_SHOTS+'/'+(path.replace(/[^a-zA-Z0-9_-]/g,'-')||'landing')+'-'+width+'-'+collapsed+'.png',fullPage:true});}
   }
  }
  // Agent deep links must not change Home, including soft navigation.

--- a/internal/userdb/userdb.go
+++ b/internal/userdb/userdb.go
@@ -158,6 +158,58 @@ func List(ns, caller, collection, scope string, where map[string]interface{}, so
 	return out, nil
 }
 
+// LatestBy returns the newest private record per group, applying the limit
+// after grouping. A busy conversation must not crowd every other one out of
+// a conversation list. Missing grouping fields have their string zero value.
+func LatestBy(ns, caller, collection string, fields []string, sortField string, limit int) ([]Record, error) {
+	if caller == "" {
+		return nil, ErrAuth
+	}
+	k, err := key(ns, collection)
+	if err != nil {
+		return nil, err
+	}
+	mu.Lock()
+	recs := load(k)
+	mu.Unlock()
+	recs = filter(recs, "mine", caller, nil)
+	sort.SliceStable(recs, func(i, j int) bool {
+		comparison := cmpValue(recs[i].Data[sortField], recs[j].Data[sortField])
+		if comparison == 0 {
+			return recs[i].Created.After(recs[j].Created)
+		}
+		return comparison > 0
+	})
+	if limit <= 0 || limit > MaxListLimit {
+		limit = MaxListLimit
+	}
+	seen := map[string]bool{}
+	var out []Record
+	for _, rec := range recs {
+		values := make([]interface{}, len(fields))
+		for i, field := range fields {
+			values[i] = rec.Data[field]
+			if values[i] == nil {
+				values[i] = ""
+			}
+		}
+		encoded, err := json.Marshal(values)
+		if err != nil {
+			return nil, err
+		}
+		group := string(encoded)
+		if seen[group] {
+			continue
+		}
+		seen[group] = true
+		out = append(out, rec)
+		if len(out) == limit {
+			break
+		}
+	}
+	return out, nil
+}
+
 // Update replaces a record's data (and public flag). Owner only.
 func Update(ns, caller, collection, id string, dataObj map[string]interface{}, public bool) (*Record, error) {
 	if caller == "" {

--- a/service/apps/editor.go
+++ b/service/apps/editor.go
@@ -43,7 +43,7 @@ func editPageHTML(a *App) string {
 	// instruction does not mention; regenerating from a description would not.
 	aiPanel := fmt.Sprintf(`<form method="POST" action="/apps/%s/ai-edit" class="ai-edit">
   <label for="instruction">Change it with AI</label>
-  <div class="ai-edit-row">
+  <div class="form-row">
     <input type="text" id="instruction" name="instruction" required
            placeholder="e.g. add a Notes field, or change the total to average">
     <button type="submit">Apply</button>
@@ -85,9 +85,6 @@ func editPageHTML(a *App) string {
 .status-msg { font-size: 13px; color: #999; margin-left: 8px; }
 .ai-edit { border: 1px solid #e0e0e0; border-radius: 8px; padding: 12px; background: #fafafa; }
 .ai-edit label { display: block; font-size: 13px; font-weight: 600; margin-bottom: 6px; }
-.ai-edit-row { display: flex; gap: 8px; }
-.ai-edit-row input { flex: 1; min-width: 0; padding: 8px 12px; border: 1px solid #e0e0e0; border-radius: 6px; font-family: inherit; font-size: 14px; }
-.ai-edit-row button { padding: 8px 20px; background: #000; color: #fff; border: none; border-radius: 6px; cursor: pointer; font-family: inherit; white-space: nowrap; }
 .ai-edit-note { font-size: 12px; color: #888; margin: 8px 0 0; }
 /* The shapes the markup below was writing inline, next to the ones it was
    already using. A field is .ed-field wherever it appears; the widths are the
@@ -99,17 +96,14 @@ func editPageHTML(a *App) string {
 .ed-w-130 { width: 130px; }
 .ed-w-140 { width: 140px; }
 .ed-tall { min-height: 50vh; }
-.ed-grow { flex: 1; min-width: 300px; }
+.ed-grow { flex: 1 1 300px; min-width: 0; max-width: 100%%; }
 .ed-grow-150 { flex: 1; min-width: 150px; }
 .ed-grow-120 { flex: 1; min-width: 120px; }
-.ed-grid { display: grid; grid-template-columns: 1fr auto; gap: 8px 12px; align-items: end; }
 .ed-row-end { display: flex; gap: 8px; align-items: end; }
-.ed-row-wrap { display: flex; gap: 8px; flex-wrap: wrap; align-items: end; }
 .ed-row-12 { display: flex; gap: 12px; flex-wrap: wrap; }
 .ed-check { display: flex; align-items: center; gap: 4px; font-size: 13px; white-space: nowrap; padding: 8px 0; }
 .ed-link-btn { color: #333; text-decoration: none; padding: 4px 12px; border: 1px solid #e0e0e0; border-radius: 6px; }
 .ed-danger { padding: 4px 12px; border: 1px solid #e0e0e0; border-radius: 6px; background: #fff; color: #c00; cursor: pointer; font-size: 13px; font-family: inherit; }
-@media (max-width: 600px) { .ai-edit-row { flex-direction: column; } }
 @media (max-width: 768px) {
   .save-bar { flex-direction: column; align-items: stretch; }
   .save-bar input.name { width: 100%%; min-width: auto; }
@@ -147,8 +141,8 @@ func editPageHTML(a *App) string {
     </div>
   </div>
 
-  <div class="save-bar ed-grid">
-    <div class="ed-row-wrap">
+  <div class="form-row">
+    <div class="form-row">
       <div class="ed-grow-150">
         <label for="appName" class="ed-label">Name</label>
         <input class="name ed-field" type="text" id="appName" placeholder="App name">

--- a/service/bookmarks/page.go
+++ b/service/bookmarks/page.go
@@ -161,9 +161,9 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 			}
 			b.WriteString(`<form method="POST" action="/bookmarks/search">` + token(r) + hidden("query", query) + hidden("kind", kind) + hidden("offset", strconv.Itoa(p.off)) + `<button>` + p.label + `</button></form>`)
 		}
-		b.WriteString(`</div><details><summary>Add a link</summary><form method="POST" action="/bookmarks" class="bookmarks-add">` + token(r) + hidden("action", "add") + `<input name="url" type="url" required maxlength="4096" placeholder="https://…" aria-label="Link"><input name="title" maxlength="1000" placeholder="Title" aria-label="Title"><button>Save link</button></form></details>`)
+		b.WriteString(`</div><details><summary>Add a link</summary><form method="POST" action="/bookmarks" class="form form-inline page-section">` + token(r) + hidden("action", "add") + `<input name="url" type="url" required maxlength="4096" placeholder="https://…" aria-label="Link"><input name="title" maxlength="1000" placeholder="Title" aria-label="Title"><button>Save link</button></form></details>`)
 	}
-	b.WriteString(`</div>` + app.ReadingCSS + `<style>.bookmarks-page{max-width:var(--page-width)}.bookmarks-add{display:flex;gap:8px;flex-wrap:wrap;margin-bottom:20px}.bookmarks-page textarea{display:block;width:100%;box-sizing:border-box;margin:8px 0}.bookmarks-add{margin-top:12px}</style>`)
+	b.WriteString(`</div>` + app.ReadingCSS + `<style>.bookmarks-page{max-width:var(--page-width)}.bookmarks-page textarea{display:block;width:100%;box-sizing:border-box;margin:8px 0}</style>`)
 	app.Respond(w, r, app.Response{Title: "Bookmarks", Description: "Your private saved reading", HTML: b.String()})
 }
 func hidden(name, value string) string {

--- a/service/browser/browser_test.go
+++ b/service/browser/browser_test.go
@@ -175,7 +175,7 @@ func TestThePageOffersBothThings(t *testing.T) {
 	}
 
 	// The checkbox is inside the form it modifies, or it submits nothing.
-	form := body[strings.Index(body, `class="form-row page-section"`):]
+	form := body[strings.Index(body, `class="form form-inline page-section"`):]
 	form = form[:strings.Index(form, "</form>")]
 	if !strings.Contains(form, `name="full"`) {
 		t.Error("the whole-page checkbox is outside the form, so it is never sent")

--- a/service/browser/browser_test.go
+++ b/service/browser/browser_test.go
@@ -175,7 +175,7 @@ func TestThePageOffersBothThings(t *testing.T) {
 	}
 
 	// The checkbox is inside the form it modifies, or it submits nothing.
-	form := body[strings.Index(body, `class="browser-form"`):]
+	form := body[strings.Index(body, `class="form-row page-section"`):]
 	form = form[:strings.Index(form, "</form>")]
 	if !strings.Contains(form, `name="full"`) {
 		t.Error("the whole-page checkbox is outside the form, so it is never sent")

--- a/service/browser/page.go
+++ b/service/browser/page.go
@@ -84,7 +84,7 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 	q := r.URL.Query()
 	target := strings.TrimSpace(q.Get("url"))
 	full := q.Get("full") != ""
-	b.WriteString(`<form class="form-row page-section" method="get" action="/browser">`)
+	b.WriteString(`<form class="form form-inline page-section" method="get" action="/browser">`)
 	b.WriteString(`<input class="browser-url" type="text" name="url" placeholder="https://example.com" ` +
 		`value="` + html.EscapeString(target) + `">`)
 	b.WriteString(`<button type="submit">Read</button>`)

--- a/service/browser/page.go
+++ b/service/browser/page.go
@@ -84,7 +84,7 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 	q := r.URL.Query()
 	target := strings.TrimSpace(q.Get("url"))
 	full := q.Get("full") != ""
-	b.WriteString(`<form class="browser-form" method="get" action="/browser">`)
+	b.WriteString(`<form class="form-row page-section" method="get" action="/browser">`)
 	b.WriteString(`<input class="browser-url" type="text" name="url" placeholder="https://example.com" ` +
 		`value="` + html.EscapeString(target) + `">`)
 	b.WriteString(`<button type="submit">Read</button>`)

--- a/service/contacts/handler.go
+++ b/service/contacts/handler.go
@@ -131,7 +131,7 @@ func listPage(w http.ResponseWriter, r *http.Request) {
 
 	// Add. Only the name is required — a contact with just a name is still
 	// worth having, and the rest can be filled in later by saying so.
-	fmt.Fprintf(&b, `<form method="POST" action="/contacts" class="contact-add">
+	fmt.Fprintf(&b, `<form method="POST" action="/contacts" class="form form-inline page-section">
   <input type="hidden" name="_csrf" value="%s">
   <input name="name" placeholder="Name" required>
   <input name="email" type="email" placeholder="Email">
@@ -139,7 +139,7 @@ func listPage(w http.ResponseWriter, r *http.Request) {
   <input name="note" placeholder="Note">
   <button type="submit">Add</button>
 </form>`, html.EscapeString(csrf))
-	b.WriteString(`<details class="mt-3"><summary>Import contacts</summary><form method="POST" action="/contacts/import" enctype="multipart/form-data" class="contact-search">` + app.CSRFField(csrf) + `<input type="file" name="file" accept=".csv,text/csv" required><button>Import CSV</button></form><p class="text-sm">Google, Outlook or a CSV with Name, Email, Phone and Note columns. Up to 500 contacts.</p></details></div>`)
+	b.WriteString(`<details class="mt-3"><summary>Import contacts</summary><form method="POST" action="/contacts/import" enctype="multipart/form-data" class="form-row mt-3">` + app.CSRFField(csrf) + `<input type="file" name="file" accept=".csv,text/csv" required><button>Import CSV</button></form><p class="text-sm">Google, Outlook or a CSV with Name, Email, Phone and Note columns. Up to 500 contacts.</p></details></div>`)
 
 	if len(people) == 0 {
 		b.WriteString(`<div class="card"><p class="text-sm text-muted">`)
@@ -193,18 +193,12 @@ func orDash(s string) string {
 // same treatment the files list gets, for the same reason: five columns on a
 // phone either scroll sideways or crush the name.
 const contactsPageCSS = `<style>
-.contact-search{display:flex;gap:8px;margin:10px 0}
-.contact-search input{flex:1;min-width:0}
-.contact-add{display:grid;grid-template-columns:repeat(auto-fit,minmax(140px,1fr));gap:8px;margin:12px 0 4px}
-.contact-add input{min-width:0}
 .contacts-table{margin-bottom:0}
 .contacts-table .contact-name{font-weight:var(--font-weight-medium)}
 .contact-actions{white-space:nowrap}
 .contact-actions form{display:inline}
 
 @media only screen and (max-width:600px){
-  .contact-add{grid-template-columns:1fr}
-  .contact-add button{width:100%}
   .contacts-table,.contacts-table tbody,.contacts-table tr,.contacts-table td{display:block;width:auto}
   .contacts-table thead{display:none}
   .contacts-table tr{padding:12px 0;border-bottom:1px solid var(--divider)}

--- a/service/contacts/handler.go
+++ b/service/contacts/handler.go
@@ -139,7 +139,7 @@ func listPage(w http.ResponseWriter, r *http.Request) {
   <input name="note" placeholder="Note">
   <button type="submit">Add</button>
 </form>`, html.EscapeString(csrf))
-	b.WriteString(`<details class="mt-3"><summary>Import contacts</summary><form method="POST" action="/contacts/import" enctype="multipart/form-data" class="form-row mt-3">` + app.CSRFField(csrf) + `<input type="file" name="file" accept=".csv,text/csv" required><button>Import CSV</button></form><p class="text-sm">Google, Outlook or a CSV with Name, Email, Phone and Note columns. Up to 500 contacts.</p></details></div>`)
+	b.WriteString(`<details class="mt-3"><summary>Import contacts</summary><form method="POST" action="/contacts/import" enctype="multipart/form-data" class="form form-inline mt-3">` + app.CSRFField(csrf) + `<input type="file" name="file" accept=".csv,text/csv" required><button>Import CSV</button></form><p class="text-sm">Google, Outlook or a CSV with Name, Email, Phone and Note columns. Up to 500 contacts.</p></details></div>`)
 
 	if len(people) == 0 {
 		b.WriteString(`<div class="card"><p class="text-sm text-muted">`)

--- a/service/flights/page.go
+++ b/service/flights/page.go
@@ -102,7 +102,7 @@ func forms(q, near string, radius int, csrf string) string {
 	return `<div class="card fl-forms">
 <form method="GET" action="/flights" class="fl-form">
 <label class="fl-label" for="fl-near">What's overhead</label>
-<div class="fl-row">
+<div class="form-row">
 <input id="fl-near" type="text" name="near" value="` + html.EscapeString(near) + `" placeholder="A place or airport — Camden, London or LHR" autocomplete="off">
 <select name="radius" aria-label="Range in nautical miles" class="fl-range">` + ranges(radius) + `</select>
 <button type="submit">Look</button>
@@ -111,7 +111,7 @@ func forms(q, near string, radius int, csrf string) string {
 </form>
 <form method="POST" action="/flights" class="fl-form">` + app.CSRFField(csrf) + `
 <label class="fl-label" for="fl-q">Where's a flight</label>
-<div class="fl-row">
+<div class="form-row">
 <input id="fl-q" type="text" name="q" value="` + html.EscapeString(q) + `" placeholder="BA117, BAW117 or G-ZBKL" autocomplete="off">
 <button type="submit">Find</button>
 </div>
@@ -225,11 +225,8 @@ func notice(msg string) string {
 
 const pageCSS = `<style>
 .fl-forms{display:flex;gap:24px;flex-wrap:wrap}
-.fl-form{flex:1;min-width:260px}
+.fl-form{flex:1 1 260px;min-width:0;max-width:100%}
 .fl-label{display:block;font-size:12px;color:#888;margin-bottom:6px}
-.fl-row{display:flex;gap:8px}
-.fl-row input{flex:1;min-width:0}
-.fl-range{flex:0 0 auto}
 .fl-here{font-size:12px;color:#888;display:inline-block;margin-top:6px}
 .fl-table{width:100%;border-collapse:collapse;font-size:13px}
 .fl-table th{text-align:left;font-weight:normal;color:#888;padding:6px 8px;border-bottom:1px solid #eee}

--- a/service/flights/status.go
+++ b/service/flights/status.go
@@ -115,7 +115,7 @@ func statusForm(r *http.Request) string {
 	if settings.Get("AVIATIONSTACK_API_KEY") == "" {
 		return b + `<p class="text-sm text-muted">Timetable and estimated times are unavailable on this instance. Live aircraft positions remain available below.</p></section>`
 	}
-	b += `<form method="POST" action="/flights" class="fl-form">` + app.CSRFField(auth.CSRFToken(r)) + `<input type="hidden" name="status_lookup" value="1"><div class="fl-row"><input name="flight" placeholder="Flight number, e.g. BA117" aria-label="Flight number"><input name="airport" placeholder="Airport, e.g. LHR" aria-label="Airport"><select name="direction" aria-label="Flight direction"><option value="arrivals">Arrivals</option><option value="departures">Departures</option></select><button>Check times</button></div><div class="d-flex gap-2 mt-3">`
+	b += `<form method="POST" action="/flights" class="fl-form">` + app.CSRFField(auth.CSRFToken(r)) + `<input type="hidden" name="status_lookup" value="1"><div class="form-row"><input name="flight" placeholder="Flight number, e.g. BA117" aria-label="Flight number"><input name="airport" placeholder="Airport, e.g. LHR" aria-label="Airport"><select name="direction" aria-label="Flight direction"><option value="arrivals">Arrivals</option><option value="departures">Departures</option></select><button>Check times</button></div><div class="form-row mt-3">`
 	for _, code := range []string{"LHR", "LGW", "MAN", "JFK", "CDG", "DXB"} {
 		b += `<button name="preset" value="` + code + `">` + code + `</button>`
 	}

--- a/service/food/page.go
+++ b/service/food/page.go
@@ -25,7 +25,7 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 
 	var b strings.Builder
 
-	b.WriteString(`<div class="card"><h3>Products</h3><form class="food-form" method="get" action="/food">`)
+	b.WriteString(`<div class="card"><h3>Products</h3><form class="form form-inline" method="get" action="/food">`)
 	fmt.Fprintf(&b, `<input class="food-input" type="text" name="q" value="%s" placeholder="Find a product — oat milk" aria-label="Product name">`,
 		html.EscapeString(find))
 	fmt.Fprintf(&b, `<input class="food-input food-code" type="text" name="barcode" value="%s" placeholder="or a barcode" aria-label="Barcode">`,
@@ -37,7 +37,7 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 	}
 	b.WriteString(`</div></div>`)
 
-	b.WriteString(`<div class="card"><h3>Hygiene ratings</h3><form class="food-form" method="get" action="/food">`)
+	b.WriteString(`<div class="card"><h3>Hygiene ratings</h3><form class="form form-inline" method="get" action="/food">`)
 	fmt.Fprintf(&b, `<input class="food-input" type="text" name="rating" value="%s" placeholder="Hygiene rating — a business name" aria-label="Business name">`,
 		html.EscapeString(rating))
 	fmt.Fprintf(&b, `<input class="food-input" type="text" name="where" value="%s" placeholder="town or postcode" aria-label="Where">`,
@@ -103,9 +103,6 @@ func Card() string {
 }
 
 const foodCSS = `<style>
-.food-form{display:flex;gap:10px;flex-wrap:wrap;align-items:center;margin:0}
-.food-form .food-input{flex:1 1 180px;min-width:0;margin:0}
-.food-form button{flex:0 0 auto;margin:0}
 .food-presets{display:flex;flex-wrap:wrap;gap:8px;margin-top:16px}
 .food-result{white-space:pre-wrap;overflow-wrap:anywhere;padding:16px;background:var(--card-background);border:1px solid var(--border-color);border-radius:8px}
 </style>`

--- a/service/images/upload.go
+++ b/service/images/upload.go
@@ -89,5 +89,5 @@ func uploadHandler(w http.ResponseWriter, r *http.Request) {
 	http.Redirect(w, r, "/images", http.StatusSeeOther)
 }
 func uploadForm(r *http.Request) string {
-	return `<details class="card"><summary>Upload an image</summary><form class="d-flex gap-2 mt-3" style="flex-wrap:wrap" method="POST" action="/images?upload=1" enctype="multipart/form-data">` + app.CSRFField(auth.CSRFToken(r)) + `<input type="file" name="file" accept="image/png,image/jpeg,image/gif" required><input name="caption" placeholder="Caption" maxlength="1000"><button>Upload</button></form><p class="text-sm text-muted">Private. PNG, JPEG or GIF, up to 8 MB and 8 megapixels. ` + html.EscapeString("GIF uploads keep the first frame.") + `</p></details>`
+	return `<details class="card"><summary>Upload an image</summary><form class="form form-inline mt-3" method="POST" action="/images?upload=1" enctype="multipart/form-data">` + app.CSRFField(auth.CSRFToken(r)) + `<input type="file" name="file" accept="image/png,image/jpeg,image/gif" required><input name="caption" placeholder="Caption" maxlength="1000"><button>Upload</button></form><p class="text-sm text-muted">Private. PNG, JPEG or GIF, up to 8 MB and 8 megapixels. ` + html.EscapeString("GIF uploads keep the first frame.") + `</p></details>`
 }

--- a/service/maps/directions.go
+++ b/service/maps/directions.go
@@ -1,8 +1,8 @@
 package maps
 
-const directionsUI = `<form id="map-directions" class="card d-flex gap-2" style="flex-wrap:wrap">
-{{csrf}}<input name="from" class="grow" placeholder="From" aria-label="Starting point" required><button type="button" id="map-start-here">Use my location</button>
-<input name="to" class="grow" placeholder="Destination" aria-label="Destination" required>
+const directionsUI = `<form id="map-directions" class="card form form-inline">
+{{csrf}}<input name="from" placeholder="From" aria-label="Starting point" required><button type="button" id="map-start-here">Use my location</button>
+<input name="to" placeholder="Destination" aria-label="Destination" required>
 <select name="mode" aria-label="Travel mode"><option value="walk">Walk</option><option value="drive">Drive</option><option value="cycle">Cycle</option><option value="transit">Public transport</option></select><button type="submit">Directions</button>
 </form><div id="map-directions-result" aria-live="polite"></div>
 <script>(function(){var form=document.getElementById('map-directions'),out=document.getElementById('map-directions-result');if(!form||form.dataset.wired)return;form.dataset.wired='1';var request=0;

--- a/service/routes/page.go
+++ b/service/routes/page.go
@@ -99,7 +99,7 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 // form is the two ends and the mode.
 func form(from, to, mode string) string {
 	var b strings.Builder
-	b.WriteString(`<form method="GET" action="/routes" class="card rt-form">`)
+	b.WriteString(`<form method="GET" action="/routes" class="card form form-inline">`)
 	b.WriteString(`<input name="from" value="` + html.EscapeString(from) +
 		`" placeholder="From — e.g. King's Cross, London" autocomplete="off" aria-label="Starting point">`)
 	b.WriteString(`<input name="to" value="` + html.EscapeString(to) +
@@ -244,11 +244,6 @@ func cosDeg(deg float64) float64 {
 }
 
 const pageCSS = `<style>
-.rt-form{display:flex;gap:8px;flex-wrap:wrap;align-items:center}
-.rt-form input{flex:1;min-width:180px;padding:8px 10px;border:1px solid var(--border-color,#d1d5db);
-  border-radius:8px;font-size:14px;font-family:inherit}
-.rt-form select{padding:8px 10px;border:1px solid var(--border-color,#d1d5db);border-radius:8px;
-  font-size:14px;font-family:inherit}
 .rt-head{margin:0 0 6px;font-size:15px}
 .rt-summary{margin:0 0 12px;font-size:14px;color:var(--text-muted,#666)}
 .rt-traffic{color:#b45309}

--- a/service/sms/conversations.go
+++ b/service/sms/conversations.go
@@ -1,0 +1,67 @@
+package sms
+
+import (
+	"html"
+	"net/url"
+	"strings"
+
+	"mu/internal/app"
+	"mu/internal/contacts"
+	"mu/internal/userdb"
+)
+
+// conversationList shows one latest-message preview per number and channel.
+// IDs come from stored messages, so URLs contain neither numbers nor text.
+func conversationList(who string, history []Message) string {
+	if len(history) == 0 {
+		return `<p class="text-muted">No conversations yet.</p>`
+	}
+	names := map[string]string{}
+	for _, c := range contacts.List(who) {
+		if n := e164(c.Phone); n != "" && c.Name != "" {
+			names[n] = c.Name
+		}
+	}
+	seen := map[string]bool{}
+	var b strings.Builder
+	b.WriteString(`<nav class="sms-conversations" aria-label="Conversations">`)
+	for _, m := range history {
+		key := m.Number + ":" + m.Channel
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		name := names[m.Number]
+		if name == "" {
+			name = m.Number
+		}
+		preview := m.Text
+		if m.Direction == "out" {
+			preview = "You: " + preview
+		}
+		b.WriteString(`<a class="sms-conversation" href="/sms?id=` + url.QueryEscape(m.ID) + `"><div class="sms-conversation-head"><strong>` + html.EscapeString(name) + `</strong>` + app.Pill(Channel(m.Channel).Label()) + `<span class="text-muted text-sm">` + html.EscapeString(app.TimeAgo(m.At)) + `</span></div>`)
+		if name != m.Number {
+			b.WriteString(`<span class="text-muted text-sm">` + html.EscapeString(m.Number) + `</span>`)
+		}
+		b.WriteString(`<span class="sms-preview">` + html.EscapeString(preview) + `</span></a>`)
+	}
+	b.WriteString(`</nav>`)
+	return b.String()
+}
+
+const conversationsCSS = `<style>
+.sms-conversations{display:flex;flex-direction:column;min-width:0}
+.sms-conversation{display:flex;flex-direction:column;gap:var(--space-control);padding:var(--space-field) 0;border-bottom:1px solid var(--border-color,#ddd);color:inherit;text-decoration:none;min-width:0}
+.sms-conversation:hover{background:var(--hover-background,#f5f5f5);text-decoration:none}
+.sms-conversation-head{display:flex;align-items:center;gap:var(--space-control);flex-wrap:wrap;min-width:0}
+.sms-conversation-head strong{overflow-wrap:anywhere}
+.sms-preview{overflow:hidden;text-overflow:ellipsis;white-space:nowrap;color:var(--text-secondary,#555)}
+</style>`
+
+func recentConversations(who string) ([]Message, error) {
+	recs, err := userdb.LatestBy(ns, who, msgs, []string{"number", "channel"}, "at", 200)
+	if err != nil {
+		return nil, err
+	}
+	return messagesFrom(recs), nil
+}

--- a/service/sms/conversations_test.go
+++ b/service/sms/conversations_test.go
@@ -1,0 +1,106 @@
+package sms
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"mu/internal/auth"
+	"mu/internal/userdb"
+)
+
+func TestConversationListSeparatesNumberAndChannel(t *testing.T) {
+	setup(t)
+	history := []Message{
+		{ID: "wa-new", Number: "+447700900111", Channel: "whatsapp", Text: "Latest WhatsApp", At: time.Now()},
+		{ID: "sms-new", Number: "+447700900111", Text: "Latest SMS", Direction: "out", At: time.Now().Add(-time.Minute)},
+		{ID: "other", Number: "+447700900222", Text: "Other person", At: time.Now().Add(-2 * time.Minute)},
+		{ID: "wa-old", Number: "+447700900111", Channel: "whatsapp", Text: "Older WhatsApp", At: time.Now().Add(-3 * time.Minute)},
+	}
+	got := conversationList("conversation-list", history)
+	if strings.Count(got, `class="sms-conversation"`) != 3 {
+		t.Fatalf("want three conversations: %s", got)
+	}
+	for _, want := range []string{"Latest WhatsApp", "You: Latest SMS", "Other person", "WhatsApp", "SMS"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("missing %q", want)
+		}
+	}
+	if strings.Contains(got, "Older WhatsApp") || strings.Contains(got, `name="text"`) {
+		t.Error("list rendered full history or reply composers")
+	}
+	if strings.Index(got, "wa-new") > strings.Index(got, "sms-new") {
+		t.Error("latest conversation should come first")
+	}
+	if strings.Contains(got, `href="/sms?id=+`) {
+		t.Error("phone number in conversation URL")
+	}
+}
+
+func TestConversationPageReadsOnlySelectedOwnedChannel(t *testing.T) {
+	setup(t)
+	const who = "conversation_owner"
+	if err := auth.Create(&auth.Account{ID: who, Approved: true}); err != nil {
+		t.Fatal(err)
+	}
+	sess, err := auth.CreateSession(who)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sms := Record(who, "in", "+447700900111", "Private SMS history", 1)
+	wa := RecordOn(ChannelWhatsApp, who, "in", "+447700900111", "Private WhatsApp history", 1)
+	foreign := Record("somebody-else", "in", "+447700900111", "Foreign history", 1)
+	for _, tc := range []struct {
+		id, want, absent, channel string
+		status                    int
+	}{
+		{sms.ID, "Private SMS history", "Private WhatsApp history", "", 200},
+		{wa.ID, "Private WhatsApp history", "Private SMS history", "whatsapp", 200},
+		{foreign.ID, "", "Foreign history", "", 404},
+		{"missing", "", "Private SMS history", "", 404},
+	} {
+		r := httptest.NewRequest(http.MethodGet, "/sms?id="+url.QueryEscape(tc.id), nil)
+		r.AddCookie(&http.Cookie{Name: "session", Value: sess.Token})
+		w := httptest.NewRecorder()
+		Handler(w, r)
+		got := w.Body.String()
+		if w.Code != tc.status {
+			t.Fatalf("id %s status %d: %s", tc.id, w.Code, got)
+		}
+		if strings.Contains(got, tc.absent) {
+			t.Errorf("leaked unrelated history for %s", tc.id)
+		}
+		if tc.status == 200 {
+			if !strings.Contains(got, tc.want) || !strings.Contains(got, `name="channel" value="`+tc.channel+`"`) {
+				t.Errorf("wrong conversation or reply channel: %s", got)
+			}
+			if strings.Count(got, `name="text"`) != 1 {
+				t.Error("want one reply composer")
+			}
+		}
+	}
+}
+
+func TestBusyConversationDoesNotHideAnotherThreadsHistory(t *testing.T) {
+	setup(t)
+	const who = "conversation-busy"
+	Record(who, "in", "+447700900111", "Older separate conversation", 1)
+	for i := 0; i < 205; i++ {
+		RecordOn(ChannelWhatsApp, who, "in", "+447700900222", "Busy thread", 1)
+	}
+	Record("other_owner", "in", "+447700900333", "Not yours", 1)
+	if _, err := userdb.Create(ns, who, msgs, map[string]interface{}{"number": "+447700900111", "text": "Legacy SMS", "direction": "in", "at": time.Now().Add(-time.Hour).Format(time.RFC3339)}, false); err != nil {
+		t.Fatal(err)
+	}
+	latest, err := recentConversations(who)
+	if err != nil || len(latest) != 2 {
+		t.Fatalf("busy thread hid another conversation: %+v, %v", latest, err)
+	}
+	got := conversationHistory(who, "+447700900111", ChannelSMS)
+	if len(got) != 2 || got[0].Text != "Older separate conversation" {
+		t.Fatalf("history was limited before selecting the conversation: %+v", got)
+	}
+}

--- a/service/sms/page.go
+++ b/service/sms/page.go
@@ -10,6 +10,7 @@ package sms
 import (
 	"html"
 	"net/http"
+	"net/url"
 	"sort"
 	"strings"
 
@@ -17,6 +18,7 @@ import (
 	"mu/internal/auth"
 	"mu/internal/contacts"
 	"mu/internal/quota"
+	"mu/internal/userdb"
 )
 
 // Handler serves /sms.
@@ -79,9 +81,33 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 	}
 	b.WriteString(`<p class="text-sm text-muted">Sent from <strong>` + html.EscapeString(from) +
 		`</strong>. ` + html.EscapeString(allowance(who)+yours) + `</p>`)
-	b.WriteString(composer(r, who))
-	b.WriteString(threads(r, who, history))
-	b.WriteString(pageCSS)
+	b.WriteString(`<div class="page-stack">`)
+	if r.URL.Query().Get("view") == "new" {
+		b.WriteString(`<div class="section-actions"><a href="/sms">← Conversations</a></div>`)
+		b.WriteString(composer(r, who))
+	} else if id := r.URL.Query().Get("id"); id != "" {
+		// The opaque message ID locates a conversation only within this account.
+		rec, err := userdb.Get(ns, who, msgs, id)
+		if err != nil || rec.Owner != who {
+			app.NotFound(w, r, "Conversation not found")
+			return
+		}
+		number, _ := rec.Data["number"].(string)
+		channel, _ := rec.Data["channel"].(string)
+		b.WriteString(`<div class="section-actions"><a href="/sms">← Conversations</a><a href="/sms?view=new">New</a></div>`)
+		b.WriteString(threads(r, who, conversationHistory(who, number, Channel(channel))))
+	} else {
+		b.WriteString(`<div class="page-action"><a class="btn" href="/sms?view=new">New</a></div>`)
+		latest, err := recentConversations(who)
+		if err != nil {
+			app.Error(w, r, http.StatusInternalServerError, "Could not load conversations")
+			return
+		}
+		b.WriteString(conversationList(who, latest))
+		b.WriteString(verifier(r, who, html.EscapeString(auth.CSRFToken(r))))
+	}
+	b.WriteString(`</div>`)
+	b.WriteString(pageCSS + conversationsCSS)
 
 	app.Respond(w, r, app.Response{Title: "SMS", Description: "Text somebody, and read what they text back", HTML: b.String()})
 }
@@ -208,7 +234,7 @@ func verifier(r *http.Request, who, csrf string) string {
 	if waiting {
 		b.WriteString(`<p class="text-sm">A code went to <strong>` + html.EscapeString(number) +
 			`</strong>. It is good for ten minutes.</p>` +
-			`<form method="POST" action="/sms" class="sms-verify-form">` +
+			`<form method="POST" action="/sms" class="form-row mt-3">` +
 			`<input type="hidden" name="_csrf" value="` + csrf + `">` +
 			`<input type="hidden" name="confirm" value="` + html.EscapeString(number) + `">` +
 			`<input name="code" inputmode="numeric" autocomplete="one-time-code" required ` +
@@ -240,7 +266,7 @@ func verifier(r *http.Request, who, csrf string) string {
 					`<input type="hidden" name="forget" value="` + html.EscapeString(n) + `"></form>`)
 			}
 		}
-		b.WriteString(`<form method="POST" action="/sms" class="sms-verify-form">` +
+		b.WriteString(`<form method="POST" action="/sms" class="form-row mt-3">` +
 			`<input type="hidden" name="_csrf" value="` + csrf + `">` +
 			`<input name="start" required placeholder="+447700900123" class="sms-in" ` +
 			`autocomplete="tel" aria-label="Your number">` +
@@ -302,12 +328,7 @@ func threads(r *http.Request, who string, history []Message) string {
 	for _, k := range order {
 		number, channel := k.number, k.channel
 		b.WriteString(`<div class="card"><h3 class="sms-who">` + html.EscapeString(number))
-		// Which channel, but only where there is a choice. An instance with no
-		// WhatsApp sender has one kind of conversation and does not need every
-		// heading labelled with it.
-		if ConfiguredFor(ChannelWhatsApp) {
-			b.WriteString(app.Pill(channel.Label()))
-		}
+		b.WriteString(app.Pill(channel.Label()))
 		b.WriteString(`</h3>`)
 		msgs := byWhom[k]
 		// Oldest first inside a conversation, which is how a conversation reads.
@@ -338,7 +359,7 @@ func threads(r *http.Request, who string, history []Message) string {
 			// way it came. Without it this replied by text to a WhatsApp
 			// conversation: a second thread on the other person's phone, from a
 			// number they do not recognise, with nothing on it to say why.
-			b.WriteString(`<form method="POST" action="/sms" class="sms-reply">` +
+			b.WriteString(`<form method="POST" action="/sms" class="form-row mt-3">` +
 				`<input type="hidden" name="_csrf" value="` + csrf + `">` +
 				`<input type="hidden" name="send" value="1">` +
 				`<input type="hidden" name="to" value="` + html.EscapeString(number) + `">` +
@@ -366,10 +387,15 @@ func handlePost(w http.ResponseWriter, r *http.Request, who string) {
 
 	var err error
 	done := ""
+	location := "/sms"
 	switch {
 	case r.Form.Get("send") != "":
 		channel := Channel(strings.TrimSpace(r.Form.Get("channel")))
-		_, err = SendOn(channel, who, r.Form.Get("to"), r.Form.Get("text"))
+		var sent *Message
+		sent, err = SendOn(channel, who, r.Form.Get("to"), r.Form.Get("text"))
+		if err == nil && sent != nil && sent.ID != "" {
+			location += "?id=" + url.QueryEscape(sent.ID)
+		}
 		done = "sent"
 	case strings.TrimSpace(r.Form.Get("start")) != "":
 		err = StartVerify(who, r.Form.Get("start"))
@@ -385,7 +411,11 @@ func handlePost(w http.ResponseWriter, r *http.Request, who string) {
 		app.Error(w, r, http.StatusBadRequest, err.Error())
 		return
 	}
-	http.Redirect(w, r, "/sms?ok="+done, http.StatusSeeOther)
+	separator := "?"
+	if strings.Contains(location, "?") {
+		separator = "&"
+	}
+	http.Redirect(w, r, location+separator+"ok="+done, http.StatusSeeOther)
 }
 
 func itoa(n int) string {
@@ -415,15 +445,13 @@ const pageCSS = `<style>
   font-family:inherit;line-height:1.5;resize:vertical}
 .sms-verify{margin-top:14px}
 .sms-verify summary{font-size:13px;color:var(--text-muted,#666);cursor:pointer}
-.sms-verify-form{display:flex;flex-wrap:wrap;gap:8px;align-items:center;margin:10px 0 0}
-.sms-who{font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:14px;margin:0 0 10px}
+.sms-who{display:flex;align-items:center;flex-wrap:wrap;gap:var(--space-control);font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:14px;margin:0 0 10px}
 .sms-msg{display:flex;flex-direction:column;gap:2px;max-width:min(80%,460px);padding:8px 12px;
   border-radius:12px;margin:0 0 8px}
 .sms-out-msg{background:#111;color:#fff;margin-left:auto;border-bottom-right-radius:4px}
 .sms-in-msg{background:var(--surface-alt,#f2f2f2);border-bottom-left-radius:4px}
 .sms-body{font-size:14px;line-height:1.45;white-space:pre-wrap;word-break:break-word}
 .sms-when{font-size:11px;opacity:.65}
-.sms-reply{display:flex;gap:8px;margin:10px 0 0}
 .sms-reply-box{flex:1;min-width:0;padding:8px 10px;border:1px solid var(--border-color,#d1d5db);
   border-radius:8px;font-size:14px;font-family:inherit}
 .sms-closed{font-size:12px;color:var(--text-muted,#999);margin:8px 0 0}

--- a/service/sms/page.go
+++ b/service/sms/page.go
@@ -234,7 +234,7 @@ func verifier(r *http.Request, who, csrf string) string {
 	if waiting {
 		b.WriteString(`<p class="text-sm">A code went to <strong>` + html.EscapeString(number) +
 			`</strong>. It is good for ten minutes.</p>` +
-			`<form method="POST" action="/sms" class="form-row mt-3">` +
+			`<form method="POST" action="/sms" class="form form-inline mt-3">` +
 			`<input type="hidden" name="_csrf" value="` + csrf + `">` +
 			`<input type="hidden" name="confirm" value="` + html.EscapeString(number) + `">` +
 			`<input name="code" inputmode="numeric" autocomplete="one-time-code" required ` +
@@ -266,7 +266,7 @@ func verifier(r *http.Request, who, csrf string) string {
 					`<input type="hidden" name="forget" value="` + html.EscapeString(n) + `"></form>`)
 			}
 		}
-		b.WriteString(`<form method="POST" action="/sms" class="form-row mt-3">` +
+		b.WriteString(`<form method="POST" action="/sms" class="form form-inline mt-3">` +
 			`<input type="hidden" name="_csrf" value="` + csrf + `">` +
 			`<input name="start" required placeholder="+447700900123" class="sms-in" ` +
 			`autocomplete="tel" aria-label="Your number">` +
@@ -359,7 +359,7 @@ func threads(r *http.Request, who string, history []Message) string {
 			// way it came. Without it this replied by text to a WhatsApp
 			// conversation: a second thread on the other person's phone, from a
 			// number they do not recognise, with nothing on it to say why.
-			b.WriteString(`<form method="POST" action="/sms" class="form-row mt-3">` +
+			b.WriteString(`<form method="POST" action="/sms" class="form form-inline mt-3">` +
 				`<input type="hidden" name="_csrf" value="` + csrf + `">` +
 				`<input type="hidden" name="send" value="1">` +
 				`<input type="hidden" name="to" value="` + html.EscapeString(number) + `">` +

--- a/service/sms/sms.go
+++ b/service/sms/sms.go
@@ -641,10 +641,27 @@ func History(owner string, limit int) []Message {
 	if limit <= 0 || limit > 200 {
 		limit = 50
 	}
-	recs, err := userdb.List(ns, owner, msgs, "mine", nil, "", "", limit)
+	return messageHistory(owner, nil, limit)
+}
+
+func conversationHistory(owner, number string, channel Channel) []Message {
+	where := map[string]interface{}{"number": number, "channel": string(channel)}
+	if channel == ChannelSMS {
+		// Missing channel is a legacy SMS; neither form may absorb WhatsApp.
+		where["channel"] = map[string]interface{}{"ne": string(ChannelWhatsApp)}
+	}
+	return messageHistory(owner, where, 200)
+}
+
+func messageHistory(owner string, where map[string]interface{}, limit int) []Message {
+	recs, err := userdb.List(ns, owner, msgs, "mine", where, "at", "desc", limit)
 	if err != nil {
 		return nil
 	}
+	return messagesFrom(recs)
+}
+
+func messagesFrom(recs []userdb.Record) []Message {
 	out := make([]Message, 0, len(recs))
 	for _, r := range recs {
 		m := Message{ID: r.ID}

--- a/service/tasks/handler.go
+++ b/service/tasks/handler.go
@@ -326,10 +326,6 @@ const taskPollJS = `<script>
 const tasksPageCSS = `<style>
 .task-add{display:flex;flex-direction:column;gap:8px;margin:10px 0 4px}
 .task-add input[type=text],.task-add input:not([type]){min-width:0}
-.task-add-row{display:flex;gap:8px;flex-wrap:wrap;align-items:center}
-.task-add-row button{flex:0 0 auto}
-.task-due{font-size:13px;color:var(--text-muted);display:flex;align-items:center;gap:6px;flex:1;min-width:200px}
-.task-due input{flex:1;min-width:0;font-family:inherit;font-size:14px;padding:9px 11px;border:1px solid #d1d5db;border-radius:6px}
 .task-assign{font-size:13px;color:var(--text-muted);display:flex;align-items:center;gap:8px;cursor:pointer}
 .task-tabs{display:flex;gap:14px;flex-wrap:wrap}
 .task-tab{font-size:13px;color:var(--text-muted);text-decoration:none}
@@ -395,8 +391,8 @@ func addForm(csrf string) string {
   <input type="hidden" name="due" value="">
   <input name="title" placeholder="What needs doing?" required>
   <input name="detail" placeholder="Detail (optional)">
-  <div class="task-add-row">
-    <label class="task-due">Due <input type="datetime-local" name="duelocal"></label>
+  <div class="form-row">
+    <label class="field-label">Due <input type="datetime-local" name="duelocal"></label>
     <button type="submit">Add</button>
   </div>
   <label class="task-assign"><input type="checkbox" name="assign" value="agent"> <span>Give it to the agent — it starts working on this now</span></label>

--- a/service/transit/page.go
+++ b/service/transit/page.go
@@ -102,7 +102,7 @@ func stopsJSON(stops []stop) []map[string]any {
 func page() string {
 	var b strings.Builder
 	b.WriteString(app.Column())
-	b.WriteString(`<div class="card"><form id="xsearch" class="xsearch"><label for="xquery">Find a London stop or station</label><div class="xsearch-row"><input id="xquery" name="q" type="search" placeholder="Stop, station or area" required maxlength="200"><button type="submit" class="btn">Search</button><button type="button" id="xnear" class="btn">Use my location</button></div></form><div id="xstops" aria-live="polite" class="xmuted">Search for a stop or use your location.</div></div>`)
+	b.WriteString(`<div class="card"><form id="xsearch" class="xsearch"><label for="xquery">Find a London stop or station</label><div class="form-row page-section"><input id="xquery" name="q" type="search" placeholder="Stop, station or area" required maxlength="200"><button type="submit" class="btn">Search</button><button type="button" id="xnear" class="btn">Use my location</button></div></form><div id="xstops" aria-live="polite" class="xmuted">Search for a stop or use your location.</div></div>`)
 
 	b.WriteString(statusCard())
 	b.WriteString(`</div>` + pageStyle + pageScript)
@@ -175,9 +175,6 @@ func Card() string {
 
 const pageStyle = `<style>
 .xsearch label{display:block;margin-bottom:8px}
-.xsearch-row{display:flex;gap:8px;flex-wrap:wrap;margin-bottom:12px}
-.xsearch-row input{flex:1;min-width:150px}
-.xsearch-row button{white-space:nowrap}
 .xmuted{color:#888;font-size:14px;margin:0}
 .xgood{color:#0f7a52;font-size:15px;margin:0;font-weight:600}
 .xline{padding:8px 0;border-bottom:1px solid var(--border-color,#eee);font-size:15px}

--- a/test/layout_browser_test.go
+++ b/test/layout_browser_test.go
@@ -2,21 +2,47 @@ package test
 
 import (
 	"encoding/json"
+	"errors"
 	"mu/account"
 	"mu/agent"
 	"mu/home"
 	"mu/internal/auth"
 	"mu/internal/service"
 	"mu/service/apps"
+	"mu/service/archive"
+	"mu/service/blog"
+	"mu/service/bookmarks"
+	"mu/service/browser"
 	"mu/service/chat"
+	"mu/service/contacts"
 	"mu/service/docs"
 	"mu/service/events"
 	"mu/service/files"
+	"mu/service/flights"
+	"mu/service/food"
+	"mu/service/hazards"
+	"mu/service/images"
+	"mu/service/mail"
+	"mu/service/maps"
 	"mu/service/markets"
 	"mu/service/news"
+	"mu/service/notes"
+	"mu/service/notify"
+	"mu/service/places"
+	"mu/service/prayer"
+	"mu/service/recall"
+	"mu/service/routes"
+	"mu/service/shell"
+	"mu/service/sms"
+	"mu/service/social"
+	"mu/service/stream"
 	"mu/service/tasks"
+	"mu/service/text"
+	"mu/service/transit"
+	"mu/service/users"
 	"mu/service/video"
 	"mu/service/weather"
+	"mu/service/web"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -32,6 +58,14 @@ func TestPageCompositionInBrowser(t *testing.T) {
 	if os.Getenv("MU_LAYOUT_BROWSER") == "" {
 		t.Skip("set MU_LAYOUT_BROWSER to run browser layout checks")
 	}
+	// Render without contacting providers, including pages that fetch on GET.
+	oldTransport := http.DefaultTransport
+	http.DefaultTransport = layoutTransport{}
+	t.Cleanup(func() { http.DefaultTransport = oldTransport })
+	t.Setenv("AVIATIONSTACK_API_KEY", "layout-fixture")
+	t.Setenv("TWILIO_ACCOUNT_SID", "AC00000000000000000000000000000000")
+	t.Setenv("TWILIO_AUTH_TOKEN", "00000000000000000000000000000000")
+	t.Setenv("TWILIO_FROM", "+447700900123")
 	const who = "layout_reader"
 	if err := auth.Create(&auth.Account{ID: who, Admin: true, Approved: true}); err != nil {
 		t.Fatal(err)
@@ -48,8 +82,15 @@ func TestPageCompositionInBrowser(t *testing.T) {
 	if _, err := tasks.Create(who, "Review the brief", "A task to verify action buttons", tasks.Me, time.Time{}); err != nil {
 		t.Fatal(err)
 	}
+	if _, err := apps.CreateApp(who, "Layout app", "layout-app", "A browser layout fixture", "", "<!doctype html><html><body>Preview</body></html>", "", 0, false); err != nil {
+		t.Fatal(err)
+	}
+	sms.Record(who, "in", "+447700900111", "First SMS message", 1)
+	sms.Record(who, "out", "+447700900111", "Latest SMS message", 1)
+	smsThread := sms.RecordOn(sms.ChannelWhatsApp, who, "in", "+447700900111", "A separate WhatsApp conversation", 1)
 	pages := map[string]string{}
-	for path, handler := range map[string]http.HandlerFunc{"/agent/new": agent.NewAgentHandler, "/agents": agent.RosterHandler, "/token": account.TokenHandler, "/apps/new": apps.Handler, "/events": events.Handler, "/files": files.Handler, "/docs": docs.Handler, "/": home.Index, "/home": home.Handler, "/tasks": tasks.Handler, "/chat": chat.Handler, "/agent/micro": agent.Handler} {
+	for path, handler := range map[string]http.HandlerFunc{"/archive": archive.Handler, "/blog": blog.Handler, "/bookmarks": bookmarks.Handler, "/browser": browser.Handler, "/contacts": contacts.Handler, "/flights": flights.Handler, "/food": food.Handler, "/hazards": hazards.Handler, "/images": images.Handler, "/mail": mail.Handler, "/maps": maps.Handler, "/notify": notify.Handler, "/places": places.Handler, "/prayer": prayer.Handler, "/recall": recall.Handler, "/routes": routes.Handler, "/shell": shell.Handler, "/sms": sms.Handler, "/sms?view=new": sms.Handler, "/sms?id=" + smsThread.ID: sms.Handler, "/social": social.Handler, "/stream": stream.Handler, "/text": text.Handler, "/transit": transit.Handler, "/users": users.Handler, "/wallet": account.Wallet, "/notes": notes.Handler, "/news": news.Handler, "/web": web.Handler, "/weather": weather.PageHandler, "/markets": markets.Handler, "/video": video.Handler, "/agent/new": agent.NewAgentHandler, "/agents": agent.RosterHandler, "/token": account.TokenHandler, "/apps/new": apps.Handler, "/apps/layout-app/edit": apps.Handler, "/apps": apps.Handler, "/events": events.Handler, "/files": files.Handler, "/docs": docs.Handler, "/": home.Index, "/home": home.Handler, "/tasks": tasks.Handler, "/chat": chat.Handler, "/agent/micro": agent.Handler} {
+		t.Log("render", path)
 		req := httptest.NewRequest("GET", path, nil)
 		if path != "/" {
 			req.AddCookie(&http.Cookie{Name: "session", Value: sess.Token})
@@ -60,6 +101,11 @@ func TestPageCompositionInBrowser(t *testing.T) {
 			t.Fatalf("%s: %d", path, rec.Code)
 		}
 		pages[path] = rec.Body.String()
+	}
+	for name := range keptItsPage {
+		if _, ok := pages["/"+name]; !ok {
+			t.Errorf("service %s has no browser fixture", name)
+		}
 	}
 	css, err := os.ReadFile("../internal/app/html/mu.css")
 	if err != nil {
@@ -77,4 +123,11 @@ func TestPageCompositionInBrowser(t *testing.T) {
 		t.Fatalf("browser checks: %v\n%s", err, out)
 	}
 	t.Log(string(out))
+}
+
+// Provider data is irrelevant to form geometry; failures are immediate and offline.
+type layoutTransport struct{}
+
+func (layoutTransport) RoundTrip(*http.Request) (*http.Response, error) {
+	return nil, errors.New("offline layout fixture")
 }


### PR DESCRIPTION
Service forms could squeeze inputs on mobile, and SMS displayed every conversation with its own reply box on one page.

Use shared wrapping form rows across services, removing bespoke row layouts. Fix tablet conversation alignment. Give SMS a conversation list grouped by number and channel, with private thread links and one reply composer. Keep the SMS name and preserve the reply channel. Group before limiting records so busy threads do not hide other conversations.

Validation: Chromium checks across all 36 service pages at 320, 390, 768, 1024 and 1440px, with sidebar states and expanded controls; SMS list, thread and new-message checks; targeted service tests, ownership/channel isolation tests, userdb tests and vet passed. Full local suite was interrupted by environment restrictions and automatic review of an existing Twilio test; CI remains the full-suite gate.