### PR TITLE
Use shared spacing between blog search and posts

### DIFF
--- a/service/blog/blog.go
+++ b/service/blog/blog.go
@@ -964,7 +964,7 @@ func handleGetBlog(w http.ResponseWriter, r *http.Request) {
 			</div>`
 		}
 		actions += `<form method="GET" action="/blog" class="search-bar"><input type="search" name="q" class="grow" placeholder="Search posts" aria-label="Search posts" value="` + stdhtml.EscapeString(query) + `"><button type="submit">Search</button></form>`
-		content = fmt.Sprintf(`<div id="blog">
+		content = fmt.Sprintf(`<div id="blog" class="page-stack">
 			%s
 			<div id="posts-list">
 				%s


### PR DESCRIPTION
The blog search touches the post list because only the controls were inside a page stack. Put the surrounding blog list view in the shared `page-stack` so it owns the standard responsive gap between controls and posts.

Uses the existing layout component without page-specific CSS. Verified the blog with the browser layout suite across mobile, tablet and desktop widths, with the desktop sidebar open and closed.