### PR TITLE
Deploy the existing CI build instead of compiling on the server

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,22 +39,33 @@ jobs:
             set -e
             test "$(uname -s)" = Linux
             case "$(uname -m)" in
-              x86_64) echo amd64 ;;
-              aarch64|arm64) echo arm64 ;;
+              x86_64) architecture=amd64 ;;
+              aarch64|arm64) architecture=arm64 ;;
               *) echo 'Unsupported server architecture' >&2; exit 1 ;;
             esac
+            printf 'MU_DEPLOY_ARCH=%s\n' "$architecture"
+
+      - name: Parse server architecture
+        if: steps.current.outputs.deploy == 'true'
+        id: architecture
+        env:
+          SSH_OUTPUT: ${{ steps.server.outputs.stdout }}
+        run: |
+          architecture=$(printf '%s\n' "$SSH_OUTPUT" | tr -d '\r' | sed -n 's/^\(out: *\)\{0,1\}MU_DEPLOY_ARCH=\(amd64\|arm64\)$/\2/p')
+          case "$architecture" in amd64|arm64) ;; *) echo "Invalid server architecture response" >&2; exit 1 ;; esac
+          echo "arch=$architecture" >> "$GITHUB_OUTPUT"
 
       - name: Download the verified build
         if: steps.current.outputs.deploy == 'true'
         uses: actions/download-artifact@v4
         with:
-          name: mu-linux-${{ steps.server.outputs.stdout }}
+          name: mu-linux-${{ steps.architecture.outputs.arch }}
           path: dist
 
       - name: Prepare transfer
         if: steps.current.outputs.deploy == 'true'
         env:
-          SERVER_ARCH: ${{ steps.server.outputs.stdout }}
+          SERVER_ARCH: ${{ steps.architecture.outputs.arch }}
         run: |
           case "$SERVER_ARCH" in amd64|arm64) ;; *) exit 1 ;; esac
           mv "dist/mu-linux-${SERVER_ARCH}" dist/mu

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,56 +1,90 @@
 name: Deploy
 
+# Called only after the main-branch test and build jobs succeed.
 on:
-  push:
-    branches: [main]
-    # A push that changes only these cannot change what the running instance
-    # serves, so it does not earn a rebuild and a restart of the live site.
-    #
-    # `docs/**` is deliberately NOT here. Those files are compiled into the
-    # binary (`//go:embed *.md` in docs/docs.go) and served at /docs — ignoring
-    # them would leave the published documentation silently stale. The rule is
-    # "not embedded, not read at runtime", not "ends in .md";
-    # TestDeployIgnoresOnlyUnservedFiles holds the line.
-    paths-ignore:
-      - 'README.md'
-      - 'CLAUDE.md'
-      - 'AGENTS.md'
-      - 'LICENSE'
-      - '.gitignore'
-      - '.github/**'
-      - 'scripts/README.md'
+  workflow_call:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: deploy-production
+  cancel-in-progress: false
 
 jobs:
   deploy:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
-      - name: Deploy to server
-        uses: appleboy/ssh-action@v1.0.3
+      - uses: actions/checkout@v4
+
+      - name: Skip superseded commits
+        id: current
+        run: |
+          latest=$(git ls-remote origin refs/heads/main | cut -f1)
+          test -n "$latest"
+          echo "deploy=$([ "$latest" = "$GITHUB_SHA" ] && echo true || echo false)" >> "$GITHUB_OUTPUT"
+
+      - name: Detect server architecture
+        if: steps.current.outputs.deploy == 'true'
+        id: server
+        uses: appleboy/ssh-action@v1
         with:
           host: ${{ secrets.DEPLOY_HOST }}
           username: mu
           port: 61194
           key: ${{ secrets.DEPLOY_KEY }}
-          script_stop: true
+          capture_stdout: true
           script: |
             set -e
