### PR TITLE
Align and prioritize Home, with a personal greeting

### DIFF
--- a/home/home.go
+++ b/home/home.go
@@ -419,23 +419,6 @@ function fetchW(la,lo){
 		viewerID = sess.Account
 	}
 
-	// The rail is built before it is placed, because whether there is a second
-	// column at all depends on whether anything goes in it.
-	//
-	// Everything in the rail belongs to an account. Signed out there is no
-	// brief, no inbox and no roster, so the rail was an empty div — and an empty
-	// grid track is still 320px wide. A logged-out visitor got a third of the
-	// screen of nothing on the left and the services pushed right, with nothing
-	// on the page to say a column was missing rather than broken. Signed in it
-	// happens too: each of the three decides its own silence, so on a new
-	// account all three are empty at once, which is the first thing anybody
-	// sees.
-	//
-	// Written as "is there anything in it" rather than "is somebody signed in",
-	// because the empty column looks the same either way and a viewer check
-	// would leave the new-account version of it standing.
-	var rail strings.Builder
-
 	// ── Cards ──
 	b.WriteString(`<div id="home-cards">`)
 
@@ -448,20 +431,8 @@ function fetchW(la,lo){
 	b.WriteString(homeViews(feed))
 	b.WriteString(`<section id="home-personal" role="tabpanel" aria-labelledby="home-view-personal"` + panelHidden(feed) + `>`)
 
-	// The personal view keeps the prompt, brief and account previews together.
-	// The box asks, the same as the signed-out page does.
-	//
-	// It searched, and the reason search won was that it is the half that works
-	// with no model — which is a constraint about a fresh install, and it got
-	// treated as a statement about the product. Every instance that has a model
-	// had its front control pointed at its own memory instead of at the thing
-	// the memory is for. The README never said that: "services and the archive
-	// become tools for agents to use".
-	//
-	// Still one control doing one thing on both pages, which was the property
-	// worth keeping from the previous answer. Where there is no model it
-	// renders the search box and says why — a degrade, not a second product.
-	//
+	// Reading order is prompt, inbox, brief, then agents.
+	b.WriteString(`<div class="home-workspace"><div class="home-primary page-stack">`)
 	{
 		b.WriteString(`<div id="home-agent">`)
 		b.WriteString(app.ChatComponent(app.ChatConfig{
@@ -491,102 +462,31 @@ function fetchW(la,lo){
 			Speak: viewerID != "",
 		}))
 
-		// The address, under the box. Quiet, because it is a fact about the
-		// agent rather than a call to action: the thing that makes this more
-		// than a chat on a page is that it answers whether or not anybody has
-		// the page open, and there was nowhere on the screen you arrive at
-		// saying so.
-		//
-		// There were suggestion chips here and they have gone. The machinery
-		// was a data attribute, a listener with a forty-try retry loop, a flex
-		// container and a class defined twice in the stylesheet — to render at
-		// most one button, only when there was unread mail, saying "read my
-		// unread email". One centred pill under a chat box, and an inbox fact
-		// sitting above the inbox section. It is a line in that section now.
-		//
-		// The other three chips had already gone for a related reason: they
-		// asked the agent to fetch things the cards below already show.
-		// No address under the box.
-		//
-		// It said "Or write to it at agent@… — from your mail, your phone,
-		// anywhere", directly beneath the thing you type into. Somebody on this
-		// screen is already talking to the agent; the address is for reaching it
-		// when you are not here, which is exactly the moment this line is not on
-		// the screen.
-		b.WriteString(statusForm(r, viewerID))
 		b.WriteString(`</div>`)
-
-		// No Online strip here, and no chat panel below.
-		//
-		// Home carried who else was on the instance, a count you could open to
-		// see the names, a bubble that slid a chat over the page, and the last
-		// thing anybody had said in it. Each piece answered the objection to
-		// the one before it and the whole was still wrong: nobody is on the
-		// other end.
-		//
-		// The argument for it was that a place ought to show you it is a place.
-		// What it actually put on the screen a person opens every day was a
-		// room with strangers in it, or nobody, which is the Discord failure —
-		// people join, see that others joined, and say nothing. The go-micro
-		// Slack worked the other way round: three people who already had a
-		// reason to talk, and it grew from there. A chat is the second thing.
-		//
-		// So the front screen is one person's: the brief, what arrived, the
-		// agents, the world. /chat is still there for somebody who goes looking
-		// for it, which is the difference between offering a room and putting
-		// one in front of you.
-
-		// data-brief, so it steps aside when somebody asks. The brief and the
-		// answer are the same shape — a paragraph of prose — and stacking them
-		// makes the reader work out where one stops; worse, every turn pushes
-		// the brief further down the page. You are told, or you ask. See
-		// hideBrief in app.ChatComponent.
-		if viewerID != "" {
-			if brief := briefHTML(viewerID); brief != "" {
-				b.WriteString(`<div id="home-brief" data-brief>` + brief + `</div>`)
-			}
-		}
-
-		// What arrived, under a heading that looks like one.
-		//
-		// Both halves of this screen are labelled the same way and each label
-		// carries a rule across the page, because two words in small caps over
-		// a list read as a caption rather than as a section — which is how the
-		// conversations came to look like loose links under the address line.
 		if viewerID != "" {
 			if peek := inbox.Preview(viewerID); peek != "" {
-				rail.WriteString(sectionRule("Inbox") + peek)
+				b.WriteString(`<div id="home-inbox">` + sectionRule("Inbox") + peek + `</div>`)
 			}
 		}
 	}
-
-	// Your agents, between what arrived and what the instance knows.
-	//
-	// Which is the order the three read in: something came in, here is who you
-	// have working on it, here is what they can reach. Without this the page
-	// was a mailbox above a content grid and the agents were somewhere else
-	// entirely — on a roster you had to go and find, on the one screen whose
-	// job is to say how things are.
-	//
-	// Not the runs block that was removed below. A run is an event and ages
-	// out; an agent is a standing thing, and this is the roster with a sign of
-	// life against each. See agent.Preview.
+	b.WriteString(`</div>`)
+	var context strings.Builder
 	if viewerID != "" {
+		if brief := briefHTML(viewerID); brief != "" {
+			context.WriteString(`<div id="home-brief" data-brief>` + brief + `</div>`)
+		}
 		if who := agent.Preview(viewerID); who != "" {
-			rail.WriteString(sectionRule("Agents") + who)
+			context.WriteString(`<div id="home-agents">` + sectionRule("Agents") + who + `</div>`)
 		}
 	}
-
-	// And what it is being paid for, last. See wallet.go for why it is at the
-	// foot and why the header's chip goes quiet on this page.
+	if context.Len() > 0 {
+		b.WriteString(`<aside class="home-context page-stack" aria-label="Daily context">` + context.String() + `</aside>`)
+	}
+	b.WriteString(`</div>`)
 	if viewerID != "" {
-		rail.WriteString(walletHTML(viewerID))
+		b.WriteString(`<details class="disclosure"><summary>Account and status</summary><div class="page-stack">` + statusForm(r, viewerID) + walletHTML(viewerID) + `</div></details>`)
 	}
 
-	// Home holds the personal workspace. Feed reuses the existing service cards.
-	if rail.Len() > 0 {
-		b.WriteString(`<div class="home-rail">` + rail.String() + `</div>`)
-	}
 	b.WriteString(`</section><section id="home-feed" role="tabpanel" aria-labelledby="home-view-feed"` + panelHidden(!feed) + `><div class="home-main full">`)
 	cards := CardsHTML(r, viewerAcc)
 	if cards == "" {
@@ -666,7 +566,7 @@ function fetchW(la,lo){
 	// That is what a banner moving from one page into the chrome looks like
 	// when the call site it left behind is not removed. See app.renderForRequest,
 	// which is the only place any of the three banners is added.
-	app.Respond(w, r, app.Response{Title: "Home", Description: "The home screen",
+	app.Respond(w, r, app.Response{Title: greeting(viewerAcc), Description: "The home screen",
 		HTML: b.String(), BodyClass: bodyClass})
 }
 

--- a/home/layout_test.go
+++ b/home/layout_test.go
@@ -38,6 +38,9 @@ func TestHomeAndFeedKeepTheirOwnContent(t *testing.T) {
 	}
 	thread.Add(thread.Message{Thread: th.ID, Account: who, From: "sender@example.com", Text: "An inbox message"})
 	body := homeFor(t, who)
+	if !strings.Contains(body, "Welcome back, "+who) {
+		t.Error("missing personal greeting")
+	}
 	personalAt := strings.Index(body, `<section id="home-personal"`)
 	feedAt := strings.Index(body, `<section id="home-feed"`)
 	if personalAt < 0 || feedAt <= personalAt {

--- a/home/layout_test.go
+++ b/home/layout_test.go
@@ -13,10 +13,14 @@ import (
 )
 
 // homeFor renders the signed-in Home for an account, as the browser gets it.
-func homeFor(t *testing.T, accountID string) string {
+func homeFor(t *testing.T, accountID string, names ...string) string {
 	t.Helper()
 
-	auth.Create(&auth.Account{ID: accountID, Name: accountID}) //nolint:errcheck
+	name := accountID
+	if len(names) > 0 {
+		name = names[0]
+	}
+	auth.Create(&auth.Account{ID: accountID, Name: name}) //nolint:errcheck
 	sess, err := auth.CreateSession(accountID)
 	if err != nil {
 		t.Fatalf("no session: %v", err)
@@ -160,5 +164,16 @@ func TestTheAccountBlockLooksLikeTheOtherRailBlocks(t *testing.T) {
 	if !strings.Contains(got, `href="/account" class="link"`) {
 		t.Error("no `Go to account` link — every other rail block ends with one, " +
 			"and it is the only route to /wallet from Home")
+	}
+}
+
+func TestGreetingTreatsDisplayNamesAsText(t *testing.T) {
+	body := homeFor(t, "greetingmarkup", `<img src=x onerror=alert(1)> & friends`)
+	want := `Welcome back, &lt;img src=x onerror=alert(1)&gt; &amp; friends`
+	if !strings.Contains(body, `<h1 id="page-title">`+want+`</h1>`) {
+		t.Error("greeting does not render the display name as text")
+	}
+	if strings.Contains(body, `<img src=x onerror=alert(1)>`) {
+		t.Error("display name became executable markup")
 	}
 }

--- a/home/views.go
+++ b/home/views.go
@@ -1,6 +1,11 @@
 package home
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+
+	"mu/internal/auth"
+)
 
 func panelHidden(hidden bool) string {
 	if hidden {
@@ -18,4 +23,14 @@ func homeViews(feed bool) string {
 <a id="home-view-personal" href="/home" role="tab" aria-controls="home-personal" aria-selected="%t" tabindex="%d">Home</a>
 <a id="home-view-feed" href="/home?view=feed" role="tab" aria-controls="home-feed" aria-selected="%t" tabindex="%d">Feed</a>
 </nav>`, !feed, homeTab, feed, feedTab)
+}
+
+// greeting avoids using the server timezone for a person's local time of day.
+func greeting(acc *auth.Account) string {
+	if acc != nil {
+		if name := strings.TrimSpace(acc.Name); name != "" {
+			return "Welcome back, " + name
+		}
+	}
+	return "Welcome back"
 }

--- a/home/views.go
+++ b/home/views.go
@@ -2,6 +2,7 @@ package home
 
 import (
 	"fmt"
+	"html"
 	"strings"
 
 	"mu/internal/auth"
@@ -29,7 +30,7 @@ func homeViews(feed bool) string {
 func greeting(acc *auth.Account) string {
 	if acc != nil {
 		if name := strings.TrimSpace(acc.Name); name != "" {
-			return "Welcome back, " + name
+			return "Welcome back, " + html.EscapeString(name)
 		}
 	}
 	return "Welcome back"

--- a/internal/app/html/mu.css
+++ b/internal/app/html/mu.css
@@ -962,6 +962,12 @@ a.btn-plain:hover {
 /* Home and Feed share the page width, but never compete for it. */
 #home-personal, #home-feed, .home-rail, .home-main { min-width: 0; }
 #home-personal[hidden], #home-feed[hidden] { display: none !important; }
+#home-personal { display: grid; gap: var(--space-section, 24px); }
+.home-workspace { display: grid; gap: var(--space-section, 24px); }
+.home-primary, .home-context { min-width: 0; }
+@media (min-width: 1100px) {
+  .home-workspace:has(.home-context) { grid-template-columns: minmax(0, 2fr) minmax(0, 1fr); align-items: start; }
+}
 
 
 

--- a/internal/app/html/mu.css
+++ b/internal/app/html/mu.css
@@ -960,8 +960,7 @@ a.btn-plain:hover {
 }
 
 /* Home and Feed share the page width, but never compete for it. */
-#home-personal { max-width: 840px; margin-inline: auto; min-width: 0; }
-#home-feed, .home-rail, .home-main { min-width: 0; }
+#home-personal, #home-feed, .home-rail, .home-main { min-width: 0; }
 #home-personal[hidden], #home-feed[hidden] { display: none !important; }
 
 

--- a/internal/app/testdata/layout.cjs
+++ b/internal/app/testdata/layout.cjs
@@ -148,6 +148,21 @@ const {chromium}=require(process.env.MU_PLAYWRIGHT_MODULE||'playwright');
    if(path==='/home') {
     assert(await page.locator('#home-personal').isVisible(),'Home is not default');
     assert(await page.locator('#home-feed').isHidden(),'Feed leaks into Home');
+    assert((await page.locator('#page-title').textContent()).includes('Welcome back'),'Home title is not a greeting');
+    const layout=await page.evaluate(()=>{
+      const rect=s=>document.querySelector(s).getBoundingClientRect();
+      return {tabs:rect('.view-switch'),personal:rect('#home-personal'),primary:rect('.home-primary'),context:rect('.home-context')};
+    });
+    assert(Math.abs(layout.tabs.x-layout.personal.x)<1,'Home is inset from tabs');
+    if(width>=1100) assert(layout.context.x>layout.primary.x+layout.primary.width,'context is not alongside primary');
+    else assert(layout.context.y>=layout.primary.y+layout.primary.height,'mobile context precedes primary');
+    const account=page.locator('#home-personal > details');
+    assert(!await account.evaluate(el=>el.open),'account controls compete with primary content');
+    await account.locator('summary').click();
+    assert(await page.locator('#home-status').isVisible(),'profile status is inaccessible');
+    assert(await page.evaluate(()=>document.documentElement.scrollWidth<=innerWidth+1),'expanded Home overflows');
+    await account.locator('summary').click();
+
     const input=page.locator('#mu-chat-input');
     await input.fill('Keep this draft');
     const marker=await page.evaluate(()=>window.testDocument);


### PR DESCRIPTION
Home's centered width cap inset its content beneath the tabs, and splitting off Feed left the personal blocks without a clear priority.

Remove the cap and arrange prompt/inbox in the main column, with brief and the existing agent activity preview alongside on desktop. Smaller screens stack prompt, inbox, brief and agents. Account and status remain available in a collapsed section below. Replace the redundant Home heading with Welcome back and the account display name when available; this avoids relying on server timezone. Feed is unchanged.

Validation: home/app package tests pass; browser checks at 320, 390, 768, 1024 and 1440px with sidebar open/closed verify tab alignment, column/stack positions, greeting, account disclosure and in-place tab switching. Desktop and mobile screenshots inspected. git diff --check passed.