### PR TITLE
Unify inbox rows, message cards and reading actions

### DIFF
--- a/inbox/conversation.go
+++ b/inbox/conversation.go
@@ -127,9 +127,11 @@ func conversationPane(accountID string, t *thread.Thread, msgs []thread.Message,
 			app.Link("Search the whole conversation", "/recall") + `</p>`)
 	}
 
+	b.WriteString(`<div class="card-list">`)
 	for _, m := range msgs {
 		b.WriteString(messageBlock(accountID, t, m, subject))
 	}
+	b.WriteString(`</div>`)
 
 	// The two things you can do with a conversation, on one line.
 	//
@@ -444,7 +446,7 @@ func messageBlock(accountID string, t *thread.Thread, m thread.Message, subject 
 		if m.Workflow != "" {
 			ran = runTools(m.Workflow)
 		}
-		return `<div class="ib-msg ib-agent">` + fromLine(messageAgentName(accountID, t, m), m.At) +
+		return `<div class="ib-msg card ib-agent">` + fromLine(messageAgentName(accountID, t, m), m.At) +
 			`<div class="ib-body">` + app.RenderString(m.Text) + `</div>` + ran + `</div>`
 	}
 	// The author, by the name the conversation knows them under rather than the
@@ -481,7 +483,7 @@ func messageBlock(accountID string, t *thread.Thread, m thread.Message, subject 
 		rendered = mail.Rendered(&mail.Message{Body: m.Text, FromID: m.From})
 	}
 	if rendered != "" {
-		return `<div class="ib-msg ib-person">` + fromLine(who, m.At) + addressLine(m) +
+		return `<div class="ib-msg card ib-person">` + fromLine(who, m.At) + addressLine(m) +
 			`<div class="ib-body">` + rendered + `</div></div>`
 	}
 	// What they wrote, and — folded away — the part of it that is this
@@ -491,7 +493,7 @@ func messageBlock(accountID string, t *thread.Thread, m thread.Message, subject 
 	// renderer above and come out with working links, and what a person wrote
 	// came out as text — so the same URL in the same conversation was clickable
 	// on one line and not on the next. See app.Linkify for the ordering.
-	return `<div class="ib-msg ib-person">` + fromLine(who, m.At) + addressLine(m) +
+	return `<div class="ib-msg card ib-person">` + fromLine(who, m.At) + addressLine(m) +
 		`<div class="ib-body ib-typed">` + app.Linkify(html.EscapeString(body)) + `</div>` +
 		quotedBlock(quote) + `</div>`
 }

--- a/inbox/kinds.go
+++ b/inbox/kinds.go
@@ -118,28 +118,25 @@ func noteRow(n *notes.Entry) string {
 	text := strings.TrimSpace(n.Text)
 	return `<div class="ib-item">` +
 		`<a class="ib-row" href="/inbox?kind=note&amp;id=` + url.QueryEscape(n.ID) + `">` +
-		`<span class="ib-meta"><span class="ib-who">Note</span>` +
-		`<span class="ib-tags">` + html.EscapeString(app.TimeAgo(n.UpdatedAt)) + `</span></span>` +
+		rowMeta("", "Note", nil, n.UpdatedAt) +
 		`<span class="ib-subject">` + html.EscapeString(trimTo(n.Title, 90)) + `</span>` +
 		`<span class="ib-snip">` + html.EscapeString(trimTo(text, 110)) + `</span></a></div>`
 }
 
 // taskRow is a task, in the same row.
 //
-// The status is a tag rather than a pill: it is a fact about the task, like the
-// channel on a conversation, and a pill in a list reads as something to press.
+// The bordered type label identifies the task; status and assignee are context.
 // What is done says so and stays on the list — a list that quietly drops
 // finished work cannot be used to check what was done.
 func taskRow(t *tasks.Task) string {
-	tags := []string{html.EscapeString(t.Status)}
+	tags := []string{t.Status}
 	if t.Assignee == tasks.Agent {
 		name := agentLabel(t.Owner, t.Agent)
 		if name == "" {
 			name = defaultAgentName()
 		}
-		tags = append(tags, html.EscapeString(name))
+		tags = append(tags, name)
 	}
-	tags = append(tags, html.EscapeString(app.TimeAgo(t.Updated)))
 
 	// The result when there is one, because a finished task's answer is the
 	// thing worth previewing; the detail is what you asked for and you know it.
@@ -154,8 +151,7 @@ func taskRow(t *tasks.Task) string {
 	}
 	return `<div class="ib-item">` +
 		`<a class="` + cls + `" href="/inbox?kind=task&amp;id=` + url.QueryEscape(t.ID) + `">` +
-		`<span class="ib-meta"><span class="ib-who">Task</span>` +
-		`<span class="ib-tags">` + strings.Join(tags, `<span class="ib-dot">·</span>`) + `</span></span>` +
+		rowMeta("", "Task", tags, t.Updated) +
 		`<span class="ib-subject">` + html.EscapeString(trimTo(t.Title, 90)) + `</span>` +
 		`<span class="ib-snip">` + html.EscapeString(trimTo(snippet, 110)) + `</span></a></div>`
 }

