### PR TITLE
Keep Home focused and add Google calendar selection

### DIFF
--- a/home/apps.go
+++ b/home/apps.go
@@ -4,24 +4,14 @@ import (
 	"html"
 	"strings"
 
+	"mu/internal/app"
 	"mu/internal/auth"
-	"mu/internal/service"
 )
 
 // appsHTML uses the same pins and service metadata as the sidebar. Defaults
 // give a new account useful starting points without displaying the catalogue.
 func appsHTML(acc *auth.Account) string {
-	names := []string{"news", "video", "web", "mail"}
-	if acc != nil && len(acc.Pinned) > 0 {
-		names = acc.PinnedServices()
-	}
-	apps := service.Pinned(names)
-	if len(apps) == 0 {
-		apps = service.Pinned([]string{"news", "video", "web", "mail"})
-	}
-	if len(apps) > 7 {
-		apps = apps[:7]
-	}
+	apps := app.ServiceShortcuts(acc)
 	var b strings.Builder
 	b.WriteString(`<nav class="home-apps page-stack" aria-label="Services">` + sectionRule("Services") + `<div class="home-apps-grid">`)
 	for _, s := range apps {

--- a/home/brief.go
+++ b/home/brief.go
@@ -320,7 +320,12 @@ func onToday(accountID string, external ...events.External) string {
 		out += " at " + html.EscapeString(next.When.In(now.Location()).Format("15:04"))
 	}
 	if rest := len(ahead) - 1; rest > 0 {
-		out += ", and " + strconv.Itoa(rest) + " more today"
+		// The Home fetch is bounded. Do not present a partial count as the total.
+		if len(external) >= events.PreviewLimit {
+			out += ", with more today"
+		} else {
+			out += ", and " + strconv.Itoa(rest) + " more today"
+		}
 	}
 	return out + "."
 }

--- a/home/brief.go
+++ b/home/brief.go
@@ -90,8 +90,8 @@ import (
 // true on the quietest day. True and useless as a sentence — who is here is its
 // own block under the box now, and it names people rather than telling you
 // there are none.
-func briefHTML(accountID string) string {
-	parts := briefParts(accountID)
+func briefHTML(accountID string, external ...events.External) string {
+	parts := briefParts(accountID, external...)
 	if len(parts) == 0 {
 		return ""
 	}
@@ -133,7 +133,7 @@ func briefHTML(accountID string) string {
 // The last clause is the world's and is the only one an account is not needed
 // for, so a signed-out reader gets it alone. That is the whole of the public
 // brief: everyone's day is the same, yours is not.
-func briefParts(accountID string) []string {
+func briefParts(accountID string, external ...events.External) []string {
 	var parts []string
 	if accountID != "" {
 		if s := waiting(accountID); s != "" {
@@ -155,7 +155,7 @@ func briefParts(accountID string) []string {
 		// day. So somebody with a dentist at four and a school pickup at three
 		// read a line about their inbox and went to look at a calendar, which
 		// is the one thing a brief is supposed to save.
-		if s := onToday(accountID); s != "" {
+		if s := onToday(accountID, external...); s != "" {
 			parts = append(parts, s)
 		}
 	}
@@ -285,7 +285,7 @@ func owed(accountID string) string {
 //
 // The next one is named, with its time, because that is the fact somebody
 // actually wants: not how many, but what and when. The count carries the rest.
-func onToday(accountID string) string {
+func onToday(accountID string, external ...events.External) string {
 	now := account.LocalNow(accountID)
 	var ahead []*events.Event
 	for _, e := range events.List(accountID) {
@@ -294,6 +294,14 @@ func onToday(accountID string) string {
 		}
 		if sameDay(e.When.In(now.Location()), now) && e.When.After(now) {
 			ahead = append(ahead, e)
+		}
+	}
+	allDay := map[*events.Event]bool{}
+	for _, e := range external {
+		if (e.AllDay && e.Start.Format("2006-01-02") <= now.Format("2006-01-02") && e.End.Format("2006-01-02") > now.Format("2006-01-02")) || (sameDay(e.Start.In(now.Location()), now) && e.Start.After(now)) {
+			item := &events.Event{Title: e.Title, When: e.Start}
+			ahead = append(ahead, item)
+			allDay[item] = e.AllDay
 		}
 	}
 	if len(ahead) == 0 {
@@ -305,8 +313,12 @@ func onToday(accountID string) string {
 	sort.Slice(ahead, func(i, j int) bool { return ahead[i].When.Before(ahead[j].When) })
 
 	next := ahead[0]
-	out := app.TextLink(next.Title, "/events") + " at " +
-		html.EscapeString(next.When.In(now.Location()).Format("15:04"))
+	out := app.TextLink(html.EscapeString(next.Title), "/events")
+	if allDay[next] {
+		out += " today"
+	} else {
+		out += " at " + html.EscapeString(next.When.In(now.Location()).Format("15:04"))
+	}
 	if rest := len(ahead) - 1; rest > 0 {
 		out += ", and " + strconv.Itoa(rest) + " more today"
 	}

--- a/home/brief_test.go
+++ b/home/brief_test.go
@@ -214,3 +214,21 @@ func TestBriefDoesNotAnnounceItsOwnDelivery(t *testing.T) {
 		t.Fatalf("schedule appeared in brief: %s", got)
 	}
 }
+
+func TestTheBriefIncludesSelectedCalendarEvents(t *testing.T) {
+	const who = "briefexternal"
+	now := time.Now()
+	next := now.Add(time.Minute)
+	if !sameDay(now, next) {
+		t.Skip("day boundary")
+	}
+	got := onToday(who, events.External{Title: "Google <meeting>", Start: next})
+	if !strings.Contains(got, "Google &lt;meeting&gt;") {
+		t.Fatalf("missing selected calendar event: %s", got)
+	}
+	start := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
+	got = onToday(who, events.External{Title: "All-day visit", Start: start, End: start.AddDate(0, 0, 1), AllDay: true})
+	if !strings.Contains(got, "All-day visit</a> today") || strings.Contains(got, " at ") {
+		t.Fatalf("all-day event treated as a timed meeting: %s", got)
+	}
+}

--- a/home/frontdoor_test.go
+++ b/home/frontdoor_test.go
@@ -17,7 +17,6 @@ package home
 //     in redirects to /home. See Index.
 
 import (
-	"os"
 	"strings"
 	"testing"
 )
@@ -37,15 +36,15 @@ func TestAStrangerIsNotOfferedReadAloud(t *testing.T) {
 	}
 }
 
-// And Home keeps both: it is where a person configures how they work.
-func TestHomeKeepsThePicker(t *testing.T) {
-	b, err := os.ReadFile("home.go")
-	if err != nil {
-		t.Fatal(err)
+// Home starts with Micro; specialist conversations remain on Agents.
+func TestHomeStartsWithMicro(t *testing.T) {
+	body := homeFor(t, "homesimplecomposer")
+	for _, control := range []string{`id="mu-chat-agent"`, `id="mu-chat-say"`} {
+		if strings.Contains(body, control) {
+			t.Errorf("Home still offers %s", control)
+		}
 	}
-	src := string(b)
-	if !strings.Contains(src, "OfferAgentPicker: viewerID != \"\"") {
-		t.Error("Home no longer offers the agent picker, so an agent somebody made\n" +
-			"can be reached from nowhere they would naturally talk to it")
+	if !strings.Contains(body, `class="mu-chat-contained"`) {
+		t.Error("Home conversation is not contained")
 	}
 }

--- a/home/home.go
+++ b/home/home.go
@@ -278,7 +278,7 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		now := time.Now()
-		external := events.ExternalEvents(sess.Account, now, now.Add(30*24*time.Hour))
+		external := events.ExternalEvents(sess.Account, now, now.Add(30*24*time.Hour), events.PreviewLimit)
 		app.RespondJSON(w, map[string]string{"upcoming": events.Preview(sess.Account, external), "brief": briefHTML(sess.Account, external...)})
 		return
 	}

--- a/home/home.go
+++ b/home/home.go
@@ -18,6 +18,7 @@ import (
 	"mu/internal/auth"
 	"mu/internal/event"
 	"mu/internal/service"
+	"mu/service/events"
 	"mu/service/news"
 )
 
@@ -269,6 +270,18 @@ func ForceRefresh() {
 }
 
 func Handler(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Query().Get("section") == "upcoming" {
+		sess, _ := auth.TrySession(r)
+		w.Header().Set("Cache-Control", "private, no-store")
+		if sess == nil {
+			http.Error(w, "Sign in to see upcoming events", http.StatusUnauthorized)
+			return
+		}
+		now := time.Now()
+		external := events.ExternalEvents(sess.Account, now, now.Add(30*24*time.Hour))
+		app.RespondJSON(w, map[string]string{"upcoming": events.Preview(sess.Account, external), "brief": briefHTML(sess.Account, external...)})
+		return
+	}
 	// An installed app opens on the app, not on a pitch.
 	//
 	// The manifest's start_url was "/", so tapping the icon on a home screen
@@ -427,38 +440,32 @@ function fetchW(la,lo){
 	b.WriteString(homeViews(feed))
 	b.WriteString(`<section id="home-personal" role="tabpanel" aria-labelledby="home-view-personal"` + panelHidden(feed) + `>`)
 
-	// Desktop keeps the prompt and inbox beside the brief and agents.
-	b.WriteString(`<div class="home-workspace">`)
-	{
-		b.WriteString(`<div id="home-agent" class="page-stack">`)
-		b.WriteString(app.ChatComponent(app.ChatConfig{
-			FooterHTML:      appsHTML(viewerAcc),
-			Ask:             true,
-			HideSuggestions: true,
-			Placeholder:     "What do you need?",
-			// Who answers, for the byline over the reply. The default agent,
-			// which is what an unpicked box reaches — see agent.DefaultName.
-			AgentName:        agent.DefaultName(),
-			OfferAgentPicker: viewerID != "",
-			// Read-back needs an answer to read, and a signed-out reader
-			// cannot get one — see ChatConfig.Speak. Same condition as the
-			// picker, and for the same reason: both are decisions about a
-			// conversation somebody is able to have.
-			Speak: viewerID != "",
-		}))
-
-		b.WriteString(`</div>`)
-	}
+	// Each column flows independently as a conversation grows.
+	b.WriteString(`<div class="home-workspace"><div class="home-column page-stack">`)
+	b.WriteString(`<div id="home-agent" class="page-stack"><script>window.muActiveAgent="";</script>`)
+	b.WriteString(app.ChatComponent(app.ChatConfig{
+		FooterHTML:      appsHTML(viewerAcc),
+		Ask:             true,
+		HideSuggestions: true,
+		Placeholder:     "What do you need?",
+		AgentName:       agent.DefaultName(),
+		Contained:       true,
+	}))
+	b.WriteString(`</div>`)
 	if viewerID != "" {
-		if brief := briefHTML(viewerID); brief != "" {
-			b.WriteString(`<div id="home-brief" data-brief class="page-stack">` + brief + `</div>`)
-		}
 		if peek := inbox.Preview(viewerID); peek != "" {
 			b.WriteString(`<div id="home-inbox" class="page-stack">` + sectionRule("Inbox") + peek + `</div>`)
 		}
+	}
+	b.WriteString(`</div>`)
+	if viewerID != "" {
+		b.WriteString(`<div class="home-column page-stack">`)
+		b.WriteString(`<div id="home-upcoming" class="page-stack">` + sectionRule("Upcoming events") + `<div data-home-upcoming aria-live="polite" class="page-stack"><p class="text-muted">Loading events…</p></div>` + `</div>`)
+		b.WriteString(`<div id="home-brief" class="page-stack">` + briefHTML(viewerID) + `</div>`)
 		if who := agent.Preview(viewerID); who != "" {
 			b.WriteString(`<div id="home-agents" class="page-stack">` + sectionRule("Agents") + who + `</div>`)
 		}
+		b.WriteString(`</div>`)
 	}
 	b.WriteString(`</div>`)
 

--- a/home/layout_test.go
+++ b/home/layout_test.go
@@ -1,11 +1,13 @@
 package home
 
 import (
+	"mu/service/events"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"mu/internal/auth"
 	"mu/internal/quota"
@@ -183,5 +185,34 @@ func TestUpcomingEndpointRequiresSession(t *testing.T) {
 	Handler(rec, httptest.NewRequest("GET", "/home?section=upcoming", nil))
 	if rec.Code != http.StatusUnauthorized || rec.Header().Get("Cache-Control") != "private, no-store" {
 		t.Fatalf("upcoming endpoint: %d, cache %q", rec.Code, rec.Header().Get("Cache-Control"))
+	}
+}
+
+func TestHomeBoundsItsExternalCalendarRead(t *testing.T) {
+	const owner = "boundedcalendar"
+	old := events.ExternalEntries
+	defer func() { events.ExternalEntries = old }()
+	calls := 0
+	events.ExternalEntries = func(got string, from, to time.Time, limit int) []events.External {
+		calls++
+		if got != owner || limit != events.PreviewLimit {
+			t.Fatalf("calendar request owner=%q limit=%d", got, limit)
+		}
+		return []events.External{{Title: "External meeting", Start: time.Now().Add(time.Hour)}}
+	}
+	homeFor(t, owner)
+	if calls != 0 {
+		t.Fatal("Home blocked on a provider request")
+	}
+	sess, err := auth.CreateSession(owner)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req := httptest.NewRequest("GET", "/home?section=upcoming&owner=someoneelse", nil)
+	req.AddCookie(&http.Cookie{Name: "session", Value: sess.Token})
+	rec := httptest.NewRecorder()
+	Handler(rec, req)
+	if rec.Code != 200 || calls != 1 || !strings.Contains(rec.Body.String(), "External meeting") {
+		t.Fatalf("preview %d, calls %d", rec.Code, calls)
 	}
 }

--- a/home/layout_test.go
+++ b/home/layout_test.go
@@ -177,3 +177,11 @@ func TestGreetingTreatsDisplayNamesAsText(t *testing.T) {
 		t.Error("display name became executable markup")
 	}
 }
+
+func TestUpcomingEndpointRequiresSession(t *testing.T) {
+	rec := httptest.NewRecorder()
+	Handler(rec, httptest.NewRequest("GET", "/home?section=upcoming", nil))
+	if rec.Code != http.StatusUnauthorized || rec.Header().Get("Cache-Control") != "private, no-store" {
+		t.Fatalf("upcoming endpoint: %d, cache %q", rec.Code, rec.Header().Get("Cache-Control"))
+	}
+}

--- a/home/publicbrief_test.go
+++ b/home/publicbrief_test.go
@@ -118,19 +118,11 @@ func TestAskingTakesTheBriefOffThePage(t *testing.T) {
 	}
 }
 
-// And Home's brief takes part, so the two pages behave the same way.
-//
-// Home puts the answer directly above it — the conversation is inside
-// #home-agent and the brief is the block after it — so without the attribute
-// every turn walks the brief down the page.
-func TestHomesBriefIsMarkedToo(t *testing.T) {
-	src, err := os.ReadFile("home.go")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !strings.Contains(string(src), `id="home-brief" data-brief`) {
-		t.Error("Home's brief is not marked data-brief, so it stays on the page\n" +
-			"under the answer while the landing page's steps aside")
+// Home's separate brief stays available while the person talks to Micro.
+func TestHomesBriefStaysAvailable(t *testing.T) {
+	body := homeFor(t, "homebriefvisible")
+	if !strings.Contains(body, `id="home-brief" class="page-stack"`) || strings.Contains(body, `id="home-brief" data-brief`) {
+		t.Error("Home brief still steps aside during a conversation")
 	}
 }
 

--- a/home/views.js
+++ b/home/views.js
@@ -1,6 +1,20 @@
 (() => {
   const home = document.getElementById('home-cards');
   if (!home) return;
+  const upcoming = home.querySelector('[data-home-upcoming]');
+  if (upcoming) {
+    fetch('/home?section=upcoming', {credentials: 'same-origin'})
+      .then(response => { if (!response.ok) throw new Error('events'); return response.json(); })
+      .then(data => {
+        upcoming.innerHTML = data.upcoming;
+        const brief = home.querySelector("#home-brief");
+        if (brief) brief.innerHTML = data.brief;
+        upcoming.querySelectorAll('[data-event-time]').forEach(node => {
+          node.textContent = new Date(node.dateTime).toLocaleString(undefined, {weekday:'short', day:'numeric', month:'short', hour:'2-digit', minute:'2-digit'});
+        });
+      })
+      .catch(() => { upcoming.innerHTML = '<p class="text-muted">Could not load events. <a href="/events">Open events</a></p>'; });
+  }
   const tabs = [...home.querySelectorAll('.view-switch [role="tab"]')];
   const positions = new Map();
   let selected = tabs.find(tab => tab.getAttribute('aria-selected') === 'true');

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -20,7 +20,6 @@ import (
 	"time"
 
 	"mu/internal/auth"
-	"mu/internal/service"
 
 	"github.com/gomarkdown/markdown"
 	"github.com/gomarkdown/markdown/ast"
@@ -1355,13 +1354,12 @@ func navAdmin(acc *auth.Account) string {
 // group scrolls if it grows; the account group below it does not move, because
 // signing out is not something to scroll for.
 //
-// Nothing is drawn at all when nothing is pinned. An empty heading over an
-// empty list is a worse answer than no heading.
+// Home and the sidebar use the same shortcuts, including defaults for new accounts.
 func navPinned(acc *auth.Account) string {
 	if acc == nil {
 		return ""
 	}
-	pinned := service.Pinned(acc.PinnedServices())
+	pinned := ServiceShortcuts(acc)
 	if len(pinned) == 0 {
 		return ""
 	}

--- a/internal/app/chat.go
+++ b/internal/app/chat.go
@@ -161,6 +161,9 @@ type ChatConfig struct {
 	// conversation is: it left the newest turn at the top, the input above it,
 	// and everything older stretching away below.
 	Transcript bool
+
+	// Contained limits the height of a conversation beneath its composer.
+	Contained bool
 }
 
 // ChatComponent returns the single, shared chat UI used everywhere Mu talks to
@@ -441,6 +444,9 @@ func ChatComponent(cfg ChatConfig) string {
 	composer := form + doors + opts
 	body := composer + suggest + conv
 	shell := `<div id="mu-chat">`
+	if cfg.Contained {
+		shell = `<div id="mu-chat" class="mu-chat-contained">`
+	}
 	if cfg.Transcript {
 		body = conv + suggest + composer
 		shell = `<div id="mu-chat" class="mu-chat-transcript">`
@@ -477,6 +483,7 @@ func ChatComponent(cfg ChatConfig) string {
    the box moved to a page the token does not reach. 30px is what mu.css sets. */
 #mu-chat-form button{flex-shrink:0;width:var(--control-h,30px);height:var(--control-h,30px);min-width:var(--control-h,30px);padding:0;background:#111;color:#fff;border:none;border-radius:6px;cursor:pointer;display:flex;align-items:center;justify-content:center;font-size:16px;line-height:1}
 #mu-chat-suggest{margin-top:16px}
+#mu-chat-suggest:empty{display:none}
 .mu-pills{display:flex;gap:8px;flex-wrap:wrap;justify-content:center}
 .mu-pills a{padding:8px 14px;border:1px solid #e0e0e0;border-radius:6px;font-size:13px;color:#555;text-decoration:none;cursor:pointer}
 .mu-pills a:hover{background:#f5f5f5}
@@ -495,6 +502,12 @@ func ChatComponent(cfg ChatConfig) string {
 #mu-chat-conv{margin-top:24px;font-size:15px;line-height:1.7;text-align:left}
 #mu-chat-conv:empty{margin-top:0}
 .mu-chat-footer{margin-top:16px}
+#mu-chat.mu-chat-contained #mu-chat-conv {
+  max-height: min(48dvh, 420px);
+  overflow-y: auto;
+  overscroll-behavior-y: contain;
+  scrollbar-gutter: stable;
+}
 /* A conversation, not a box.
 
    The turns scroll in their own region and the input sits under them, which is
@@ -602,6 +615,7 @@ var conv=document.getElementById('mu-chat-conv');
 // A transcript keeps its input at the bottom and its newest turn above it.
 // See ChatConfig.Transcript.
 var transcript=!!document.querySelector('#mu-chat.mu-chat-transcript');
+var contained=!!document.querySelector('#mu-chat.mu-chat-contained');
 
 // The brief steps aside when you ask.
 //
@@ -613,8 +627,8 @@ var transcript=!!document.querySelector('#mu-chat.mu-chat-transcript');
 // of the page ends up below a conversation.
 //
 // So asking replaces it, and starting a fresh session brings it back. Anything
-// marked data-brief takes part; the landing page and Home both mark theirs, and
-// nothing else has to know this exists.
+// marked data-brief takes part. Home keeps its brief in a separate column,
+// so it remains available during a conversation.
 function briefs(){return document.querySelectorAll('[data-brief]');}
 function hideBrief(){var n=briefs();for(var i=0;i<n.length;i++){n[i].hidden=true;}}
 function showBrief(){var n=briefs();for(var i=0;i<n.length;i++){n[i].hidden=false;}}
@@ -630,12 +644,13 @@ function revealQuestion(node){
   if(transcript){toBottom(false);return;}
   requestAnimationFrame(function(){
     if(!node||!node.isConnected)return;
+    if(contained){conv.scrollTo({top:node.getBoundingClientRect().top-conv.getBoundingClientRect().top+conv.scrollTop,behavior:"smooth"});return;}
     node.style.scrollMarginTop=Math.max(64,(form?form.getBoundingClientRect().height:0)+24)+"px";
     node.scrollIntoView({behavior:"smooth",block:"start"});
   });
 }
 function toBottom(force,smooth){
-  if(!transcript) return;
+  if(!transcript&&!contained) return;
   if(!force && !nearBottom()) return;
   requestAnimationFrame(function(){
     conv.scrollTo({top:conv.scrollHeight,behavior:smooth?'smooth':'auto'});

--- a/internal/app/html/composition.css
+++ b/internal/app/html/composition.css
@@ -59,6 +59,10 @@
 .page-stack > *, .page-section > * { margin-block: 0; min-width: 0; }
 .section-actions, .check-label { display: flex; flex-wrap: wrap; align-items: center; gap: var(--space-control); }
 .section-actions { font-size: 14px; }
+.check-label { flex-wrap: nowrap; align-items: flex-start; }
+.check-label > span { min-width: 0; overflow-wrap: anywhere; }
+fieldset.form-group { border: 0; padding: 0; min-inline-size: 0; }
+fieldset.form-group > legend { padding: 0; }
 .check-label input { width: auto; margin: 0; }
 .choices { display: flex; flex-wrap: wrap; gap: var(--space-control); }
 .choice { position: relative; max-width: 100%; }

--- a/internal/app/html/mu.css
+++ b/internal/app/html/mu.css
@@ -963,14 +963,14 @@ a.btn-plain:hover {
 #home-personal, #home-feed, .home-rail, .home-main { min-width: 0; }
 #home-personal[hidden], #home-feed[hidden] { display: none !important; }
 #home-personal { display: grid; gap: var(--space-section, 24px); }
-.home-workspace { display: grid; gap: var(--space-section, 24px); }
+.home-workspace { display: grid; gap: var(--space-section, 24px); align-items: start; }
+.home-column { min-width: 0; gap: var(--space-section, 24px); }
+#home-brief:empty { display: none; }
 @media (min-width: 1100px) {
-  .home-workspace:has(#home-brief, #home-agents) { grid-template-columns: minmax(0, 2fr) minmax(0, 1fr); align-items: start; }
-  #home-agent { grid-column: 1; grid-row: 1; }
-  #home-brief { grid-column: 2; grid-row: 1; }
-  #home-inbox { grid-column: 1; grid-row: 2; }
-  #home-agents { grid-column: 2; grid-row: 2; }
+  .home-workspace:has(#home-brief, #home-agents, #home-upcoming) { grid-template-columns: minmax(0, 2fr) minmax(0, 1fr); }
 }
+
+
 
 
 
@@ -7788,9 +7788,9 @@ a:hover, a:hover * { text-decoration: none !important; }
 }
 
 /* A compact launcher shares the sidebar's pins and service catalogue. */
-.home-apps-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(64px, 80px)); gap: var(--space-control, 8px); }
+.home-apps-grid { display: grid; grid-template-columns: repeat(auto-fit, 56px); gap: var(--space-field, 16px); }
 .home-apps-grid a { display: flex; flex-direction: column; align-items: center; gap: var(--space-control, 8px); color: inherit; text-decoration: none; font-size: 12px; text-align: center; overflow-wrap: anywhere; }
-.home-app-icon { display: grid; place-items: center; width: 48px; height: 48px; border: 1px solid var(--card-border, #e8e8e8); border-radius: 12px; background: var(--card-bg, #fafafa); }
+.home-app-icon { display: grid; place-items: center; width: 56px; height: 56px; box-sizing: border-box; border: 1px solid var(--card-border, #e8e8e8); border-radius: 12px; background: var(--card-bg, #fafafa); }
 .home-apps-grid a:hover .home-app-icon { background: var(--hover-bg, #f5f5f5); }
 .home-app-icon img { width: 26px; height: 26px; object-fit: contain; }
 @media (max-width: 700px) {

--- a/internal/app/shortcuts.go
+++ b/internal/app/shortcuts.go
@@ -1,0 +1,17 @@
+package app
+
+import (
+	"mu/internal/auth"
+	"mu/internal/service"
+)
+
+// ServiceShortcuts is the shared Home and sidebar selection. Empty or stale
+// pins fall back to everyday services available on this instance.
+func ServiceShortcuts(acc *auth.Account) []service.Spec {
+	if acc != nil {
+		if pinned := service.Pinned(acc.Pinned); len(pinned) > 0 {
+			return pinned
+		}
+	}
+	return service.Pinned([]string{"news", "video", "web", "mail"})
+}

--- a/internal/google/calendars.go
+++ b/internal/google/calendars.go
@@ -1,0 +1,126 @@
+package google
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+)
+
+// Calendar is a readable calendar on the connected Google account.
+type Calendar struct {
+	ID              string `json:"id"`
+	Summary         string `json:"summary"`
+	SummaryOverride string `json:"summaryOverride"`
+	Primary         bool   `json:"primary"`
+}
+
+// SelectedCalendars returns a copy of this account's selection. Existing grants
+// keep their primary calendar until the person explicitly changes the selection.
+func SelectedCalendars(accountID string) []string {
+	mu.RLock()
+	defer mu.RUnlock()
+	c := conns[accountID]
+	if c == nil || c.Calendars == nil {
+		return []string{"primary"}
+	}
+	return append([]string{}, c.Calendars...)
+}
+
+// Calendars lists all readable calendars, including those hidden in Google's UI.
+func Calendars(accountID string) ([]Calendar, error) {
+	token, err := accessToken(accountID)
+	if err != nil {
+		return nil, err
+	}
+	q := url.Values{"maxResults": {"250"}, "minAccessRole": {"reader"}, "showHidden": {"true"}}
+	var calendars []Calendar
+	seen := map[string]bool{}
+	for {
+		req, _ := http.NewRequest(http.MethodGet, "https://www.googleapis.com/calendar/v3/users/me/calendarList?"+q.Encode(), nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+		resp, err := httpClient.Do(req)
+		if err != nil {
+			return nil, err
+		}
+		if resp.StatusCode != http.StatusOK {
+			resp.Body.Close()
+			return nil, fmt.Errorf("google calendar list: %s", resp.Status)
+		}
+		var out struct {
+			Items         []Calendar `json:"items"`
+			NextPageToken string     `json:"nextPageToken"`
+		}
+		err = json.NewDecoder(resp.Body).Decode(&out)
+		resp.Body.Close()
+		if err != nil {
+			return nil, err
+		}
+		for _, c := range out.Items {
+			if c.ID == "" {
+				continue
+			}
+			if c.SummaryOverride != "" {
+				c.Summary = c.SummaryOverride
+			}
+			if c.Summary == "" {
+				c.Summary = c.ID
+			}
+			calendars = append(calendars, c)
+		}
+		if out.NextPageToken == "" {
+			return calendars, nil
+		}
+		if seen[out.NextPageToken] {
+			return nil, fmt.Errorf("google calendar list repeated a page token")
+		}
+		seen[out.NextPageToken] = true
+		q.Set("pageToken", out.NextPageToken)
+	}
+}
+
+// SetCalendars validates selections against the caller's own Google grant and
+// saves them together. Google free/busy supports up to 50 calendars per query.
+func SetCalendars(accountID string, ids []string) error {
+	if !HasScope(accountID, CalendarScope) {
+		return ErrNotConnected
+	}
+	if len(ids) > 50 {
+		return fmt.Errorf("choose up to 50 calendars")
+	}
+	mu.RLock()
+	connection := conns[accountID]
+	mu.RUnlock()
+	available, err := Calendars(accountID)
+	if err != nil {
+		return err
+	}
+	allowed := map[string]bool{}
+	for _, c := range available {
+		allowed[c.ID] = true
+	}
+	selected := make([]string, 0, len(ids))
+	seen := map[string]bool{}
+	for _, id := range ids {
+		if !allowed[id] {
+			return fmt.Errorf("a selected calendar is no longer available; reload and try again")
+		}
+		if !seen[id] {
+			selected = append(selected, id)
+			seen[id] = true
+		}
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	c := conns[accountID]
+	if c == nil || c != connection {
+		return ErrNotConnected
+	}
+	previous := c.Calendars
+	c.Calendars = selected
+	if err := save(); err != nil {
+		c.Calendars = previous
+		return err
+	}
+	return nil
+}

--- a/internal/google/calendars_test.go
+++ b/internal/google/calendars_test.go
@@ -59,6 +59,14 @@ func TestCalendarSelectionIsPrivateValidatedAndPersistent(t *testing.T) {
 	if !reflect.DeepEqual(SelectedCalendars("alice"), want) {
 		t.Fatal("reauthorization lost selection")
 	}
+	Store("alice", "", "refresh-without-profile", []string{CalendarScope})
+	if !reflect.DeepEqual(SelectedCalendars("alice"), want) {
+		t.Fatal("unavailable account lookup reset selection")
+	}
+	Store("alice", "ALICE@example.com", "refresh-with-profile", []string{CalendarScope})
+	if !reflect.DeepEqual(SelectedCalendars("alice"), want) {
+		t.Fatal("recovering account lookup reset selection")
+	}
 	reset()
 	Load()
 	if !reflect.DeepEqual(SelectedCalendars("alice"), want) {
@@ -69,6 +77,11 @@ func TestCalendarSelectionIsPrivateValidatedAndPersistent(t *testing.T) {
 	if !reflect.DeepEqual(SelectedCalendars("alice"), want) {
 		t.Fatal("selection aliases stored state")
 	}
+	Store("alice", "different@example.com", "other-account-refresh", []string{CalendarScope})
+	if !reflect.DeepEqual(SelectedCalendars("alice"), []string{"primary"}) {
+		t.Fatal("different Google account inherited old calendar selection")
+	}
+
 }
 
 func TestSelectedCalendarsMergeEventsBeforeLimitingAndShareBusySelection(t *testing.T) {
@@ -150,5 +163,19 @@ func TestSharedInvitationsAppearOnceButRecurrencesRemain(t *testing.T) {
 	got, err := Events("alice", time.Now(), time.Now().Add(48*time.Hour), 0)
 	if err != nil || len(got) != 2 {
 		t.Fatalf("shared recurring invitation: %+v, %v", got, err)
+	}
+}
+
+func TestCalendarPreviewDoesNotReadUnneededProviderPages(t *testing.T) {
+	calendarFixture(t, func(r *http.Request) (*http.Response, error) {
+		if r.URL.Query().Get("maxResults") != "3" || r.URL.Query().Get("pageToken") != "" {
+			t.Error("preview read beyond its limit")
+		}
+		return calendarResponse(`{"nextPageToken":"unneeded","items":[{"summary":"One","start":{"dateTime":"2026-09-10T08:00:00Z"}},{"summary":"Two","start":{"dateTime":"2026-09-10T09:00:00Z"}},{"summary":"Three","start":{"dateTime":"2026-09-10T10:00:00Z"}}]}`), nil
+	})
+	conns["alice"].Calendars = []string{"personal", "work"}
+	got, err := Events("alice", time.Now(), time.Now().Add(30*24*time.Hour), 3)
+	if err != nil || len(got) != 3 {
+		t.Fatalf("preview %v, %v", got, err)
 	}
 }

--- a/internal/google/calendars_test.go
+++ b/internal/google/calendars_test.go
@@ -1,0 +1,154 @@
+package google
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+)
+
+func calendarFixture(t *testing.T, handler calendarTransport) {
+	t.Helper()
+	reset()
+	old := httpClient
+	t.Cleanup(func() { httpClient = old; reset() })
+	httpClient = &http.Client{Transport: handler}
+	Store("alice", "alice@example.com", "refresh", []string{CalendarScope})
+	access["alice"] = cachedToken{token: "alice", expires: time.Now().Add(time.Hour)}
+}
+
+func calendarResponse(body string) *http.Response {
+	return &http.Response{StatusCode: 200, Body: io.NopCloser(strings.NewReader(body)), Header: make(http.Header)}
+}
+
+func TestCalendarSelectionIsPrivateValidatedAndPersistent(t *testing.T) {
+	calls := 0
+	calendarFixture(t, func(r *http.Request) (*http.Response, error) {
+		if r.Header.Get("Authorization") != "Bearer alice" {
+			t.Error("wrong account credential")
+		}
+		if !strings.HasSuffix(r.URL.Path, "/calendarList") || r.URL.Query().Get("minAccessRole") != "reader" {
+			t.Error("not listing readable calendars")
+		}
+		calls++
+		if r.URL.Query().Get("pageToken") == "next" {
+			return calendarResponse(`{"items":[{"id":"work","summary":"Work"}]}`), nil
+		}
+		return calendarResponse(`{"items":[{"id":"alice@example.com","summary":"Personal","primary":true}],"nextPageToken":"next"}`), nil
+	})
+	if err := SetCalendars("alice", []string{"alice@example.com", "work", "work"}); err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"alice@example.com", "work"}
+	if got := SelectedCalendars("alice"); !reflect.DeepEqual(got, want) || calls != 2 {
+		t.Fatalf("selection %v, requests %d", got, calls)
+	}
+	if err := SetCalendars("alice", []string{"someone-elses-calendar"}); err == nil {
+		t.Fatal("accepted calendar outside the owner's list")
+	}
+	if !reflect.DeepEqual(SelectedCalendars("alice"), want) {
+		t.Fatal("invalid selection changed saved settings")
+	}
+	if err := SetCalendars("bob", []string{"work"}); err != ErrNotConnected {
+		t.Fatalf("unconnected account: %v", err)
+	}
+	Store("alice", "alice@example.com", "new-refresh", []string{CalendarScope})
+	if !reflect.DeepEqual(SelectedCalendars("alice"), want) {
+		t.Fatal("reauthorization lost selection")
+	}
+	reset()
+	Load()
+	if !reflect.DeepEqual(SelectedCalendars("alice"), want) {
+		t.Fatal("restart lost selection")
+	}
+	copy := SelectedCalendars("alice")
+	copy[0] = "other"
+	if !reflect.DeepEqual(SelectedCalendars("alice"), want) {
+		t.Fatal("selection aliases stored state")
+	}
+}
+
+func TestSelectedCalendarsMergeEventsBeforeLimitingAndShareBusySelection(t *testing.T) {
+	calendarFixture(t, func(r *http.Request) (*http.Response, error) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/freeBusy"):
+			var body struct {
+				Items []struct {
+					ID string `json:"id"`
+				} `json:"items"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Error(err)
+			}
+			if len(body.Items) != 2 || body.Items[0].ID != "personal" || body.Items[1].ID != "work/calendar" {
+				t.Errorf("wrong busy calendars: %+v", body)
+			}
+			return calendarResponse(`{"calendars":{"personal":{"busy":[{"start":"2026-09-10T12:00:00Z","end":"2026-09-10T13:00:00Z"}]},"work/calendar":{"busy":[{"start":"2026-09-10T08:00:00Z","end":"2026-09-10T09:00:00Z"}]}}}`), nil
+		case strings.Contains(r.URL.EscapedPath(), "work%2Fcalendar"):
+			return calendarResponse(`{"items":[{"summary":"Earlier work","start":{"dateTime":"2026-09-10T08:00:00Z"}},{"summary":"Later work","start":{"dateTime":"2026-09-10T16:00:00Z"}}]}`), nil
+		case strings.Contains(r.URL.Path, "/personal/events"):
+			return calendarResponse(`{"items":[{"summary":"Personal","start":{"dateTime":"2026-09-10T12:00:00Z"}}]}`), nil
+		default:
+			t.Errorf("unexpected URL %s", r.URL)
+			return calendarResponse(`{}`), nil
+		}
+	})
+	conns["alice"].Calendars = []string{"personal", "work/calendar"}
+	now := time.Now()
+	entries, err := Events("alice", now, now.Add(24*time.Hour), 2)
+	if err != nil || len(entries) != 2 || entries[0].Title != "Earlier work" || entries[1].Title != "Personal" {
+		t.Fatalf("merged events: %+v, %v", entries, err)
+	}
+	busy, err := Busy("alice", now, now.Add(24*time.Hour))
+	if err != nil || len(busy) != 2 {
+		t.Fatalf("busy: %+v, %v", busy, err)
+	}
+}
+
+func TestAnExplicitEmptySelectionSurvivesRestartAndMakesNoCalendarRequests(t *testing.T) {
+	calendarFixture(t, func(r *http.Request) (*http.Response, error) {
+		if !strings.HasSuffix(r.URL.Path, "/calendarList") {
+			t.Error("requested an unselected calendar")
+		}
+		return calendarResponse(`{"items":[]}`), nil
+	})
+	if err := SetCalendars("alice", nil); err != nil {
+		t.Fatal(err)
+	}
+	reset()
+	Load()
+	access["alice"] = cachedToken{token: "alice", expires: time.Now().Add(time.Hour)}
+	if got := SelectedCalendars("alice"); got == nil || len(got) != 0 {
+		t.Fatalf("empty selection reverted to default: %v", got)
+	}
+	now := time.Now()
+	if got, err := Events("alice", now, now.Add(time.Hour), 3); err != nil || len(got) != 0 {
+		t.Fatalf("events %v %v", got, err)
+	}
+	if got, err := Busy("alice", now, now.Add(time.Hour)); err != nil || len(got) != 0 {
+		t.Fatalf("busy %v %v", got, err)
+	}
+}
+
+func TestBusyDoesNotTreatCalendarErrorsAsFreeTime(t *testing.T) {
+	calendarFixture(t, func(r *http.Request) (*http.Response, error) {
+		return calendarResponse(`{"calendars":{"primary":{"errors":[{"reason":"notFound"}]}}}`), nil
+	})
+	if _, err := Busy("alice", time.Now(), time.Now().Add(time.Hour)); err == nil {
+		t.Fatal("unreadable calendar treated as free")
+	}
+}
+
+func TestSharedInvitationsAppearOnceButRecurrencesRemain(t *testing.T) {
+	calendarFixture(t, func(r *http.Request) (*http.Response, error) {
+		return calendarResponse(`{"items":[{"iCalUID":"invite","summary":"Meeting","start":{"dateTime":"2026-09-10T12:00:00Z"}},{"iCalUID":"invite","summary":"Meeting","start":{"dateTime":"2026-09-11T12:00:00Z"}}]}`), nil
+	})
+	conns["alice"].Calendars = []string{"personal", "work"}
+	got, err := Events("alice", time.Now(), time.Now().Add(48*time.Hour), 0)
+	if err != nil || len(got) != 2 {
+		t.Fatalf("shared recurring invitation: %+v, %v", got, err)
+	}
+}

--- a/internal/google/google.go
+++ b/internal/google/google.go
@@ -26,6 +26,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -54,6 +55,8 @@ type Connection struct {
 	RefreshToken string    `json:"refresh_token"`
 	Scopes       []string  `json:"scopes,omitempty"`
 	Connected    time.Time `json:"connected"`
+	// Nil preserves the primary-calendar default; an empty list selects none.
+	Calendars []string `json:"calendars"`
 }
 
 var (
@@ -85,12 +88,12 @@ func Load() {
 }
 
 // save persists connections. Callers hold mu.
-func save() {
+func save() error {
 	list := make([]*Connection, 0, len(conns))
 	for _, c := range conns {
 		list = append(list, c)
 	}
-	_ = data.SaveJSON(storeKey, list)
+	return data.SaveJSON(storeKey, list)
 }
 
 // Connected reports whether an account has granted anything at all.
@@ -207,7 +210,12 @@ func Store(accountID, email, refreshToken string, scopes []string) {
 	}
 	mu.Lock()
 	defer mu.Unlock()
+	var calendars []string
+	if old := conns[accountID]; old != nil && old.Email == email {
+		calendars = old.Calendars
+	}
 	conns[accountID] = &Connection{
+		Calendars:    calendars,
 		AccountID:    accountID,
 		Email:        email,
 		RefreshToken: refreshToken,
@@ -366,27 +374,26 @@ type Period struct {
 	End   time.Time
 }
 
-// Busy returns the account's booked periods in a window, from their primary
-// calendar.
-//
-// Primary only, which is a real limit worth naming: somebody keeping work and
-// personal calendars separate will get an answer computed from one of them, and
-// "you are free" is exactly the answer that must not be over-confident. Widening
-// this means listing calendarList and passing every id here.
-//
-// freeBusy rather than events.list, because "when am I free" needs only the
-// shape of the week. It returns times and no titles, so the narrower question
-// is answered with the narrower data.
+// Busy returns booked periods from the selected calendars, using the same
+// selection as Events. Free/busy reads times without fetching event titles.
 func Busy(accountID string, from, to time.Time) ([]Period, error) {
 	token, err := accessToken(accountID)
 	if err != nil {
 		return nil, err
 	}
 
+	ids := SelectedCalendars(accountID)
+	if len(ids) == 0 {
+		return nil, nil
+	}
+	items := make([]map[string]string, 0, len(ids))
+	for _, id := range ids {
+		items = append(items, map[string]string{"id": id})
+	}
 	body, _ := json.Marshal(map[string]any{
 		"timeMin": from.Format(time.RFC3339),
 		"timeMax": to.Format(time.RFC3339),
-		"items":   []map[string]string{{"id": "primary"}},
+		"items":   items,
 	})
 	req, _ := http.NewRequest(http.MethodPost,
 		"https://www.googleapis.com/calendar/v3/freeBusy", bytes.NewReader(body))
@@ -404,7 +411,8 @@ func Busy(accountID string, from, to time.Time) ([]Period, error) {
 
 	var out struct {
 		Calendars map[string]struct {
-			Busy []struct {
+			Errors []json.RawMessage `json:"errors"`
+			Busy   []struct {
 				Start string `json:"start"`
 				End   string `json:"end"`
 			} `json:"busy"`
@@ -416,6 +424,9 @@ func Busy(accountID string, from, to time.Time) ([]Period, error) {
 
 	var periods []Period
 	for _, cal := range out.Calendars {
+		if len(cal.Errors) > 0 {
+			return nil, fmt.Errorf("google calendar could not read availability for a selected calendar")
+		}
 		for _, b := range cal.Busy {
 			start, err1 := time.Parse(time.RFC3339, b.Start)
 			end, err2 := time.Parse(time.RFC3339, b.End)
@@ -430,6 +441,8 @@ func Busy(accountID string, from, to time.Time) ([]Period, error) {
 
 // Entry is one event on the person's real calendar.
 type Entry struct {
+	// UID identifies the same invitation appearing on several selected calendars.
+	UID      string `json:"-"`
 	Title    string
 	Start    time.Time
 	End      time.Time
@@ -448,6 +461,50 @@ func Events(accountID string, from, to time.Time, limit int) ([]Entry, error) {
 	if err != nil {
 		return nil, err
 	}
+	ids := SelectedCalendars(accountID)
+	// Bound concurrency so several calendars do not serialize provider latency.
+	type result struct {
+		entries []Entry
+		err     error
+	}
+	results := make([]result, len(ids))
+	var wg sync.WaitGroup
+	sem := make(chan struct{}, 4)
+	for i, id := range ids {
+		wg.Add(1)
+		go func(i int, id string) {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
+			results[i].entries, results[i].err = calendarEvents(token, id, from, to, limit)
+		}(i, id)
+	}
+	wg.Wait()
+	var entries []Entry
+	seen := map[string]bool{}
+	for _, result := range results {
+		if result.err != nil {
+			return nil, result.err
+		}
+		for _, e := range result.entries {
+			if e.UID != "" {
+				key := e.UID + "/" + e.Start.UTC().Format(time.RFC3339)
+				if seen[key] {
+					continue
+				}
+				seen[key] = true
+			}
+			entries = append(entries, e)
+		}
+	}
+	sort.SliceStable(entries, func(i, j int) bool { return entries[i].Start.Before(entries[j].Start) })
+	if limit > 0 && len(entries) > limit {
+		entries = entries[:limit]
+	}
+	return entries, nil
+}
+
+func calendarEvents(token, calendarID string, from, to time.Time, limit int) ([]Entry, error) {
 	pageSize := 250
 	if limit > 0 {
 		pageSize = min(limit, pageSize)
@@ -464,7 +521,7 @@ func Events(accountID string, from, to time.Time, limit int) ([]Entry, error) {
 	seen := map[string]bool{}
 	for {
 		req, _ := http.NewRequest(http.MethodGet,
-			"https://www.googleapis.com/calendar/v3/calendars/primary/events?"+q.Encode(), nil)
+			"https://www.googleapis.com/calendar/v3/calendars/"+url.PathEscape(calendarID)+"/events?"+q.Encode(), nil)
 		req.Header.Set("Authorization", "Bearer "+token)
 
 		resp, err := httpClient.Do(req)
@@ -480,6 +537,7 @@ func Events(accountID string, from, to time.Time, limit int) ([]Entry, error) {
 		var out struct {
 			NextPageToken string `json:"nextPageToken"`
 			Items         []struct {
+				UID      string `json:"iCalUID"`
 				Summary  string `json:"summary"`
 				Location string `json:"location"`
 				Status   string `json:"status"`
@@ -503,7 +561,7 @@ func Events(accountID string, from, to time.Time, limit int) ([]Entry, error) {
 			if it.Status == "cancelled" {
 				continue
 			}
-			e := Entry{Title: strings.TrimSpace(it.Summary), Location: strings.TrimSpace(it.Location)}
+			e := Entry{UID: it.UID, Title: strings.TrimSpace(it.Summary), Location: strings.TrimSpace(it.Location)}
 			if e.Title == "" {
 				e.Title = "(no title)"
 			}

--- a/internal/google/google.go
+++ b/internal/google/google.go
@@ -211,7 +211,7 @@ func Store(accountID, email, refreshToken string, scopes []string) {
 	mu.Lock()
 	defer mu.Unlock()
 	var calendars []string
-	if old := conns[accountID]; old != nil && old.Email == email {
+	if old := conns[accountID]; old != nil && (old.Email == "" || email == "" || strings.EqualFold(old.Email, email)) {
 		calendars = old.Calendars
 	}
 	conns[accountID] = &Connection{

--- a/internal/server/hooks.go
+++ b/internal/server/hooks.go
@@ -94,22 +94,20 @@ func wireHooks() {
 			return google.HasScope(owner, google.CalendarScope)
 		}
 		events.ExternalAccount = google.ConnectedEmail
-		events.ExternalBusy = func(owner string, from, to time.Time) []events.Slot {
+		events.ExternalBusy = func(owner string, from, to time.Time) ([]events.Slot, error) {
+			if !google.HasScope(owner, google.CalendarScope) {
+				return nil, nil
+			}
 			periods, err := google.Busy(owner, from, to)
 			if err != nil {
-				// A calendar that cannot be read must not make "when am I
-				// free" fail. The answer narrows to what Mu knows, which is
-				// what it was before this was wired at all.
-				if err != google.ErrNotConnected {
-					app.Log("events", "google busy for %s: %v", owner, err)
-				}
-				return nil
+				app.Log("events", "google busy for %s: %v", owner, err)
+				return nil, fmt.Errorf("Google Calendar availability is unavailable; try again or check your calendar selection at /events")
 			}
 			slots := make([]events.Slot, 0, len(periods))
 			for _, p := range periods {
 				slots = append(slots, events.Slot{Start: p.Start, End: p.End})
 			}
-			return slots
+			return slots, nil
 		}
 		contacts.ExternalConnected = func(owner string) bool {
 			return google.HasScope(owner, google.ContactsScope)
@@ -128,8 +126,8 @@ func wireHooks() {
 			}
 			return out
 		}
-		events.ExternalEntries = func(owner string, from, to time.Time) []events.External {
-			entries, err := google.Events(owner, from, to, 0)
+		events.ExternalEntries = func(owner string, from, to time.Time, limit int) []events.External {
+			entries, err := google.Events(owner, from, to, limit)
 			if err != nil {
 				if err != google.ErrNotConnected {
 					app.Log("events", "google events for %s: %v", owner, err)

--- a/service/events/calendars.go
+++ b/service/events/calendars.go
@@ -1,0 +1,33 @@
+package events
+
+import (
+	"html"
+	"strings"
+
+	"mu/internal/google"
+)
+
+func calendarsHTML(owner, csrf string) string {
+	if !google.HasScope(owner, google.CalendarScope) {
+		return ""
+	}
+	calendars, err := google.Calendars(owner)
+	if err != nil {
+		return `<p class="notice bad">Could not load your calendars. Reload to try again.</p>`
+	}
+	selected := map[string]bool{}
+	for _, id := range google.SelectedCalendars(owner) {
+		selected[id] = true
+	}
+	var b strings.Builder
+	b.WriteString(`<form method="POST" action="/events" class="form page-section"><input type="hidden" name="_csrf" value="` + html.EscapeString(csrf) + `"><input type="hidden" name="action" value="calendars"><fieldset class="form-group"><legend class="field-label">Calendars</legend><p class="text-sm text-muted">Choose which calendars appear in your agenda, brief and upcoming events, and count towards your availability.</p>`)
+	for _, c := range calendars {
+		checked := ""
+		if selected[c.ID] || (c.Primary && selected["primary"]) {
+			checked = " checked"
+		}
+		b.WriteString(`<label class="check-label"><input type="checkbox" name="calendars" value="` + html.EscapeString(c.ID) + `"` + checked + `><span>` + html.EscapeString(c.Summary) + `</span></label>`)
+	}
+	b.WriteString(`</fieldset><div class="form-actions"><button type="submit">Save calendars</button></div></form>`)
+	return b.String()
+}

--- a/service/events/external.go
+++ b/service/events/external.go
@@ -43,10 +43,10 @@ func (e External) Length() time.Duration {
 var (
 	// ExternalBusy returns booked periods from an attached calendar. Set by
 	// main.go when Google is configured.
-	ExternalBusy func(owner string, from, to time.Time) []Slot
+	ExternalBusy func(owner string, from, to time.Time) ([]Slot, error)
 
 	// ExternalEntries returns what is scheduled on an attached calendar.
-	ExternalEntries func(owner string, from, to time.Time) []External
+	ExternalEntries func(owner string, from, to time.Time, limit int) []External
 
 	// ExternalConnected reports whether this owner has attached one. Kept
 	// separate from the two above so the UI can tell "nothing booked" apart
@@ -64,19 +64,20 @@ var (
 
 // externalBusy is the guarded call: a hook that is unset, or an owner who never
 // connected anything, contributes nothing rather than failing.
-func externalBusy(owner string, from, to time.Time) []Slot {
+func externalBusy(owner string, from, to time.Time) ([]Slot, error) {
 	if ExternalBusy == nil || owner == "" {
-		return nil
+		return nil, nil
 	}
 	return ExternalBusy(owner, from, to)
 }
 
 // ExternalEvents reads the owner's connected calendars within a window.
-func ExternalEvents(owner string, from, to time.Time) []External {
+// A positive limit bounds the result; zero reads the full window.
+func ExternalEvents(owner string, from, to time.Time, limit int) []External {
 	if ExternalEntries == nil || owner == "" {
 		return nil
 	}
-	return ExternalEntries(owner, from, to)
+	return ExternalEntries(owner, from, to, limit)
 }
 
 // HasExternal reports whether this owner has an outside calendar attached.

--- a/service/events/external.go
+++ b/service/events/external.go
@@ -71,8 +71,8 @@ func externalBusy(owner string, from, to time.Time) []Slot {
 	return ExternalBusy(owner, from, to)
 }
 
-// externalEntries is the guarded call for what is scheduled.
-func externalEntries(owner string, from, to time.Time) []External {
+// ExternalEvents reads the owner's connected calendars within a window.
+func ExternalEvents(owner string, from, to time.Time) []External {
 	if ExternalEntries == nil || owner == "" {
 		return nil
 	}

--- a/service/events/external_test.go
+++ b/service/events/external_test.go
@@ -1,6 +1,9 @@
 package events
 
 import (
+	"context"
+	"fmt"
+	"mu/internal/service"
 	"strings"
 	"testing"
 	"time"
@@ -11,8 +14,8 @@ func withExternal(t *testing.T, connected bool, busy []Slot, entries []External)
 	t.Helper()
 	pc, pb, pe, pa := ExternalConnected, ExternalBusy, ExternalEntries, ExternalAccount
 	ExternalConnected = func(string) bool { return connected }
-	ExternalBusy = func(string, time.Time, time.Time) []Slot { return busy }
-	ExternalEntries = func(string, time.Time, time.Time) []External { return entries }
+	ExternalBusy = func(string, time.Time, time.Time) ([]Slot, error) { return busy, nil }
+	ExternalEntries = func(string, time.Time, time.Time, int) []External { return entries }
 	ExternalAccount = func(string) string { return "someone@example.com" }
 	t.Cleanup(func() {
 		ExternalConnected, ExternalBusy, ExternalEntries, ExternalAccount = pc, pb, pe, pa
@@ -28,7 +31,7 @@ func TestFreeCountsTheCalendarYouAlreadyKeep(t *testing.T) {
 
 	// Nothing attached: the whole working day is open.
 	withExternal(t, false, nil, nil)
-	if got := Free("nobody", q); len(got) != 1 || got[0].Duration() != 8*time.Hour {
+	if got := freeSlots(t, "nobody", q); len(got) != 1 || got[0].Duration() != 8*time.Hour {
 		t.Fatalf("an empty calendar was not free all day: %+v", got)
 	}
 
@@ -37,7 +40,7 @@ func TestFreeCountsTheCalendarYouAlreadyKeep(t *testing.T) {
 		Start: day.Add(12 * time.Hour), End: day.Add(13 * time.Hour),
 	}}, nil)
 
-	slots := Free("nobody", q)
+	slots := freeSlots(t, "nobody", q)
 	if len(slots) != 2 {
 		t.Fatalf("an outside meeting did not split the day: %+v", slots)
 	}
@@ -69,7 +72,10 @@ func TestBusyPeriodsFromBothCalendarsMerge(t *testing.T) {
 		Start: day.Add(12*time.Hour + 30*time.Minute), End: day.Add(14 * time.Hour),
 	}}, nil)
 
-	busy := booked(owner, day, day.AddDate(0, 0, 1))
+	busy, err := booked(owner, day, day.AddDate(0, 0, 1))
+	if err != nil {
+		t.Fatal(err)
+	}
 	if len(busy) != 1 {
 		t.Fatalf("overlapping busy periods did not merge: %+v", busy)
 	}
@@ -167,5 +173,21 @@ func TestTheCalendarCardOnlyAppearsWhenItCanWork(t *testing.T) {
 	}
 	if !strings.Contains(connected, `href="/account"`) {
 		t.Errorf("the card does not say where to manage it:\n%s", connected)
+	}
+}
+
+func TestUnavailableCalendarCannotProduceFreeSlots(t *testing.T) {
+	old := ExternalBusy
+	defer func() { ExternalBusy = old }()
+	unavailable := fmt.Errorf("calendar unavailable")
+	ExternalBusy = func(string, time.Time, time.Time) ([]Slot, error) { return nil, unavailable }
+	now := time.Now()
+	if slots, err := Free("alice", FreeQuery{From: now, To: now.Add(24 * time.Hour)}); err != unavailable || len(slots) != 0 {
+		t.Fatalf("unavailable calendar produced free slots: %v, %v", slots, err)
+	}
+	var rsp FreeResponse
+	err := (Server{}).Free(service.WithAccount(context.Background(), "alice"), &FreeRequest{}, &rsp)
+	if err != unavailable || len(rsp.Slots) != 0 || rsp.Text != "" {
+		t.Fatalf("service concealed unavailable calendar: %+v, %v", rsp, err)
 	}
 }

--- a/service/events/free.go
+++ b/service/events/free.go
@@ -41,7 +41,7 @@ type FreeQuery struct {
 
 // Free returns the stretches inside the window where nothing is booked and the
 // slot is at least Minutes long.
-func Free(owner string, q FreeQuery) []Slot {
+func Free(owner string, q FreeQuery) ([]Slot, error) {
 	if q.Minutes <= 0 {
 		q.Minutes = 30
 	}
@@ -53,7 +53,10 @@ func Free(owner string, q FreeQuery) []Slot {
 	}
 	want := time.Duration(q.Minutes) * time.Minute
 
-	busy := booked(owner, q.From, q.To)
+	busy, err := booked(owner, q.From, q.To)
+	if err != nil {
+		return nil, err
+	}
 
 	var out []Slot
 	// Walk a day at a time so working hours can be applied per day rather than
@@ -73,7 +76,7 @@ func Free(owner string, q FreeQuery) []Slot {
 		}
 		out = append(out, freeWithin(open, close, busy, want)...)
 	}
-	return out
+	return out, nil
 }
 
 // freeWithin subtracts the busy periods from one open stretch.
@@ -104,7 +107,11 @@ func freeWithin(open, close time.Time, busy []Slot, want time.Duration) []Slot {
 // answer usable: a meeting that exists in Google and a reminder that exists
 // here overlap in the person's actual day, and two lists would have made the
 // caller reconcile them.
-func booked(owner string, from, to time.Time) []Slot {
+func booked(owner string, from, to time.Time) ([]Slot, error) {
+	external, err := externalBusy(owner, from, to)
+	if err != nil {
+		return nil, err
+	}
 	var busy []Slot
 	for _, e := range List(owner) {
 		start := e.When
@@ -114,7 +121,7 @@ func booked(owner string, from, to time.Time) []Slot {
 		}
 		busy = append(busy, Slot{Start: start, End: end})
 	}
-	for _, s := range externalBusy(owner, from, to) {
+	for _, s := range external {
 		if !s.End.After(from) || !s.Start.Before(to) {
 			continue
 		}
@@ -132,7 +139,7 @@ func booked(owner string, from, to time.Time) []Slot {
 		}
 		merged = append(merged, b)
 	}
-	return merged
+	return merged, nil
 }
 
 // Length is how long an event lasts, defaulting to the same half hour the .ics

--- a/service/events/free_test.go
+++ b/service/events/free_test.go
@@ -32,7 +32,7 @@ func clear(owner string) {
 // offering 3am is not an answer anybody wants.
 func TestFreeRespectsWorkingHours(t *testing.T) {
 	clear("alice")
-	slots := Free("alice", FreeQuery{
+	slots := freeSlots(t, "alice", FreeQuery{
 		From: day(0, 0), To: day(23, 59), Minutes: 30, DayStart: 9, DayEnd: 18,
 	})
 	if len(slots) != 1 {
@@ -51,7 +51,7 @@ func TestFreeSubtractsWhatIsBooked(t *testing.T) {
 	}
 	defer clear("alice")
 
-	slots := Free("alice", FreeQuery{From: day(0, 0), To: day(23, 59), Minutes: 30, DayStart: 9, DayEnd: 18})
+	slots := freeSlots(t, "alice", FreeQuery{From: day(0, 0), To: day(23, 59), Minutes: 30, DayStart: 9, DayEnd: 18})
 	if len(slots) != 2 {
 		t.Fatalf("expected the day either side of the meeting, got %v", slots)
 	}
@@ -75,10 +75,10 @@ func TestFreeOnlyOffersSlotsLongEnough(t *testing.T) {
 	}
 	defer clear("alice")
 
-	if got := Free("alice", FreeQuery{From: day(0, 0), To: day(23, 59), Minutes: 30, DayStart: 9, DayEnd: 18}); len(got) != 1 {
+	if got := freeSlots(t, "alice", FreeQuery{From: day(0, 0), To: day(23, 59), Minutes: 30, DayStart: 9, DayEnd: 18}); len(got) != 1 {
 		t.Errorf("the 30-minute gap was not offered for a 30-minute slot: %v", got)
 	}
-	if got := Free("alice", FreeQuery{From: day(0, 0), To: day(23, 59), Minutes: 60, DayStart: 9, DayEnd: 18}); len(got) != 0 {
+	if got := freeSlots(t, "alice", FreeQuery{From: day(0, 0), To: day(23, 59), Minutes: 60, DayStart: 9, DayEnd: 18}); len(got) != 0 {
 		t.Errorf("a 30-minute gap was offered for an hour: %v", got)
 	}
 }
@@ -95,7 +95,7 @@ func TestOverlappingEventsAreMerged(t *testing.T) {
 	}
 	defer clear("alice")
 
-	slots := Free("alice", FreeQuery{From: day(0, 0), To: day(23, 59), Minutes: 30, DayStart: 9, DayEnd: 18})
+	slots := freeSlots(t, "alice", FreeQuery{From: day(0, 0), To: day(23, 59), Minutes: 30, DayStart: 9, DayEnd: 18})
 	for _, s := range slots {
 		if s.Start.Before(day(13, 0)) && s.End.After(day(10, 0)) {
 			t.Errorf("a slot was offered inside a booked stretch: %s–%s", s.Start, s.End)
@@ -112,10 +112,10 @@ func TestFreeIsPerOwner(t *testing.T) {
 	}
 	defer clear("alice")
 
-	if got := Free("alice", FreeQuery{From: day(0, 0), To: day(23, 59), DayStart: 9, DayEnd: 18}); len(got) != 0 {
+	if got := freeSlots(t, "alice", FreeQuery{From: day(0, 0), To: day(23, 59), DayStart: 9, DayEnd: 18}); len(got) != 0 {
 		t.Errorf("alice's day is full but she was offered %v", got)
 	}
-	if got := Free("bob", FreeQuery{From: day(0, 0), To: day(23, 59), DayStart: 9, DayEnd: 18}); len(got) == 0 {
+	if got := freeSlots(t, "bob", FreeQuery{From: day(0, 0), To: day(23, 59), DayStart: 9, DayEnd: 18}); len(got) == 0 {
 		t.Error("bob was blocked by alice's calendar")
 	}
 }
@@ -157,4 +157,13 @@ func indexOf(h, n string) int {
 		}
 	}
 	return -1
+}
+
+func freeSlots(t *testing.T, owner string, q FreeQuery) []Slot {
+	t.Helper()
+	slots, err := Free(owner, q)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return slots
 }

--- a/service/events/handler.go
+++ b/service/events/handler.go
@@ -10,6 +10,7 @@ import (
 
 	"mu/internal/app"
 	"mu/internal/auth"
+	"mu/internal/google"
 )
 
 // Handler serves the /events page: schedule a reminder, see what's upcoming,
@@ -29,6 +30,17 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 
 	if r.Method == http.MethodPost {
 		switch r.FormValue("action") {
+		case "calendars":
+			if !auth.StrictCSRF(r) {
+				http.Error(w, "Invalid form token", http.StatusForbidden)
+				return
+			}
+			if err := google.SetCalendars(owner, r.PostForm["calendars"]); err != nil {
+				http.Redirect(w, r, "/events?calendar=failed", http.StatusSeeOther)
+				return
+			}
+			http.Redirect(w, r, "/events?calendar=saved", http.StatusSeeOther)
+			return
 		case "cancel":
 			Cancel(owner, r.FormValue("id"))
 		case "create":
@@ -68,7 +80,7 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 
 	up := Upcoming(owner)
 	now := time.Now()
-	ext := externalEntries(owner, now, now.Add(30*24*time.Hour))
+	ext := ExternalEvents(owner, now, now.Add(30*24*time.Hour))
 
 	if len(up) == 0 && len(ext) == 0 {
 		b.WriteString(`<p class="text-muted text-base">Nothing scheduled. Add a reminder above, or just ask the agent: <em>"remind me to call the dentist tomorrow at 3pm"</em>.</p>`)
@@ -181,6 +193,8 @@ func calendarCard(owner, status, csrf string) string {
 
 	note := ""
 	switch status {
+	case "saved":
+		note = `<p class="notice ok">Calendar selection saved.</p>`
 	case "connected":
 		note = `<p class="notice ok">Connected. Your calendar is now included in what's scheduled and when you're free.</p>`
 	case "disconnected":
@@ -204,6 +218,7 @@ func calendarCard(owner, status, csrf string) string {
 		}
 		b.WriteString(`<h4 class="m-0 mb-2 text-base">` + html.EscapeString(ExternalName) + who + `</h4>`)
 		b.WriteString(`<p class="text-sm text-secondary m-0 mb-3">Read-only. Mu can see what's on it, and cannot change it.</p>`)
+		b.WriteString(calendarsHTML(owner, csrf))
 		// No disconnect here. Withdrawing access is one action covering
 		// everything granted — Google revokes the whole grant at once — so it
 		// belongs with the rest of the inventory rather than repeated on every
@@ -212,7 +227,7 @@ func calendarCard(owner, status, csrf string) string {
 			`<a href="/account">your account</a>.</p>`)
 	} else {
 		b.WriteString(`<h4 class="m-0 mb-2 text-base">Connect your ` + html.EscapeString(ExternalName) + `</h4>`)
-		b.WriteString(`<p class="text-sm text-secondary m-0 mb-3">Right now "when am I free" only counts what you scheduled here. Connect your calendar and it counts everything. Read-only — Mu can see what's on it, and cannot change it.</p>`)
+		b.WriteString(`<p class="text-sm text-secondary m-0 mb-3">Right now "when am I free" only counts what you scheduled here. Connect Google Calendar and choose which calendars to include. Read-only — Mu can see what's on it, and cannot change it.</p>`)
 		b.WriteString(`<a href="/oauth2/google/calendar" class="btn">Connect ` + html.EscapeString(ExternalName) + `</a>`)
 	}
 	b.WriteString(`</div>`)

--- a/service/events/handler.go
+++ b/service/events/handler.go
@@ -80,7 +80,7 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 
 	up := Upcoming(owner)
 	now := time.Now()
-	ext := ExternalEvents(owner, now, now.Add(30*24*time.Hour))
+	ext := ExternalEvents(owner, now, now.Add(30*24*time.Hour), 0)
 
 	if len(up) == 0 && len(ext) == 0 {
 		b.WriteString(`<p class="text-muted text-base">Nothing scheduled. Add a reminder above, or just ask the agent: <em>"remind me to call the dentist tomorrow at 3pm"</em>.</p>`)

--- a/service/events/preview.go
+++ b/service/events/preview.go
@@ -1,0 +1,44 @@
+package events
+
+import (
+	"html"
+	"strings"
+	"time"
+)
+
+// Preview is a compact, read-only overview of the owner's next events.
+func Preview(owner string, external []External) string {
+	if owner == "" {
+		return ""
+	}
+	now := time.Now()
+	rows := mergedRows(Upcoming(owner), external)
+	var b strings.Builder
+	b.WriteString(`<div class="page-stack">`)
+	count := 0
+	for _, row := range rows {
+		title, when, allDay := row.External.Title, row.When, row.External.AllDay
+		if row.Event != nil {
+			if row.Event.Kind == "brief" || row.When.Before(now) {
+				continue
+			}
+			title = row.Event.Title
+		}
+		label := when.Format("Mon 2 Jan, 15:04")
+		stamp := ` data-event-time`
+		if allDay {
+			label = when.Format("Mon 2 Jan") + ", all day"
+			stamp = ""
+		}
+		b.WriteString(`<a href="/events" class="link page-stack gap-2"><span>` + html.EscapeString(title) + `</span><small class="text-muted"><time datetime="` + when.Format(time.RFC3339) + `"` + stamp + `>` + html.EscapeString(label) + `</time></small></a>`)
+		count++
+		if count == 3 {
+			break
+		}
+	}
+	if count == 0 {
+		b.WriteString(`<p class="text-muted">No upcoming events to show.</p>`)
+	}
+	b.WriteString(`</div><a href="/events" class="link">Go to events →</a>`)
+	return b.String()
+}

--- a/service/events/preview.go
+++ b/service/events/preview.go
@@ -6,6 +6,9 @@ import (
 	"time"
 )
 
+// PreviewLimit bounds the Home overview and its provider reads.
+const PreviewLimit = 3
+
 // Preview is a compact, read-only overview of the owner's next events.
 func Preview(owner string, external []External) string {
 	if owner == "" {
@@ -32,7 +35,7 @@ func Preview(owner string, external []External) string {
 		}
 		b.WriteString(`<a href="/events" class="link page-stack gap-2"><span>` + html.EscapeString(title) + `</span><small class="text-muted"><time datetime="` + when.Format(time.RFC3339) + `"` + stamp + `>` + html.EscapeString(label) + `</time></small></a>`)
 		count++
-		if count == 3 {
+		if count == PreviewLimit {
 			break
 		}
 	}

--- a/service/events/preview_test.go
+++ b/service/events/preview_test.go
@@ -20,7 +20,7 @@ func TestPreviewCombinesOwnedAndExternalEventsAndLimitsRows(t *testing.T) {
 	Create("previewother", "Someone else's reminder", now.Add(time.Hour), "")
 	old := ExternalEntries
 	defer func() { ExternalEntries = old }()
-	ExternalEntries = func(got string, from, to time.Time) []External {
+	ExternalEntries = func(got string, from, to time.Time, limit int) []External {
 		if got != owner {
 			t.Errorf("wrong calendar owner %q", got)
 		}
@@ -30,7 +30,7 @@ func TestPreviewCombinesOwnedAndExternalEventsAndLimitsRows(t *testing.T) {
 			{Title: "Not in preview", Start: now.Add(4 * time.Hour)},
 		}
 	}
-	body := Preview(owner, ExternalEvents(owner, now, now.Add(30*24*time.Hour)))
+	body := Preview(owner, ExternalEvents(owner, now, now.Add(30*24*time.Hour), PreviewLimit))
 	for _, want := range []string{"Earlier &lt;meeting&gt;", "Local reminder", "Later meeting", "Go to events"} {
 		if !strings.Contains(body, want) {
 			t.Errorf("missing %q", want)

--- a/service/events/preview_test.go
+++ b/service/events/preview_test.go
@@ -1,0 +1,76 @@
+package events
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"mu/internal/auth"
+)
+
+func TestPreviewCombinesOwnedAndExternalEventsAndLimitsRows(t *testing.T) {
+	const owner = "previewowner"
+	defer DeleteAll(owner)
+	defer DeleteAll("previewother")
+	now := time.Now()
+	Create(owner, "Local reminder", now.Add(2*time.Hour), "")
+	Create("previewother", "Someone else's reminder", now.Add(time.Hour), "")
+	old := ExternalEntries
+	defer func() { ExternalEntries = old }()
+	ExternalEntries = func(got string, from, to time.Time) []External {
+		if got != owner {
+			t.Errorf("wrong calendar owner %q", got)
+		}
+		return []External{
+			{Title: "Earlier <meeting>", Start: now.Add(time.Hour)},
+			{Title: "Later meeting", Start: now.Add(3 * time.Hour)},
+			{Title: "Not in preview", Start: now.Add(4 * time.Hour)},
+		}
+	}
+	body := Preview(owner, ExternalEvents(owner, now, now.Add(30*24*time.Hour)))
+	for _, want := range []string{"Earlier &lt;meeting&gt;", "Local reminder", "Later meeting", "Go to events"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("missing %q", want)
+		}
+	}
+	if strings.Contains(body, "Someone else's") || strings.Contains(body, "Not in preview") {
+		t.Fatal("wrong events in preview")
+	}
+	if strings.Index(body, "Earlier &lt;") > strings.Index(body, "Local reminder") {
+		t.Fatal("events not chronological")
+	}
+	if Preview("", nil) != "" {
+		t.Fatal("guest preview exposed")
+	}
+}
+
+func TestCalendarSelectionRequiresSessionAndCSRF(t *testing.T) {
+	const owner = "calendarform"
+	if err := auth.Create(&auth.Account{ID: owner}); err != nil {
+		t.Fatal(err)
+	}
+	sess, err := auth.CreateSession(owner)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, tc := range []struct {
+		signed bool
+		token  string
+		code   int
+	}{{false, "", 303}, {true, "", 403}, {true, "bad", 403}} {
+		form := url.Values{"action": {"calendars"}, "calendars": {"private-calendar"}, "_csrf": {tc.token}, "owner": {"someoneelse"}}
+		req := httptest.NewRequest("POST", "/events", strings.NewReader(form.Encode()))
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		if tc.signed {
+			req.AddCookie(&http.Cookie{Name: "session", Value: sess.Token})
+		}
+		rec := httptest.NewRecorder()
+		Handler(rec, req)
+		if rec.Code != tc.code {
+			t.Fatalf("status %d want %d", rec.Code, tc.code)
+		}
+	}
+}

--- a/service/events/service.go
+++ b/service/events/service.go
@@ -111,7 +111,7 @@ func (Server) List(ctx context.Context, req *ListRequest, rsp *ListResponse) err
 	// from. Both facts are the same fact: Mu did not schedule these and cannot
 	// cancel them, so offering an id would be offering something that fails.
 	now := time.Now()
-	external := externalEntries(owner, now, now.Add(14*24*time.Hour))
+	external := ExternalEvents(owner, now, now.Add(14*24*time.Hour))
 	xs, xe := service.PageRange(len(external), req.Offset, req.Limit)
 	rsp.External, rsp.ExternalTotal = external[xs:xe], len(external)
 	if xe < len(external) {

--- a/service/events/service.go
+++ b/service/events/service.go
@@ -111,7 +111,7 @@ func (Server) List(ctx context.Context, req *ListRequest, rsp *ListResponse) err
 	// from. Both facts are the same fact: Mu did not schedule these and cannot
 	// cancel them, so offering an id would be offering something that fails.
 	now := time.Now()
-	external := ExternalEvents(owner, now, now.Add(14*24*time.Hour))
+	external := ExternalEvents(owner, now, now.Add(14*24*time.Hour), 0)
 	xs, xe := service.PageRange(len(external), req.Offset, req.Limit)
 	rsp.External, rsp.ExternalTotal = external[xs:xe], len(external)
 	if xe < len(external) {
@@ -204,7 +204,11 @@ func (Server) Free(ctx context.Context, req *FreeRequest, rsp *FreeResponse) err
 	if req.DayEnd == 0 && req.DayStart == 0 {
 		q.DayStart, q.DayEnd = 9, 18
 	}
-	rsp.Slots = Free(owner, q)
+	slots, err := Free(owner, q)
+	if err != nil {
+		return err
+	}
+	rsp.Slots = slots
 	want := req.Minutes
 	if want <= 0 {
 		want = 30

--- a/service/events/update_test.go
+++ b/service/events/update_test.go
@@ -36,7 +36,7 @@ func TestUpdatePreservesIdentityAndChecksOwner(t *testing.T) {
 
 func TestExternalCalendarPagesAreStructured(t *testing.T) {
 	old := ExternalEntries
-	ExternalEntries = func(owner string, from, to time.Time) []External {
+	ExternalEntries = func(owner string, from, to time.Time, limit int) []External {
 		return []External{{Title: "First", Start: from}, {Title: "Second", Start: from.Add(time.Hour)}}
 	}
 	defer func() { ExternalEntries = old }()


### PR DESCRIPTION
Home conversations currently stretch the page and move the Agents section because both columns share grid rows. Calendar integration also reads only the primary Google calendar.

This separates Home into independent columns, bounds the conversation beneath the input, removes the Home agent picker and Speak controls, and shares service shortcuts with the sidebar. Empty or stale pins use News, Video, Web and Mail. Service icons align with section headings on mobile; service cards remain in Feed, with existing view state preserved.

Upcoming events sit above Brief and load in the background. Events now offers an account-scoped Google calendar checklist. Saved selections feed agenda listings, Home's brief and upcoming events, and availability. Existing grants default to primary; selections survive restart and reauthorization. Shared invitations are deduplicated without dropping recurrences. Calendar titles are escaped in the brief.

Validation: targeted Home/app/Events/architecture tests, Google tests with race detection, binary build, and browser layout checks at 320–1440px with sidebar open and closed. Browser interaction checks cover saving calendar selections, retained Home/Feed content, bounded replies and emulated touch keyboard dismissal. Provider tests use fixtures; no live Google account was modified.