### PR TITLE
Open Home assistant above the dashboard

### DIFF
--- a/agent/preview.go
+++ b/agent/preview.go
@@ -147,17 +147,8 @@ func Preview(accountID string) string {
 		}
 		b.WriteString(`</a>`)
 	}
-	// Where the rest of them are, said the same way the inbox block says it.
-	// Home shows five; an account with six had no way on from here except the
-	// sidebar, and a block that lists some of a thing should say where all of it
-	// is. Same class as the inbox's, because it is the same affordance — two
-	// blocks that end in a link out should not end differently.
-	//
-	// In the card rather than under it, and that is the whole reason this moved
-	// when the inbox's did: they are the same affordance, so they are in the
-	// same place. See inbox.Preview for the argument.
-	b.WriteString(app.Link("Go to agents", "/agents"))
 	b.WriteString(`</div>`)
+	b.WriteString(app.SectionLink("Go to agents", "/agents"))
 	return b.String()
 }
 

--- a/home/apps.go
+++ b/home/apps.go
@@ -31,6 +31,6 @@ func appsHTML(acc *auth.Account) string {
 	for _, s := range apps {
 		b.WriteString(`<a href="` + html.EscapeString(s.Page) + `"><span class="home-app-icon"><img src="/` + html.EscapeString(s.NavIcon()) + `" alt=""></span><span>` + html.EscapeString(s.NavLabel()) + `</span></a>`)
 	}
-	b.WriteString(`</div><a href="/services" class="link">Go to services →</a></nav>`)
+	b.WriteString(`</div>` + app.SectionLink("Go to services", "/services") + `</nav>`)
 	return b.String()
 }

--- a/home/apps_test.go
+++ b/home/apps_test.go
@@ -25,7 +25,7 @@ func TestAppsAlwaysOfferUsefulDefaults(t *testing.T) {
 				t.Errorf("missing default %s for %#v", name, acc)
 			}
 		}
-		if !strings.Contains(body, sectionRule("Services")) || !strings.Contains(body, `</div><a href="/services" class="link">Go to services →</a>`) {
+		if !strings.Contains(body, sectionRule("Services")) || !strings.Contains(body, `</div><a class="section-link" href="/services">Go to services →</a>`) {
 			t.Error("launcher heading or catalogue link misplaced")
 		}
 	}

--- a/home/frontdoor_test.go
+++ b/home/frontdoor_test.go
@@ -44,7 +44,7 @@ func TestHomeStartsWithMicro(t *testing.T) {
 			t.Errorf("Home still offers %s", control)
 		}
 	}
-	if !strings.Contains(body, `class="mu-chat-contained"`) {
+	if !strings.Contains(body, `class="mu-chat-contained mu-chat-overlay"`) {
 		t.Error("Home conversation is not contained")
 	}
 }

--- a/home/home.go
+++ b/home/home.go
@@ -448,6 +448,7 @@ function fetchW(la,lo){
 		Placeholder:     "What do you need?",
 		AgentName:       agent.DefaultName(),
 		Contained:       true,
+		Overlay:         true,
 	}))
 	b.WriteString(`</div>`)
 	if viewerID != "" {

--- a/home/home.go
+++ b/home/home.go
@@ -431,12 +431,12 @@ function fetchW(la,lo){
 	b.WriteString(`<div id="home-cards">`)
 
 	// Date + invite/settings above the input
-	b.WriteString(dateHTML)
+	b.WriteString(`<div class="page-section compact-stack page-stack">` + dateHTML)
 	feed := r.URL.Query().Get("view") == "feed" || r.URL.Query().Get("mode") == "display"
 	if r.URL.Query().Get("q") != "" || r.URL.Query().Get("prompt") != "" {
 		feed = false
 	}
-	b.WriteString(homeViews(feed))
+	b.WriteString(homeViews(feed) + `</div>`)
 	b.WriteString(`<section id="home-personal" role="tabpanel" aria-labelledby="home-view-personal"` + panelHidden(feed) + `>`)
 
 	// Each column flows independently as a conversation grows.

--- a/inbox/preview.go
+++ b/inbox/preview.go
@@ -104,20 +104,8 @@ func Preview(accountID string) string {
 			`</span><span class="peek-when">` + html.EscapeString(app.TimeAgo(t.Updated)) + `</span></span>` +
 			`<span class="peek-line">` + line + where + `</span></a>`)
 	}
-	// In the card, not under it.
-	//
-	// It was under, on the argument that the card is the conversations and the
-	// way on is not one of them. That reasoning holds for what the link *is*
-	// and was wrong about what it looks like: a bare anchor floating below a
-	// bordered box belongs to nothing, and Home now has a rail of these boxes
-	// beside a grid of service cards which put their own More link inside the
-	// border. Two shapes for the same affordance on one screen.
-	//
-	// The row it might be confused with is the objection that put it outside,
-	// and the answer is that it does not look like one — .card-link is a bold
-	// link with an arrow after it, and the rows above are two lines of text.
-	b.WriteString(app.Link("Go to inbox", "/inbox"))
 	b.WriteString(`</div>`)
+	b.WriteString(app.SectionLink("Go to inbox", "/inbox"))
 	return b.String()
 }
 

