### PR TITLE
Match inbox conversations to their services and preserve note line breaks

### DIFF
--- a/home/about.go
+++ b/home/about.go
@@ -16,7 +16,7 @@ import (
 func AboutHandler(w http.ResponseWriter, r *http.Request) {
 	var b strings.Builder
 	b.WriteString(app.Column())
-	b.WriteString(`<div class="card"><h3>What Micro is</h3>` +
+	b.WriteString(`<div class="card">` +
 		`<p>Micro is a personal assistant. You write to it the way you would write to a ` +
 		`person — from the web, by email, by text, on WhatsApp, or from a program — and it ` +
 		`answers, remembers, and does things on your behalf. It reads your mail, searches ` +
@@ -27,7 +27,6 @@ func AboutHandler(w http.ResponseWriter, r *http.Request) {
 		`archive, inbox and agent system that make those capabilities available. You can ` +
 		`run Mu yourself and Micro remains the default agent and front door.</p>` +
 		`</div>`)
-	b.WriteString(`<div class="page-action"><a class="btn" href="/signup">Sign up</a> · <a href="https://github.com/micro/mu">Source</a></div>`)
 
 	b.WriteString(app.Close())
 

--- a/home/contact.go
+++ b/home/contact.go
@@ -105,9 +105,7 @@ func contactBody(acc *auth.Account) string {
 	// under a collapsed rail. Four pages a stranger reads in one sitting, at
 	// three different widths and two different left edges. See app.Column.
 	b.WriteString(app.Column())
-	b.WriteString(`<div class="card"><h3>How to reach Micro</h3>`)
-	b.WriteString(`<p class="ccap">The same assistant, the same memory, whichever way you write. ` +
-		`A conversation you start by text is one you can carry on here.</p>`)
+	b.WriteString(`<div class="card">`)
 	b.WriteString(`<div class="clist">`)
 	// The ways a person writes to it, and not the ways a program calls it.
 	//
@@ -145,32 +143,10 @@ func contactBody(acc *auth.Account) string {
 	// number and no mail domain the card would be a name and a URL, which is a
 	// bookmark, and the button would be a promise of more than it does.
 	if client.Savable() {
-		b.WriteString(`<p class="mt-4">` + app.ActionLink("/contact.vcf", "Add to contacts") +
-			`</p><p class="ccap">Saves ` + html.EscapeString(agent.DefaultName()) +
-			` to your phone with every number and address on it.</p>`)
+		b.WriteString(`<div class="section-actions">` + app.ActionLink("/contact.vcf", "Add to contacts") + `</div>`)
 	}
 
-	// What it needs from you before any of these answer.
-	//
-	// This said texting needs an account and left mail alone, so the Email row
-	// above it — "write to it and it writes back" — was a promise this instance
-	// does not keep for the reader it was written for. A stranger who mails
-	// agent@ is dropped without a reply and without a record: see
-	// service/mail/smtp.go, where AccountForVerifiedEmail returns nothing and
-	// the message is discarded. A stranger who texts the number is filed and
-	// not answered, because service/sms only wakes an agent for a sender the
-	// account knows.
-	//
-	// So the caveat covers every row except the web, which is the one door a
-	// guest really can walk through — the box on the front page answers without
-	// an account, bounded. Naming the exception is what keeps this a fact rather
-	// than a wall: there is something you can try right now, and the rest is
-	// what an account is for.
-	if acc == nil {
-		b.WriteString(`<p class="cnext">These answer once it knows who you are. ` +
-			`The box on the <a href="/">front page</a> works without an account — ` +
-			`for the rest, <a href="/signup">make one</a> and verify your number.</p>`)
-	} else if !numberVerified(acc.ID) {
+	if acc != nil && !numberVerified(acc.ID) {
 		b.WriteString(`<p class="cnext">It will not recognise you by phone until you have ` +
 			`<a href="/sms">verified a number</a> as yours. Mail and the web already know you.</p>`)
 	}
@@ -200,7 +176,6 @@ const contactCSS = `<style>
 a.caddr{color:#0645ad}
 a.caddr:hover{text-decoration:underline}
 .cnote{grid-column:2;font-size:13px;color:#888}
-.ccap{color:#666;font-size:14px;line-height:1.5;margin:0}
 .cnext{margin:16px 0 0;font-size:14px;color:#666}
 @media (max-width:520px){
   .crow{grid-template-columns:1fr}

--- a/home/contact_test.go
+++ b/home/contact_test.go
@@ -20,13 +20,8 @@ import (
 // sign up before they can find out what they would be signing up to.
 func TestTheCardIsReadableWithoutAnAccount(t *testing.T) {
 	body := contactBody(nil)
-	if !strings.Contains(body, "How to reach Micro") {
-		t.Error("the card has no heading")
-	}
-	// And it says what a signed-out reader has to do to use the phone half,
-	// rather than showing a number that will not recognise them.
-	if !strings.Contains(body, `href="/signup"`) {
-		t.Error("signed out, the card does not say that texting needs an account first")
+	if !strings.Contains(body, ">Web<") {
+		t.Error("the public card has no contact options")
 	}
 	// The route table has to agree. A public page listed as gated is a page
 	// nobody outside can read, whatever this function returns.
@@ -57,35 +52,5 @@ func TestTheContactCardIsNotADeveloperPage(t *testing.T) {
 	// that is always there.
 	if !strings.Contains(body, ">Web<") {
 		t.Error("the card lists no way in at all")
-	}
-}
-
-// Signed out, the card says what actually answers.
-//
-// The Email row reads "write to it and it writes back", and for the reader this
-// page exists for — a stranger deciding whether to have an account — that is not
-// true: service/mail drops mail from a sender with no account, and service/sms
-// files a text from an unknown number without waking anything. The caveat used
-// to cover texting only, so the one row it left alone was the one making the
-// strongest promise.
-func TestASignedOutReaderIsToldWhatAnswers(t *testing.T) {
-	body := contactBody(nil)
-	at := strings.Index(body, `class="cnext"`)
-	if at < 0 {
-		t.Fatal("signed out, the card carries no caveat at all")
-	}
-	note := body[at:]
-	// The exception is named, because there is one and it is the whole reason
-	// somebody would stay on the site: the box answers a guest.
-	if !strings.Contains(note, `href="/"`) {
-		t.Error("the caveat does not name the one door a guest can walk through")
-	}
-	if !strings.Contains(note, `href="/signup"`) {
-		t.Error("the caveat does not say what would open the others")
-	}
-	// And it is not about the phone alone any more.
-	if strings.HasPrefix(strings.TrimPrefix(note, `class="cnext">`), "Texting works") {
-		t.Error("the caveat still covers texting only, leaving the mail row's " +
-			"promise standing for somebody with no account")
 	}
 }

--- a/home/pricing.go
+++ b/home/pricing.go
@@ -99,13 +99,6 @@ func PricingHandler(w http.ResponseWriter, r *http.Request) {
 	start += `</div>`
 	b.WriteString(start)
 
-	b.WriteString(`<div class="card"><h3>Running it yourself</h3>` +
-		`<p>Run your own instance with your API keys and pay the providers directly. ` +
-		`Without payments configured, the instance does not charge its users.</p>` +
-		`<p class="text-sm"><a href="/install">How to run it</a> · ` +
-		`<a href="/about">What this is</a> · ` +
-		`<a href="https://github.com/micro/mu">The source</a></p></div>`)
-
 	b.WriteString(dailyLimitsHTML())
 	b.WriteString(app.Close())
 

--- a/inbox/conversation.go
+++ b/inbox/conversation.go
@@ -127,7 +127,16 @@ func conversationPane(accountID string, t *thread.Thread, msgs []thread.Message,
 			app.Link("Search the whole conversation", "/recall") + `</p>`)
 	}
 
-	b.WriteString(`<div class="card-list">`)
+	switch t.Client {
+	case "whatsapp":
+		b.WriteString(`<div class="bubble-list whatsapp-transcript">`)
+	case "sms":
+		b.WriteString(`<div class="message-list sms-transcript">`)
+	case thread.ChatClient:
+		b.WriteString(`<div class="message-list chat-transcript">`)
+	default:
+		b.WriteString(`<div class="card-list">`)
+	}
 	for _, m := range msgs {
 		b.WriteString(messageBlock(accountID, t, m, subject))
 	}
@@ -440,20 +449,22 @@ func messageAgentName(accountID string, t *thread.Thread, m thread.Message) stri
 // through the untrusted renderer, because model output is exactly what that
 // renderer is for.
 func messageBlock(accountID string, t *thread.Thread, m thread.Message, subject string) string {
-	m.Text = withoutSubject(m.Text, subject)
+	if !textConversation(t) {
+		m.Text = withoutSubject(m.Text, subject)
+	}
 	if m.Role == thread.RoleAgent {
 		ran := ""
 		if m.Workflow != "" {
 			ran = runTools(m.Workflow)
 		}
-		return `<div class="ib-msg card ib-agent">` + fromLine(messageAgentName(accountID, t, m), m.At) +
+		return messageOpen(t, m, accountID, "ib-agent") + messageFrom(t, messageAgentName(accountID, t, m), m.At) +
 			`<div class="ib-body">` + app.RenderString(m.Text) + `</div>` + ran + `</div>`
 	}
 	// The author, by the name the conversation knows them under rather than the
 	// address on the message. A thread where three people have written is three
 	// names; one where the display name arrived later says it on every line.
 	who := "You"
-	if m.From != "" {
+	if m.From != "" && m.From != accountID {
 		who = m.From
 		for _, p := range thread.Parties(accountID, t.ID) {
 			if p.Kind == thread.RolePerson && p.Key == m.From && p.Name != "" {
@@ -461,6 +472,10 @@ func messageBlock(accountID string, t *thread.Thread, m thread.Message, subject 
 				break
 			}
 		}
+	}
+	if textConversation(t) {
+		return messageOpen(t, m, accountID, "ib-person") + messageFrom(t, who, m.At) +
+			`<div class="ib-body ib-typed">` + app.Linkify(html.EscapeString(m.Text)) + `</div></div>`
 	}
 	// Mail is rendered by the mail service, not by this page.
 	//
@@ -496,6 +511,35 @@ func messageBlock(accountID string, t *thread.Thread, m thread.Message, subject 
 	return `<div class="ib-msg card ib-person">` + fromLine(who, m.At) + addressLine(m) +
 		`<div class="ib-body ib-typed">` + app.Linkify(html.EscapeString(body)) + `</div>` +
 		quotedBlock(quote) + `</div>`
+}
+
+// Text conversations keep every typed line, without email subject/quote handling.
+func textConversation(t *thread.Thread) bool {
+	return t.Client == thread.ChatClient || onAPhone(t.Client)
+}
+
+func messageOpen(t *thread.Thread, m thread.Message, accountID, role string) string {
+	classes := "ib-msg card " + role
+	if textConversation(t) {
+		classes = "ib-msg message " + role
+	}
+	if t.Client == "whatsapp" {
+		classes = "ib-msg bubble " + role
+		if m.Role != thread.RoleAgent && (m.From == "" || m.From == accountID) {
+			classes += " bubble-outgoing"
+		}
+	}
+	return `<div class="` + classes + `">`
+}
+
+// Chat uses the room's byline and adjacent, updating timestamp.
+func messageFrom(t *thread.Thread, who string, at time.Time) string {
+	if t.Client != thread.ChatClient {
+		return fromLine(who, at)
+	}
+	return `<div class="you"><span class="ib-who-l">` + html.EscapeString(who) +
+		`</span> <span class="msg-when" data-timestamp="` + strconv.FormatInt(at.Unix(), 10) + `">` +
+		html.EscapeString(app.TimeAgo(at)) + `</span></div>`
 }
 
 // quotedBlock is the fold: a control that says there is more and shows it.

--- a/inbox/items.go
+++ b/inbox/items.go
@@ -88,7 +88,7 @@ func itemPage(w http.ResponseWriter, r *http.Request, owner, kind, id string) {
 				`<input type="hidden" name="action" value="save"><textarea name="text" class="record-body" rows="14" maxlength="2000" required aria-label="Note">` + html.EscapeString(note.Text) +
 				`</textarea><div class="form-actions"><button type="submit">Save</button><a class="btn btn-quiet" href="` + html.EscapeString(dest) + `">Cancel</a></div></form>`
 		} else {
-			body += `<div class="markdown-content">` + string(app.Render([]byte(note.Text))) + `</div><div class="form-actions"><a class="btn btn-quiet" href="` + html.EscapeString(dest+"&edit=1") + `">Edit</a>` +
+			body += `<div class="markdown-content">` + string(app.RenderLines([]byte(note.Text))) + `</div><div class="form-actions"><a class="btn btn-quiet" href="` + html.EscapeString(dest+"&edit=1") + `">Edit</a>` +
 				`<form method="POST" action="` + html.EscapeString(dest) + `" onsubmit="return confirm('Delete this note?')">` + app.CSRFField(csrf) +
 				`<input type="hidden" name="action" value="delete"><button class="btn btn-danger" type="submit">Delete</button></form></div>`
 		}

--- a/inbox/kinds.go
+++ b/inbox/kinds.go
@@ -44,6 +44,7 @@ import (
 
 	"mu/internal/app"
 	"mu/internal/notes"
+	"mu/internal/thread"
 	"mu/service/tasks"
 )
 
@@ -83,9 +84,12 @@ type item struct {
 func everything(r *http.Request, accountID, box, only string) []item {
 	var out []item
 
-	if only == "" || only == kindMessage {
+	if only != kindNote && only != kindTask {
 		all := arrivals(accountID)
 		for _, t := range all {
+			if only != "" && only != kindMessage && t.Client != only {
+				continue
+			}
 			// The mailbox narrows conversations only. A note has no agent and no
 			// alias, so a mailbox is not a question that can be asked of it —
 			// and a box filter that silently dropped every note would look like
@@ -163,13 +167,8 @@ func taskRow(t *tasks.Task) string {
 // what sort of thing it is — and a row that mixed the two would let somebody
 // pick a combination that is always empty.
 //
-// Drawn only when there is a second kind to filter to. On an instance where
-// nobody has written a note or made a task, three chips offering to show none of
-// them is furniture that teaches the page is broken.
-func kinds(accountID, current string) string {
-	if len(notes.All(accountID)) == 0 && len(tasks.List(accountID, "")) == 0 {
-		return ""
-	}
+// Keep service names visible even before the first item arrives.
+func kinds(current string) string {
 	var b strings.Builder
 	// "Type", not "Kind". Kind is this repository's own word — data.Vocabulary
 	// calls them kinds and the URL still says kind=, because that vocabulary
@@ -182,7 +181,10 @@ func kinds(accountID, current string) string {
 	b.WriteString(`<div class="ib-boxes ib-kinds"><span class="ib-axis">Type</span>`)
 	for _, k := range []struct{ label, val string }{
 		{"Everything", ""},
-		{"Messages", kindMessage},
+		{"Mail", mailClient},
+		{"Chat", thread.ChatClient},
+		{"SMS", thread.SMSClient},
+		{"WhatsApp", thread.WhatsAppClient},
 		{"Notes", kindNote},
 		{"Tasks", kindTask},
 	} {
@@ -202,6 +204,8 @@ func kinds(accountID, current string) string {
 // typo in a view name should show you the page rather than a refusal.
 func kindOf(v string) string {
 	switch strings.ToLower(strings.TrimSpace(v)) {
+	case mailClient, thread.ChatClient, thread.SMSClient, thread.WhatsAppClient:
+		return strings.ToLower(strings.TrimSpace(v))
 	case kindMessage:
 		return kindMessage
 	case kindNote:

--- a/inbox/kinds_test.go
+++ b/inbox/kinds_test.go
@@ -195,3 +195,21 @@ func TestAReplyIsAlwaysAMessage(t *testing.T) {
 		t.Errorf("a reply with ?kind=note is not forced back to a message:\n%s", body)
 	}
 }
+
+func TestServiceFiltersSelectTheirOwnConversations(t *testing.T) {
+	const who = "servicefilters"
+	for _, client := range []string{"mail", "chat", "sms", "whatsapp"} {
+		said(t, who, client, "sender-"+client, "", "Only the "+client+" thread")
+	}
+	for _, client := range []string{"mail", "chat", "sms", "whatsapp"} {
+		body := inboxOf(t, who, "?kind="+client)
+		for _, other := range []string{"mail", "chat", "sms", "whatsapp"} {
+			if strings.Contains(body, "Only the "+other+" thread") != (client == other) {
+				t.Errorf("%s filter includes wrong conversations: %s", client, body)
+			}
+		}
+	}
+	if got := newKinds(""); !strings.Contains(got, ">Mail</a>") || strings.Contains(got, ">Message</a>") {
+		t.Errorf("compose picker does not call email Mail: %s", got)
+	}
+}

--- a/inbox/mailrender_test.go
+++ b/inbox/mailrender_test.go
@@ -150,3 +150,21 @@ func TestOlderBriefWithoutMailReferenceRendersMarkdown(t *testing.T) {
 		t.Fatal("changed chat formatting")
 	}
 }
+
+func TestTextConversationsKeepTheirWholeMessage(t *testing.T) {
+	for _, client := range []string{thread.ChatClient, "sms", "whatsapp"} {
+		t.Run(client, func(t *testing.T) {
+			const text = "Meet tomorrow\n\n> Bring the paperwork\n<b>literal</b>\nhttps://example.com"
+			th := &thread.Thread{Client: client, Subject: "Meet tomorrow"}
+			got := messageBlock("owner", th, thread.Message{From: "sender", Text: text}, th.Subject)
+			for _, want := range []string{"Meet tomorrow\n\n&gt; Bring", "&lt;b&gt;literal&lt;/b&gt;", `href="https://example.com"`} {
+				if !strings.Contains(got, want) {
+					t.Errorf("text changed: %s", got)
+				}
+			}
+			if strings.Contains(got, "ib-addrs") || strings.Contains(got, "ib-quoted") {
+				t.Errorf("email formatting in text: %s", got)
+			}
+		})
+	}
+}

--- a/inbox/new.go
+++ b/inbox/new.go
@@ -83,6 +83,9 @@ func NewHandler(w http.ResponseWriter, r *http.Request) {
 		// gets typed into the boxes is not, and does not travel that way.
 		Kind: kindOf(r.FormValue("kind")),
 	}
+	if f.Kind != kindNote && f.Kind != kindTask {
+		f.Kind = kindMessage
+	}
 	// A reply is always a message. The kind picker is for something you are
 	// starting; answering a conversation has already decided what it is, and
 	// offering to turn the reply into a note would be a control that throws the
@@ -547,12 +550,15 @@ func writeOne(w http.ResponseWriter, r *http.Request, accountID string, f form) 
 
 	// Named for what is being written. "New message" over a note form is the
 	// page telling you it is doing something other than what it is doing.
-	title, desc := "New message", "Write one"
+	title, desc := "New mail", "Write an email"
 	switch writing {
 	case kindNote:
 		title, desc = "New note", "Write something down"
 	case kindTask:
 		title, desc = "New task", "Something that needs doing"
+	}
+	if texting {
+		title, desc = "Reply on "+channel.Label(), "Send a text"
 	}
 	app.Respond(w, r, app.Response{Title: title, Description: desc, HTML: b.String()})
 }
@@ -651,7 +657,7 @@ func newKinds(current string) string {
 	var b strings.Builder
 	b.WriteString(`<div class="ib-boxes ib-new-kinds">`)
 	for _, k := range []struct{ label, val string }{
-		{"Message", kindMessage},
+		{"Mail", kindMessage},
 		{"Note", kindNote},
 		{"Task", kindTask},
 	} {

--- a/inbox/page.go
+++ b/inbox/page.go
@@ -212,7 +212,7 @@ func list(w http.ResponseWriter, r *http.Request, accountID, box string) {
 	// is enough to say they are two things.
 	b.WriteString(`<div class="ib-filters">`)
 	b.WriteString(boxes(accountID, all, box))
-	b.WriteString(kinds(accountID, kind))
+	b.WriteString(kinds(kind))
 	b.WriteString(`</div>`)
 
 	// What is waiting to be let in, above the mailbox and only when there is

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -965,22 +965,27 @@ func CardWithIcon(id, title, icon, content string) string {
 //
 // For repo-shipped markdown that deliberately embeds HTML, use RenderTrusted.
 func Render(md []byte) []byte {
-	return render(md, false, false)
+	return render(md, false, false, 0)
 }
 
 // RenderTrusted converts markdown to HTML with raw HTML passed through. Only
 // for content that ships in the binary (the docs) — never for anything
 // that arrived over the network.
 func RenderTrusted(md []byte) []byte {
-	return render(md, true, false)
+	return render(md, true, false, 0)
 }
 
 // RenderNoImages formats private conversation context without loading sender images.
 func RenderNoImages(md []byte) []byte {
-	return render(md, false, true)
+	return render(md, false, true, 0)
 }
 
-func render(md []byte, trusted, noImages bool) []byte {
+// RenderLines renders untrusted Markdown while preserving typed line breaks.
+func RenderLines(md []byte) []byte {
+	return render(md, false, false, parser.HardLineBreak)
+}
+
+func render(md []byte, trusted, noImages bool, extra parser.Extensions) []byte {
 	// Strip LaTeX dollar sign escapes and protect plain currency before
 	// parsing markdown so downstream MathJax scanners do not treat blog cards
 	// or other rendered content as inline math.
@@ -989,7 +994,7 @@ func render(md []byte, trusted, noImages bool) []byte {
 	// create markdown parser with extensions. MathJax is intentionally disabled:
 	// Mu renders everyday prose more often than formulas, and paired currency
 	// amounts such as "$1 billion ... $94,000" must remain readable text.
-	extensions := (parser.CommonExtensions &^ parser.MathJax) | parser.AutoHeadingIDs | parser.NoEmptyLineBeforeBlock
+	extensions := (parser.CommonExtensions &^ parser.MathJax) | parser.AutoHeadingIDs | parser.NoEmptyLineBeforeBlock | extra
 	p := parser.NewWithExtensions(extensions)
 	doc := p.Parse(md)
 

--- a/internal/app/html/mu.css
+++ b/internal/app/html/mu.css
@@ -1622,18 +1622,18 @@ body:has(#messages) #chat-back-link {
   white-space: nowrap;
 }
 
-#messages p {
+:is(#messages, .chat-transcript) p {
   margin-top: 8px;
   margin-bottom: 12px;
   line-height: 1.5;
 }
 
-#messages ul, #messages ol {
+:is(#messages, .chat-transcript) ul, :is(#messages, .chat-transcript) ol {
   margin: 10px 0;
   padding-left: 25px;
 }
 
-#messages li {
+:is(#messages, .chat-transcript) li {
   margin-bottom: 8px;
   line-height: 1.5;
 }
@@ -1642,13 +1642,13 @@ body:has(#messages) #chat-back-link {
    the top of a page: it marks a section of an answer and should not be bigger
    than the room's own furniture. h4 is here because the renderer caps at it —
    see renderMarkdown in mu.js. */
-#messages h1, #messages h2, #messages h3, #messages h4 {
+:is(#messages, .chat-transcript) h1, :is(#messages, .chat-transcript) h2, :is(#messages, .chat-transcript) h3, :is(#messages, .chat-transcript) h4 {
   margin-top: 20px;
   margin-bottom: 12px;
   font-size: 15px;
 }
 
-#messages code {
+:is(#messages, .chat-transcript) code {
   margin: 10px 0;
 }
 
@@ -1656,7 +1656,7 @@ body:has(#messages) #chat-back-link {
    what it was asked about and rules off between sections, and none of the three
    had a rule — so they arrived as unstyled browser defaults in the middle of a
    conversation. */
-#messages pre {
+:is(#messages, .chat-transcript) pre {
   margin: 10px 0;
   padding: 10px 12px;
   background: var(--hover-background, #f5f5f5);
@@ -1664,16 +1664,16 @@ body:has(#messages) #chat-back-link {
   overflow-x: auto;
 }
 
-#messages pre code { margin: 0; background: none; padding: 0 }
+:is(#messages, .chat-transcript) pre code { margin: 0; background: none; padding: 0 }
 
-#messages blockquote {
+:is(#messages, .chat-transcript) blockquote {
   margin: 10px 0;
   padding-left: 12px;
   border-left: 2px solid var(--border-color, #f0f0f0);
   color: var(--text-secondary, #555);
 }
 
-#messages hr {
+:is(#messages, .chat-transcript) hr {
   border: 0;
   border-top: 1px solid var(--border-color, #f0f0f0);
   margin: 14px 0;
@@ -3556,6 +3556,36 @@ a.highlight {
   line-height: 1.5;
   word-wrap: break-word;
   overflow-wrap: anywhere;
+}
+
+/* Text transcripts share spacing and wrapping. Chat keeps the room's open
+   message layout, SMS is compact plain text, and WhatsApp uses bubbles. */
+.message-list { display: flex; flex-direction: column; gap: var(--space-section, 24px); min-width: 0; }
+.message-list > .message { margin: 0; min-width: 0; overflow-wrap: anywhere; }
+.sms-transcript { gap: var(--space-field, 16px); }
+.chat-transcript .ib-body { font-size: inherit; }
+
+.bubble-list { display: flex; flex-direction: column; gap: var(--space-control, 8px); min-width: 0; }
+.bubble-list > .bubble {
+  box-sizing: border-box;
+  align-self: flex-start;
+  min-width: 0;
+  width: fit-content;
+  max-width: min(90%, 40rem);
+  margin: 0;
+  padding: var(--space-control, 8px) var(--space-field, 16px);
+  border: var(--border-width, 1px) solid var(--card-border, #e8e8e8);
+  background: var(--card-background, #fff);
+}
+.bubble-list > .bubble-outgoing {
+  align-self: flex-end;
+  border-radius: 12px 0 12px 12px;
+  background: var(--surface-alt, #f2f2f2);
+}
+.bubble-list .ib-from, .sms-transcript .ib-from { flex-wrap: wrap; }
+.whatsapp-transcript > .bubble-outgoing {
+  background: var(--whatsapp-outgoing-background, #d9fdd3);
+  border-color: var(--whatsapp-outgoing-border, #c5e8c0);
 }
 
 /* A cell that must not grow: truncate rather than push the table wide. */

--- a/internal/app/render_security_test.go
+++ b/internal/app/render_security_test.go
@@ -164,3 +164,21 @@ func TestConversationContextDoesNotLoadImages(t *testing.T) {
 		t.Fatal(out)
 	}
 }
+
+func TestRenderLinesPreservesNotesAndSafety(t *testing.T) {
+	text := "First line\n**Second line**\n\n- one\n- two\n\n```\na\nb\n```\n\n<script>alert(1)</script>\n\n[bad](javascript:alert(1))"
+	got := string(RenderLines([]byte(text)))
+	for _, want := range []string{"First line<br", "<strong>Second line</strong>", "<ul>", "<code>a\nb\n</code>"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("missing %q in %s", want, got)
+		}
+	}
+	for _, unsafe := range []string{"<script", `href="javascript:`} {
+		if strings.Contains(got, unsafe) {
+			t.Errorf("unsafe note HTML: %s", got)
+		}
+	}
+	if strings.Contains(string(Render([]byte("First\nSecond"))), "<br") {
+		t.Error("note line breaks changed the default Markdown renderer")
+	}
+}

--- a/internal/app/testdata/layout.cjs
+++ b/internal/app/testdata/layout.cjs
@@ -89,11 +89,33 @@ const {chromium}=require(process.env.MU_PLAYWRIGHT_MODULE||'playwright');
    }
    if(path.startsWith('/inbox?id=')) {
     const cards=page.locator('.ib-msg');
+    const bubbles=await page.locator('.bubble-list').count()>0;
+    const texts=bubbles||await page.locator('.message-list').count()>0;
+    const chat=await page.locator('.chat-transcript').count()>0;
     assert(await cards.count()===3,'conversation fixture is incomplete');
     await cards.first().locator('.ib-who-l').evaluate(e=>e.textContent='a-long-sender-address-that-must-wrap-without-hiding-the-date@example.com');
     const metrics=await cards.evaluateAll(es=>es.map(e=>{const r=e.getBoundingClientRect(),s=getComputedStyle(e);return {top:r.top,bottom:r.bottom,width:r.width,scroll:e.scrollWidth,client:e.clientWidth,border:s.borderTopStyle,weight:getComputedStyle(e.querySelector('.ib-who-l')).fontWeight};}));
-    assert(metrics.every(m=>m.border!=='none'&&Number(m.weight)>=700&&m.scroll<=m.client+1),`message card/sender regression at ${width}: ${JSON.stringify(metrics)}`);
-    for(let i=1;i<metrics.length;i++)assert(metrics[i].top-metrics[i-1].bottom>=8,'message cards run together');
+    assert(metrics.every(m=>(texts&&!bubbles||m.border!=='none')&&Number(m.weight)>=700&&m.scroll<=m.client+1),`message card/sender regression at ${width}: ${JSON.stringify(metrics)}`);
+    for(let i=1;i<metrics.length;i++)assert(metrics[i].top-metrics[i-1].bottom>=8,'messages run together');
+    if(texts) {
+     assert(await cards.first().locator('.ib-typed').innerText().then(t=>t.includes('Second line\n> Keep this typed line')),'text message lost typed lines');
+     assert(await page.locator('.ib-addrs,.ib-quoted').count()===0,'email formatting leaked into texts');
+     if(chat)assert(await cards.first().locator('.you .msg-when').count()===1,'chat lost its room byline');
+    }
+    if(bubbles) {
+     assert(await cards.last().evaluate(e=>getComputedStyle(e).backgroundColor==='rgb(217, 253, 211)'),'WhatsApp reply lost its light green background');
+     const outgoing=page.locator('.bubble-outgoing');
+     assert(await outgoing.count()===1,'own reply not distinguished');
+     assert(await outgoing.locator('.ib-who-l').innerText()==='You','own reply mislabeled');
+     const sides=await page.locator('.bubble-list').evaluate(e=>{const r=e.getBoundingClientRect(),first=e.firstElementChild.getBoundingClientRect(),last=e.lastElementChild.getBoundingClientRect();return {left:first.left-r.left,right:r.right-last.right,inset:last.left-r.left};});
+     assert(Math.abs(sides.left)<1&&Math.abs(sides.right)<1&&sides.inset>0,`bubble alignment at ${width}: ${JSON.stringify(sides)}`);
+    }
+   }
+   if(path.startsWith('/inbox?kind=note&')) {
+    const note=page.locator('.record-card .markdown-content');
+    assert(await note.locator('p').first().locator('br').count()===2,`note lost typed line breaks: ${await note.innerHTML()}`);
+    assert(await note.locator('strong').innerText()==='Call before leaving','note lost Markdown formatting');
+    assert(await note.locator('li').count()===2,'note lost its list');
    }
    if(path==='/inbox') {
     const rows=page.locator('.ib-item');

--- a/test/layout_browser_test.go
+++ b/test/layout_browser_test.go
@@ -95,26 +95,33 @@ func TestPageCompositionInBrowser(t *testing.T) {
 	if err := data.IndexSync("video_layout-video", data.KindVideo, "A layout video", "Video description", map[string]any{"channel": "Publisher"}); err != nil {
 		t.Fatal(err)
 	}
-	recordnotes.Add(who, "A note in the inbox", "Remember to book the appointment")
+	recordnotes.Add(who, "A note in the inbox", "Remember to book the appointment\nBring the paperwork\n**Call before leaving**\n\n- Check the time\n- Pack a pen")
 	if err := data.IndexSync("layout-news", data.KindNews, "A news article", "Article text", map[string]any{"url": "https://example.com/article", "description": "A short article", "posted_at": time.Now()}); err != nil {
 		t.Fatal(err)
 	}
 	inboxThread := ""
-	for _, client := range []string{"mail", "chat", "whatsapp"} {
+	conversationPages := map[string]http.HandlerFunc{}
+	for _, client := range []string{"mail", "chat", "sms", "whatsapp"} {
 		th := thread.Open(who, client, "a-long-sender-name-for-mobile@example.com")
 		if th == nil {
 			t.Fatal("could not create inbox fixture")
 		}
-		thread.Add(thread.Message{Thread: th.ID, Account: who, From: "sender@example.com", Text: "An inbox conversation on " + client})
+		thread.Add(thread.Message{Thread: th.ID, Account: who, From: "sender@example.com", Text: "An inbox conversation on " + client + "\nSecond line\n> Keep this typed line"})
+		conversationPages["/inbox?id="+th.ID] = inbox.Handler
 		if client == "mail" {
 			inboxThread = th.ID
-			thread.Add(thread.Message{Thread: th.ID, Account: who, Role: thread.RoleAgent, From: "Micro", Text: "I found the details. Here is the summary."})
-			thread.Add(thread.Message{Thread: th.ID, Account: who, From: who, Text: "Thanks, please follow up tomorrow."})
 		}
+		thread.Add(thread.Message{Thread: th.ID, Account: who, Role: thread.RoleAgent, From: "Micro", Text: "I found the details. Here is the summary."})
+		thread.Add(thread.Message{Thread: th.ID, Account: who, From: who, Text: "Thanks, please follow up tomorrow.\nI will be there."})
 	}
 	pages := map[string]string{}
 	policies := map[string]string{}
-	for path, handler := range map[string]http.HandlerFunc{"/inbox": inbox.Handler, "/inbox?id=" + inboxThread: inbox.Handler, "/archive": archive.Handler, "/blog": blog.Handler, "/bookmarks": bookmarks.Handler, "/browser": browser.Handler, "/contacts": contacts.Handler, "/flights": flights.Handler, "/food": food.Handler, "/hazards": hazards.Handler, "/images": images.Handler, "/mail": mail.Handler, "/maps": maps.Handler, "/notify": notify.Handler, "/places": places.Handler, "/prayer": prayer.Handler, "/recall": recall.Handler, "/routes": routes.Handler, "/shell": shell.Handler, "/sms": sms.Handler, "/sms?view=new": sms.Handler, "/sms?id=" + smsThread.ID: sms.Handler, "/social": social.Handler, "/stream": stream.Handler, "/text": text.Handler, "/transit": transit.Handler, "/users": users.Handler, "/wallet": account.Wallet, "/notes": notes.Handler, "/news": news.Handler, "/news?id=layout-news": news.Handler, "/web": web.Handler, "/weather": weather.PageHandler, "/markets": markets.Handler, "/video": video.Handler, "/video?id=layout-video&autoplay=1": video.Handler, "/signup": account.Signup, "/agent/new": agent.NewAgentHandler, "/agents": agent.RosterHandler, "/token": account.TokenHandler, "/apps/new": apps.Handler, "/apps/layout-app/edit": apps.Handler, "/apps": apps.Handler, "/events": events.Handler, "/files": files.Handler, "/docs": docs.Handler, "/": home.Index, "/home": home.Handler, "/tasks": tasks.Handler, "/chat": chat.Handler, "/agent/micro": agent.Handler} {
+	handlers := map[string]http.HandlerFunc{"/about": home.AboutHandler, "/contact": home.ContactHandler, "/inbox/new": inbox.NewHandler, "/inbox": inbox.Handler, "/inbox?id=" + inboxThread: inbox.Handler, "/archive": archive.Handler, "/blog": blog.Handler, "/bookmarks": bookmarks.Handler, "/browser": browser.Handler, "/contacts": contacts.Handler, "/flights": flights.Handler, "/food": food.Handler, "/hazards": hazards.Handler, "/images": images.Handler, "/mail": mail.Handler, "/maps": maps.Handler, "/notify": notify.Handler, "/places": places.Handler, "/prayer": prayer.Handler, "/recall": recall.Handler, "/routes": routes.Handler, "/shell": shell.Handler, "/sms": sms.Handler, "/sms?view=new": sms.Handler, "/sms?id=" + smsThread.ID: sms.Handler, "/social": social.Handler, "/stream": stream.Handler, "/text": text.Handler, "/transit": transit.Handler, "/users": users.Handler, "/wallet": account.Wallet, "/notes": notes.Handler, "/news": news.Handler, "/news?id=layout-news": news.Handler, "/web": web.Handler, "/weather": weather.PageHandler, "/markets": markets.Handler, "/video": video.Handler, "/video?id=layout-video&autoplay=1": video.Handler, "/signup": account.Signup, "/agent/new": agent.NewAgentHandler, "/agents": agent.RosterHandler, "/token": account.TokenHandler, "/apps/new": apps.Handler, "/apps/layout-app/edit": apps.Handler, "/apps": apps.Handler, "/events": events.Handler, "/files": files.Handler, "/docs": docs.Handler, "/": home.Index, "/home": home.Handler, "/tasks": tasks.Handler, "/chat": chat.Handler, "/agent/micro": agent.Handler}
+	for path, handler := range conversationPages {
+		handlers[path] = handler
+	}
+	handlers["/inbox?kind=note&id="+recordnotes.All(who)[0].ID] = inbox.Handler
+	for path, handler := range handlers {
 		t.Log("render", path)
 		req := httptest.NewRequest("GET", path, nil)
 		if path != "/" {


### PR DESCRIPTION
Inbox text conversations inherited email-style cards, address rows and quote stripping, while notes collapsed single line breaks.

- Render SMS as compact plain text, WhatsApp as white/light-green bubbles, and chat with the existing room message layout and byline styles. Keep mail on its shared service renderer.
- Preserve the complete typed text in chat/SMS/WhatsApp. Notes preserve single line breaks through the shared safe Markdown renderer, retaining lists, emphasis and code blocks.
- Replace the Messages filter with Mail, Chat, SMS and WhatsApp filters that select their respective services. Call email Mail in the New picker and page heading; text replies retain their channel name.
- Remove the requested introductory headings, promotional copy and links from About and Contact, plus the Running it yourself section from Pricing.

Validation: inbox, app and home package tests pass; browser checks cover 320/390/768/1024/1440px, desktop sidebar states, all conversation types, note line breaks, New, About and Contact. Rendering tests cover escaping, links, preserved text and Markdown safety.