### PR TITLE
Fix agent model test cleanup racing background data writes

### DIFF
--- a/agent/model_test.go
+++ b/agent/model_test.go
@@ -5,6 +5,9 @@ import (
 	"testing"
 )
 
+// These tests use the suite home from TestMain: background data writes may
+// outlive an individual test, so a per-test home can race TempDir cleanup.
+//
 // An agent's model reaches the run.
 //
 // This is the wiring that was missing, and it was missing in the quietest
@@ -15,7 +18,6 @@ import (
 // used the instance default anyway, with nothing on screen to say which had
 // happened.
 func TestYourOwnAgentsModelReachesTheRun(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
 	t.Setenv("ATLAS_API_KEY", "atlas-test")
 
 	const owner = "picker"
@@ -23,6 +25,11 @@ func TestYourOwnAgentsModelReachesTheRun(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	t.Cleanup(func() {
+		if err := RemoveAgent(owner, a.ID); err != nil {
+			t.Error(err)
+		}
+	})
 	if err := SetModel(owner, a.ID, "deepseek-ai/deepseek-v4-flash"); err != nil {
 		t.Fatal(err)
 	}
@@ -46,7 +53,6 @@ func TestYourOwnAgentsModelReachesTheRun(t *testing.T) {
 // Not at the model call, which happens minutes later on a run somebody is
 // waiting for, by which time the person who chose it has gone.
 func TestAModelWeCannotRunIsRefused(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
 	t.Setenv("ANTHROPIC_API_KEY", "")
 	t.Setenv("ATLAS_API_KEY", "atlas-test")
 
@@ -55,6 +61,11 @@ func TestAModelWeCannotRunIsRefused(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	t.Cleanup(func() {
+		if err := RemoveAgent(owner, a.ID); err != nil {
+			t.Error(err)
+		}
+	})
 
 	// No Anthropic key here, so a Claude id is a run that cannot happen.
 	if err := SetModel(owner, a.ID, "claude-sonnet-5"); err == nil {
@@ -69,7 +80,6 @@ func TestAModelWeCannotRunIsRefused(t *testing.T) {
 // Clearing it goes back to the instance default, which is what an agent has
 // before anybody chooses and what it must return to when a provider is removed.
 func TestClearingTheModelIsAllowed(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
 	t.Setenv("ATLAS_API_KEY", "atlas-test")
 
 	const owner = "picker3"
@@ -77,6 +87,11 @@ func TestClearingTheModelIsAllowed(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	t.Cleanup(func() {
+		if err := RemoveAgent(owner, a.ID); err != nil {
+			t.Error(err)
+		}
+	})
 	if err := SetModel(owner, a.ID, "deepseek-ai/deepseek-v4-flash"); err != nil {
 		t.Fatal(err)
 	}
@@ -92,7 +107,6 @@ func TestClearingTheModelIsAllowed(t *testing.T) {
 // description and the scope, and a field it does not know about must survive
 // that — otherwise renaming an agent silently resets what it thinks with.
 func TestEditingDoesNotClearTheModel(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
 	t.Setenv("ATLAS_API_KEY", "atlas-test")
 
 	const owner = "picker4"
@@ -100,6 +114,11 @@ func TestEditingDoesNotClearTheModel(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	t.Cleanup(func() {
+		if err := RemoveAgent(owner, a.ID); err != nil {
+			t.Error(err)
+		}
+	})
 	if err := SetModel(owner, a.ID, "deepseek-ai/deepseek-v4-flash"); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Main CI failed after TestYourOwnAgentsModelReachesTheRun passed its assertions: TempDir cleanup found .mu/data being modified by a background writer.

Use the agent suite's existing temporary home instead of changing HOME to a directory deleted after each model test. Explicitly remove each created agent to preserve test isolation and repeatability. No production behaviour changes.

Validation: the full agent package passes; all four model tests pass 20 consecutive runs. This fixes the observed cleanup failure without sleeps or retries.