--- a/internal/app/chat.go
+++ b/internal/app/chat.go
@@ -164,6 +164,8 @@ type ChatConfig struct {
 
 	// Contained limits the height of a conversation beneath its composer.
 	Contained bool
+	// Overlay opens the composer and conversation above the host page on focus.
+	Overlay bool
 }
 
 // ChatComponent returns the single, shared chat UI used everywhere Mu talks to
@@ -447,6 +449,9 @@ func ChatComponent(cfg ChatConfig) string {
 	if cfg.Contained {
 		shell = `<div id="mu-chat" class="mu-chat-contained">`
 	}
+	if cfg.Overlay {
+		shell = `<div id="mu-chat" class="mu-chat-contained mu-chat-overlay">`
+	}
 	if cfg.Transcript {
 		body = conv + suggest + composer
 		shell = `<div id="mu-chat" class="mu-chat-transcript">`
@@ -508,6 +513,18 @@ func ChatComponent(cfg ChatConfig) string {
   overscroll-behavior-y: contain;
   scrollbar-gutter: stable;
 }
+#mu-chat.mu-chat-overlay #mu-chat-conv { margin-top:12px; }
+#mu-chat.mu-chat-overlay:not(.mu-console-open) #mu-chat-conv { display:none; }
+.mu-console { box-sizing:border-box; width:min(880px,calc(100% - 32px)); height:min(800px,calc(100dvh - 48px)); max-height:none; max-width:none; padding:16px; border:1px solid var(--card-border,#ddd); border-radius:12px; background:var(--background-color,#fff); color:var(--text-primary,#222); }
+body:has(.mu-console[open]) { overflow:hidden; }
+.mu-console::backdrop { background:rgba(0,0,0,.28); }
+.mu-console[open] { display:flex; flex-direction:column; }
+.mu-console-head { display:flex; align-items:center; justify-content:space-between; margin-bottom:12px; font-size:14px; }
+.mu-console-close { font:inherit; font-weight:400; cursor:pointer; }
+.mu-console #mu-chat { display:flex; flex-direction:column; min-height:0; flex:1; max-width:none; }
+.mu-console #mu-chat-form { flex-shrink:0; position:static; }
+.mu-console #mu-chat #mu-chat-conv { flex:1; min-height:0; max-height:none; overflow:auto; overflow-anchor:none; }
+@media(max-width:600px){.mu-console{width:100%;height:100dvh;margin:0;border:0;border-radius:0;padding:12px;}}
 /* A conversation, not a box.
 
    The turns scroll in their own region and the input sits under them, which is
@@ -615,6 +632,7 @@ var conv=document.getElementById('mu-chat-conv');
 // A transcript keeps its input at the bottom and its newest turn above it.
 // See ChatConfig.Transcript.
 var transcript=!!document.querySelector('#mu-chat.mu-chat-transcript');
+var overlay=!!document.querySelector("#mu-chat.mu-chat-overlay");
 var contained=!!document.querySelector('#mu-chat.mu-chat-contained');
 
 // The brief steps aside when you ask.
@@ -640,6 +658,34 @@ function nearBottom(){
   return (conv.scrollTop+conv.clientHeight)>=(conv.scrollHeight-nearEnough);
 }
 var nearEnough=120;
+if(overlay && input && form){
+ var shell=document.getElementById('mu-chat');
+ var slot=document.createElement('div');
+ shell.before(slot); slot.appendChild(shell);
+ var dialog=document.createElement('dialog'); dialog.className='mu-console';
+ dialog.setAttribute('aria-label','Assistant');
+ dialog.innerHTML='<div class="mu-console-head"><span>Assistant</span><button type="button" class="mu-console-close">Close</button></div>';
+ slot.appendChild(dialog);
+ var closing=false;
+ function openConsole(){
+  if(closing || dialog.open || !shell.isConnected)return;
+  slot.style.minHeight=shell.getBoundingClientRect().height+'px';
+  dialog.appendChild(shell);shell.classList.add('mu-console-open');
+  dialog.showModal();fitConv();input.focus({preventScroll:true});
+ }
+ function closeConsole(){if(dialog.open)dialog.close();}
+ dialog.querySelector('button').addEventListener('click',closeConsole);
+ dialog.addEventListener('click',function(e){if(e.target===dialog){var r=dialog.getBoundingClientRect();if(e.clientX<r.left||e.clientX>r.right||e.clientY<r.top||e.clientY>r.bottom)closeConsole();}});
+ dialog.addEventListener('close',function(){
+  closing=true;shell.classList.remove('mu-console-open');slot.insertBefore(shell,dialog);
+  slot.style.minHeight='';
+  input.focus({preventScroll:true});setTimeout(function(){closing=false;},0);
+ });
+ input.addEventListener('focus',openConsole);
+ input.addEventListener('click',openConsole);
+ form.addEventListener('submit',openConsole,true);
+}
+
 function revealQuestion(node){
   if(transcript){toBottom(false);return;}
   requestAnimationFrame(function(){
@@ -650,7 +696,7 @@ function revealQuestion(node){
   });
 }
 function toBottom(force,smooth){
-  if(!transcript&&!contained) return;
+  if(overlay||(!transcript&&!contained)) return;
   if(!force && !nearBottom()) return;
   requestAnimationFrame(function(){
     conv.scrollTo({top:conv.scrollHeight,behavior:smooth?'smooth':'auto'});
@@ -679,6 +725,11 @@ function screenH(){
   return window.visualViewport ? window.visualViewport.height+window.visualViewport.offsetTop : window.innerHeight;
 }
 function fitConv(){
+  if(overlay){
+    var panel=document.querySelector('.mu-console[open]');
+    if(panel){var view=window.visualViewport;var h=view?view.height:window.innerHeight;var mobile=window.innerWidth<=600;panel.style.height=Math.min(mobile?h:h-48, mobile?h:800)+'px';panel.style.top=(view?view.offsetTop:0)+'px';}
+    return;
+  }
   if(!transcript||!conv) return;
   if(document.body.classList.contains("chat-page")){conv.style.maxHeight="none";return;}
   var top=conv.getBoundingClientRect().top;

--- a/internal/app/chat.go
+++ b/internal/app/chat.go
@@ -513,9 +513,10 @@ func ChatComponent(cfg ChatConfig) string {
   overscroll-behavior-y: contain;
   scrollbar-gutter: stable;
 }
-#mu-chat.mu-chat-overlay #mu-chat-conv { margin-top:12px; }
+#mu-chat.mu-chat-overlay #mu-chat-conv { margin-top:var(--space-control,8px); }
 #mu-chat.mu-chat-overlay:not(.mu-console-open) #mu-chat-conv { display:none; }
 .mu-console { box-sizing:border-box; width:min(880px,calc(100% - 32px)); height:min(800px,calc(100dvh - 48px)); max-height:none; max-width:none; padding:16px; border:1px solid var(--card-border,#ddd); border-radius:12px; background:var(--background-color,#fff); color:var(--text-primary,#222); }
+html:has(.mu-chat-overlay) { scrollbar-gutter:stable; }
 body:has(.mu-console[open]) { overflow:hidden; }
 .mu-console::backdrop { background:rgba(0,0,0,.28); }
 .mu-console[open] { display:flex; flex-direction:column; }
@@ -679,7 +680,7 @@ if(overlay && input && form){
  dialog.addEventListener('close',function(){
   closing=true;shell.classList.remove('mu-console-open');slot.insertBefore(shell,dialog);
   slot.style.minHeight='';
-  input.focus({preventScroll:true});setTimeout(function(){closing=false;},0);
+  if(window.matchMedia('(pointer:coarse)').matches){input.blur();}else{input.focus({preventScroll:true});}setTimeout(function(){closing=false;},0);
  });
  input.addEventListener('focus',openConsole);
  input.addEventListener('click',openConsole);
@@ -880,6 +881,7 @@ function agentName(){
 
 var viewEpoch=0,detachActive=null;
 function ask(q){
+ if(overlay)openConsole();
   q=String(q||'').trim();
   if(!q)return;
   var epoch=viewEpoch;

--- a/internal/app/chat_completion_test.go
+++ b/internal/app/chat_completion_test.go
@@ -19,7 +19,12 @@ func TestChatCompletionAndRecovery(t *testing.T) {
 	}
 	text := string(src)
 	start := strings.Index(text, "function ask(q){")
-	end := strings.Index(text, "form.addEventListener('submit',")
+	end := -1
+	if start >= 0 {
+		if offset := strings.Index(text[start:], "form.addEventListener('submit',"); offset >= 0 {
+			end = start + offset
+		}
+	}
 	if start < 0 || end <= start {
 		t.Fatal("chat function not found")
 	}

--- a/internal/app/html/composition.css
+++ b/internal/app/html/composition.css
@@ -147,3 +147,6 @@ a.btn-secondary:hover, .btn-secondary:hover {
 @container (min-width: 560px) { .home-apps-grid > a:nth-child(8) { display: flex; } }
 @container (min-width: 632px) { .home-apps-grid > a:nth-child(9) { display: flex; } }
 @container (min-width: 704px) { .home-apps-grid > a:nth-child(10) { display: flex; } }
+
+/* Date and view tabs form one compact Home header. */
+#home-cards > #home-date { margin-block-end: var(--space-control); }

--- a/internal/app/html/composition.css
+++ b/internal/app/html/composition.css
@@ -148,5 +148,10 @@ a.btn-secondary:hover, .btn-secondary:hover {
 @container (min-width: 632px) { .home-apps-grid > a:nth-child(9) { display: flex; } }
 @container (min-width: 704px) { .home-apps-grid > a:nth-child(10) { display: flex; } }
 
-/* Date and view tabs form one compact Home header. */
-#home-cards > #home-date { margin-block-end: var(--space-control); }
+/* Shared compact header and preview navigation. */
+.page-stack.compact-stack { gap: var(--space-control); }
+.page-stack.compact-stack > * { margin-block: 0; }
+.section-link { display:block; margin:0; font-size:13px; font-weight:400; color:var(--text-primary,#111); text-decoration:none; }
+.section-link:hover { text-decoration:underline; }
+
+@media(max-width:640px){#home-cards .view-switch{justify-content:center;}}

--- a/internal/app/section.go
+++ b/internal/app/section.go
@@ -1,0 +1,8 @@
+package app
+
+import "html"
+
+// SectionLink opens the full collection beneath a compact preview.
+func SectionLink(label, href string) string {
+	return `<a class="section-link" href="` + html.EscapeString(href) + `">` + html.EscapeString(label) + ` →</a>`
+}

--- a/internal/app/testdata/chat_completion.js
+++ b/internal/app/testdata/chat_completion.js
@@ -1,3 +1,4 @@
+globalThis.overlay=false;
 const fs=require('fs'),assert=require('assert');
 const source=JSON.parse(fs.readFileSync(0,'utf8'));
 const frame=e=>'data: '+JSON.stringify(e)+'\n\n';

--- a/service/events/preview.go
+++ b/service/events/preview.go
@@ -2,6 +2,7 @@ package events
 
 import (
 	"html"
+	"mu/internal/app"
 	"strings"
 	"time"
 )
@@ -44,6 +45,6 @@ func Preview(owner string, external []External) string {
 	if count == 0 {
 		b.WriteString(`<p class="text-muted">No upcoming events to show.</p>`)
 	}
-	b.WriteString(`</div><a href="/events" class="link">Go to events →</a>`)
+	b.WriteString(`</div>` + app.SectionLink("Go to events", "/events"))
 	return b.String()
 }


### PR DESCRIPTION
Home conversations pushed the dashboard down and automatically followed the bottom of long answers. Add an opt-in console overlay to the shared chat component and enable it on Home. Focusing the input opens a native modal dialog; Close, Escape, or clicking the desktop backdrop returns to Home without losing the conversation. The dashboard keeps its position and hidden conversations occupy no space.

Keep each submitted question at the top of the conversation rather than following the answer's bottom. Halve the input-to-question gap to 12px. Size the console to the visual viewport for mobile keyboards. Halve the date/weather-to-tabs gap to 8px.

Validation: internal/app and Home short tests passed. Browser checks at 390px and 1440px exercised submission with a long SSE response, stable scroll position, unchanged dashboard geometry, Close, reopening and Escape. Update the completion-test source extraction to locate the submit handler after ask(), since the overlay also registers a submit listener.