### PR TITLE
Fix Home conversation placement and touch submission

### DIFF
--- a/home/home.go
+++ b/home/home.go
@@ -432,10 +432,10 @@ function fetchW(la,lo){
 	{
 		b.WriteString(`<div id="home-agent" class="page-stack">`)
 		b.WriteString(app.ChatComponent(app.ChatConfig{
-			ComposerFooterHTML: appsHTML(viewerAcc),
-			Ask:                true,
-			HideSuggestions:    true,
-			Placeholder:        "What do you need?",
+			FooterHTML:      appsHTML(viewerAcc),
+			Ask:             true,
+			HideSuggestions: true,
+			Placeholder:     "What do you need?",
 			// Who answers, for the byline over the reply. The default agent,
 			// which is what an unpicked box reaches — see agent.DefaultName.
 			AgentName:        agent.DefaultName(),

--- a/internal/app/chat.go
+++ b/internal/app/chat.go
@@ -42,9 +42,9 @@ func JSAttr(s string) string {
 
 // ChatConfig configures the shared chat component.
 type ChatConfig struct {
-	// ComposerFooterHTML is trusted, pre-rendered content kept below the composer
-	// controls and above the conversation. Callers must escape user text.
-	ComposerFooterHTML string
+	// FooterHTML is trusted, pre-rendered content below the conversation and
+	// composer. Callers must escape user text.
+	FooterHTML string
 	// Ask makes this box talk to the agent. Without it, it searches.
 	//
 	// A default of search rather than of asking, because the pages that want a
@@ -439,14 +439,15 @@ func ChatComponent(cfg ChatConfig) string {
 
 	// Two orders, one component. See ChatConfig.Transcript.
 	composer := form + doors + opts
-	if cfg.ComposerFooterHTML != "" {
-		composer = `<div class="page-stack">` + composer + cfg.ComposerFooterHTML + `</div>`
-	}
 	body := composer + suggest + conv
 	shell := `<div id="mu-chat">`
 	if cfg.Transcript {
 		body = conv + suggest + composer
 		shell = `<div id="mu-chat" class="mu-chat-transcript">`
+	}
+
+	if cfg.FooterHTML != "" {
+		body += `<div class="mu-chat-footer">` + cfg.FooterHTML + `</div>`
 	}
 
 	html := shell + `
@@ -493,6 +494,7 @@ func ChatComponent(cfg ChatConfig) string {
 #mu-chat-doors a:hover{text-decoration:underline}
 #mu-chat-conv{margin-top:24px;font-size:15px;line-height:1.7;text-align:left}
 #mu-chat-conv:empty{margin-top:0}
+.mu-chat-footer{margin-top:16px}
 /* A conversation, not a box.
 
    The turns scroll in their own region and the input sits under them, which is
@@ -825,7 +827,9 @@ function ask(q){
   var byName=agentName();
   if(byName){var by=document.createElement('div');by.className='mu-by';by.textContent=byName;conv.appendChild(by);}
   var a=document.createElement('div');a.className='mu-agent';conv.appendChild(a);
-  input.value='';saveDraft();input.style.height='auto';input.focus();
+  input.value='';saveDraft();input.style.height='auto';
+  var touchInput=window.matchMedia('(pointer: coarse)').matches;
+  if(touchInput){input.blur();}else{input.focus();}
 
   var terminal=false,flowID='',recoveryThread='',completionTimer=null;
   var workLabel='Working';
@@ -878,7 +882,11 @@ function ask(q){
   //
   // In a box the exchange is anchored under the input instead, which is what
   // Home wants: you typed at the top and the answer appears under it.
-  if(transcript){ toBottom(true,true); } else { u.scrollIntoView({behavior:'smooth',block:'start'}); }
+  if(transcript){ toBottom(true,true); } else {
+    revealQuestion(u);
+    // Re-align after the mobile keyboard has finished shrinking the viewport.
+    if(touchInput)setTimeout(function(){if(epoch===viewEpoch)revealQuestion(u);},350);
+  }
   var streamText='';
   var body=JSON.stringify({prompt:q,attachment:(!contextId?attachment:""),history:history.slice(-6),context_id:contextId||'',agent:(window.muActiveAgent||''),cards:true});
   // Accept says which of the two doors at /agent this is.

--- a/internal/app/chat_footer_test.go
+++ b/internal/app/chat_footer_test.go
@@ -1,0 +1,17 @@
+package app
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestChatFooterFollowsConversation(t *testing.T) {
+	for _, transcript := range []bool{false, true} {
+		body := ChatComponent(ChatConfig{Ask: true, Transcript: transcript, FooterHTML: `<nav id="service-launcher">Services</nav>`})
+		conversation := strings.Index(body, `id="mu-chat-conv"`)
+		footer := strings.Index(body, `id="service-launcher"`)
+		if conversation < 0 || footer < conversation {
+			t.Fatal("services interrupt the conversation")
+		}
+	}
+}

--- a/internal/app/testdata/chat_completion.js
+++ b/internal/app/testdata/chat_completion.js
@@ -1,11 +1,11 @@
 const fs=require('fs'),assert=require('assert');
 const source=JSON.parse(fs.readFileSync(0,'utf8'));
 const frame=e=>'data: '+JSON.stringify(e)+'\n\n';
-async function scenario(frames,stall=false){
+async function scenario(frames,stall=false,touch=false){
  const paints=[],children=[],timeouts=[];
- const element=()=>({className:'',style:{},isConnected:true,focus(){},scrollIntoView(){},set innerHTML(v){this.html=v;paints.push(v)},get innerHTML(){return this.html||''}});
+ const element=()=>({className:'',style:{},isConnected:true,focus(){this.focused=true},blur(){this.focused=false;this.blurred=true},scrollIntoView(){},set innerHTML(v){this.html=v;paints.push(v)},get innerHTML(){return this.html||''}});
  let idx=0,polls=0,scrolls=0;
- const env={viewEpoch:0,detachActive:null,hideBrief(){},sugDiv:element(),conv:{appendChild(e){children.push(e)}},document:{createElement:element},input:element(),saveDraft(){},save(){},esc:String,agentName(){return 'Micro'},toBottom(){},revealQuestion(node){assert(node.isConnected);assert.equal(node.className,"mu-user");scrolls++},transcript:false,history:[],contextId:'',attachment:'',window:{dispatchEvent(){}},CustomEvent:class{},TextDecoder,AbortController,
+ const env={viewEpoch:0,detachActive:null,hideBrief(){},sugDiv:element(),conv:{appendChild(e){children.push(e)}},document:{createElement:element},input:element(),saveDraft(){},save(){},esc:String,agentName(){return 'Micro'},toBottom(){},revealQuestion(node){assert(node.isConnected);assert.equal(node.className,"mu-user");scrolls++},transcript:false,history:[],contextId:'',attachment:'',window:{dispatchEvent(){},matchMedia(){return {matches:touch}}},CustomEvent:class{},TextDecoder,AbortController,
  setInterval(){return 1},clearInterval(){},setTimeout(fn,ms){timeouts.push({fn,ms});return timeouts.length},clearTimeout(){},
  fetch(url){
   if(url.startsWith('/agent/pending')){polls++;return Promise.resolve({ok:true,json:()=>Promise.resolve({waiting:false,html:'<div>Recovered</div>',answer_html:'Recovered',text:'Recovered'})})}
@@ -15,6 +15,9 @@ async function scenario(frames,stall=false){
  for(let i=0;i<100;i++)await Promise.resolve();
  if(stall){const timer=timeouts.find(t=>t.ms===4000);assert(timer,'missing live completion watchdog');timer.fn();for(let i=0;i<100;i++)await Promise.resolve();}
  if(env.history.length)assert(scrolls>0,"completed landing answer was not revealed");
+ assert(scrolls>0,"submitted question was not revealed");
+ if(touch){assert(env.input.blurred,"touch keyboard was not dismissed");const timer=timeouts.find(t=>t.ms===350);assert(timer);timer.fn();}
+ else assert(env.input.focused,"desktop input lost focus");
  return {paints,answer:children[children.length-1],polls,history:env.history};
 }
 (async()=>{
@@ -25,5 +28,6 @@ async function scenario(frames,stall=false){
  r=await scenario([id],true);assert.equal(r.answer.innerHTML,'Recovered');assert.equal(r.history.length,1);
  r=await scenario([id,'data: {"type":"response"']);assert.equal(r.answer.innerHTML,'Recovered');
  r=await scenario([id,frame({type:'error',message:'Failed'}),frame({type:'tool_done'})]);assert(r.answer.innerHTML.includes('Failed'));assert.equal(r.polls,0);
+ await scenario([id,frame({type:'response',html:'Touch answer',text:'Touch answer'})],false,true);
  console.log('completion scenarios passed');
 })().catch(e=>{console.error(e);process.exitCode=1});


### PR DESCRIPTION
The Services launcher interrupted Home's input and conversation, and submitting explicitly refocused the input so the mobile keyboard stayed open.

Render supplemental footer content after the conversation. On touch devices blur the input after a nonempty submission; retain desktop focus. Reveal the submitted question with the existing scroll offset helper, and realign after the keyboard closing animation.

Validation: Home and shared app tests pass; binary builds. Regression coverage checks footer ordering, submission scrolling, touch blur and retained desktop focus. Completion/recovery scenarios still pass.