-            cd ~/src/mu
-            git pull origin main
-            source ~/.env
-            # Static, so the binary can be mounted into a sandbox container.
-            #
-            # The sandbox image is Alpine, which has musl and no glibc loader,
-            # and a Go binary built the ordinary way on this host is
-            # dynamically linked against one. Mount that into a box and the
-            # shell answers "not found" about a file `ls -l` has just listed.
-            #
-            # The release workflow has always built this way; this deploy did
-            # not, and this is the build that runs on the server. See
-            # service/sandbox/equip.go, which refuses to mount a binary the
-            # box could not run.
-            CGO_ENABLED=0 go install
-            # One-time: switch to socket activation for zero-downtime restarts.
-            # Idempotent, self-verifying, and guarded so it can never fail a deploy.
-            sh scripts/deploy/enable-zero-downtime.sh || true
-            sudo -n systemctl restart mu
-            echo "Deploy complete"
+            test "$(uname -s)" = Linux
+            case "$(uname -m)" in
+              x86_64) echo amd64 ;;
+              aarch64|arm64) echo arm64 ;;
+              *) echo 'Unsupported server architecture' >&2; exit 1 ;;
+            esac
+
+      - name: Download the verified build
+        if: steps.current.outputs.deploy == 'true'
+        uses: actions/download-artifact@v4
+        with:
+          name: mu-linux-${{ steps.server.outputs.stdout }}
+          path: dist
+
+      - name: Prepare transfer
+        if: steps.current.outputs.deploy == 'true'
+        env:
+          SERVER_ARCH: ${{ steps.server.outputs.stdout }}
+        run: |
+          case "$SERVER_ARCH" in amd64|arm64) ;; *) exit 1 ;; esac
+          mv "dist/mu-linux-${SERVER_ARCH}" dist/mu
+          cp scripts/deploy/install-binary.sh scripts/deploy/enable-zero-downtime.sh dist/
+          (cd dist && sha256sum mu > SHA256SUMS)
+
+      - name: Upload staged binary
+        if: steps.current.outputs.deploy == 'true'
+        uses: appleboy/scp-action@v1
+        with:
+          host: ${{ secrets.DEPLOY_HOST }}
+          username: mu
+          port: 61194
+          key: ${{ secrets.DEPLOY_KEY }}
+          source: dist/*
+          target: /home/mu/.cache/mu-deploy/${{ github.run_id }}-${{ github.run_attempt }}
+          strip_components: 1
+
+      - name: Install and restart
+        if: steps.current.outputs.deploy == 'true'
+        uses: appleboy/ssh-action@v1
+        env:
+          DEPLOY_STAGE: /home/mu/.cache/mu-deploy/${{ github.run_id }}-${{ github.run_attempt }}
+        with:
+          host: ${{ secrets.DEPLOY_HOST }}
+          username: mu
+          port: 61194
+          key: ${{ secrets.DEPLOY_KEY }}
+          envs: DEPLOY_STAGE
+          script: |
+            set -e
+            sh "$DEPLOY_STAGE/install-binary.sh" "$DEPLOY_STAGE"
+            rm -rf "$DEPLOY_STAGE"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,8 +59,31 @@ jobs:
       # failed build and a silent hole in the install path.
       - name: Build every release target
         run: |
+          mkdir -p "$RUNNER_TEMP/mu-build"
           for target in linux/amd64 linux/arm64 darwin/amd64 darwin/arm64; do
             os="${target%/*}"; arch="${target#*/}"
             echo "Building ${os}/${arch}"
-            CGO_ENABLED=0 GOOS="${os}" GOARCH="${arch}" go build -o /dev/null .
+            CGO_ENABLED=0 GOOS="${os}" GOARCH="${arch}" go build -trimpath -o "$RUNNER_TEMP/mu-build/mu-${os}-${arch}" .
           done
+
+      - uses: actions/upload-artifact@v4
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        with:
+          name: mu-linux-amd64
+          path: ${{ runner.temp }}/mu-build/mu-linux-amd64
+          retention-days: 7
+          if-no-files-found: error
+
+      - uses: actions/upload-artifact@v4
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        with:
+          name: mu-linux-arm64
+          path: ${{ runner.temp }}/mu-build/mu-linux-arm64
+          retention-days: 7
+          if-no-files-found: error
+
+  deploy:
+    needs: [test, build]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    uses: ./.github/workflows/deploy.yml
+    secrets: inherit

--- a/scripts/deploy/README.md
+++ b/scripts/deploy/README.md
@@ -37,7 +37,8 @@ existing artifact; neither the deploy job nor the server recompiles it.
 
 The server verifies the transfer checksum, checks that the binary runs, and
 atomically replaces the executable configured in `mu.service`. The previous
-binary is kept alongside it as `mu.previous` and restored if restarting fails.
+binary is kept alongside it as `mu.previous` and restored if restarting fails or the new process exits/restarts during a ten-second
+stability check.
 The socket stays up during the restart. Deployment runs are serialized, and
 superseded commits are skipped before transfer.
 

--- a/scripts/deploy/README.md
+++ b/scripts/deploy/README.md
@@ -30,14 +30,20 @@ Point nginx at the same address the socket listens on (`127.0.0.1:8080`).
 
 ## Redeploy
 
