### PR TITLE
Open the brief thread from notifications and format scheduled email

### DIFF
--- a/agent/mail/record.go
+++ b/agent/mail/record.go
@@ -24,6 +24,7 @@ package mail
 // of this that is special enough to reach past it.
 
 import (
+	"net/url"
 	"strings"
 
 	"mu/agent"
@@ -79,4 +80,14 @@ func recordDelivery(m mail.InboundMail) {
 		thread.Join(m.Owner, th.ID, thread.Party{
 			Kind: thread.RolePerson, Key: m.From, Name: name})
 	}
+}
+
+// InboxURL records a delivery before returning its owner-scoped conversation link.
+// Recording is idempotent by Message-ID, including when the subscriber runs first.
+func InboxURL(m mail.InboundMail) string {
+	recordDelivery(m)
+	if th := thread.Find(m.Owner, Client, chainKey(m)); th != nil {
+		return "/inbox?id=" + url.QueryEscape(th.ID)
+	}
+	return "/inbox"
 }

--- a/agent/mail/record_test.go
+++ b/agent/mail/record_test.go
@@ -123,3 +123,20 @@ func TestAReplyLandsOnTheSameConversation(t *testing.T) {
 		t.Fatalf("%d messages on the chain, want 2", len(msgs))
 	}
 }
+
+func TestNotificationOpensDeliveredThread(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	m := mail.InboundMail{Owner: "notification-owner", From: "agent@example.test", To: "user+brief@example.test", Subject: "Morning brief", Text: "Your day", MessageID: "<notification-brief@example.test>"}
+	link := InboxURL(m)
+	recordDelivery(m)
+	th := thread.Find(m.Owner, Client, chainKey(m))
+	if th == nil || link != "/inbox?id="+th.ID {
+		t.Fatalf("wrong notification link: %s", link)
+	}
+	if len(thread.Messages(m.Owner, th.ID, 10)) != 1 {
+		t.Fatal("duplicate delivery")
+	}
+	if thread.Get("another-owner", th.ID) != nil {
+		t.Fatal("thread leaked across owners")
+	}
+}

--- a/agent/work/work.go
+++ b/agent/work/work.go
@@ -46,7 +46,9 @@ import (
 	"sync"
 	"time"
 
+	"github.com/google/uuid"
 	"mu/agent"
+	mailagent "mu/agent/mail"
 	"mu/internal/ai"
 	"mu/internal/app"
 	"mu/internal/auth"
@@ -346,15 +348,25 @@ func deliver(r request, answer string, err error) {
 	if accErr != nil {
 		return
 	}
+	tag := "scheduled"
+	isBrief := false
 	if e := events.Brief(r.Account); e != nil && e.ID == r.ID {
-		if err == nil {
-			event.Announce("brief", body, "/inbox", r.Account)
-		}
+		isBrief = true
+		tag = "brief"
 		body += "\n\n---\n[Disable or manage your morning brief](" + origin.Self() + "/events#morning-brief)."
 	}
-	mail.SendMessageTo(mail.Delivery{ //nolint:errcheck
+	messageID := "<" + uuid.NewString() + "@" + mail.ConfiguredDomain() + ">"
+	delivery := mail.Delivery{
 		From: "Mu", FromID: "agent@" + mail.ConfiguredDomain(),
-		To: acc.Name, ToID: acc.ID, Tag: "scheduled",
-		Subject: r.Title, Body: body,
-	})
+		To: acc.Name, ToID: acc.ID, Tag: tag,
+		Subject: r.Title, Body: body, MessageID: messageID,
+	}
+	if sendErr := mail.SendMessageTo(delivery); sendErr != nil {
+		app.Log("work", "delivering scheduled result for %s: %v", r.Account, sendErr)
+		return
+	}
+	if isBrief && err == nil {
+		link := mailagent.InboxURL(mail.InboundMail{Owner: acc.ID, From: delivery.FromID, FromName: delivery.From, To: acc.Name + "+" + tag + "@" + mail.ConfiguredDomain(), Subject: r.Title, Body: delivery.Body, MessageID: messageID, Tag: tag})
+		event.Announce("brief", strings.TrimSpace(answer), link, r.Account)
+	}
 }

--- a/agent/work/work.go
+++ b/agent/work/work.go
@@ -366,7 +366,7 @@ func deliver(r request, answer string, err error) {
 		return
 	}
 	if isBrief && err == nil {
-		link := mailagent.InboxURL(mail.InboundMail{Owner: acc.ID, From: delivery.FromID, FromName: delivery.From, To: acc.Name + "+" + tag + "@" + mail.ConfiguredDomain(), Subject: r.Title, Body: delivery.Body, MessageID: messageID, Tag: tag})
+		link := mailagent.InboxURL(mail.InboundMail{Owner: acc.ID, From: delivery.FromID, FromName: delivery.From, To: acc.ID + "+" + tag + "@" + mail.ConfiguredDomain(), Subject: r.Title, Body: delivery.Body, MessageID: messageID, Tag: tag})
 		event.Announce("brief", strings.TrimSpace(answer), link, r.Account)
 	}
 }

--- a/internal/server/hooks.go
+++ b/internal/server/hooks.go
@@ -296,7 +296,7 @@ func wireHooks() {
 			push.Send(accountID, push.Notification{
 				Title: title,
 				Body:  "From " + from,
-				URL:   "/inbox",
+				URL:   mailagent.InboxURL(m),
 				Tag:   "mail-" + from,
 			})
 		}

