### PR TITLE
Add Mark all as read and an agent mail marking tool

### DIFF
--- a/service/mail/mail.go
+++ b/service/mail/mail.go
@@ -576,6 +576,18 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if r.Method == http.MethodPost && r.FormValue("action") == "mark_read" {
+		if !auth.StrictCSRF(r) {
+			http.Error(w, "Invalid form token", http.StatusForbidden)
+			return
+		}
+		if _, err := markRead(acc.ID, r.PostForm["ids"], r.PostFormValue("all") == "true"); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		http.Redirect(w, r, "/mail", http.StatusSeeOther)
+		return
+	}
 	if r.URL.Query().Get("view") == "outbox" {
 		outboxPage(w, r, acc.ID)
 		return
@@ -1438,6 +1450,10 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 	tabs := fmt.Sprintf(`<div class="mail-tabs"><a href="/mail" class="%s">%s</a><a href="/mail?view=sent" class="%s">Sent</a><a href="/mail?view=outbox" class="mail-tab">Outbox</a><a href="/mail?view=filtered" class="%s">%s</a></div>`,
 		inboxClass, inboxLabel, sentClass, filteredClass, filteredLabel)
 
+	readAction := ""
+	if unreadCount > 0 && view != "sent" && view != "filtered" {
+		readAction = `<form method="POST" action="/mail" class="section-actions page-section">` + app.CSRFField(auth.CSRFToken(r)) + `<input type="hidden" name="action" value="mark_read"><input type="hidden" name="all" value="true"><button type="submit" class="btn btn-quiet">Mark all as read</button></form>`
+	}
 	// Search bar
 	searchBar := mailSearchBar(searchTerm(r), auth.CSRFToken(r))
 
@@ -1445,7 +1461,7 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 		Action:  "/mail?compose=true",
 		Label:   "New",
 		Filters: tabs,
-		Content: addressPanel(acc.ID) + tagFilter(userInbox, acc.ID, viewTag) + searchBar +
+		Content: addressPanel(acc.ID) + tagFilter(userInbox, acc.ID, viewTag) + searchBar + readAction +
 			`<div id="mailbox">` + content + `</div>`,
 	})
 

--- a/service/mail/mark.go
+++ b/service/mail/mark.go
@@ -1,0 +1,83 @@
+package mail
+
+import (
+	"context"
+	"fmt"
+	"mu/internal/service"
+)
+
+type MarkReadRequest struct {
+	IDs []string `json:"ids" description:"Message IDs to mark read; use all instead to clear the inbox unread count"`
+	All bool     `json:"all" description:"Explicitly mark all current inbox mail as read"`
+}
+
+type MarkReadResponse struct {
+	Updated int    `json:"updated"`
+	Text    string `json:"text"`
+}
+
+// MarkRead changes unread state without claiming to have reviewed the content.
+func (Server) MarkRead(ctx context.Context, req *MarkReadRequest, rsp *MarkReadResponse) error {
+	count, err := markRead(service.AccountFrom(ctx), req.IDs, req.All)
+	if err != nil {
+		return err
+	}
+	rsp.Updated = count
+	rsp.Text = fmt.Sprintf("Marked %d mail messages as read. This only changes their read status; it does not review or triage their contents.", count)
+	return nil
+}
+
+func markRead(owner string, ids []string, all bool) (int, error) {
+	if owner == "" {
+		return 0, fmt.Errorf("sign in to mark mail read")
+	}
+	if all == (len(ids) > 0) {
+		return 0, fmt.Errorf("provide message ids or all=true, not both")
+	}
+	mutex.Lock()
+	defer mutex.Unlock()
+	wanted := make(map[string]bool, len(ids))
+	for _, id := range ids {
+		wanted[id] = true
+	}
+	var changed []*Message
+	for _, m := range messages {
+		if m.ToID != owner || m.Spam {
+			continue
+		}
+		if all || wanted[m.ID] {
+			delete(wanted, m.ID)
+			if !m.Read {
+				changed = append(changed, m)
+			}
+		}
+	}
+	if len(wanted) > 0 {
+		return 0, fmt.Errorf("message not found in your inbox")
+	}
+	if len(changed) == 0 {
+		return 0, nil
+	}
+	for _, m := range changed {
+		m.Read = true
+	}
+	if err := save(); err != nil {
+		for _, m := range changed {
+			m.Read = false
+		}
+		return 0, err
+	}
+	if inbox := inboxes[owner]; inbox != nil {
+		inbox.UnreadCount = 0
+		for _, t := range inbox.Threads {
+			t.HasUnread = false
+			for _, m := range t.Messages {
+				if m.ToID == owner && !m.Read {
+					t.HasUnread = true
+					inbox.UnreadCount++
+				}
+			}
+		}
+	}
+	return len(changed), nil
+}