--- a/inbox/page.go
+++ b/inbox/page.go
@@ -27,6 +27,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"mu/internal/app"
 	"mu/internal/auth"
@@ -314,41 +315,10 @@ func rowWith(r *http.Request, accountID string, t thread.Thread, preview string)
 		snippet = trimTo(text, 110)
 	}
 
-	// Who, where from, and when — on their own line above the subject.
-	//
-	// These have been three arrangements and each broke for the same reason:
-	// they were competing with the subject for one line. Beside it they pushed
-	// the subject off; in a fixed column they left a ragged gap on every row
-	// that had one label instead of two; as pills they were two boxes of
-	// chrome in the middle of a sentence. On a phone there was never room for
-	// any of it.
-	//
-	// A row is three lines now, which is what a mail client on a phone has
-	// always been: who it is from and when, then what it is about, then the
-	// first of what it says. Nothing competes, because nothing shares a line.
-	//
-	// Plain text separated by middots rather than pills. A pill is for a thing
-	// you can act on; the channel a message arrived by is a fact about it, and
-	// two facts in boxes read as two buttons.
-	// Who on the left, everything qualifying it on the right.
-	//
-	// All four ran together on the left for a commit, which put the date — the
-	// one thing on this row somebody scans a column of — at the end of a
-	// sentence whose length depends on how long the sender's name is, so it
-	// landed in a different place on every row. A date column is read down; it
-	// cannot be read down when it moves.
-	//
-	// The split is by kind. Who wrote is what the row is about; the channel, the
-	// agent whose box it is and how long ago are all facts *about* that, and
-	// they belong together at the end where the eye finishes.
 	var tags []string
-	if c := app.ClientName(t.Client); c != "" {
-		tags = append(tags, html.EscapeString(c))
-	}
 	if name := agentLabel(accountID, t.Agent); name != "" {
-		tags = append(tags, html.EscapeString(trimTo(name, labelChars)))
+		tags = append(tags, trimTo(name, labelChars))
 	}
-	tags = append(tags, html.EscapeString(app.TimeAgo(t.Updated)))
 
 	// Unread, which is what makes this a mailbox rather than a log. Without it
 	// every row looks the same and the page has to be read top to bottom every
@@ -367,14 +337,31 @@ func rowWith(r *http.Request, accountID string, t thread.Thread, preview string)
 	//
 	// Beside the link rather than inside it: a form cannot live in an <a>, and
 	// nesting a submit inside a navigation target means a click has two
-	// meanings. So the row is a flex pair — the link, which fills it, and this.
+	// meanings. The row reserves an action column even when there is no form.
 	return `<div class="ib-item">` +
 		`<a class="` + cls + `" href="/inbox?id=` + url.QueryEscape(t.ID) + `"` + titleAttr(full) + `>` +
-		`<span class="ib-meta"><span class="ib-who">` + html.EscapeString(who) + `</span>` +
-		`<span class="ib-tags">` + strings.Join(tags, `<span class="ib-dot">·</span>`) + `</span></span>` +
+		rowMeta(who, app.ClientName(t.Client), tags, t.Updated) +
 		`<span class="ib-subject">` + html.EscapeString(trimTo(subject, 90)) + `</span>` +
 		`<span class="ib-snip">` + html.EscapeString(snippet) + `</span></a>` +
 		rowDelete(r, t.ID) + `</div>`
