### PR TITLE
Rebalance Home, link individual events, and remove Markets converter

### DIFF
--- a/home/home.go
+++ b/home/home.go
@@ -444,7 +444,6 @@ function fetchW(la,lo){
 	b.WriteString(`<div class="home-workspace"><div class="home-column page-stack">`)
 	b.WriteString(`<div id="home-agent" class="page-stack"><script>window.muActiveAgent="";</script>`)
 	b.WriteString(app.ChatComponent(app.ChatConfig{
-		FooterHTML:      appsHTML(viewerAcc),
 		Ask:             true,
 		HideSuggestions: true,
 		Placeholder:     "What do you need?",
@@ -452,6 +451,10 @@ function fetchW(la,lo){
 		Contained:       true,
 	}))
 	b.WriteString(`</div>`)
+	if viewerID != "" {
+		b.WriteString(`<div id="home-brief" class="page-stack">` + briefHTML(viewerID) + `</div>`)
+	}
+	b.WriteString(appsHTML(viewerAcc))
 	if viewerID != "" {
 		if peek := inbox.Preview(viewerID); peek != "" {
 			b.WriteString(`<div id="home-inbox" class="page-stack">` + sectionRule("Inbox") + peek + `</div>`)
@@ -461,7 +464,6 @@ function fetchW(la,lo){
 	if viewerID != "" {
 		b.WriteString(`<div class="home-column page-stack">`)
 		b.WriteString(`<div id="home-upcoming" class="page-stack">` + sectionRule("Upcoming") + `<div data-home-upcoming aria-live="polite" class="page-stack"><p class="text-muted">Loading events…</p></div>` + `</div>`)
-		b.WriteString(`<div id="home-brief" class="page-stack">` + briefHTML(viewerID) + `</div>`)
 		if who := agent.Preview(viewerID); who != "" {
 			b.WriteString(`<div id="home-agents" class="page-stack">` + sectionRule("Agents") + who + `</div>`)
 		}

--- a/home/home.go
+++ b/home/home.go
@@ -277,8 +277,7 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "Sign in to see upcoming events", http.StatusUnauthorized)
 			return
 		}
-		now := time.Now()
-		external := events.ExternalEvents(sess.Account, now, now.Add(30*24*time.Hour), events.PreviewLimit)
+		external := events.Overview(sess.Account, events.PreviewLimit)
 		app.RespondJSON(w, map[string]string{"upcoming": events.Preview(sess.Account, external), "brief": briefHTML(sess.Account, external...)})
 		return
 	}
@@ -452,7 +451,7 @@ function fetchW(la,lo){
 	}))
 	b.WriteString(`</div>`)
 	if viewerID != "" {
-		b.WriteString(`<div id="home-brief" class="page-stack">` + briefHTML(viewerID) + `</div>`)
+		b.WriteString(`<div id="home-brief" class="page-stack">` + briefHTML(viewerID, events.CachedOverview(viewerID)...) + `</div>`)
 	}
 	b.WriteString(appsHTML(viewerAcc))
 	if viewerID != "" {
@@ -463,7 +462,7 @@ function fetchW(la,lo){
 	b.WriteString(`</div>`)
 	if viewerID != "" {
 		b.WriteString(`<div class="home-column page-stack">`)
-		b.WriteString(`<div id="home-upcoming" class="page-stack">` + sectionRule("Upcoming") + `<div data-home-upcoming aria-live="polite" class="page-stack"><p class="text-muted">Loading events…</p></div>` + `</div>`)
+		b.WriteString(`<div id="home-upcoming" class="page-stack">` + sectionRule("Upcoming") + `<div data-home-upcoming aria-live="polite" class="page-stack">` + events.Preview(viewerID, events.CachedOverview(viewerID)) + `</div>` + `</div>`)
 		if who := agent.Preview(viewerID); who != "" {
 			b.WriteString(`<div id="home-agents" class="page-stack">` + sectionRule("Agents") + who + `</div>`)
 		}

--- a/internal/app/html/composition.css
+++ b/internal/app/html/composition.css
@@ -134,7 +134,7 @@ a.btn-secondary:hover, .btn-secondary:hover {
 
 /* Compact previews keep metadata close and separate adjacent entries. */
 .compact-list { display: flex; flex-direction: column; }
-.compact-list-item { display: flex; flex-direction: column; gap: 2px; padding-block: 12px; }
+.compact-list > .compact-list-item { display: flex; flex-direction: column; gap: 2px; padding-block: var(--space-control); margin: 0; font-size: 14px; font-weight: 400; }
 .compact-list-item:first-child { padding-block-start: 0; }
 .compact-list-item:last-child { padding-block-end: 0; }
 .compact-list-item + .compact-list-item { border-top: 1px solid var(--card-border, #e8e8e8); }

--- a/internal/google/google.go
+++ b/internal/google/google.go
@@ -441,6 +441,7 @@ func Busy(accountID string, from, to time.Time) ([]Period, error) {
 
 // Entry is one event on the person's real calendar.
 type Entry struct {
+	URL string `json:"url,omitempty"`
 	// UID identifies the same invitation appearing on several selected calendars.
 	UID      string `json:"-"`
 	Title    string
@@ -537,6 +538,7 @@ func calendarEvents(token, calendarID string, from, to time.Time, limit int) ([]
 		var out struct {
 			NextPageToken string `json:"nextPageToken"`
 			Items         []struct {
+				URL      string `json:"htmlLink"`
 				UID      string `json:"iCalUID"`
 				Summary  string `json:"summary"`
 				Location string `json:"location"`
@@ -561,7 +563,7 @@ func calendarEvents(token, calendarID string, from, to time.Time, limit int) ([]
 			if it.Status == "cancelled" {
 				continue
 			}
-			e := Entry{UID: it.UID, Title: strings.TrimSpace(it.Summary), Location: strings.TrimSpace(it.Location)}
+			e := Entry{URL: it.URL, UID: it.UID, Title: strings.TrimSpace(it.Summary), Location: strings.TrimSpace(it.Location)}
 			if e.Title == "" {
 				e.Title = "(no title)"
 			}

--- a/internal/server/hooks.go
+++ b/internal/server/hooks.go
@@ -137,7 +137,7 @@ func wireHooks() {
 			out := make([]events.External, 0, len(entries))
 			for _, e := range entries {
 				out = append(out, events.External{
-					Title: e.Title, Start: e.Start, End: e.End,
+					URL: e.URL, Title: e.Title, Start: e.Start, End: e.End,
 					Location: e.Location, AllDay: e.AllDay, Source: events.ExternalName,
 				})
 			}

--- a/service/events/detail.go
+++ b/service/events/detail.go
@@ -1,0 +1,49 @@
+package events
+
+import (
+	"html"
+	"net/http"
+	"net/url"
+	"time"
+
+	"mu/internal/app"
+)
+
+func eventURL(id string) string { return "/events?id=" + url.QueryEscape(id) }
+
+// Only navigation URLs are accepted from an external calendar.
+func externalURL(e External) string {
+	u, err := url.Parse(e.URL)
+	if err == nil && u.Scheme == "https" && u.Host != "" {
+		return u.String()
+	}
+	return "/events"
+}
+
+func ownedEvent(owner, id string) *Event {
+	mu.RLock()
+	defer mu.RUnlock()
+	e := events[id]
+	if e == nil || e.Owner != owner {
+		return nil
+	}
+	copy := *e
+	return &copy
+}
+
+func detailHandler(w http.ResponseWriter, r *http.Request, owner, id string) {
+	e := ownedEvent(owner, id)
+	if e == nil {
+		http.NotFound(w, r)
+		return
+	}
+	body := `<div class="page-col page-stack"><article class="card page-stack"><p><time datetime="` + e.When.Format(time.RFC3339) + `" data-event-time>` + html.EscapeString(e.When.Format("Mon 2 Jan, 15:04")) + `</time></p>`
+	if e.Note != "" {
+		body += `<div style="white-space:pre-wrap">` + html.EscapeString(e.Note) + `</div>`
+	}
+	if e.Repeat != "" {
+		body += `<p>Repeats: ` + html.EscapeString(e.Repeat) + `</p>`
+	}
+	body += `<a class="link" href="` + html.EscapeString(GoogleCalendarURL(e.Title, e.When, e.Note)) + `" target="_blank" rel="noopener">Add to calendar</a></article><a class="link" href="/events">Back to events →</a></div>`
+	app.Respond(w, r, app.Response{Title: e.Title, HTML: body})
+}

--- a/service/events/detail.go
+++ b/service/events/detail.go
@@ -45,5 +45,6 @@ func detailHandler(w http.ResponseWriter, r *http.Request, owner, id string) {
 		body += `<p>Repeats: ` + html.EscapeString(e.Repeat) + `</p>`
 	}
 	body += `<a class="link" href="` + html.EscapeString(GoogleCalendarURL(e.Title, e.When, e.Note)) + `" target="_blank" rel="noopener">Add to calendar</a></article><a class="link" href="/events">Back to events →</a></div>`
+	body += `<script>document.querySelectorAll('time[data-event-time]').forEach(function(el){var d=new Date(el.dateTime);if(!isNaN(d.getTime()))el.textContent=d.toLocaleString(undefined,{weekday:'short',day:'numeric',month:'short',hour:'2-digit',minute:'2-digit'});});</script>`
 	app.Respond(w, r, app.Response{Title: e.Title, HTML: body})
 }

--- a/service/events/detail_test.go
+++ b/service/events/detail_test.go
@@ -1,0 +1,32 @@
+package events
+
+import "testing"
+
+func TestEventDetailsRespectOwner(t *testing.T) {
+	mu.Lock()
+	events["detail-owner-test"] = &Event{ID: "detail-owner-test", Owner: "alice", Title: "Private"}
+	mu.Unlock()
+	defer func() { mu.Lock(); delete(events, "detail-owner-test"); mu.Unlock() }()
+	if ownedEvent("bob", "detail-owner-test") != nil {
+		t.Fatal("another owner's event disclosed")
+	}
+	e := ownedEvent("alice", "detail-owner-test")
+	if e == nil {
+		t.Fatal("owner cannot read event")
+	}
+	e.Title = "Changed"
+	if ownedEvent("alice", "detail-owner-test").Title != "Private" {
+		t.Fatal("read returned mutable stored record")
+	}
+}
+
+func TestExternalEventLinksRejectScripts(t *testing.T) {
+	for _, raw := range []string{"javascript:alert(1)", "//evil.example", "data:text/html,test"} {
+		if externalURL(External{URL: raw}) != "/events" {
+			t.Fatal(raw)
+		}
+	}
+	if externalURL(External{URL: "https://calendar.google.com/calendar/event?eid=123"}) == "/events" {
+		t.Fatal("valid event link rejected")
+	}
+}

--- a/service/events/external.go
+++ b/service/events/external.go
@@ -21,6 +21,7 @@ import "time"
 // External is one entry on a calendar Mu does not own. Read-only by
 // construction: there is no id here to cancel by, because Mu cannot cancel it.
 type External struct {
+	URL      string    `json:"url,omitempty"`
 	Title    string    `json:"title"`
 	Start    time.Time `json:"start"`
 	End      time.Time `json:"end"`

--- a/service/events/handler.go
+++ b/service/events/handler.go
@@ -58,6 +58,10 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if id := r.URL.Query().Get("id"); id != "" {
+		detailHandler(w, r, owner, id)
+		return
+	}
 	csrf := auth.CSRFToken(r)
 	var b strings.Builder
 
@@ -102,7 +106,7 @@ func eventRow(e *Event, csrf string) string {
 	}
 	return fmt.Sprintf(`<div class="pick-row-box">
 <div class="grow">
-  <div class="semibold text-base">%s</div>
+  <a class="text-base no-underline" href="%s">%s</a>
   <div class="text-sm link-colour">%s</div>
   %s
 </div>
@@ -114,6 +118,7 @@ func eventRow(e *Event, csrf string) string {
   <button type="submit" title="Cancel" class="plain-btn faint">&times;</button>
 </form>
 </div>`,
+		html.EscapeString(eventURL(e.ID)),
 		html.EscapeString(e.Title),
 		e.When.Local().Format("Mon 2 Jan, 15:04"),
 		note,
@@ -163,12 +168,12 @@ func externalRow(x External) string {
 	}
 	return fmt.Sprintf(`<div class="pick-row-box soft">
 <div class="grow">
-  <div class="semibold text-base">%s</div>
+  <a class="text-base no-underline" href="%s">%s</a>
   <div class="text-sm link-colour">%s</div>
   %s
 </div>
 <span class="text-2xs text-muted nowrap">%s</span>
-</div>`, html.EscapeString(x.Title), html.EscapeString(when), where, html.EscapeString(source))
+</div>`, html.EscapeString(externalURL(x)), html.EscapeString(x.Title), html.EscapeString(when), where, html.EscapeString(source))
 }
 
 // calendarCard is the ask, and afterwards the receipt.

--- a/service/events/handler.go
+++ b/service/events/handler.go
@@ -73,8 +73,7 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 	b.WriteString(briefScheduleHTML(owner, csrf))
 
 	up := Upcoming(owner)
-	now := time.Now()
-	ext := ExternalEvents(owner, now, now.Add(30*24*time.Hour), 0)
+	ext := Overview(owner, 0)
 
 	if len(up) == 0 && len(ext) == 0 {
 		b.WriteString(`<p class="text-muted text-base">Nothing scheduled. Choose New to add an event, or ask the agent: <em>"remind me to call the dentist tomorrow at 3pm"</em>.</p>`)

--- a/service/events/overview.go
+++ b/service/events/overview.go
@@ -1,0 +1,85 @@
+package events
+
+import (
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"mu/internal/google"
+)
+
+type overviewSnapshot struct {
+	entries []External
+	expires time.Time
+}
+
+var overviewCache = struct {
+	sync.Mutex
+	values  map[string]overviewSnapshot
+	pending map[string]chan struct{}
+}{values: make(map[string]overviewSnapshot), pending: make(map[string]chan struct{})}
+
+func overviewKey(owner string, limit int) string {
+	account := ""
+	if ExternalAccount != nil {
+		account = ExternalAccount(owner)
+	}
+	return account + "\x00" + owner + "\x00" + strconv.Itoa(limit) + "\x00" + strings.Join(google.SelectedCalendars(owner), "\x00")
+}
+
+// CachedOverview provides the last calendar snapshot without waiting on a provider.
+// Local events are always read directly by Preview.
+func CachedOverview(owner string) []External {
+	if owner == "" || (ExternalConnected != nil && !HasExternal(owner)) {
+		return nil
+	}
+	key := overviewKey(owner, PreviewLimit)
+	overviewCache.Lock()
+	defer overviewCache.Unlock()
+	return futureEntries(overviewCache.values[key].entries)
+}
+
+func futureEntries(entries []External) []External {
+	now := time.Now()
+	var out []External
+	for _, e := range entries {
+		if e.Start.After(now) || (e.AllDay && e.End.After(now)) {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+// Overview reuses a recent snapshot across Home and Events. The caller's account
+// and selected calendars identify the snapshot; response HTML is never shared.
+func Overview(owner string, limit int) []External {
+	if owner == "" || (ExternalConnected != nil && !HasExternal(owner)) {
+		return nil
+	}
+	key := overviewKey(owner, limit)
+	overviewCache.Lock()
+	snapshot, ok := overviewCache.values[key]
+	if ok && time.Now().Before(snapshot.expires) {
+		overviewCache.Unlock()
+		return futureEntries(snapshot.entries)
+	}
+	if ready := overviewCache.pending[key]; ready != nil {
+		overviewCache.Unlock()
+		<-ready
+		return Overview(owner, limit)
+	}
+	ready := make(chan struct{})
+	overviewCache.pending[key] = ready
+	overviewCache.Unlock()
+	defer func() { overviewCache.Lock(); delete(overviewCache.pending, key); close(ready); overviewCache.Unlock() }()
+	now := time.Now()
+	entries := ExternalEvents(owner, now, now.Add(30*24*time.Hour), limit)
+	overviewCache.Lock()
+	if len(overviewCache.values) >= 512 {
+		overviewCache.values = make(map[string]overviewSnapshot)
+	}
+	overviewCache.values[key] = overviewSnapshot{entries: append([]External(nil), entries...), expires: time.Now().Add(2 * time.Minute)}
+	overviewCache.Unlock()
+	return entries
+}

--- a/service/events/overview_test.go
+++ b/service/events/overview_test.go
@@ -1,0 +1,34 @@
+package events
+
+import (
+	"testing"
+	"time"
+)
+
+func TestOverviewCachesByOwner(t *testing.T) {
+	oldEntries, oldConnected := ExternalEntries, ExternalConnected
+	defer func() { ExternalEntries = oldEntries; ExternalConnected = oldConnected }()
+	ExternalConnected = func(string) bool { return true }
+	calls := 0
+	ExternalEntries = func(owner string, _, _ time.Time, limit int) []External {
+		calls++
+		if limit != PreviewLimit {
+			t.Fatal("unbounded preview")
+		}
+		return []External{{Title: owner, Start: time.Now().Add(time.Hour)}}
+	}
+	a, b := "overview-test-a", "overview-test-b"
+	Overview(a, PreviewLimit)
+	Overview(a, PreviewLimit)
+	Overview(b, PreviewLimit)
+	if calls != 2 {
+		t.Fatalf("provider calls: %d", calls)
+	}
+	if got := CachedOverview(a); len(got) != 1 || got[0].Title != a {
+		t.Fatal("wrong cached account")
+	}
+	ExternalConnected = func(string) bool { return false }
+	if len(CachedOverview(a)) != 0 {
+		t.Fatal("disconnected calendar still shown")
+	}
+}

--- a/service/events/preview.go
+++ b/service/events/preview.go
@@ -20,12 +20,14 @@ func Preview(owner string, external []External) string {
 	b.WriteString(`<div class="card compact-list">`)
 	count := 0
 	for _, row := range rows {
+		href := externalURL(row.External)
 		title, when, allDay := row.External.Title, row.When, row.External.AllDay
 		if row.Event != nil {
 			if row.Event.Kind == "brief" || row.When.Before(now) {
 				continue
 			}
 			title = row.Event.Title
+			href = eventURL(row.Event.ID)
 		}
 		label := when.Format("Mon 2 Jan, 15:04")
 		stamp := ` data-event-time`
@@ -33,7 +35,7 @@ func Preview(owner string, external []External) string {
 			label = when.Format("Mon 2 Jan") + ", all day"
 			stamp = ""
 		}
-		b.WriteString(`<a href="/events" class="link compact-list-item"><span>` + html.EscapeString(title) + `</span><small class="text-muted"><time datetime="` + when.Format(time.RFC3339) + `"` + stamp + `>` + html.EscapeString(label) + `</time></small></a>`)
+		b.WriteString(`<a href="` + html.EscapeString(href) + `" class="link compact-list-item"><span>` + html.EscapeString(title) + `</span><small class="text-muted"><time datetime="` + when.Format(time.RFC3339) + `"` + stamp + `>` + html.EscapeString(label) + `</time></small></a>`)
 		count++
 		if count == PreviewLimit {
 			break

--- a/service/markets/markets.go
+++ b/service/markets/markets.go
@@ -862,7 +862,7 @@ func handleHTML(w http.ResponseWriter, r *http.Request, category string) {
 	priceData := AllPriceData()
 
 	// Generate HTML for the selected category
-	body := generateMarketsPage(priceData, category, converterHTML(r))
+	body := generateMarketsPage(priceData, category, "")
 
 	app.Respond(w, r, app.Response{
 		Title:       "Markets",

--- a/service/video/thumbnail.go
+++ b/service/video/thumbnail.go
@@ -3,7 +3,9 @@ package video
 import (
 	"io"
 	"net/http"
+	"net/url"
 	"regexp"
+	"strings"
 	"sync"
 	"time"
 
@@ -134,11 +136,22 @@ func thumbSrc(id, apiURL string) string {
 	if u := ThumbURL(id); u != "" {
 		return u
 	}
+	// Playlist artwork is usually a thumbnail of one of its videos. Resolve
+	// that video ID, never the playlist ID or the CDN's signed query string.
+	u, err := url.Parse(apiURL)
+	if err == nil && u.Hostname() == "i.ytimg.com" {
+		parts := strings.Split(strings.Trim(u.Path, "/"), "/")
+		if len(parts) == 3 && (parts[0] == "vi" || parts[0] == "vi_webp") {
+			if local := ThumbURL(parts[1]); local != "" {
+				return local
+			}
+		}
+	}
 	return apiURL
 }
 
 // remoteThumb matches a YouTube thumbnail URL of any size.
-var remoteThumb = regexp.MustCompile(`https?://i\.ytimg\.com/vi/([A-Za-z0-9_-]{11})/[a-zA-Z0-9_]+\.jpg`)
+var remoteThumb = regexp.MustCompile(`https?://i\.ytimg\.com/(?:vi|vi_webp)/([A-Za-z0-9_-]{11})/[a-zA-Z0-9_]+\.(?:jpg|webp)(?:\?[^"\s<>]*)?`)
 
 // ProxyThumbnails rewrites Google's thumbnail URLs to Mu's own path.
 //

--- a/service/video/thumbrender_test.go
+++ b/service/video/thumbrender_test.go
@@ -93,11 +93,20 @@ func TestThumbSrcPrefersTheLocalPath(t *testing.T) {
 		t.Errorf("thumbSrc(%q, remote) = %q, want the local path", id, got)
 	}
 
-	// A channel or playlist id is not a video id, so there is no local
-	// thumbnail to serve and the API's own URL is all there is. Falling back is
-	// right; silently emitting an empty src would not be.
+	// Playlist and channel results can use artwork belonging to a video.
 	const channel = "UCXuqSBlHAE6Xw-yeJA0Tunw"
-	if got := thumbSrc(channel, remote); got != remote {
-		t.Errorf("thumbSrc(channelID, remote) = %q, want the API URL", got)
+	if got := thumbSrc(channel, remote); got != "/video/thumb?id="+id {
+		t.Errorf("thumbSrc(channelID, remote) = %q, want the artwork video’s local URL", got)
+	}
+}
+
+func TestPlaylistThumbnailDiscardsCDNQuery(t *testing.T) {
+	const remote = "https://i.ytimg.com/vi/hE2HEj1JBcI/hqdefault.jpg?sqp=abc&rs=xyz"
+	const want = "/video/thumb?id=hE2HEj1JBcI"
+	if got := thumbSrc("PL_playlist_long_identifier", remote); got != want {
+		t.Fatal(got)
+	}
+	if got := ProxyThumbnails(`<img src="` + remote + `">`); got != `<img src="`+want+`">` {
+		t.Fatal(got)
 	}
 }


### PR DESCRIPTION
Place Brief between the assistant and Services, with Inbox below. Keep Upcoming and Agents in the right column.

Upcoming inherited top margins and semibold text from the general link class. Explicit compact-list spacing removes those margins, uses 8px row padding and normal 14px text, and retains dividers.

Mu event titles now open an owner-checked detail page with the date, note and repeat schedule. Google events link to the provider's individual event page from Home and Events. Accept only HTTPS external navigation links. Remove the converter from the Markets page.

Validation: Home, Events, Google, server and Markets short tests passed, including new ownership and external-link safety tests. Existing mobile form and responsive launcher browser checks passed.