--- a/service/mail/mark_test.go
+++ b/service/mail/mark_test.go
@@ -1,0 +1,38 @@
+package mail
+
+import "testing"
+
+func TestMarkReadOwnInboxOnly(t *testing.T) {
+	mutex.Lock()
+	old := messages
+	setMessages([]*Message{
+		{ID: "mark-a", ThreadID: "mark-a", ToID: "mark-owner", FromID: "sender", Body: "hello"},
+		{ID: "mark-b", ThreadID: "mark-b", ToID: "mark-other", FromID: "sender", Body: "private"},
+		{ID: "mark-spam", ThreadID: "mark-spam", ToID: "mark-owner", Spam: true},
+	})
+	rebuildInboxes()
+	mutex.Unlock()
+	defer func() { mutex.Lock(); setMessages(old); rebuildInboxes(); mutex.Unlock() }()
+	if _, err := markRead("mark-owner", []string{"mark-a", "mark-b"}, false); err == nil {
+		t.Fatal("accepted another owner's mail")
+	}
+	if messages[0].Read {
+		t.Fatal("partially applied invalid selection")
+	}
+	if _, err := markRead("mark-owner", nil, false); err == nil {
+		t.Fatal("implicit bulk action")
+	}
+	n, err := markRead("mark-owner", nil, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 1 || !messages[0].Read || messages[1].Read || messages[2].Read {
+		t.Fatal("incorrect bulk scope")
+	}
+	if GetUnreadCount("mark-owner") != 0 {
+		t.Fatal("unread count not updated")
+	}
+	if n, err := markRead("mark-owner", nil, true); err != nil || n != 0 {
+		t.Fatal("not idempotent")
+	}
+}

--- a/service/mail/service.go
+++ b/service/mail/service.go
@@ -122,7 +122,7 @@ var Spec = service.Spec{
 	Scoped:      true,
 	Icon:        "mail.png",
 	Endpoints: map[string]service.Endpoint{
-		"MarkRead": {Doc: "Mark specified inbox message IDs, or explicitly all current inbox messages, as read. Changes read status only; does not read, summarize or triage the content.", Needs: service.Account, Destructive: true},
+		"MarkRead": {Doc: "Mark specified inbox message IDs, or explicitly all current inbox messages, as read. Changes read status only; does not read, summarize or triage the content.", Needs: service.Account, Writes: true},
 		"Read":     {Doc: "Read your correspondence by id in bounded body-character pages, including attachment names. Follow the returned next offset for the rest. Omitting id retains the legacy inbox summary"},
 		"Inbox":    {Doc: "List the account's most recent messages — read my mail, check my inbox"},
 		"Search":   {Doc: "Search the account's mail and return matching messages"},

--- a/service/mail/service.go
+++ b/service/mail/service.go
@@ -122,9 +122,10 @@ var Spec = service.Spec{
 	Scoped:      true,
 	Icon:        "mail.png",
 	Endpoints: map[string]service.Endpoint{
-		"Read":   {Doc: "Read your correspondence by id in bounded body-character pages, including attachment names. Follow the returned next offset for the rest. Omitting id retains the legacy inbox summary"},
-		"Inbox":  {Doc: "List the account's most recent messages — read my mail, check my inbox"},
-		"Search": {Doc: "Search the account's mail and return matching messages"},
+		"MarkRead": {Doc: "Mark specified inbox message IDs, or explicitly all current inbox messages, as read. Changes read status only; does not read, summarize or triage the content.", Needs: service.Account, Destructive: true},
+		"Read":     {Doc: "Read your correspondence by id in bounded body-character pages, including attachment names. Follow the returned next offset for the rest. Omitting id retains the legacy inbox summary"},
+		"Inbox":    {Doc: "List the account's most recent messages — read my mail, check my inbox"},
+		"Search":   {Doc: "Search the account's mail and return matching messages"},
 		// Aliased to the name it had, because an agent that learned mail_address
 		// last week should not find it gone. What it returns changed shape, and
 		// the name had to follow: an instance with no mail domain has no address


### PR DESCRIPTION
Unread mail could be cleared only by opening individual threads or using internal code. Add a Mark all as read button on Mail and a scoped mail_mark_read tool accepting explicit message IDs or all=true.

Validate every selected message belongs to the caller before changing anything. Bulk marking excludes filtered spam and other accounts, saves once, rolls back read flags on persistence failure, and updates cached unread counts. The UI uses a CSRF-protected POST. Marking changes state only; the tool explicitly does not claim content was reviewed or triaged.

Validation: service/mail short tests passed, including mixed-owner rejection without partial mutation, explicit bulk intent, spam exclusion, unread counts and idempotence.