+}
+
+// rowMeta gives every inbox kind the same label and date positions. The
+// context can wrap on narrow screens; the date keeps its own column.
+func rowMeta(who, kind string, tags []string, at time.Time) string {
+	context := ""
+	if who != "" {
+		context = `<span class="ib-who">` + html.EscapeString(who) + `</span>`
+	}
+	if kind != "" {
+		context += app.Pill(kind)
+	}
+	if len(tags) > 0 {
+		context += `<span class="ib-tags">` + html.EscapeString(strings.Join(tags, " · ")) + `</span>`
+	}
+	return `<span class="ib-meta"><span class="ib-context">` + context +
+		`</span><time class="ib-when" datetime="` + at.Format(time.RFC3339) + `">` +
+		html.EscapeString(app.TimeAgo(at)) + `</time></span>`
 }
 
 // rowDelete is the cross at the end of a row.

--- a/internal/app/html/mu.css
+++ b/internal/app/html/mu.css
@@ -140,12 +140,12 @@ html, body {
   box-sizing: inherit;
 }
 
-/* Links share one bold, un-underlined treatment. */
+/* Links default to bold; action components set their own font weight. */
 a {
   color: #000;
   text-decoration: none !important;
   font-size: 0.9em;
-  font-weight: bold !important;
+  font-weight: bold;
   transition: opacity var(--transition-fast);
 }
 
