### PR TITLE
Separate event creation and refine Home previews

### DIFF
--- a/home/apps.go
+++ b/home/apps.go
@@ -6,12 +6,26 @@ import (
 
 	"mu/internal/app"
 	"mu/internal/auth"
+	"mu/internal/service"
 )
 
 // appsHTML uses the same pins and service metadata as the sidebar. Defaults
 // give a new account useful starting points without displaying the catalogue.
 func appsHTML(acc *auth.Account) string {
 	apps := app.ServiceShortcuts(acc)
+	seen := make(map[string]bool)
+	for _, s := range apps {
+		seen[s.Name] = true
+	}
+	for _, s := range service.Pinned([]string{"news", "video", "web", "mail", "notes", "tasks", "events", "maps", "weather", "markets"}) {
+		if !seen[s.Name] {
+			apps = append(apps, s)
+			seen[s.Name] = true
+		}
+	}
+	if len(apps) > 10 {
+		apps = apps[:10]
+	}
 	var b strings.Builder
 	b.WriteString(`<nav class="home-apps page-stack" aria-label="Services">` + sectionRule("Services") + `<div class="home-apps-grid">`)
 	for _, s := range apps {

--- a/home/apps_test.go
+++ b/home/apps_test.go
@@ -30,7 +30,7 @@ func TestAppsAlwaysOfferUsefulDefaults(t *testing.T) {
 		}
 	}
 	body := appsHTML(&auth.Account{Pinned: []string{"video"}})
-	if !strings.Contains(body, `href="/video"`) || strings.Contains(body, `href="/news"`) {
-		t.Error("explicit pins were not used")
+	if strings.Index(body, `href="/video"`) < 0 || strings.Index(body, `href="/video"`) > strings.Index(body, `href="/news"`) {
+		t.Error("explicit pins were not placed first")
 	}
 }

--- a/home/home.go
+++ b/home/home.go
@@ -460,7 +460,7 @@ function fetchW(la,lo){
 	b.WriteString(`</div>`)
 	if viewerID != "" {
 		b.WriteString(`<div class="home-column page-stack">`)
-		b.WriteString(`<div id="home-upcoming" class="page-stack">` + sectionRule("Upcoming events") + `<div data-home-upcoming aria-live="polite" class="page-stack"><p class="text-muted">Loading events…</p></div>` + `</div>`)
+		b.WriteString(`<div id="home-upcoming" class="page-stack">` + sectionRule("Upcoming") + `<div data-home-upcoming aria-live="polite" class="page-stack"><p class="text-muted">Loading events…</p></div>` + `</div>`)
 		b.WriteString(`<div id="home-brief" class="page-stack">` + briefHTML(viewerID) + `</div>`)
 		if who := agent.Preview(viewerID); who != "" {
 			b.WriteString(`<div id="home-agents" class="page-stack">` + sectionRule("Agents") + who + `</div>`)

--- a/internal/app/html/composition.css
+++ b/internal/app/html/composition.css
@@ -131,3 +131,19 @@ a.btn-secondary:hover, .btn-secondary:hover {
 /* Tables need the available page width, rather than a prose measure. */
 .log-tables .card { max-width: none; width: 100%; }
 #content:has(.log-tables) { max-width: none; }
+
+/* Compact previews keep metadata close and separate adjacent entries. */
+.compact-list { display: flex; flex-direction: column; }
+.compact-list-item { display: flex; flex-direction: column; gap: 2px; padding-block: 12px; }
+.compact-list-item:first-child { padding-block-start: 0; }
+.compact-list-item:last-child { padding-block-end: 0; }
+.compact-list-item + .compact-list-item { border-top: 1px solid var(--card-border, #e8e8e8); }
+/* The launcher fits its column, including when the sidebar changes width. */
+.home-apps { container-type: inline-size; }
+.home-apps-grid > a:nth-child(n+5) { display: none; }
+@container (min-width: 344px) { .home-apps-grid > a:nth-child(5) { display: flex; } }
+@container (min-width: 416px) { .home-apps-grid > a:nth-child(6) { display: flex; } }
+@container (min-width: 488px) { .home-apps-grid > a:nth-child(7) { display: flex; } }
+@container (min-width: 560px) { .home-apps-grid > a:nth-child(8) { display: flex; } }
+@container (min-width: 632px) { .home-apps-grid > a:nth-child(9) { display: flex; } }
+@container (min-width: 704px) { .home-apps-grid > a:nth-child(10) { display: flex; } }

--- a/service/events/brief_page.go
+++ b/service/events/brief_page.go
@@ -45,7 +45,7 @@ func briefScheduleHTML(owner string, csrf ...string) string {
 		title = "Evening brief"
 	}
 	var b strings.Builder
-	b.WriteString(`<section id="morning-brief" class="page-section"><h3>` + title + `</h3><p>Your email brief, with calendar, weather and relevant updates.</p><div class="page-stack"><p class="text-muted">` + html.EscapeString(status) + `</p><details class="disclosure"><summary>` + label + `</summary><form method="POST" action="/events" class="form">` + app.CSRFField(token) + `<input type="hidden" name="action" value="brief-schedule">`)
+	b.WriteString(`<section id="morning-brief" class="card page-stack"><h3>` + title + `</h3><p>Your email brief, with calendar, weather and relevant updates.</p><div class="page-stack"><p class="text-muted">` + html.EscapeString(status) + `</p><details class="disclosure"><summary>` + label + `</summary><form method="POST" action="/events" class="form">` + app.CSRFField(token) + `<input type="hidden" name="action" value="brief-schedule">`)
 	selectField := func(name, title, value string, values ...string) {
 		b.WriteString(`<label class="field-label">` + title + `<select class="form-input" name="` + name + `">`)
 		for _, v := range values {

--- a/service/events/handler.go
+++ b/service/events/handler.go
@@ -61,29 +61,19 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 	csrf := auth.CSRFToken(r)
 	var b strings.Builder
 
-	// Add form. The datetime-local value is local to the browser; a tiny script
-	// converts it to an RFC3339 UTC instant on submit so 3pm means the user's
-	// 3pm regardless of the server's timezone.
-	b.WriteString(`<div class="page-col">`)
+	if r.URL.Query().Get("new") == "1" {
+		app.Respond(w, r, app.Response{Title: "New event", HTML: eventForm(csrf)})
+		return
+	}
+	b.WriteString(`<div class="page-col page-stack"><div class="page-action"><a class="btn" href="/events?new=1">New</a></div>`)
 	b.WriteString(briefScheduleHTML(owner, csrf))
-	b.WriteString(`<form method="POST" action="/events" onsubmit="var d=this.whenlocal.value;if(d){this.when.value=new Date(d).toISOString()}" class="form page-section">`)
-	b.WriteString(`<input type="hidden" name="_csrf" value="` + html.EscapeString(csrf) + `">`)
-	b.WriteString(`<input type="hidden" name="action" value="create">`)
-	b.WriteString(`<input type="hidden" name="when" value="">`)
-	b.WriteString(`<input type="text" name="title" placeholder="Remind me to…" required maxlength="140" class="form-input text-base">`)
-	b.WriteString(`<div class="d-flex gap-2 flex-wrap">`)
-	b.WriteString(`<input type="datetime-local" name="whenlocal" required class="form-input text-base grow">`)
-	b.WriteString(`<button type="submit">Schedule</button>`)
-	b.WriteString(`</div>`)
-	b.WriteString(`<input type="text" name="note" placeholder="Note (optional)" maxlength="280" class="form-input text-base">`)
-	b.WriteString(`</form>`)
 
 	up := Upcoming(owner)
 	now := time.Now()
 	ext := ExternalEvents(owner, now, now.Add(30*24*time.Hour), 0)
 
 	if len(up) == 0 && len(ext) == 0 {
-		b.WriteString(`<p class="text-muted text-base">Nothing scheduled. Add a reminder above, or just ask the agent: <em>"remind me to call the dentist tomorrow at 3pm"</em>.</p>`)
+		b.WriteString(`<p class="text-muted text-base">Nothing scheduled. Choose New to add an event, or ask the agent: <em>"remind me to call the dentist tomorrow at 3pm"</em>.</p>`)
 	} else {
 		b.WriteString(`<h3 class="lead-15 m-0 mb-3">Upcoming</h3>`)
 		b.WriteString(`<div class="d-flex flex-column gap-2">`)
@@ -206,7 +196,7 @@ func calendarCard(owner, status, csrf string) string {
 	}
 
 	var b strings.Builder
-	b.WriteString(`<div class="card mt-6">`)
+	b.WriteString(`<div class="card">`)
 	b.WriteString(note)
 
 	if HasExternal(owner) {

--- a/service/events/new.go
+++ b/service/events/new.go
@@ -1,0 +1,14 @@
+package events
+
+import "mu/internal/app"
+
+// eventForm keeps creation separate from the agenda and briefing settings.
+func eventForm(csrf string) string {
+	return `<div class="page-col"><form method="POST" action="/events" class="form" onsubmit="var d=this.whenlocal.value;if(d){this.when.value=new Date(d).toISOString()}">` + app.CSRFField(csrf) +
+		`<input type="hidden" name="action" value="create"><input type="hidden" name="when" value="">
+ <label class="field-label">Title<input type="text" name="title" required maxlength="140" placeholder="What is happening?"></label>
+ <label class="field-label">Date and time<input type="datetime-local" name="whenlocal" required></label>
+ <label class="field-label">Note (optional)<textarea name="note" rows="3" maxlength="280"></textarea></label>
+ <div class="form-actions"><button type="submit">Schedule</button><a href="/events" class="btn btn-quiet">Cancel</a></div>
+ </form></div>`
+}

--- a/service/events/preview.go
+++ b/service/events/preview.go
@@ -17,7 +17,7 @@ func Preview(owner string, external []External) string {
 	now := time.Now()
 	rows := mergedRows(Upcoming(owner), external)
 	var b strings.Builder
-	b.WriteString(`<div class="page-stack">`)
+	b.WriteString(`<div class="card compact-list">`)
 	count := 0
 	for _, row := range rows {
 		title, when, allDay := row.External.Title, row.When, row.External.AllDay
@@ -33,7 +33,7 @@ func Preview(owner string, external []External) string {
 			label = when.Format("Mon 2 Jan") + ", all day"
 			stamp = ""
 		}
-		b.WriteString(`<a href="/events" class="link page-stack gap-2"><span>` + html.EscapeString(title) + `</span><small class="text-muted"><time datetime="` + when.Format(time.RFC3339) + `"` + stamp + `>` + html.EscapeString(label) + `</time></small></a>`)
+		b.WriteString(`<a href="/events" class="link compact-list-item"><span>` + html.EscapeString(title) + `</span><small class="text-muted"><time datetime="` + when.Format(time.RFC3339) + `"` + stamp + `>` + html.EscapeString(label) + `</time></small></a>`)
 		count++
 		if count == PreviewLimit {
 			break


### PR DESCRIPTION
Events mixed creation with morning briefing settings. Move creation behind New, with a New event page and labelled Title, Date and time, and optional Note fields before Schedule/Cancel. Give Morning brief its own card.

Rename Home's event overview to Upcoming and put events in a compact card with subtle separators and closer dates. Fill the Services launcher with available everyday services after pins, capped at ten. Container queries show only as many icons as fit in a single row (four on small phones, five with more room, up to ten).

Validation: go test ./home ./service/events -short passed. Browser checks at 320/390/1440 found no event form overflow; launcher checks confirmed 4/5/7/10 visible icons at the corresponding container widths. Shared composition styles handle spacing.