### PR TITLE
Update go-micro and migrate AI providers to model package

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	gmai "go-micro.dev/v6/ai"
+	gmai "go-micro.dev/v6/model"
 )
 
 func quoteJSONString(s string) string {

--- a/agent/cost_test.go
+++ b/agent/cost_test.go
@@ -10,7 +10,8 @@ import (
 	"testing"
 
 	gmagent "go-micro.dev/v6/agent"
-	gmai "go-micro.dev/v6/ai"
+	gmai "go-micro.dev/v6/model"
+	"go-micro.dev/v6/registry"
 	"go-micro.dev/v6/store"
 
 	"mu/internal/app"
@@ -62,6 +63,7 @@ func TestARunIsPricedFromItsOwnTimeline(t *testing.T) {
 		// 100 input at $2/M is 0.02c, 50 output at $10/M is 0.05c.
 		gmagent.Model("claude-sonnet-5"),
 		gmagent.WithStore(runs),
+		gmagent.WithRegistry(registry.NewMemoryRegistry()),
 	)
 	defer a.Stop()
 	if _, err := a.Ask(context.Background(), "what did this cost"); err != nil {

--- a/agent/fallback.go
+++ b/agent/fallback.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"strings"
 
-	gmai "go-micro.dev/v6/ai"
+	gmai "go-micro.dev/v6/model"
 	"mu/internal/ai"
 	"mu/internal/app"
 	"mu/internal/settings"

--- a/agent/inject_account_test.go
+++ b/agent/inject_account_test.go
@@ -6,7 +6,7 @@ import (
 
 	"mu/internal/service"
 
-	gmai "go-micro.dev/v6/ai"
+	gmai "go-micro.dev/v6/model"
 )
 
 // TestInjectAccountBindsCallerToContext is a security regression test. The

--- a/agent/live_test.go
+++ b/agent/live_test.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 	"testing"
 
-	gmai "go-micro.dev/v6/ai"
+	gmai "go-micro.dev/v6/model"
 )
 
 func TestLiveToolHooksIncludeRefusedCalls(t *testing.T) {

--- a/agent/local/local.go
+++ b/agent/local/local.go
@@ -29,10 +29,10 @@ import (
 	"strings"
 	"time"
 
-	gmai "go-micro.dev/v6/ai"
-	"go-micro.dev/v6/ai/anthropic"
-	"go-micro.dev/v6/ai/atlascloud"
-	"go-micro.dev/v6/ai/openai"
+	gmai "go-micro.dev/v6/model"
+	"go-micro.dev/v6/model/anthropic"
+	"go-micro.dev/v6/model/atlascloud"
+	"go-micro.dev/v6/model/openai"
 
 	"mu/internal/ai"
 	"mu/internal/settings"

--- a/agent/memory.go
+++ b/agent/memory.go
@@ -59,7 +59,7 @@ import (
 	"fmt"
 	"strings"
 
-	gmai "go-micro.dev/v6/ai"
+	gmai "go-micro.dev/v6/model"
 )
 
 // historyBudget is how much conversation one question may carry, in characters.

--- a/agent/native.go
+++ b/agent/native.go
@@ -14,7 +14,7 @@ import (
 	"time"
 
 	gmagent "go-micro.dev/v6/agent"
-	gmai "go-micro.dev/v6/ai"
+	gmai "go-micro.dev/v6/model"
 	"go-micro.dev/v6/store"
 
 	"mu/internal/ai"

--- a/agent/native_test.go
+++ b/agent/native_test.go
@@ -3,7 +3,7 @@ package agent
 import (
 	"testing"
 
-	gmai "go-micro.dev/v6/ai"
+	gmai "go-micro.dev/v6/model"
 )
 
 func TestNativeToolCallKeyDedupesEquivalentInputs(t *testing.T) {

--- a/agent/outcome_test.go
+++ b/agent/outcome_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	gmagent "go-micro.dev/v6/agent"
+	"go-micro.dev/v6/registry"
 	"go-micro.dev/v6/store"
 )
 
@@ -26,6 +27,7 @@ func TestARunsShapeIsRecorded(t *testing.T) {
 		gmagent.Provider("costtest"),
 		gmagent.Model("claude-sonnet-5"),
 		gmagent.WithStore(runs),
+		gmagent.WithRegistry(registry.NewMemoryRegistry()),
 	)
 	defer a.Stop()
 	if _, err := a.Ask(context.Background(), "how did this go"); err != nil {

--- a/agent/retrieval.go
+++ b/agent/retrieval.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"time"
 
-	gmai "go-micro.dev/v6/ai"
+	gmai "go-micro.dev/v6/model"
 	"mu/internal/app"
 	"mu/internal/auth"
 	"mu/internal/data"

--- a/agent/retrieval_test.go
+++ b/agent/retrieval_test.go
@@ -2,7 +2,7 @@ package agent
 
 import (
 	"context"
-	gmai "go-micro.dev/v6/ai"
+	gmai "go-micro.dev/v6/model"
 	"mu/internal/thread"
 	"testing"
 	"time"

--- a/agent/tool_failure_test.go
+++ b/agent/tool_failure_test.go
@@ -2,7 +2,7 @@ package agent
 
 import (
 	"context"
-	gmai "go-micro.dev/v6/ai"
+	gmai "go-micro.dev/v6/model"
 	"strings"
 	"testing"
 )

--- a/agent/toolname_test.go
+++ b/agent/toolname_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	gmai "go-micro.dev/v6/ai"
+	gmai "go-micro.dev/v6/model"
 	"mu/internal/service"
 	"mu/service/shell"
 )

--- a/agent/toolprogress_test.go
+++ b/agent/toolprogress_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	gmai "go-micro.dev/v6/ai"
+	gmai "go-micro.dev/v6/model"
 )
 
 // A run that does the same kind of thing twice says so twice.

--- a/agent/tools_test.go
+++ b/agent/tools_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	gmai "go-micro.dev/v6/ai"
+	gmai "go-micro.dev/v6/model"
 
 	"mu/internal/service"
 	"mu/service/blog"

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -1194,3 +1194,63 @@ cached tools. Reconnect the client to refresh discovery after a deployment.
 ### Flight schedules and estimates
 
 Set `AVIATIONSTACK_API_KEY` in `/admin/config` to enable scheduled, estimated and actual flight times on `/flights`. Without it, the existing aircraft tracking still works. Lookups return up to 20 provider records; missing estimates are shown as unavailable. Set the `flights_status` price in `quota.json` to cover your provider plan (the shipped price is 3 credits per lookup).
+
+## Extending a running instance
+
+Mu uses go-micro to run its built-in services and agent loops. There are three
+ways to build on an instance; they have different deployment requirements.
+
+### Agents hosted by Mu
+
+Open `/agents` while signed in and create an agent with a name, instructions,
+and the services it may use. This is stored configuration: you do not fork,
+recompile or restart Mu to create an agent. Mu runs its loop using the instance's
+configured model providers. Talk to it from its agent page or use:
+
+```sh
+mu ask --agent research "Summarise the latest news"
+```
+
+The CLI must be logged into the intended instance. Creating an agent does not
+install arbitrary executable code or start a separate operating-system process.
+
+### Programs using Mu
+
+An independently running agent or application can call Mu's authenticated HTTP
+API at `/api/v1/<service>/<method>` or use its tools through `/mcp`. Point the
+client at your instance and give it a token with the access it needs. The client
+owns its execution and, for an external agent, its model and reasoning loop.
+Mu supplies capabilities. No Mu rebuild is needed, and the default in-memory
+registry can stay enabled.
+
+### Services running outside Mu
+
+Mu can discover separately running go-micro services through mDNS. The external
+service must register its RPC handlers with a go-micro mDNS registry and use a
+compatible HTTP transport. Its advertised address must be reachable from Mu.
+Use a unique service name that does not collide with a built-in service.
+
+Start Mu in the corresponding discovery mode:
+
+```sh
+MU_REGISTRY=mdns mu --serve
+```
+
+Run the external service separately on the same discovery network. Mu reads
+service names and endpoints from the registry and can invoke them dynamically;
+adding another compatible service does not require rebuilding Mu. Discovery
+of RPC methods does not supply a custom service web page.
+
+This mode is for an isolated, trusted network. Registry entries and RPC calls
+are not authenticated by this mechanism. Mu also advertises its own services,
+and switching to mDNS switches its internal calls from in-memory transport to
+HTTP. Do not expose these RPC listeners to an untrusted network. The event
+broker remains in memory; service discovery does not establish a shared event
+bus. Configure `MU_REGISTRY` in the process environment and restart Mu when
+changing discovery mode.
+
+Use your process manager, such as systemd or Docker, to start, supervise and
+stop the external service. Mu currently discovers and calls it; Mu does not
+install or manage its process. A separately written Go module linked into Mu
+is different again: importing that module requires a rebuild. Forking is only
+necessary when you want to maintain changes to Mu itself.

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/emersion/go-msgauth v0.7.0
 	github.com/emersion/go-sasl v0.0.0-20241020182733-b788ff22d5a6
 	github.com/emersion/go-smtp v0.24.0
+	github.com/felixge/httpsnoop v1.0.4
 	github.com/go-webauthn/webauthn v0.16.0
 	github.com/gomarkdown/markdown v0.0.0-20250311123330-531bef5e742b
 	github.com/google/uuid v1.6.0
@@ -20,7 +21,7 @@ require (
 	github.com/mrz1836/go-sanitize v1.5.3
 	github.com/piquette/finance-go v1.1.0
 	github.com/pkg/sftp v1.13.11
-	go-micro.dev/v6 v6.13.1-0.20260903114747-7be9734354a8
+	go-micro.dev/v6 v6.13.1-0.20260910093304-a43bfe1d2c6e
 	golang.org/x/crypto v0.54.0
 	golang.org/x/net v0.56.0
 	golang.org/x/sync v0.22.0
@@ -43,7 +44,6 @@ require (
 	github.com/cloudflare/circl v1.6.0 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.5 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
-	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.9.0 // indirect
 	github.com/go-json-experiment/json v0.0.0-20260623181947-01eb4420fa68 // indirect

--- a/go.sum
+++ b/go.sum
@@ -168,8 +168,8 @@ github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcY
 github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1 h1:gEOO8jv9F4OT7lGCjxCBTO/36wtF6j2nSip77qHd4x4=
 github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1/go.mod h1:Ohn+xnUBiLI6FVj/9LpzZWtj1/D6lUovWYBkxHVV3aM=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
-go-micro.dev/v6 v6.13.1-0.20260903114747-7be9734354a8 h1:ZcAKTYmGnBB+m7QhF1DGbZt4a4rmnimqQCiJiaYiSXs=
-go-micro.dev/v6 v6.13.1-0.20260903114747-7be9734354a8/go.mod h1:HHDv8c+yRqE8Q9dRJtUM9MJTkHyKgPVxaxidsrhnM+c=
+go-micro.dev/v6 v6.13.1-0.20260910093304-a43bfe1d2c6e h1:7AuM6e4pzndu7pGT28lnJMuBSi+uMECqWLZgCJzGwxc=
+go-micro.dev/v6 v6.13.1-0.20260910093304-a43bfe1d2c6e/go.mod h1:HHDv8c+yRqE8Q9dRJtUM9MJTkHyKgPVxaxidsrhnM+c=
 go.etcd.io/bbolt v1.4.0 h1:TU77id3TnN/zKr7CO/uk+fBCwF2jGcMuw2B/FMAzYIk=
 go.etcd.io/bbolt v1.4.0/go.mod h1:AsD+OCi/qPN1giOX1aiLAha3o1U8rAz65bvN4j0sRuk=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=

--- a/internal/ai/gemini_schema.go
+++ b/internal/ai/gemini_schema.go
@@ -2,8 +2,8 @@ package ai
 
 import (
 	"context"
-	gmai "go-micro.dev/v6/ai"
-	"go-micro.dev/v6/ai/gemini"
+	gmai "go-micro.dev/v6/model"
+	"go-micro.dev/v6/model/gemini"
 )
 
 // The pinned framework's built-in plan tool omits the schema of its steps.

--- a/internal/ai/gemini_schema_test.go
+++ b/internal/ai/gemini_schema_test.go
@@ -2,7 +2,7 @@ package ai
 
 import (
 	gmagent "go-micro.dev/v6/agent"
-	gmai "go-micro.dev/v6/ai"
+	gmai "go-micro.dev/v6/model"
 	"testing"
 )
 

--- a/internal/ai/live_test.go
+++ b/internal/ai/live_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 	"time"
 
-	gmai "go-micro.dev/v6/ai"
+	gmai "go-micro.dev/v6/model"
 )
 
 func TestLiveTokensBeforeCompletionWithTools(t *testing.T) {

--- a/internal/ai/micro.go
+++ b/internal/ai/micro.go
@@ -8,11 +8,11 @@ import (
 	"strings"
 	"time"
 
-	gmai "go-micro.dev/v6/ai"
-	_ "go-micro.dev/v6/ai/anthropic"
-	_ "go-micro.dev/v6/ai/atlascloud"
-	_ "go-micro.dev/v6/ai/gemini"
-	_ "go-micro.dev/v6/ai/openai"
+	gmai "go-micro.dev/v6/model"
+	_ "go-micro.dev/v6/model/anthropic"
+	_ "go-micro.dev/v6/model/atlascloud"
+	_ "go-micro.dev/v6/model/gemini"
+	_ "go-micro.dev/v6/model/openai"
 
 	"mu/internal/app"
 	"mu/internal/settings"

--- a/internal/ai/openrouter.go
+++ b/internal/ai/openrouter.go
@@ -3,8 +3,8 @@ package ai
 import (
 	"strings"
 
-	gmai "go-micro.dev/v6/ai"
-	"go-micro.dev/v6/ai/openai"
+	gmai "go-micro.dev/v6/model"
+	"go-micro.dev/v6/model/openai"
 
 	"mu/internal/settings"
 )

--- a/internal/ai/openrouter_test.go
+++ b/internal/ai/openrouter_test.go
@@ -3,7 +3,7 @@ package ai
 import (
 	"testing"
 
-	gmai "go-micro.dev/v6/ai"
+	gmai "go-micro.dev/v6/model"
 
 	"mu/internal/settings"
 )

--- a/internal/service/docs_wiring_test.go
+++ b/internal/service/docs_wiring_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"go-micro.dev/v6/ai"
+	ai "go-micro.dev/v6/model"
 )
 
 // DocsProbe is a handler used to prove the Docs wiring end to end.

--- a/internal/service/identity_test.go
+++ b/internal/service/identity_test.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"go-micro.dev/v6/ai"
+	ai "go-micro.dev/v6/model"
 )
 
 func TestAccountRoundTrip(t *testing.T) {


### PR DESCRIPTION
Update the pinned go-micro revision to a43bfe1d2c6e (v6.13.1-0.20260910093304-a43bfe1d2c6e), including the provider package rename reported in micro/go-micro#4917. Migrate provider and test imports from ai to model, and refresh module checksums.

Give two model-only agent tests an explicit memory registry so they do not attempt mDNS discovery. Document current configured-agent, external-client and external-service extension paths in the installation guide, including lifecycle and trust limitations.

Validation: binary builds; agent tests pass after the registry correction; agent subpackages, internal/ai, internal/service, Home, Inbox and shared app tests pass. go mod tidy and formatting checked.