-Unchanged from before — the deploy workflow's `systemctl restart mu` still works
-(restart `mu.service`, not the socket):
+The main-branch CI build retains its Linux binaries as artifacts. After the
+same run passes tests (including the race detector), it calls the deployment
+workflow. That workflow selects the server's architecture and transfers the
+existing artifact; neither the deploy job nor the server recompiles it.
 
-```bash
-git pull origin main
-go install
-sudo systemctl restart mu.service   # socket stays up → connections queue, no 502
-```
+The server verifies the transfer checksum, checks that the binary runs, and
+atomically replaces the executable configured in `mu.service`. The previous
+binary is kept alongside it as `mu.previous` and restored if restarting fails.
+The socket stays up during the restart. Deployment runs are serialized, and
+superseded commits are skipped before transfer.
+
+The server needs SSH, standard Linux file utilities and permission for user
+`mu` to restart the service. Go and a source checkout are no longer used by
+deployment; keep the service's existing working directory and environment file.
 
 ## Notes
 

--- a/scripts/deploy/install-binary.sh
+++ b/scripts/deploy/install-binary.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+# Install a staged CI binary without compiling on the live server.
+set -eu
+stage=$(cd "$1" && pwd)
+(cd "$stage" && sha256sum -c SHA256SUMS)
+
+# Use the service's actual executable path, including custom install locations.
+start=$(systemctl show --property=ExecStart --value mu.service)
+binary=$(printf '%s\n' "$start" | sed -n 's/^{ path=\([^ ;]*\) ;.*/\1/p')
+case "$binary" in /*/mu) ;; *) echo 'Cannot identify the Mu executable' >&2; exit 1 ;; esac
+binary=$(readlink -f "$binary")
+test -f "$binary"
+
+# Copy beside the destination before renaming: never write over a running file.
+next=$(mktemp "${binary}.next.XXXXXX")
+trap 'rm -f "$next"' EXIT HUP INT TERM
+install -m 0755 "$stage/mu" "$next"
+"$next" version
+cp -p "$binary" "${binary}.previous"
+mv -f "$next" "$binary"
+
+# Preserve the existing idempotent socket-activation migration.
+sh "$stage/enable-zero-downtime.sh" || true
+if sudo -n systemctl restart mu.service && systemctl is-active --quiet mu.service; then
+  echo 'Deploy complete'
+else
+  echo 'Restart failed; restoring the previous binary' >&2
+  mv -f "${binary}.previous" "$binary"
+  sudo -n systemctl restart mu.service
+  exit 1
+fi

--- a/scripts/deploy/install-binary.sh
+++ b/scripts/deploy/install-binary.sh
@@ -21,7 +21,18 @@ mv -f "$next" "$binary"
 
 # Preserve the existing idempotent socket-activation migration.
 sh "$stage/enable-zero-downtime.sh" || true
-if sudo -n systemctl restart mu && systemctl is-active --quiet mu.service; then
+# Type=simple becomes active before initialization finishes. Require the same
+# process to remain active for ten seconds, including across automatic restarts.
+stable() {
+  pid=$(systemctl show --property=MainPID --value mu.service)
+  case "$pid" in ''|0|*[!0-9]*) return 1 ;; esac
+  for check in 1 2 3 4 5; do
+    sleep 2
+    systemctl is-active --quiet mu.service || return 1
+    test "$(systemctl show --property=MainPID --value mu.service)" = "$pid" || return 1
+  done
+}
+if sudo -n systemctl restart mu && stable; then
   echo 'Deploy complete'
 else
   echo 'Restart failed; restoring the previous binary' >&2

--- a/scripts/deploy/install-binary.sh
+++ b/scripts/deploy/install-binary.sh
@@ -21,11 +21,11 @@ mv -f "$next" "$binary"
 
 # Preserve the existing idempotent socket-activation migration.
 sh "$stage/enable-zero-downtime.sh" || true
-if sudo -n systemctl restart mu.service && systemctl is-active --quiet mu.service; then
+if sudo -n systemctl restart mu && systemctl is-active --quiet mu.service; then
   echo 'Deploy complete'
 else
   echo 'Restart failed; restoring the previous binary' >&2
   mv -f "${binary}.previous" "$binary"
-  sudo -n systemctl restart mu.service
+  sudo -n systemctl restart mu
   exit 1
 fi

--- a/test/deploy_binary_test.go
+++ b/test/deploy_binary_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestInstallCIBinary(t *testing.T) {
-	for _, scenario := range []string{"success", "corrupt", "cannot-run", "restart-fails"} {
+	for _, scenario := range []string{"success", "corrupt", "cannot-run", "restart-fails", "late-exit", "restart-loop"} {
 		t.Run(scenario, func(t *testing.T) {
 			root := t.TempDir()
 			stage, bin, mocks := filepath.Join(root, "stage"), filepath.Join(root, "bin"), filepath.Join(root, "mocks")
@@ -42,17 +42,27 @@ func TestInstallCIBinary(t *testing.T) {
 			write(filepath.Join(stage, "enable-zero-downtime.sh"), "#!/bin/sh\nexit 0\n")
 			write(filepath.Join(mocks, "systemctl"), `#!/bin/sh
 case "$1" in
- show) printf '{ path=%s ; argv[]=%s --serve ; }\n' "$TEST_BINARY" "$TEST_BINARY" ;;
+ show)
+  if [ "$2" = --property=MainPID ]; then
+   if [ "$TEST_SCENARIO" = restart-loop ] && test -e "$TEST_LOG.pid"; then echo 456; else echo 123; fi
+   touch "$TEST_LOG.pid"
+   exit 0
+  fi
+  printf '{ path=%s ; argv[]=%s --serve ; }\n' "$TEST_BINARY" "$TEST_BINARY" ;;
  restart)
   echo restart >> "$TEST_LOG"
   if [ "$TEST_SCENARIO" = restart-fails ] && ! test -e "$TEST_LOG.failed"; then
    touch "$TEST_LOG.failed"
    exit 1
   fi ;;
- is-active) exit 0 ;;
+ is-active)
+  if [ "$TEST_SCENARIO" = late-exit ] && test -e "$TEST_LOG.active"; then exit 1; fi
+  touch "$TEST_LOG.active"
+  exit 0 ;;
  *) exit 99 ;;
 esac
 `)
+			write(filepath.Join(mocks, "sleep"), "#!/bin/sh\nexit 0\n")
 			write(filepath.Join(mocks, "sudo"), "#!/bin/sh\n[ \"$1\" = -n ] && shift\nexec \"$@\"\n")
 			// Keep an open handle to verify atomic replacement preserves the old inode.
 			handle, err := os.Open(installed)
@@ -91,11 +101,49 @@ esac
 			if scenario == "success" {
 				expected = 1
 			}
-			if scenario == "restart-fails" {
+			if scenario == "restart-fails" || scenario == "late-exit" || scenario == "restart-loop" {
 				expected = 2
 			}
 			if count != expected {
 				t.Fatalf("restart count %d, want %d", count, expected)
+			}
+		})
+	}
+}
+
+func TestDeployArchitectureOutput(t *testing.T) {
+	workflow, err := os.ReadFile(at(".github/workflows/deploy.yml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(workflow)
+	start := strings.Index(text, "          architecture=$(printf")
+	if start < 0 {
+		t.Fatal("missing architecture parser")
+	}
+	end := strings.Index(text[start:], "\n\n")
+	if end < 0 {
+		t.Fatal("missing parser end")
+	}
+	script := "set -e\n" + text[start:start+end]
+	for _, tt := range []struct{ name, input, want string }{
+		{"bare", "MU_DEPLOY_ARCH=amd64\n", "arch=amd64\n"},
+		{"formatted", "======CMD======\nprintf 'MU_DEPLOY_ARCH=%s\\n' \"$architecture\"\n======END======\nout: MU_DEPLOY_ARCH=arm64\r\nSuccessfully executed commands\n", "arch=arm64\n"},
+		{"unknown", "MU_DEPLOY_ARCH=unknown\n", ""},
+		{"duplicate", "MU_DEPLOY_ARCH=amd64\nMU_DEPLOY_ARCH=arm64\n", ""},
+		{"noise", "amd64\n", ""},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			output := filepath.Join(t.TempDir(), "output")
+			cmd := exec.Command("sh", "-c", script)
+			cmd.Env = append(os.Environ(), "SSH_OUTPUT="+tt.input, "GITHUB_OUTPUT="+output)
+			log, err := cmd.CombinedOutput()
+			if (err == nil) != (tt.want != "") {
+				t.Fatalf("unexpected result %v: %s", err, log)
+			}
+			got, _ := os.ReadFile(output)
+			if string(got) != tt.want {
+				t.Fatalf("got %q, want %q", got, tt.want)
 			}
 		})
 	}

--- a/test/deploy_binary_test.go
+++ b/test/deploy_binary_test.go
@@ -1,0 +1,102 @@
+package test
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestInstallCIBinary(t *testing.T) {
+	for _, scenario := range []string{"success", "corrupt", "cannot-run", "restart-fails"} {
+		t.Run(scenario, func(t *testing.T) {
+			root := t.TempDir()
+			stage, bin, mocks := filepath.Join(root, "stage"), filepath.Join(root, "bin"), filepath.Join(root, "mocks")
+			for _, dir := range []string{stage, bin, mocks} {
+				if err := os.MkdirAll(dir, 0755); err != nil {
+					t.Fatal(err)
+				}
+			}
+			write := func(path, body string) {
+				t.Helper()
+				if err := os.WriteFile(path, []byte(body), 0755); err != nil {
+					t.Fatal(err)
+				}
+			}
+			installed := filepath.Join(bin, "mu")
+			old := "#!/bin/sh\necho old\n"
+			fresh := "#!/bin/sh\necho new\n"
+			if scenario == "cannot-run" {
+				fresh = "#!/bin/sh\nexit 1\n"
+			}
+			write(installed, old)
+			write(filepath.Join(stage, "mu"), fresh)
+			sum := fmt.Sprintf("%x  mu\n", sha256.Sum256([]byte(fresh)))
+			write(filepath.Join(stage, "SHA256SUMS"), sum)
+			if scenario == "corrupt" {
+				write(filepath.Join(stage, "mu"), fresh+"# truncated transfer\n")
+			}
+			write(filepath.Join(stage, "enable-zero-downtime.sh"), "#!/bin/sh\nexit 0\n")
+			write(filepath.Join(mocks, "systemctl"), `#!/bin/sh
+case "$1" in
+ show) printf '{ path=%s ; argv[]=%s --serve ; }\n' "$TEST_BINARY" "$TEST_BINARY" ;;
+ restart)
+  echo restart >> "$TEST_LOG"
+  if [ "$TEST_SCENARIO" = restart-fails ] && ! test -e "$TEST_LOG.failed"; then
+   touch "$TEST_LOG.failed"
+   exit 1
+  fi ;;
+ is-active) exit 0 ;;
+ *) exit 99 ;;
+esac
+`)
+			write(filepath.Join(mocks, "sudo"), "#!/bin/sh\n[ \"$1\" = -n ] && shift\nexec \"$@\"\n")
+			// Keep an open handle to verify atomic replacement preserves the old inode.
+			handle, err := os.Open(installed)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer handle.Close()
+			cmd := exec.Command("sh", at("scripts/deploy/install-binary.sh"), stage)
+			log := filepath.Join(root, "restarts")
+			cmd.Env = append(os.Environ(), "PATH="+mocks+":"+os.Getenv("PATH"), "TEST_BINARY="+installed, "TEST_SCENARIO="+scenario, "TEST_LOG="+log)
+			out, err := cmd.CombinedOutput()
+			if (err == nil) != (scenario == "success") {
+				t.Fatalf("unexpected result %v: %s", err, out)
+			}
+			got, err := os.ReadFile(installed)
+			if err != nil {
+				t.Fatal(err)
+			}
+			want := old
+			if scenario == "success" {
+				want = fresh
+			}
+			if string(got) != want {
+				t.Fatalf("installed binary = %q, want %q", got, want)
+			}
+			before := make([]byte, len(old))
+			if _, err := handle.ReadAt(before, 0); err != nil {
+				t.Fatal(err)
+			}
+			if string(before) != old {
+				t.Fatal("running binary was overwritten in place")
+			}
+			restarts, _ := os.ReadFile(log)
+			count := strings.Count(string(restarts), "restart")
+			expected := 0
+			if scenario == "success" {
+				expected = 1
+			}
+			if scenario == "restart-fails" {
+				expected = 2
+			}
+			if count != expected {
+				t.Fatalf("restart count %d, want %d", count, expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
CI currently compiles all release targets into /dev/null, while deployment separately pulls main and compiles again on the live server.

Retain the Linux binaries from that existing CI build as artifacts. After the same main-branch run passes both tests (including race detection) and builds, call a reusable deployment workflow. It detects the host architecture, downloads that run's matching artifact and transfers it over SSH. There is no additional build in deployment or on the server.

Install via a staged checksum-verified binary and atomic rename at the service's configured executable path. Keep the previous binary and restore it on restart failure. Preserve socket activation. Serialize deployments and skip superseded commits. Deployment no longer pulls the source checkout or sources its environment; systemd keeps its existing working directory and environment configuration. All successful main pushes now follow this pipeline, including workflow changes.

Validation: actionlint passed for both workflows. Installer tests cover success, corrupt transfers, failed executable checks and restart rollback, including preservation of the running file's inode. Targeted deploy tests and a static Linux build passed. Live artifact transfer and restart require the main-branch deployment run.