### PR TITLE
Simplify Home and move status editing to profiles

### DIFF
--- a/home/apps.go
+++ b/home/apps.go
@@ -12,7 +12,7 @@ import (
 // give a new account useful starting points without displaying the catalogue.
 func appsHTML(acc *auth.Account) string {
 	names := []string{"notes", "tasks", "events", "mail", "chat", "web", "video"}
-	if acc != nil && len(acc.PinnedServices()) > 0 {
+	if acc != nil {
 		names = acc.PinnedServices()
 	}
 	apps := service.Pinned(names)

--- a/home/apps.go
+++ b/home/apps.go
@@ -1,0 +1,29 @@
+package home
+
+import (
+	"html"
+	"strings"
+
+	"mu/internal/auth"
+	"mu/internal/service"
+)
+
+// appsHTML uses the same pins and service metadata as the sidebar. Defaults
+// give a new account useful starting points without displaying the catalogue.
+func appsHTML(acc *auth.Account) string {
+	names := []string{"notes", "tasks", "events", "mail", "chat", "web", "video"}
+	if acc != nil && len(acc.PinnedServices()) > 0 {
+		names = acc.PinnedServices()
+	}
+	apps := service.Pinned(names)
+	if len(apps) > 7 {
+		apps = apps[:7]
+	}
+	var b strings.Builder
+	b.WriteString(`<nav class="home-apps" aria-label="Apps"><div class="home-apps-heading">Apps</div><div class="home-apps-grid">`)
+	for _, s := range apps {
+		b.WriteString(`<a href="` + html.EscapeString(s.Page) + `"><img src="/` + html.EscapeString(s.NavIcon()) + `" alt=""><span>` + html.EscapeString(s.NavLabel()) + `</span></a>`)
+	}
+	b.WriteString(`<a href="/services"><span class="home-apps-all" aria-hidden="true">⋯</span><span>All services</span></a></div></nav>`)
+	return b.String()
+}

--- a/home/home.go
+++ b/home/home.go
@@ -269,10 +269,6 @@ func ForceRefresh() {
 }
 
 func Handler(w http.ResponseWriter, r *http.Request) {
-	if r.Method == http.MethodPost && r.FormValue("action") == "status" {
-		statusHandler(w, r)
-		return
-	}
 	// An installed app opens on the app, not on a pitch.
 	//
 	// The manifest's start_url was "/", so tapping the icon on a home screen
@@ -436,25 +432,13 @@ function fetchW(la,lo){
 	{
 		b.WriteString(`<div id="home-agent" class="page-stack">`)
 		b.WriteString(app.ChatComponent(app.ChatConfig{
-			ComposerFooterHTML: statusForm(r, viewerID),
+			ComposerFooterHTML: appsHTML(viewerAcc),
 			Ask:                true,
 			HideSuggestions:    true,
 			Placeholder:        "What do you need?",
 			// Who answers, for the byline over the reply. The default agent,
 			// which is what an unpicked box reaches — see agent.DefaultName.
-			AgentName: agent.DefaultName(),
-			// No doors row here, and the front door keeps it.
-			//
-			// It was on both for a while, on the argument that the box is the one
-			// control the two pages share and it read as a different product on
-			// each. That is consistency of the component and not of the page: the
-			// row is a way to reach the services, the front door has no other
-			// one, and this page has two — Services in the rail, and a grid of
-			// those same services below the fold.
-			//
-			// So on the front door it is navigation and here it was a third row
-			// of furniture stacked under one input, above the agent picker and
-			// the read-aloud toggle, duplicating a rail six inches to the left.
+			AgentName:        agent.DefaultName(),
 			OfferAgentPicker: viewerID != "",
 			// Read-back needs an answer to read, and a signed-out reader
 			// cannot get one — see ChatConfig.Speak. Same condition as the

--- a/inbox/person.go
+++ b/inbox/person.go
@@ -96,6 +96,18 @@ func PersonHandler(w http.ResponseWriter, r *http.Request) {
 	// cannot currently look at. Clicking your own name in /users and landing in
 	// your inbox is the report that found it.
 	you := them.ID == acc.ID
+	if r.Method == http.MethodPost {
+		if !you {
+			http.Error(w, "You can only edit your own status.", http.StatusForbidden)
+			return
+		}
+		if r.FormValue("action") != "status" {
+			http.Error(w, "Unknown action", http.StatusBadRequest)
+			return
+		}
+		statusHandler(w, r)
+		return
+	}
 
 	var convs []thread.Thread
 	if !you {
@@ -125,7 +137,9 @@ func PersonHandler(w http.ResponseWriter, r *http.Request) {
 	b.WriteString(`<div class="ib-person">`)
 	b.WriteString(`<p class="ib-person-sub">` + html.EscapeString(handle) + `</p>`)
 	b.WriteString(personFacts(them))
-	if status := user.Status(them.ID); status != "" {
+	if you {
+		b.WriteString(statusForm(r, acc.ID))
+	} else if status := user.Status(them.ID); status != "" {
 		b.WriteString(`<p class="text-secondary">` + html.EscapeString(status) + `</p>`)
 	}
 	// New message belongs on a page that already has one.

--- a/inbox/status.go
+++ b/inbox/status.go
@@ -1,4 +1,4 @@
-package home
+package inbox
 
 import (
 	_ "embed"
@@ -43,7 +43,7 @@ func statusHandler(w http.ResponseWriter, r *http.Request) {
 		json.NewEncoder(w).Encode(map[string]string{"status": user.Status(acc.ID)})
 		return
 	}
-	http.Redirect(w, r, "/home", http.StatusSeeOther)
+	http.Redirect(w, r, "/@"+acc.ID, http.StatusSeeOther)
 }
 
 //go:embed status.js
@@ -56,7 +56,14 @@ func statusForm(r *http.Request, id string) string {
 	text := user.Status(id)
 	label := "“" + text + "”"
 	if text == "" {
-		label = "What are you up to?"
+		label = "Set status"
 	}
-	return `<div id="home-status" class="page-stack" data-csrf="` + html.EscapeString(auth.CSRFToken(r)) + `">` + `<div class="form-actions inline-edit"><button type="button" class="link-button inline-edit-value" data-status-label aria-label="Change your public profile status">` + html.EscapeString(label) + `</button><button type="button" class="link-button inline-edit-action" data-status-edit>Edit</button><input data-status-input hidden maxlength="160" aria-label="Your public profile status" value="` + html.EscapeString(text) + `"></div><small class="inline-edit-feedback" data-status-feedback role="status" aria-live="polite"></small></div><script>` + statusJS + `</script>`
+	return `<div id="profile-status" class="page-stack" data-url="/@` + html.EscapeString(id) + `" data-csrf="` + html.EscapeString(auth.CSRFToken(r)) + `">` + `<div class="form-actions inline-edit"><button type="button" class="link-button inline-edit-value" data-status-label aria-label="Change your public profile status">` + html.EscapeString(label) + `</button><button type="button" class="link-button inline-edit-action" data-status-edit` + editHidden(text) + `>Edit</button><input data-status-input hidden maxlength="160" aria-label="Your public profile status" value="` + html.EscapeString(text) + `"></div><small class="inline-edit-feedback" data-status-feedback role="status" aria-live="polite"></small></div><script>` + statusJS + `</script>`
+}
+
+func editHidden(text string) string {
+	if text == "" {
+		return " hidden"
+	}
+	return ""
 }

--- a/inbox/status.js
+++ b/inbox/status.js
@@ -1,5 +1,5 @@
 (function () {
-  var root = document.getElementById('home-status');
+  var root = document.getElementById('profile-status');
   if (!root) return;
   var label = root.querySelector('[data-status-label]');
   var edit = root.querySelector('[data-status-edit]');
@@ -10,14 +10,14 @@
   // Soft navigation serializes this DOM, including an in-flight editor.
   if (input.readOnly) feedback.textContent = 'Save interrupted. Press Enter or tap away to retry.';
   input.readOnly = false;
-  edit.hidden = editing;
+  edit.hidden = editing || !saved;
   input.addEventListener('input', function () { input.defaultValue = input.value; });
   function close() {
     editing = false;
     input.hidden = true;
     label.hidden = false;
-    edit.hidden = false;
-    label.textContent = saved ? '“' + saved + '”' : 'What are you up to?';
+    edit.hidden = !saved;
+    label.textContent = saved ? '“' + saved + '”' : 'Set status';
   }
   function open() {
     if (saving) return;
@@ -40,7 +40,7 @@
     var controller = new AbortController();
     var timeout = setTimeout(function () { controller.abort(); }, 15000);
     try {
-      var response = await fetch('/home', {
+      var response = await fetch(root.dataset.url, {
         method: 'POST', credentials: 'same-origin', signal: controller.signal,
         headers: {'Accept': 'application/json', 'Content-Type': 'application/x-www-form-urlencoded'},
         body: new URLSearchParams({action: 'status', status: input.value, _csrf: root.dataset.csrf})

--- a/inbox/status_test.go
+++ b/inbox/status_test.go
@@ -1,4 +1,4 @@
-package home
+package inbox
 
 import (
 	"mu/internal/auth"

--- a/inbox/testdata/status.cjs
+++ b/inbox/testdata/status.cjs
@@ -35,7 +35,7 @@ function setup(restored) {
  assert.equal(s.label.textContent, '“New status”'); assert.equal(s.input.hidden, true);
  s.label.listeners.click(); s.input.value = ''; const cleared = s.input.listeners.blur();
  s.reply({ok:true,json:async()=>({status:''})}); await cleared;
- assert.equal(s.label.textContent, 'What are you up to?');
+ assert.equal(s.label.textContent, 'Set status');
  s.label.listeners.click(); s.input.value = 'Keep my draft'; const failed = s.input.listeners.blur();
  s.reply({ok:false}); await failed;
  assert.equal(s.input.value, 'Keep my draft'); assert.equal(s.input.hidden, false);

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -1460,7 +1460,7 @@ func navBottom(acc *auth.Account, here string) string {
 	// Profile was under it and is gone with the page. /@you is not a page about
 	// you any more, it is the conversation with somebody — and your own resolves
 	// to your inbox, which is already the first thing in the nav.
-	return `<div class="nav-me-who">Signed in as <span id="nav-username">@` + username + `</span></div>
+	return `<div class="nav-me-who">Signed in as <a id="nav-username" href="/@` + username + `">@` + username + `</a></div>
           <a id="nav-account" href="/account"><img src="/account.png?` + Version + `"><span class="label">Account</span></a>` + navAdmin(acc) + `
           <a id="nav-logout" href="/logout"><img src="/logout.png?` + Version + `"><span class="label">Log out</span></a>
           <a id="nav-login" href="/login" class="d-none"><img src="/account.png?` + Version + `"><span class="label">Login</span></a>`

--- a/internal/app/chat.go
+++ b/internal/app/chat.go
@@ -460,7 +460,7 @@ func ChatComponent(cfg ChatConfig) string {
 /* Reading back, beside who is answering — the same kind of decision. */
 #mu-chat-say{display:flex;align-items:center;gap:6px;cursor:pointer}
 #mu-chat-say input{margin:0}
-#mu-chat-opts{display:flex;align-items:center;gap:14px;flex-wrap:wrap;margin:6px 0 0}
+#mu-chat-opts{display:flex;align-items:center;gap:14px;flex-wrap:wrap;margin:0}
 #mu-chat-opts:empty{margin:0}
 #mu-chat-agent{display:flex;align-items:center;gap:8px;font-size:12px;color:#999;cursor:pointer;user-select:none}
 .mu-chat-agent-label{font-size:10px;text-transform:uppercase;letter-spacing:.1em;font-weight:600;color:#aaa}
@@ -507,7 +507,7 @@ func ChatComponent(cfg ChatConfig) string {
    resize, so there is no constant to be wrong on somebody's screen. */
 .mu-chat-transcript{display:flex;flex-direction:column}
 .mu-chat-transcript #mu-chat-form{position:static;flex:none;margin:0}
-.mu-chat-transcript #mu-chat-opts{margin:6px 0 0;flex:none}
+.mu-chat-transcript #mu-chat-opts{margin:0;flex:none}
 /* Margin only when there is something to separate.
    An empty conversation and an empty suggestion row are two zero-height
    divs, and their bottom margins still stack: 24px of nothing above the box,

--- a/internal/app/html/mu.css
+++ b/internal/app/html/mu.css
@@ -659,7 +659,7 @@ td {
   overflow: hidden;
   text-overflow: ellipsis;
 }
-.nav-me-who span { display: inline-block; color: var(--text-primary, #333) }
+.nav-me-who #nav-username { display: inline; padding: 0; color: var(--text-primary, #333); font-size: inherit; }
 
 /* Credit balance, pinned above the account links so the number is in view on
    every page. Empty and low are coloured because "0 credits" in the same grey
@@ -7785,4 +7785,15 @@ a:hover, a:hover * { text-decoration: none !important; }
  body.chat-page .mu-chat-transcript #mu-chat-conv { flex:1 1 0; max-height:none; min-height:0; }
  body.chat-page #chat-form { padding-bottom:0; }
  body.chat-page.typing .mu-chat-transcript #mu-chat-opts { display:none; }
+}
+
+/* A compact launcher shares the sidebar's pins and service catalogue. */
+.home-apps-heading { color: var(--text-muted, #707070); font-size: 12px; text-transform: uppercase; letter-spacing: .06em; margin-bottom: var(--space-control, 8px); }
+.home-apps-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(64px, 1fr)); gap: var(--space-control, 8px); }
+.home-apps-grid a { display: flex; flex-direction: column; align-items: center; gap: var(--space-control, 8px); padding: var(--space-control, 8px) 0; color: inherit; text-decoration: none; font-size: 12px; text-align: center; overflow-wrap: anywhere; border-radius: 8px; }
+.home-apps-grid a:hover { background: var(--hover-bg, #f5f5f5); }
+.home-apps-grid img, .home-apps-all { width: 24px; height: 24px; object-fit: contain; }
+.home-apps-all { display: grid; place-items: center; font-size: 24px; line-height: 1; }
+@media (max-width: 700px) {
+  #home-cards > .view-switch { justify-content: center; }
 }

--- a/internal/app/html/mu.js
+++ b/internal/app/html/mu.js
@@ -505,6 +505,7 @@ function setSession() {
       if (navLogin) navLogin.style.display = 'none';
       if (navUsername && sess.account) {
         navUsername.textContent = '@' + sess.account;
+        navUsername.setAttribute('href', '/@' + encodeURIComponent(sess.account));
         navUsername.style.display = 'inline-block';
         var navMeAv = document.getElementById("nav-me-av");
         if (navMeAv) navMeAv.textContent = sess.account.charAt(0).toUpperCase();

--- a/internal/app/nav_admin_test.go
+++ b/internal/app/nav_admin_test.go
@@ -66,8 +66,8 @@ func TestTheBottomIsWhoYouAreAndTheWayOut(t *testing.T) {
 			t.Errorf("%s is not under the name, where what is yours belongs", mine)
 		}
 	}
-	if strings.Contains(bottom, `href="/@someone"`) {
-		t.Error("the rail still links a profile page that no longer exists")
+	if !strings.Contains(bottom, `id="nav-username" href="/@someone"`) {
+		t.Error("the signed-in username does not link to the profile")
 	}
 	// The rest stay in the rail. They are the instance's services, not your
 	// account's pages, and a wallet under your name is the disclosure menu

--- a/internal/app/nav_icons_test.go
+++ b/internal/app/nav_icons_test.go
@@ -64,6 +64,9 @@ func TestEveryAccountMenuEntryHasAnIcon(t *testing.T) {
 			id = row[i+4:]
 			id = id[:strings.Index(id, `"`)]
 		}
+		if id == "nav-username" {
+			continue
+		} // Inline identity link, not a menu row.
 		if !strings.Contains(row[:strings.Index(row, "</a>")], "<img ") {
 			t.Errorf("the %s entry has no icon", id)
 		}


### PR DESCRIPTION
Home should keep the assistant central while making services easy to reach. Add a compact Apps launcher below the assistant controls using the same pinned services as the sidebar, with defaults and an All services link. Remove Home status, tighten composer control spacing and centre mobile Home/Feed tabs.

Move the existing status editor and save handling to the owner's profile. Link the sidebar username to that profile. Other profiles display a status only when set; editing another person's status is forbidden.

Validation: Home, Inbox and shared app tests pass. Binary builds. Home layout checked at 320, 768 and 1440px. Existing status lifecycle and session/CSRF tests moved with the editor.