### PR TITLE
Make Home apps useful by default and shorten deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,6 +1,6 @@
 name: Deploy
 
-# Called only after the main-branch test and build jobs succeed.
+# Called after the main-branch build succeeds; tests run on pull requests.
 on:
   workflow_call:
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   test:
+    # Validate pull requests once; main builds the artifact that is deployed.
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -83,7 +85,7 @@ jobs:
           if-no-files-found: error
 
   deploy:
-    needs: [test, build]
+    needs: [build]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     uses: ./.github/workflows/deploy.yml
     secrets: inherit

--- a/agent/model_test.go
+++ b/agent/model_test.go
@@ -5,6 +5,9 @@ import (
 	"testing"
 )
 
+// These tests use the suite home from TestMain: background data writes may
+// outlive an individual test, so a per-test home can race TempDir cleanup.
+//
 // An agent's model reaches the run.
 //
 // This is the wiring that was missing, and it was missing in the quietest
@@ -15,7 +18,6 @@ import (
 // used the instance default anyway, with nothing on screen to say which had
 // happened.
 func TestYourOwnAgentsModelReachesTheRun(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
 	t.Setenv("ATLAS_API_KEY", "atlas-test")
 
 	const owner = "picker"
@@ -23,6 +25,11 @@ func TestYourOwnAgentsModelReachesTheRun(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	t.Cleanup(func() {
+		if err := RemoveAgent(owner, a.ID); err != nil {
+			t.Error(err)
+		}
+	})
 	if err := SetModel(owner, a.ID, "deepseek-ai/deepseek-v4-flash"); err != nil {
 		t.Fatal(err)
 	}
@@ -46,7 +53,6 @@ func TestYourOwnAgentsModelReachesTheRun(t *testing.T) {
 // Not at the model call, which happens minutes later on a run somebody is
 // waiting for, by which time the person who chose it has gone.
 func TestAModelWeCannotRunIsRefused(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
 	t.Setenv("ANTHROPIC_API_KEY", "")
 	t.Setenv("ATLAS_API_KEY", "atlas-test")
 
@@ -55,6 +61,11 @@ func TestAModelWeCannotRunIsRefused(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	t.Cleanup(func() {
+		if err := RemoveAgent(owner, a.ID); err != nil {
+			t.Error(err)
+		}
+	})
 
 	// No Anthropic key here, so a Claude id is a run that cannot happen.
 	if err := SetModel(owner, a.ID, "claude-sonnet-5"); err == nil {
@@ -69,7 +80,6 @@ func TestAModelWeCannotRunIsRefused(t *testing.T) {
 // Clearing it goes back to the instance default, which is what an agent has
 // before anybody chooses and what it must return to when a provider is removed.
 func TestClearingTheModelIsAllowed(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
 	t.Setenv("ATLAS_API_KEY", "atlas-test")
 
 	const owner = "picker3"
@@ -77,6 +87,11 @@ func TestClearingTheModelIsAllowed(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	t.Cleanup(func() {
+		if err := RemoveAgent(owner, a.ID); err != nil {
+			t.Error(err)
+		}
+	})
 	if err := SetModel(owner, a.ID, "deepseek-ai/deepseek-v4-flash"); err != nil {
 		t.Fatal(err)
 	}
@@ -92,7 +107,6 @@ func TestClearingTheModelIsAllowed(t *testing.T) {
 // description and the scope, and a field it does not know about must survive
 // that — otherwise renaming an agent silently resets what it thinks with.
 func TestEditingDoesNotClearTheModel(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
 	t.Setenv("ATLAS_API_KEY", "atlas-test")
 
 	const owner = "picker4"
@@ -100,6 +114,11 @@ func TestEditingDoesNotClearTheModel(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	t.Cleanup(func() {
+		if err := RemoveAgent(owner, a.ID); err != nil {
+			t.Error(err)
+		}
+	})
 	if err := SetModel(owner, a.ID, "deepseek-ai/deepseek-v4-flash"); err != nil {
 		t.Fatal(err)
 	}

--- a/agent/model_test.go
+++ b/agent/model_test.go
@@ -5,9 +5,6 @@ import (
 	"testing"
 )
 
-// These tests use the suite home from TestMain: background data writes may
-// outlive an individual test, so a per-test home can race TempDir cleanup.
-//
 // An agent's model reaches the run.
 //
 // This is the wiring that was missing, and it was missing in the quietest
@@ -18,6 +15,7 @@ import (
 // used the instance default anyway, with nothing on screen to say which had
 // happened.
 func TestYourOwnAgentsModelReachesTheRun(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
 	t.Setenv("ATLAS_API_KEY", "atlas-test")
 
 	const owner = "picker"
@@ -25,11 +23,6 @@ func TestYourOwnAgentsModelReachesTheRun(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	t.Cleanup(func() {
-		if err := RemoveAgent(owner, a.ID); err != nil {
-			t.Error(err)
-		}
-	})
 	if err := SetModel(owner, a.ID, "deepseek-ai/deepseek-v4-flash"); err != nil {
 		t.Fatal(err)
 	}
@@ -53,6 +46,7 @@ func TestYourOwnAgentsModelReachesTheRun(t *testing.T) {
 // Not at the model call, which happens minutes later on a run somebody is
 // waiting for, by which time the person who chose it has gone.
 func TestAModelWeCannotRunIsRefused(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
 	t.Setenv("ANTHROPIC_API_KEY", "")
 	t.Setenv("ATLAS_API_KEY", "atlas-test")
 
@@ -61,11 +55,6 @@ func TestAModelWeCannotRunIsRefused(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	t.Cleanup(func() {
-		if err := RemoveAgent(owner, a.ID); err != nil {
-			t.Error(err)
-		}
-	})
 
 	// No Anthropic key here, so a Claude id is a run that cannot happen.
 	if err := SetModel(owner, a.ID, "claude-sonnet-5"); err == nil {
@@ -80,6 +69,7 @@ func TestAModelWeCannotRunIsRefused(t *testing.T) {
 // Clearing it goes back to the instance default, which is what an agent has
 // before anybody chooses and what it must return to when a provider is removed.
 func TestClearingTheModelIsAllowed(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
 	t.Setenv("ATLAS_API_KEY", "atlas-test")
 
 	const owner = "picker3"
@@ -87,11 +77,6 @@ func TestClearingTheModelIsAllowed(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	t.Cleanup(func() {
-		if err := RemoveAgent(owner, a.ID); err != nil {
-			t.Error(err)
-		}
-	})
 	if err := SetModel(owner, a.ID, "deepseek-ai/deepseek-v4-flash"); err != nil {
 		t.Fatal(err)
 	}
@@ -107,6 +92,7 @@ func TestClearingTheModelIsAllowed(t *testing.T) {
 // description and the scope, and a field it does not know about must survive
 // that — otherwise renaming an agent silently resets what it thinks with.
 func TestEditingDoesNotClearTheModel(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
 	t.Setenv("ATLAS_API_KEY", "atlas-test")
 
 	const owner = "picker4"
@@ -114,11 +100,6 @@ func TestEditingDoesNotClearTheModel(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	t.Cleanup(func() {
-		if err := RemoveAgent(owner, a.ID); err != nil {
-			t.Error(err)
-		}
-	})
 	if err := SetModel(owner, a.ID, "deepseek-ai/deepseek-v4-flash"); err != nil {
 		t.Fatal(err)
 	}

--- a/home/apps.go
+++ b/home/apps.go
@@ -11,19 +11,22 @@ import (
 // appsHTML uses the same pins and service metadata as the sidebar. Defaults
 // give a new account useful starting points without displaying the catalogue.
 func appsHTML(acc *auth.Account) string {
-	names := []string{"notes", "tasks", "events", "mail", "chat", "web", "video"}
-	if acc != nil {
+	names := []string{"news", "video", "web", "mail"}
+	if acc != nil && len(acc.Pinned) > 0 {
 		names = acc.PinnedServices()
 	}
 	apps := service.Pinned(names)
+	if len(apps) == 0 {
+		apps = service.Pinned([]string{"news", "video", "web", "mail"})
+	}
 	if len(apps) > 7 {
 		apps = apps[:7]
 	}
 	var b strings.Builder
-	b.WriteString(`<nav class="home-apps" aria-label="Apps"><div class="home-apps-heading">Apps</div><div class="home-apps-grid">`)
+	b.WriteString(`<nav class="home-apps page-stack" aria-label="Apps">` + sectionRule("Apps") + `<div class="home-apps-grid">`)
 	for _, s := range apps {
-		b.WriteString(`<a href="` + html.EscapeString(s.Page) + `"><img src="/` + html.EscapeString(s.NavIcon()) + `" alt=""><span>` + html.EscapeString(s.NavLabel()) + `</span></a>`)
+		b.WriteString(`<a href="` + html.EscapeString(s.Page) + `"><span class="home-app-icon"><img src="/` + html.EscapeString(s.NavIcon()) + `" alt=""></span><span>` + html.EscapeString(s.NavLabel()) + `</span></a>`)
 	}
-	b.WriteString(`<a href="/services"><span class="home-apps-all" aria-hidden="true">⋯</span><span>All services</span></a></div></nav>`)
+	b.WriteString(`</div><a href="/services" class="link">All services →</a></nav>`)
 	return b.String()
 }

--- a/home/apps_test.go
+++ b/home/apps_test.go
@@ -1,0 +1,36 @@
+package home
+
+import (
+	"strings"
+	"testing"
+
+	"mu/internal/auth"
+	"mu/internal/service"
+	"mu/service/mail"
+	"mu/service/news"
+	"mu/service/video"
+	"mu/service/web"
+)
+
+func TestAppsAlwaysOfferUsefulDefaults(t *testing.T) {
+	for _, spec := range []service.Spec{news.Spec, video.Spec, web.Spec, mail.Spec} {
+		if err := service.Register(spec); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, acc := range []*auth.Account{nil, {}, {Pinned: []string{}}, {Pinned: []string{"removed-service"}}} {
+		body := appsHTML(acc)
+		for _, name := range []string{"news", "video", "web", "mail"} {
+			if !strings.Contains(body, `href="/`+name+`"`) {
+				t.Errorf("missing default %s for %#v", name, acc)
+			}
+		}
+		if !strings.Contains(body, sectionRule("Apps")) || !strings.Contains(body, `</div><a href="/services" class="link">All services →</a>`) {
+			t.Error("launcher heading or catalogue link misplaced")
+		}
+	}
+	body := appsHTML(&auth.Account{Pinned: []string{"video"}})
+	if !strings.Contains(body, `href="/video"`) || strings.Contains(body, `href="/news"`) {
+		t.Error("explicit pins were not used")
+	}
+}

--- a/internal/app/html/mu.css
+++ b/internal/app/html/mu.css
@@ -7788,12 +7788,11 @@ a:hover, a:hover * { text-decoration: none !important; }
 }
 
 /* A compact launcher shares the sidebar's pins and service catalogue. */
-.home-apps-heading { color: var(--text-muted, #707070); font-size: 12px; text-transform: uppercase; letter-spacing: .06em; margin-bottom: var(--space-control, 8px); }
-.home-apps-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(64px, 1fr)); gap: var(--space-control, 8px); }
-.home-apps-grid a { display: flex; flex-direction: column; align-items: center; gap: var(--space-control, 8px); padding: var(--space-control, 8px) 0; color: inherit; text-decoration: none; font-size: 12px; text-align: center; overflow-wrap: anywhere; border-radius: 8px; }
-.home-apps-grid a:hover { background: var(--hover-bg, #f5f5f5); }
-.home-apps-grid img, .home-apps-all { width: 24px; height: 24px; object-fit: contain; }
-.home-apps-all { display: grid; place-items: center; font-size: 24px; line-height: 1; }
+.home-apps-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(64px, 80px)); gap: var(--space-control, 8px); }
+.home-apps-grid a { display: flex; flex-direction: column; align-items: center; gap: var(--space-control, 8px); color: inherit; text-decoration: none; font-size: 12px; text-align: center; overflow-wrap: anywhere; }
+.home-app-icon { display: grid; place-items: center; width: 48px; height: 48px; border: 1px solid var(--card-border, #e8e8e8); border-radius: 12px; background: var(--card-bg, #fafafa); }
+.home-apps-grid a:hover .home-app-icon { background: var(--hover-bg, #f5f5f5); }
+.home-app-icon img { width: 26px; height: 26px; object-fit: contain; }
 @media (max-width: 700px) {
   #home-cards > .view-switch { justify-content: center; }
 }

--- a/scripts/deploy/README.md
+++ b/scripts/deploy/README.md
@@ -30,8 +30,8 @@ Point nginx at the same address the socket listens on (`127.0.0.1:8080`).
 
 ## Redeploy
 
-The main-branch CI build retains its Linux binaries as artifacts. After the
-same run passes tests (including the race detector), it calls the deployment
+Pull requests run tests, including the race detector. The main-branch build
+retains its Linux binaries as artifacts and then calls the deployment
 workflow. That workflow selects the server's architecture and transfers the
 existing artifact; neither the deploy job nor the server recompiles it.
 


### PR DESCRIPTION
Home could render an empty Apps section with a stretched catalogue tile. Show News, Video, Web and Mail when there are no usable explicit pins (including deliberately empty pins, as now requested). Use compact rounded icon tiles, the shared section heading rule and a normal All services → link outside the grid.

Keep full tests and race detection on pull requests. Main pushes build and deploy the produced artifact without repeating that test suite. Deployment still requires a successful build, verifies the transferred binary and retains rollback checks. Direct pushes to main now have build validation only; tests belong before merge.

Validation: Home/shared app tests and binary build passed; regression checks cover absent, empty, stale and explicit pins; actionlint passed for both workflows.