### PR TITLE
Fix Home tab spacing and remove macOS builds from deployment path

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Test
+name: Build and deploy
 
 on:
   push:
@@ -46,23 +46,17 @@ jobs:
           go-version: '1.26'
           cache: true
 
-      # Every target the release cuts, not just the one this runner is.
-      #
-      # v1.5.0 has no binaries attached because this was `go build .` on
-      # linux/amd64 and the release cross-compiles four. internal/container's
-      # pty used TIOCSPTLCK and TIOCGPTN with no build constraint, so both
-      # darwin targets failed to compile — and `set -e` took the whole step
-      # down before `gh release create` ran. Everything was green on main;
-      # the first sign was a release with nothing in it, and the first person
-      # to feel it was somebody running the documented installer without Go.
-      #
-      # A tag is the worst place to learn a platform does not compile. It
-      # costs a couple of minutes here and it is the difference between a
-      # failed build and a silent hole in the install path.
-      - name: Build every release target
+      # PRs verify every release platform; main builds deployment artifacts only.
+      - name: Build binaries
+        env:
+          EVENT_NAME: ${{ github.event_name }}
         run: |
           mkdir -p "$RUNNER_TEMP/mu-build"
-          for target in linux/amd64 linux/arm64 darwin/amd64 darwin/arm64; do
+          targets="linux/amd64 linux/arm64"
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            targets="$targets darwin/amd64 darwin/arm64"
+          fi
+          for target in $targets; do
             os="${target%/*}"; arch="${target#*/}"
             echo "Building ${os}/${arch}"
             CGO_ENABLED=0 GOOS="${os}" GOARCH="${arch}" go build -trimpath -o "$RUNNER_TEMP/mu-build/mu-${os}-${arch}" .

--- a/internal/app/html/composition.css
+++ b/internal/app/html/composition.css
@@ -55,7 +55,7 @@
 .form.page-section { margin-block-end: var(--space-section); }
 /* An in-page view switch. Panels keep their own content and state. */
 .view-switch { display: flex; gap: var(--space-field); border-bottom: 1px solid var(--card-border, #e8e8e8); margin-block: 0 var(--space-section); }
-.view-switch [role=tab] { display: inline-flex; align-items: center; min-height: 44px; padding: var(--space-control); border-bottom: 2px solid transparent; color: var(--text-muted, #707070); font-weight: 400; text-decoration: none; }
+.view-switch [role=tab] { box-sizing: border-box; display: inline-flex; align-items: center; min-height: 44px; padding: var(--space-control); border-bottom: 2px solid transparent; color: var(--text-muted, #707070); font-weight: 400; text-decoration: none; }
 .view-switch [role=tab][aria-selected=true] { color: var(--text-primary, #3c3c3c); border-bottom-color: currentColor; }
 .page-stack > *, .page-section > * { margin-block: 0; min-width: 0; }
 .section-actions, .check-label { display: flex; flex-wrap: wrap; align-items: center; gap: var(--space-control); }

--- a/internal/app/html/mu.css
+++ b/internal/app/html/mu.css
@@ -890,7 +890,7 @@ a.btn-plain:hover {
 
 #home-date {
   color: #888;
-  margin: 0 0 16px;
+  margin: 0;
   display: flex;
   align-items: center;
   gap: 8px;


### PR DESCRIPTION
The date's ID selector kept its old 16px bottom margin despite the compact stack's reset. Remove that source margin so the parent owns the 8px gap. Size view tabs with border-box so padding is included in their 44px minimum height.

Production already depends only on build, not tests, but it waited for four sequential platform builds. Keep all four release target checks on PRs; main builds only the Linux amd64/arm64 artifacts required by deployment. Rename the workflow from Test to Build and deploy so status is clearer.

Validation: browser measurements at 390px and 1440px confirm an 8px date-to-tabs gap and 44px tab height with the actual shared CSS. Parsed workflow YAML and verified deployment depends only on build and tests remain PR-only.