@@ -1863,7 +1863,7 @@ body:has(#messages) #chat-back-link {
   display: inline-block;
   color: var(--accent-color) !important;
   font-size: 10px !important;
-  font-weight: bold !important;
+  font-weight: bold;
   text-transform: uppercase;
   letter-spacing: 0.04em;
   background: transparent;
@@ -1881,7 +1881,7 @@ body:has(#messages) #chat-back-link {
   display: inline-block;
   color: var(--text-primary, #1a1a1a) !important;
   font-size: 10px !important;
-  font-weight: bold !important;
+  font-weight: bold;
   text-transform: uppercase;
   letter-spacing: 0.04em;
   margin-right: 8px;
@@ -2630,7 +2630,7 @@ a.highlight {
   display: inline-block;
   color: var(--text-secondary) !important;
   font-size: 10px !important;
-  font-weight: bold !important;
+  font-weight: bold;
   text-transform: uppercase;
   letter-spacing: 0.05em;
   background: transparent;
@@ -3383,6 +3383,7 @@ a.highlight {
 }
 
 .mini-btn {
+  font-weight: var(--font-weight-normal, 400);
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -5342,7 +5343,7 @@ a.card-hover:hover {
   display: inline-block;
   color: var(--accent-color) !important;
   font-size: 10px !important;
-  font-weight: bold !important;
+  font-weight: bold;
   text-transform: uppercase;
   letter-spacing: 0.04em;
   background: transparent;
@@ -6338,17 +6339,10 @@ button.pill:hover {
   color: var(--text-muted, #888);
 }
 
-/* A rule between messages, not a quote bar beside them.
-   Each message carried a 2px left border and 16px of margin, which reads as a
-   blockquote — the mark for "somebody else said this" — on every message in
-   the thread including your own. A thread is a stack of messages and what
-   separates them is a line across, the way every mail client draws it: the
-   eye needs to know where one ends, not that all of them are quotations. */
-.ib-msg { padding: 16px 0; border-bottom: var(--border-width, 1px) solid var(--card-border, #e8e8e8) }
-.ib-msg:first-child { padding-top: 0 }
-.ib-msg:last-child { border-bottom: none; padding-bottom: 0 }
-.ib-from { display: flex; align-items: baseline; gap: 10px; margin-bottom: 6px }
-.ib-who-l { font-size: 13px; font-weight: var(--font-weight-medium, 500); color: var(--text-primary, #1a1a1a) }
+/* Messages use the shared card and card-list components. The sender is the
+   visual anchor of each card; dates stay secondary. */
+.ib-from { display: flex; align-items: baseline; gap: 8px; margin-bottom: 8px }
+.ib-who-l { font-size: 14px; font-weight: var(--font-weight-bold, 700); color: var(--text-primary, #1a1a1a); min-width: 0; overflow-wrap: anywhere }
 .ib-at { margin-left: auto; flex: none; font-size: 11px; color: var(--text-muted, #888); white-space: nowrap }
 .ib-body { font-size: 14px; line-height: var(--line-height, 1.6) }
 .ib-body p:first-child { margin-top: 0 }
@@ -6381,9 +6375,7 @@ button.pill:hover {
 .ib-quoted > summary::-webkit-details-marker { display: none }
 .ib-quoted > summary:hover { border-color: #bbb }
 
-/* The quote itself reads as a quote: indented behind a rule, muted, and in the
-   whitespace it arrived with. This is the one place .ib-msg's own rule about
-   not drawing quote bars does not apply — here it is genuinely a quotation. */
+/* Quoted content keeps its indentation inside the message card. */
 .ib-quoted-text {
   margin-top: 10px;
   padding-left: 12px;

--- a/internal/app/html/mu.css
+++ b/internal/app/html/mu.css
@@ -6140,8 +6140,10 @@ button.pill:hover {
    The bleed is padding plus a matching negative margin, so the highlight
    reaches past the text without moving anything. */
 .ib-item {
-  display: flex;
-  align-items: flex-start;
+  display: grid;
+  /* Reserve the same action column for mail, notes, tasks and chats. */
+  grid-template-columns: minmax(0, 1fr) var(--control-h-sm);
+  align-items: start;
   gap: 8px;
   padding: 0 10px;
   margin: 0 -10px;
@@ -6224,11 +6226,9 @@ button.pill:hover {
 /* No pointer to hover with, so the cross is simply there. */
 @media (hover: none) { .ib-del-go { opacity: 1 } }
 
-/* The cross sits on the first line of the row at every width, which is what
-   flex-start on .ib-item gives it — the baseline alignment it used to have was
-   right for a one-line row and drifted down the card once the row had three.
-   The nudge keeps it on the sender's line rather than above it. */
-.ib-del { padding-top: 12px }
+/* Align the delete control with the metadata line in its reserved column. */
+.ib-del { padding-top: 11px; min-height: var(--control-h-sm); }
+.ib-del-go { min-height: var(--control-h-sm); }
 /* Unread marks the two lines that say what the message is. Not the snippet:
    it is the body, and a bold body is a row shouting. */
 .ib-row.unseen .ib-meta,
@@ -6258,52 +6258,42 @@ button.pill:hover {
   flex: 1;
 }
 
-/* Who, where from, and when. Small and muted, because it is how you decide
-   whether to read the two lines under it rather than something to read. */
-/* Who wrote, and everything qualifying it, on one line at opposite ends.
-
-   All four ran together on the left for a commit, which put the date — the one
-   thing on this row somebody scans a column of — at the end of a sentence whose
-   length depends on the sender's name, so it landed somewhere different on
-   every row. A date column is read down and cannot be when it moves.
-
-   No wrap. The whole row is three fixed lines and a fourth appearing when a
-   name is long would make the list uneven; the sender truncates instead, and
-   the tags are short by construction. */
+/* Context may wrap, but the date stays aligned independently of labels,
+   sender length and the presence of a delete control. */
 .ib-meta {
-  display: flex;
-  align-items: baseline;
-  gap: 0 10px;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) max-content;
+  align-items: start;
+  gap: 8px;
   font-size: 12px;
   font-weight: var(--font-weight-medium, 500);
   color: var(--text-secondary, #555);
   min-width: 0;
 }
-
-/* Who. Takes the slack and truncates, because it is the one part of this line
-   whose length is somebody else's to decide. */
-.ib-who {
+.ib-context {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 4px 8px;
   min-width: 0;
+}
+.ib-who, .ib-tags {
+  min-width: 0;
+  max-width: 100%;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
-
-/* The channel, the box and how long ago, at the end where the eye finishes.
-   margin-left:auto rather than justify-content on the parent, so it holds when
-   the sender is missing and .ib-who renders empty. */
-.ib-tags {
-  display: flex;
-  align-items: baseline;
-  gap: 0 6px;
-  margin-left: auto;
-  flex: none;
+.ib-tags, .ib-when {
   color: var(--text-muted, #888);
   font-weight: var(--font-weight-normal, 400);
+}
+.ib-when {
+  display: inline-flex;
+  align-items: center;
+  min-height: var(--control-h-sm);
   white-space: nowrap;
 }
-
-.ib-dot { color: var(--text-faint, #ccc); font-weight: var(--font-weight-normal, 400) }
 
 /* An explicit weight, because the row is a link and `a` is bold app-wide.
    Anything inside a link that does not declare a weight inherits that, so the

--- a/internal/app/testdata/layout.cjs
+++ b/internal/app/testdata/layout.cjs
@@ -58,6 +58,7 @@ const {chromium}=require(process.env.MU_PLAYWRIGHT_MODULE||'playwright');
     await more.locator('summary').click();
     assert(await more.getByRole('button',{name:'Save',exact:true}).isVisible(),'saved-video controls are missing');
     assert(await more.getByRole('link',{name:'Discuss',exact:true}).isVisible());
+    assert(await more.getByRole('link',{name:'Discuss',exact:true}).evaluate(e=>getComputedStyle(e).fontWeight==='400'),'Discuss still inherits bold link weight');
     assert(await more.getByRole('link',{name:'Discuss',exact:true}).evaluate(e=>getComputedStyle(e).color!==getComputedStyle(e).backgroundColor),'More control text is unreadable');
     await more.locator('summary').click();
     assert(await page.locator('#playBtn').isHidden());
@@ -78,6 +79,21 @@ const {chromium}=require(process.env.MU_PLAYWRIGHT_MODULE||'playwright');
     await page.locator('#captcha').fill(String(numbers[0]+numbers[1]));
     assert(await page.locator('#signup').evaluate(e=>e.checkValidity()),'signup cannot submit valid fields');
     assert(await page.locator('#signup button').isVisible(),'signup button is hidden');
+   }
+   if(path==='/news?id=layout-news') {
+    for(const name of ['Read Original','Discuss']) {
+     const link=page.getByRole('link',{name,exact:true});
+     assert(await link.isVisible(),`missing ${name} action`);
+     assert(await link.evaluate(e=>getComputedStyle(e).fontWeight==='400'),`${name} still bold`);
+    }
+   }
+   if(path.startsWith('/inbox?id=')) {
+    const cards=page.locator('.ib-msg');
+    assert(await cards.count()===3,'conversation fixture is incomplete');
+    await cards.first().locator('.ib-who-l').evaluate(e=>e.textContent='a-long-sender-address-that-must-wrap-without-hiding-the-date@example.com');
+    const metrics=await cards.evaluateAll(es=>es.map(e=>{const r=e.getBoundingClientRect(),s=getComputedStyle(e);return {top:r.top,bottom:r.bottom,width:r.width,scroll:e.scrollWidth,client:e.clientWidth,border:s.borderTopStyle,weight:getComputedStyle(e.querySelector('.ib-who-l')).fontWeight};}));
+    assert(metrics.every(m=>m.border!=='none'&&Number(m.weight)>=700&&m.scroll<=m.client+1),`message card/sender regression at ${width}: ${JSON.stringify(metrics)}`);
+    for(let i=1;i<metrics.length;i++)assert(metrics[i].top-metrics[i-1].bottom>=8,'message cards run together');
    }
    if(path==='/inbox') {
     const rows=page.locator('.ib-item');

--- a/internal/app/testdata/layout.cjs
+++ b/internal/app/testdata/layout.cjs
@@ -79,6 +79,22 @@ const {chromium}=require(process.env.MU_PLAYWRIGHT_MODULE||'playwright');
     assert(await page.locator('#signup').evaluate(e=>e.checkValidity()),'signup cannot submit valid fields');
     assert(await page.locator('#signup button').isVisible(),'signup button is hidden');
    }
+   if(path==='/inbox') {
+    const rows=page.locator('.ib-item');
+    assert(await rows.count()>=5,'mixed inbox fixture is incomplete');
+    const labels=await rows.locator('.ib-meta .pill').allTextContents();
+    for(const kind of ['Mail','Chat','Note','Task','WhatsApp'])assert(labels.includes(kind),`missing bordered ${kind} label`);
+    await rows.first().locator('.ib-who').evaluate(e=>e.textContent='A very long sender name that needs room on a narrow phone');
+    await rows.last().locator('.ib-when').evaluate(e=>e.textContent='3 weeks ago');
+    const positions=await rows.evaluateAll(rows=>rows.map(row=>{
+     const date=row.querySelector('.ib-when').getBoundingClientRect(),meta=row.querySelector('.ib-meta').getBoundingClientRect(),badge=row.querySelector('.pill');
+     return {date:date.right,top:date.top-meta.top,border:getComputedStyle(badge).borderTopStyle,delete:!!row.querySelector('.ib-del')};
+    }));
+    assert(positions.some(r=>r.delete)&&positions.some(r=>!r.delete),'must check rows with and without delete');
+    assert(Math.max(...positions.map(r=>r.date))-Math.min(...positions.map(r=>r.date))<1,`inbox dates misaligned at ${width}: ${JSON.stringify(positions)}`);
+    assert(positions.every(r=>Math.abs(r.top)<1&&r.border!=='none'),'inbox dates moved or labels lost their border');
+    assert(await rows.evaluateAll(rows=>rows.every(r=>r.scrollWidth<=r.clientWidth+1)),`inbox rows overflow at ${width}`);
+   }
    if(path==='/sms') {
     assert(await page.locator('.sms-conversation').count()===2,'SMS and WhatsApp merged in list');
     assert(await page.locator('input[name=text]').count()===0,'reply boxes leaked onto list');

--- a/service/news/headlines_test.go
+++ b/service/news/headlines_test.go
@@ -36,6 +36,12 @@ func TestHeadlinesReturnsOneStoryPerTopic(t *testing.T) {
 	}
 	// The response and rendered card select the same stories, in the same order.
 	html := generateHeadlinesHTML(cardPosts(GetFeed()))
+	if strings.Contains(html, ">Read</a>") {
+		t.Fatal("headlines duplicate their title links with Read actions")
+	}
+	if strings.Count(html, `href="/news?id=`) != len(rsp.Items) {
+		t.Fatal("each headline should retain one clickable article title")
+	}
 	last := -1
 	for _, h := range rsp.Items {
 		pos := strings.Index(html, h.Title)

--- a/service/news/news.go
+++ b/service/news/news.go
@@ -1234,12 +1234,6 @@ func generateHeadlinesHTML(headlines []*Post) string {
 		}
 		summary := getSummary(h)
 
-		// Add Read Summary link on the right side of source
-		summaryLink := ""
-		if h.ID != "" {
-			summaryLink = fmt.Sprintf(` · <a href="/news?id=%s">Read</a>`, h.ID)
-		}
-
 		fmt.Fprintf(&sb, `
 			<div class="headline">
 			   %s
@@ -1247,8 +1241,8 @@ func generateHeadlinesHTML(headlines []*Post) string {
 			   <span class="title">%s</span>
 			  </a>
 			 <span class="description">%s</span>
-			 <div class="summary">%s%s</div>
-			`, categoryBadge, link, h.Title, h.Description, summary, summaryLink)
+			 <div class="summary">%s</div>
+			`, categoryBadge, link, h.Title, h.Description, summary)
 		sb.WriteString(`</div>`)
 	}
 

--- a/test/layout_browser_test.go
+++ b/test/layout_browser_test.go
@@ -96,16 +96,25 @@ func TestPageCompositionInBrowser(t *testing.T) {
 		t.Fatal(err)
 	}
 	recordnotes.Add(who, "A note in the inbox", "Remember to book the appointment")
+	if err := data.IndexSync("layout-news", data.KindNews, "A news article", "Article text", map[string]any{"url": "https://example.com/article", "description": "A short article", "posted_at": time.Now()}); err != nil {
+		t.Fatal(err)
+	}
+	inboxThread := ""
 	for _, client := range []string{"mail", "chat", "whatsapp"} {
 		th := thread.Open(who, client, "a-long-sender-name-for-mobile@example.com")
 		if th == nil {
 			t.Fatal("could not create inbox fixture")
 		}
-		thread.Add(thread.Message{Thread: th.ID, Account: who, Text: "An inbox conversation on " + client})
+		thread.Add(thread.Message{Thread: th.ID, Account: who, From: "sender@example.com", Text: "An inbox conversation on " + client})
+		if client == "mail" {
+			inboxThread = th.ID
+			thread.Add(thread.Message{Thread: th.ID, Account: who, Role: thread.RoleAgent, From: "Micro", Text: "I found the details. Here is the summary."})
+			thread.Add(thread.Message{Thread: th.ID, Account: who, From: who, Text: "Thanks, please follow up tomorrow."})
+		}
 	}
 	pages := map[string]string{}
 	policies := map[string]string{}
-	for path, handler := range map[string]http.HandlerFunc{"/inbox": inbox.Handler, "/archive": archive.Handler, "/blog": blog.Handler, "/bookmarks": bookmarks.Handler, "/browser": browser.Handler, "/contacts": contacts.Handler, "/flights": flights.Handler, "/food": food.Handler, "/hazards": hazards.Handler, "/images": images.Handler, "/mail": mail.Handler, "/maps": maps.Handler, "/notify": notify.Handler, "/places": places.Handler, "/prayer": prayer.Handler, "/recall": recall.Handler, "/routes": routes.Handler, "/shell": shell.Handler, "/sms": sms.Handler, "/sms?view=new": sms.Handler, "/sms?id=" + smsThread.ID: sms.Handler, "/social": social.Handler, "/stream": stream.Handler, "/text": text.Handler, "/transit": transit.Handler, "/users": users.Handler, "/wallet": account.Wallet, "/notes": notes.Handler, "/news": news.Handler, "/web": web.Handler, "/weather": weather.PageHandler, "/markets": markets.Handler, "/video": video.Handler, "/video?id=layout-video&autoplay=1": video.Handler, "/signup": account.Signup, "/agent/new": agent.NewAgentHandler, "/agents": agent.RosterHandler, "/token": account.TokenHandler, "/apps/new": apps.Handler, "/apps/layout-app/edit": apps.Handler, "/apps": apps.Handler, "/events": events.Handler, "/files": files.Handler, "/docs": docs.Handler, "/": home.Index, "/home": home.Handler, "/tasks": tasks.Handler, "/chat": chat.Handler, "/agent/micro": agent.Handler} {
+	for path, handler := range map[string]http.HandlerFunc{"/inbox": inbox.Handler, "/inbox?id=" + inboxThread: inbox.Handler, "/archive": archive.Handler, "/blog": blog.Handler, "/bookmarks": bookmarks.Handler, "/browser": browser.Handler, "/contacts": contacts.Handler, "/flights": flights.Handler, "/food": food.Handler, "/hazards": hazards.Handler, "/images": images.Handler, "/mail": mail.Handler, "/maps": maps.Handler, "/notify": notify.Handler, "/places": places.Handler, "/prayer": prayer.Handler, "/recall": recall.Handler, "/routes": routes.Handler, "/shell": shell.Handler, "/sms": sms.Handler, "/sms?view=new": sms.Handler, "/sms?id=" + smsThread.ID: sms.Handler, "/social": social.Handler, "/stream": stream.Handler, "/text": text.Handler, "/transit": transit.Handler, "/users": users.Handler, "/wallet": account.Wallet, "/notes": notes.Handler, "/news": news.Handler, "/news?id=layout-news": news.Handler, "/web": web.Handler, "/weather": weather.PageHandler, "/markets": markets.Handler, "/video": video.Handler, "/video?id=layout-video&autoplay=1": video.Handler, "/signup": account.Signup, "/agent/new": agent.NewAgentHandler, "/agents": agent.RosterHandler, "/token": account.TokenHandler, "/apps/new": apps.Handler, "/apps/layout-app/edit": apps.Handler, "/apps": apps.Handler, "/events": events.Handler, "/files": files.Handler, "/docs": docs.Handler, "/": home.Index, "/home": home.Handler, "/tasks": tasks.Handler, "/chat": chat.Handler, "/agent/micro": agent.Handler} {
 		t.Log("render", path)
 		req := httptest.NewRequest("GET", path, nil)
 		if path != "/" {

--- a/test/layout_browser_test.go
+++ b/test/layout_browser_test.go
@@ -6,9 +6,12 @@ import (
 	"mu/account"
 	"mu/agent"
 	"mu/home"
+	"mu/inbox"
 	"mu/internal/auth"
 	"mu/internal/data"
+	recordnotes "mu/internal/notes"
 	"mu/internal/service"
+	"mu/internal/thread"
 	"mu/service/apps"
 	"mu/service/archive"
 	"mu/service/blog"
@@ -92,9 +95,17 @@ func TestPageCompositionInBrowser(t *testing.T) {
 	if err := data.IndexSync("video_layout-video", data.KindVideo, "A layout video", "Video description", map[string]any{"channel": "Publisher"}); err != nil {
 		t.Fatal(err)
 	}
+	recordnotes.Add(who, "A note in the inbox", "Remember to book the appointment")
+	for _, client := range []string{"mail", "chat", "whatsapp"} {
+		th := thread.Open(who, client, "a-long-sender-name-for-mobile@example.com")
+		if th == nil {
+			t.Fatal("could not create inbox fixture")
+		}
+		thread.Add(thread.Message{Thread: th.ID, Account: who, Text: "An inbox conversation on " + client})
+	}
 	pages := map[string]string{}
 	policies := map[string]string{}
-	for path, handler := range map[string]http.HandlerFunc{"/archive": archive.Handler, "/blog": blog.Handler, "/bookmarks": bookmarks.Handler, "/browser": browser.Handler, "/contacts": contacts.Handler, "/flights": flights.Handler, "/food": food.Handler, "/hazards": hazards.Handler, "/images": images.Handler, "/mail": mail.Handler, "/maps": maps.Handler, "/notify": notify.Handler, "/places": places.Handler, "/prayer": prayer.Handler, "/recall": recall.Handler, "/routes": routes.Handler, "/shell": shell.Handler, "/sms": sms.Handler, "/sms?view=new": sms.Handler, "/sms?id=" + smsThread.ID: sms.Handler, "/social": social.Handler, "/stream": stream.Handler, "/text": text.Handler, "/transit": transit.Handler, "/users": users.Handler, "/wallet": account.Wallet, "/notes": notes.Handler, "/news": news.Handler, "/web": web.Handler, "/weather": weather.PageHandler, "/markets": markets.Handler, "/video": video.Handler, "/video?id=layout-video&autoplay=1": video.Handler, "/signup": account.Signup, "/agent/new": agent.NewAgentHandler, "/agents": agent.RosterHandler, "/token": account.TokenHandler, "/apps/new": apps.Handler, "/apps/layout-app/edit": apps.Handler, "/apps": apps.Handler, "/events": events.Handler, "/files": files.Handler, "/docs": docs.Handler, "/": home.Index, "/home": home.Handler, "/tasks": tasks.Handler, "/chat": chat.Handler, "/agent/micro": agent.Handler} {
+	for path, handler := range map[string]http.HandlerFunc{"/inbox": inbox.Handler, "/archive": archive.Handler, "/blog": blog.Handler, "/bookmarks": bookmarks.Handler, "/browser": browser.Handler, "/contacts": contacts.Handler, "/flights": flights.Handler, "/food": food.Handler, "/hazards": hazards.Handler, "/images": images.Handler, "/mail": mail.Handler, "/maps": maps.Handler, "/notify": notify.Handler, "/places": places.Handler, "/prayer": prayer.Handler, "/recall": recall.Handler, "/routes": routes.Handler, "/shell": shell.Handler, "/sms": sms.Handler, "/sms?view=new": sms.Handler, "/sms?id=" + smsThread.ID: sms.Handler, "/social": social.Handler, "/stream": stream.Handler, "/text": text.Handler, "/transit": transit.Handler, "/users": users.Handler, "/wallet": account.Wallet, "/notes": notes.Handler, "/news": news.Handler, "/web": web.Handler, "/weather": weather.PageHandler, "/markets": markets.Handler, "/video": video.Handler, "/video?id=layout-video&autoplay=1": video.Handler, "/signup": account.Signup, "/agent/new": agent.NewAgentHandler, "/agents": agent.RosterHandler, "/token": account.TokenHandler, "/apps/new": apps.Handler, "/apps/layout-app/edit": apps.Handler, "/apps": apps.Handler, "/events": events.Handler, "/files": files.Handler, "/docs": docs.Handler, "/": home.Index, "/home": home.Handler, "/tasks": tasks.Handler, "/chat": chat.Handler, "/agent/micro": agent.Handler} {
 		t.Log("render", path)
 		req := httptest.NewRequest("GET", path, nil)
 		if path != "/" {


### PR DESCRIPTION
Inbox dates shifted because delete forms consumed space on some rows, and plain type labels made the mixed list harder to scan. Inside threads, light sender text and bottom borders made messages difficult to separate. Reading actions also inherited a forced bold link style.

Reserve an action column on every inbox row, give dates their own column, and use the shared bordered Pill for type labels. Wrap messages in the shared card/card-list components with stronger sender names. Mail/DMARC rendering and task detail rendering continue to use the existing service renderers.

Let components override the default link weight and give small actions an explicit normal weight, including Discuss and Read Original. Remove redundant Read links from the headlines card while preserving clickable titles.

Validation: inbox, app and news package tests pass, including shared DMARC rendering and headline link checks. Offline Chromium checks pass at 320, 390, 768, 1024 and 1440px with both desktop sidebar states: mixed-row dates align, type labels have borders, long sender text fits, messages have separate cards, and Discuss/Read Original compute to normal weight. Mobile/desktop screenshots reviewed.