--- a/service/mail/forward.go
+++ b/service/mail/forward.go
@@ -162,6 +162,10 @@ From %s · read and reply at %s/inbox
 You are getting this because mail sent to your Mu address is copied to you here.
 Stop these emails: %s`, text, from, base, stop)
 
+	rendered := html.EscapeString(text)
+	if (m.Tag == "brief" || m.Tag == "scheduled") && m.From == "agent@"+ConfiguredDomain() {
+		rendered = app.RenderString(text)
+	}
 	htmlBody = fmt.Sprintf(`<div style="font:14px/1.6 -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;color:#222">
 <div style="white-space:pre-wrap">%s</div>
 <hr style="border:0;border-top:1px solid #e5e5e5;margin:24px 0 12px">
@@ -169,7 +173,7 @@ Stop these emails: %s`, text, from, base, stop)
 <p style="color:#999;font-size:12px;margin:0">You are getting this because mail sent to your Mu address is copied to you here.
 <a href="%s" style="color:#999">Stop these emails</a>.</p>
 </div>`,
-		html.EscapeString(text), html.EscapeString(from),
+		rendered, html.EscapeString(from),
 		html.EscapeString(base), html.EscapeString(stop))
 
 	return plain, htmlBody

--- a/service/mail/forward_test.go
+++ b/service/mail/forward_test.go
@@ -139,3 +139,16 @@ func TestAReplyToAForwardedMessageReachesTheSender(t *testing.T) {
 			"Reply-To is an address a mail client cannot deliver to", got.replyTo)
 	}
 }
+
+func TestScheduledForwardRendersFormatting(t *testing.T) {
+	m := InboundMail{From: "agent@" + ConfiguredDomain(), Tag: "brief", Text: "**Today**\n\n- Meeting", Body: "**Today**\n\n- Meeting"}
+	_, rendered := forwardBody(m, "brief-render-owner")
+	if !strings.Contains(rendered, "<strong>Today</strong>") || strings.Contains(rendered, "**Today**") {
+		t.Fatal("markdown leaked into HTML email")
+	}
+	m.Text = "**Today** <script>alert(1)</script>"
+	_, rendered = forwardBody(m, "brief-render-owner")
+	if !strings.Contains(rendered, "<strong>Today</strong>") || strings.Contains(rendered, "<script>") {
+		t.Fatal("HTML formatting was lost or unsafe")
+	}
+}

--- a/service/mail/imapbox.go
+++ b/service/mail/imapbox.go
@@ -38,6 +38,7 @@ package mail
 import (
 	"encoding/base64"
 	"fmt"
+	"mu/internal/app"
 	"sort"
 	"strings"
 	"sync"
@@ -429,10 +430,10 @@ func imapRender(m *Message) []byte {
 	header("In-Reply-To", m.ReplyTo)
 	b.WriteString("MIME-Version: 1.0\r\n")
 
-	body := strings.ReplaceAll(m.Body, "\r\n", "\n")
+	body := strings.ReplaceAll(clientBody(m), "\r\n", "\n")
 	body = strings.ReplaceAll(body, "\n", "\r\n")
 	bodyType := "text/plain; charset=utf-8"
-	if imapLooksHTML(m.Body) {
+	if imapLooksHTML(clientBody(m)) {
 		bodyType = "text/html; charset=utf-8"
 	}
 
@@ -632,10 +633,10 @@ func imapQuoted(s string) string {
 // about a part that is not there will ask for it and get nothing back.
 func imapBodyStructure(m *Message) string {
 	sub := "PLAIN"
-	if imapLooksHTML(m.Body) {
+	if imapLooksHTML(clientBody(m)) {
 		sub = "HTML"
 	}
-	body := strings.ReplaceAll(m.Body, "\n", "\r\n")
+	body := strings.ReplaceAll(clientBody(m), "\n", "\r\n")
 	text := fmt.Sprintf(`("TEXT" %q ("CHARSET" "UTF-8") NIL NIL "8BIT" %d %d)`,
 		sub, len(body), strings.Count(body, "\r\n")+1)
 	if m.Attachment == "" {
@@ -650,4 +651,12 @@ func imapBodyStructure(m *Message) string {
 	att := fmt.Sprintf(`(%q %q ("NAME" %s) NIL NIL "BASE64" %d)`,
 		kind, subtype, imapQuoted(m.AttachmentName), size)
 	return "(" + text + att + ` "MIXED")`
+}
+
+// clientBody formats generated scheduled mail for ordinary email clients.
+func clientBody(m *Message) string {
+	if (m.Tag == "brief" || m.Tag == "scheduled") && m.FromID == "agent@"+ConfiguredDomain() && !imapLooksHTML(m.Body) {
+		return app.RenderString(m.Body)
+	}
+	return m.Body
 }


### PR DESCRIPTION
Morning briefs used the generic scheduled tag and both brief and mail notifications linked only to Inbox. Give future morning briefs the brief tag, leaving other scheduled results under scheduled. Record delivery idempotently before resolving the owner-scoped Inbox thread URL, so notifications can open the actual conversation even if the mail recorder subscriber has not run yet. Announce a successful brief only after mail delivery succeeds.

Format scheduled agent Markdown for forwarded HTML email and IMAP rather than exposing Markdown syntax. Keep stored content unchanged and retain agent@ as the sender/reply address.

Validation: agent/mail, agent/work, internal/server and service/mail short tests passed. Added regression checks for notification thread identity, owner isolation, duplicate recording, and safe scheduled-email formatting. Existing scheduled mail is not retagged; no mail was deleted.