### PR TITLE
Stream agent answers into sandboxed apps

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 **A personal server: one Go binary you can self-host that carries a web app, an
 HTTP API, a CLI, an MCP server and an installable PWA over the same 36 services
-and 133 tools.** `go build ./...` produces it; nothing else has to be running.
+and 134 tools.** `go build ./...` produces it; nothing else has to be running.
 
 It is not a framework or a set of libraries. It is a thing that runs, that you
 sign into, and that other programs can call.

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1247,7 +1247,7 @@ func sse(w http.ResponseWriter, event map[string]any) {
 // caller could fall back to a second pipeline when it had not. There is no
 // second pipeline, so there is nothing to report: a failure is reported to the
 // person who asked, on the stream they are already reading.
-func streamNativeSSE(w http.ResponseWriter, accountID, prompt string, opts QueryOpts, flow *Flow, threadID string) {
+func streamNativeSSE(w http.ResponseWriter, accountID, prompt string, opts QueryOpts, flow *Flow, threadID string, streamText bool) {
 	// One writer, and something on the wire while nothing is happening.
 	//
 	// The hooks below are called from whatever goroutine is running the tool,
@@ -1356,6 +1356,17 @@ func streamNativeSSE(w http.ResponseWriter, accountID, prompt string, opts Query
 			send(map[string]any{"type": "tool_done", "name": run.Label, "message": run.Label + " — done"})
 		},
 	}
+	// Text deltas are opt-in: existing Home and landing clients still receive
+	// one final, formatted answer. Fresh-news answers stay buffered until their
+	// recency checks have run. The final response always supersedes the deltas.
+	if streamText && !shouldHoldNativeNewsStreamTokens(prompt, nil) {
+		sopts.Stream.Token = func(text string) {
+			wmu.Lock()
+			defer wmu.Unlock()
+			emitted = true
+			sse(w, map[string]any{"type": "stream_token", "text": text})
+		}
+	}
 	answer, err := queryWithFallback(accountID, prompt, sopts)
 	if err != nil {
 		// Whether anything was on screen already decides how it reads, not
@@ -1427,8 +1438,9 @@ func handleQuery(w http.ResponseWriter, r *http.Request) {
 		Prompt     string `json:"prompt"`
 		Attachment string `json:"attachment"`
 		Model      string `json:"model"`
-		Agent      string `json:"agent"`      // optional: user-defined agent id to answer as
-		ContextID  string `json:"context_id"` // optional: prior flow to continue from
+		Agent      string `json:"agent"`       // optional: user-defined agent id to answer as
+		ContextID  string `json:"context_id"`  // optional: prior flow to continue from
+		StreamText bool   `json:"stream_text"` // opt-in answer deltas, followed by the final response
 		// Cards asks for the reader's home cards to be included as context, so
 		// a question about what they watch is answered from what is already
 		// known rather than fetched again.
@@ -1642,7 +1654,7 @@ func handleQuery(w http.ResponseWriter, r *http.Request) {
 	// question still streams.
 	nopts.Thread = threadID
 	routedPrompt, nopts := Routed(req.Prompt, nopts)
-	streamNativeSSE(w, accountID, routedPrompt, nopts, flow, threadID)
+	streamNativeSSE(w, accountID, routedPrompt, nopts, flow, threadID, req.StreamText)
 }
 
 func isLatestTechnologyNewsPrompt(lower string) bool {

--- a/agent/app_stream_test.go
+++ b/agent/app_stream_test.go
@@ -1,0 +1,53 @@
+package agent
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestAnswerDeltasAreOptIn(t *testing.T) {
+	noProviders(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body struct{ Stream bool }
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Error(err)
+			return
+		}
+		if body.Stream {
+			w.Header().Set("Content-Type", "text/event-stream")
+			fmt.Fprint(w, "data: {\"choices\":[{\"index\":0,\"delta\":{\"content\":\"Hello\"}}]}\n\n")
+			w.(http.Flusher).Flush()
+			fmt.Fprint(w, "data: {\"choices\":[{\"index\":0,\"delta\":{\"content\":\" world\"},\"finish_reason\":\"stop\"}]}\n\ndata: [DONE]\n\n")
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"choices":[{"index":0,"message":{"role":"assistant","content":"Hello world"},"finish_reason":"stop"}]}`)
+	}))
+	defer srv.Close()
+	t.Setenv("OPENAI_BASE_URL", srv.URL)
+	t.Setenv("OPENAI_MODEL", "test-model")
+	for _, tc := range []struct {
+		name, prompt   string
+		stream, deltas bool
+	}{
+		{"existing client", "Greet the reader", false, false},
+		{"assistant app", "Greet the reader", true, true},
+		{"news guard", "Explain today's latest AI news", true, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			streamNativeSSE(w, "", tc.prompt, QueryOpts{Public: true, System: "Answer briefly."}, &Flow{ID: "stream-test"}, "", tc.stream)
+			body := w.Body.String()
+			if strings.Contains(body, `"type":"stream_token"`) != tc.deltas {
+				t.Fatalf("unexpected delta behaviour: %s", body)
+			}
+			if !strings.Contains(body, `"text":"Hello world"`) || !strings.Contains(body, `"type":"done"`) || strings.Contains(body, `"type":"error"`) {
+				t.Fatalf("missing final answer: %s", body)
+			}
+		})
+	}
+}

--- a/agent/durable_test.go
+++ b/agent/durable_test.go
@@ -13,6 +13,9 @@ package agent
 // produced it, not by the code that was streaming it to somebody.
 
 import (
+	"go/ast"
+	"go/parser"
+	"go/token"
 	"os"
 	"path/filepath"
 	"strings"
@@ -64,15 +67,27 @@ func TestTheAnswerIsRecordedByTheRunNotTheStream(t *testing.T) {
 	if i < 0 {
 		t.Fatal("nothing records the answer in the streaming path any more")
 	}
-	// The call sits after the streaming is done with — between it and the
-	// preceding stream_token there should be no loop.
-	before := src[:i]
-	if last := strings.LastIndex(before, "stream_token"); last >= 0 {
-		if strings.Contains(before[last:], "for ") {
-			t.Error("Answered is inside a token loop, so an interrupted stream would " +
-				"record a partial answer or none")
-		}
+	// Inspect nesting: an unrelated error-handling loop between the token
+	// callback and Answered does not put Answered inside that callback.
+	file, err := parser.ParseFile(token.NewFileSet(), "agent.go", b, 0)
+	if err != nil {
+		t.Fatal(err)
 	}
+	ast.Inspect(file, func(n ast.Node) bool {
+		switch n.(type) {
+		case *ast.FuncLit, *ast.ForStmt, *ast.RangeStmt:
+			ast.Inspect(n, func(child ast.Node) bool {
+				if call, ok := child.(*ast.CallExpr); ok {
+					if name, ok := call.Fun.(*ast.Ident); ok && name.Name == "Answered" {
+						t.Error("Answered is inside a loop or callback, rather than recording the completed run")
+					}
+				}
+				return true
+			})
+			return false
+		}
+		return true
+	})
 }
 
 // And the record itself keeps it: an answer written down is readable by

--- a/internal/app/chat.go
+++ b/internal/app/chat.go
@@ -664,8 +664,8 @@ if(overlay && input && form){
  var slot=document.createElement('div');
  shell.before(slot); slot.appendChild(shell);
  var dialog=document.createElement('dialog'); dialog.className='mu-console';
- dialog.setAttribute('aria-label','Assistant');
- dialog.innerHTML='<div class="mu-console-head"><span>Assistant</span><button type="button" class="mu-console-close">Close</button></div>';
+ dialog.setAttribute('aria-label','Micro');
+ dialog.innerHTML='<div class="mu-console-head"><span>Micro</span><button type="button" class="mu-console-close">Close</button></div>';
  slot.appendChild(dialog);
  var closing=false;
  function openConsole(){

--- a/server.json
+++ b/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "mu.micro/mu",
-  "description": "A personal agent: it has an email address and it answers. News, web search, mail, markets, weather, places, transit, files, calendar, contacts and notes behind it. 133 tools, one endpoint.",
+  "description": "A personal agent: it has an email address and it answers. News, web search, mail, markets, weather, places, transit, files, calendar, contacts and notes behind it. 134 tools, one endpoint.",
   "repository": {
     "url": "https://github.com/micro/mu",
     "source": "github"

--- a/service/apps/agent_stream.go
+++ b/service/apps/agent_stream.go
@@ -1,0 +1,8 @@
+package apps
+
+import _ "embed"
+
+// The parent owns the connection; app code never receives session credentials.
+//
+//go:embed static/agent-stream.js
+var appAgentStreamJS string

--- a/service/apps/agent_stream_test.go
+++ b/service/apps/agent_stream_test.go
@@ -1,0 +1,27 @@
+package apps
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+func TestAppStreamingBridge(t *testing.T) {
+	node, err := exec.LookPath("node")
+	if err != nil {
+		t.Skip("node is needed to execute the browser bridge tests")
+	}
+	payload, err := json.Marshal(map[string]string{"bridge": appBridgeJS("assistant"), "shim": appShimJS})
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(t.TempDir(), "bridge.json")
+	if err := os.WriteFile(path, payload, 0600); err != nil {
+		t.Fatal(err)
+	}
+	if out, err := exec.Command(node, "testdata/agent-stream.mjs", path).CombinedOutput(); err != nil {
+		t.Fatalf("%v\n%s", err, out)
+	}
+}

--- a/service/apps/build.go
+++ b/service/apps/build.go
@@ -295,6 +295,7 @@ Beyond those two there is a window.mu API, for the things the web has no name fo
   mu.user()                                      the signed-in user
   mu.ai(prompt)                                  a model call, returns text
   mu.agent(prompt)                               the agent, with tools, returns an answer
+  mu.agent.stream(prompt, {context_id, onEvent})   streamed answer; resolves {answer, flow_id, thread}. Continue with thread as context_id. onEvent receives stream_token.text and progress; final response replaces deltas
   mu.web.fetch(url,{method,headers,body})        fetch a page from the open web
   mu.services()                                  what services exist here
 

--- a/service/apps/sandbox.go
+++ b/service/apps/sandbox.go
@@ -75,9 +75,10 @@ var bridgeOps = map[string]bridgeOp{
 	// Writing, and spending. Each of these already charges or rate-limits the
 	// viewer through the central write gate; the app cannot reach anything the
 	// person could not do themselves on the page.
-	"blog.create": {Method: "POST", Path: "/blog"},
-	"chat":        {Method: "POST", Path: "/chat"},
-	"agent":       {Method: "POST", Path: "/agent/run"},
+	"blog.create":  {Method: "POST", Path: "/blog"},
+	"chat":         {Method: "POST", Path: "/chat"},
+	"agent":        {Method: "POST", Path: "/agent/run"},
+	"agent.stream": {Method: "POST", Path: "/agent"},
 
 	// Who is looking. The session endpoint returns the account, not a
 	// credential — an app knowing whose data it is showing is the point.
@@ -134,15 +135,27 @@ const appShimJS = `<script>
   var seq=0, waiting={};
   window.addEventListener('message', function(e){
     var m=e.data;
-    if(!m||m.mu!=='reply'||!waiting[m.id]) return;
-    var w=waiting[m.id]; delete waiting[m.id];
+    if(e.source!==parent||!m||!waiting[m.id]) return;
+    var w=waiting[m.id];
+    if(m.mu==='event'){
+      if(w.onEvent){try{w.onEvent(m.event)}catch(err){
+        delete waiting[m.id]; clearTimeout(w.timer);
+        parent.postMessage({mu:'cancel',id:m.id},'*'); w.reject(err);
+      }}
+      return;
+    }
+    if(m.mu!=='reply') return;
+    delete waiting[m.id]; clearTimeout(w.timer);
     if(m.error){ w.reject(new Error(m.error)); } else { w.resolve(m.result); }
   });
-  function ask(op, args){
+  function ask(op, args, onEvent){
     return new Promise(function(resolve,reject){
-      var id=++seq; waiting[id]={resolve:resolve,reject:reject};
+      var id=++seq; waiting[id]={resolve:resolve,reject:reject,onEvent:onEvent};
       parent.postMessage({mu:'call', id:id, op:op, args:args||{}}, '*');
-      setTimeout(function(){ if(waiting[id]){ delete waiting[id]; reject(new Error('timed out')); } }, 60000);
+      waiting[id].timer=setTimeout(function(){ if(waiting[id]){
+        delete waiting[id]; parent.postMessage({mu:'cancel',id:id},'*');
+        reject(new Error('Connection timed out. The request may still be running; check your conversation before trying again.'));
+      } }, op==='agent.stream'?360000:60000);
     });
   }
   function proxy(op,body){ return ask('sdk:'+op, body); }
@@ -208,6 +221,12 @@ const appShimJS = `<script>
       try{var r=eval(code);return{ok:true,result:String(r)}}
       catch(e){return{ok:false,error:e.message}}
     },
+  };
+  // Opt-in streaming returns the final answer and conversation identifiers.
+  // onEvent receives progress and text deltas; response is authoritative.
+  mu.agent.stream=function(prompt,options){
+    options=options||{};
+    return ask('agent.stream',{body:{prompt:prompt,context_id:options.context_id||''}},options.onEvent);
   };
   // ── The web platform, over the same bridge ──────────────────────
   //
@@ -348,6 +367,7 @@ func appBridgeJS(slug string) string {
   var SLUG=` + jsString(slug) + `;
   var frame=document.getElementById('app-frame');
   var j='application/json';
+  ` + appAgentStreamJS + `
 
   function csrf(){var m=document.cookie.match(/(?:^|; )csrf_token=([^;]+)/);return m?decodeURIComponent(m[1]):'';}
 
@@ -366,10 +386,11 @@ func appBridgeJS(slug string) string {
 
   window.addEventListener('message', function(e){
     var m=e.data;
-    if(!m||m.mu!=='call') return;
+    if(!m||(m.mu!=='call'&&m.mu!=='cancel')) return;
     // Only the frame we created. A sandboxed frame has a null origin, so the
     // window identity is the check that means anything.
     if(!frame||e.source!==frame.contentWindow) return;
+    if(m.mu==='cancel'){cancelStream(m.id);return;}
 
     var op=String(m.op||''), args=m.args||{};
 
@@ -400,6 +421,10 @@ func appBridgeJS(slug string) string {
       init.headers['Content-Type']=j;
       init.headers['X-CSRF-Token']=csrf();
       init.body=JSON.stringify(args.body||{});
+    }
+    if(op==='agent.stream'){
+      streamAgent(e.source,m.id,path,args.body||{},init);
+      return;
     }
     fetch(path,init)
       .then(function(r){return r.json().catch(function(){return {}})})

--- a/service/apps/sandbox_test.go
+++ b/service/apps/sandbox_test.go
@@ -133,7 +133,7 @@ func TestEveryOperationTheShimUsesIsGranted(t *testing.T) {
 		"weather", "news", "markets", "video", "social", "search", "chat",
 		"blog.list", "blog.read", "blog.create",
 		"places.search", "places.nearby", "apps.list", "apps.read",
-		"agent", "user",
+		"agent", "agent.stream", "user",
 	} {
 		if _, ok := bridgeOps[op]; !ok {
 			t.Errorf("the shim calls %q and the table does not grant it", op)

--- a/service/apps/static/agent-stream.js
+++ b/service/apps/static/agent-stream.js
@@ -5,7 +5,13 @@ function cancelStream(id){
   if(s){streams.delete(id);s.abort();}
 }
 function cancelStreams(){streams.forEach(function(s){s.abort()});streams.clear();}
-if(frame) frame.addEventListener('load',cancelStreams);
+var frameLoaded=false;
+if(frame) frame.addEventListener('load',function(){
+  // An inline app script can start work before its first load event. That
+  // event finishes initialization; only subsequent loads leave a document.
+  if(frameLoaded) cancelStreams();
+  frameLoaded=true;
+});
 window.addEventListener('pagehide',cancelStreams);
 
 async function streamAgent(win,id,path,body,init){

--- a/service/apps/static/agent-stream.js
+++ b/service/apps/static/agent-stream.js
@@ -1,0 +1,75 @@
+// Included inside the sandbox parent's bridge, after frame and j are defined.
+var streams=new Map();
+function cancelStream(id){
+  var s=streams.get(id);
+  if(s){streams.delete(id);s.abort();}
+}
+function cancelStreams(){streams.forEach(function(s){s.abort()});streams.clear();}
+if(frame) frame.addEventListener('load',cancelStreams);
+window.addEventListener('pagehide',cancelStreams);
+
+async function streamAgent(win,id,path,body,init){
+  if(!Number.isSafeInteger(id)||streams.has(id)) return;
+  var controller=new AbortController();
+  streams.set(id,controller);
+  var timer=setTimeout(function(){controller.abort()},360000);
+  var reader;
+  function current(){return streams.get(id)===controller;}
+  try{
+    init.signal=controller.signal;
+    init.headers.Accept='text/event-stream';
+    // The same fixed endpoint and authenticated write gate as the web client.
+    init.body=JSON.stringify({prompt:body.prompt,context_id:body.context_id||'',stream_text:true});
+    var response=await fetch(path,init);
+    if(!response.ok){
+      var failure=await response.json().catch(function(){return {}});
+      throw new Error(failure.error||('Request failed ('+response.status+')'));
+    }
+    if(!(response.headers.get('Content-Type')||'').includes('text/event-stream')||!response.body){
+      throw new Error('The server did not return an agent stream.');
+    }
+    reader=response.body.getReader();
+    var decoder=new TextDecoder(),buffer='',lines=[],result=null,done=false,flow='',thread='';
+    function dispatch(){
+      if(!lines.length) return;
+      var event=JSON.parse(lines.join('\n'));lines=[];
+      if(event.type==='error') throw new Error(event.message||'The agent could not finish.');
+      if(event.type==='flow_id'){flow=event.flow_id||'';thread=event.thread||'';}
+      if(event.type==='response') result={answer:event.text,flow_id:event.flow_id||flow,thread:thread};
+      if(event.type==='done'){done=true;return;}
+      if(['flow_id','working','tool_start','tool_done','stream_token','response'].includes(event.type)&&current()){
+        win.postMessage({mu:'event',id:id,event:event},'*');
+      }
+    }
+    function consume(text,eof){
+      buffer+=text;
+      var pos;
+      while((pos=buffer.indexOf('\n'))!==-1){
+        var line=buffer.slice(0,pos).replace(/\r$/,'');buffer=buffer.slice(pos+1);
+        if(line==='') dispatch();
+        else if(line.startsWith('data:')) lines.push(line.slice(5).replace(/^ /,''));
+        if(done) return;
+      }
+      if(buffer.length>1048576) throw new Error('Agent event exceeds the size limit.');
+      if(eof&&buffer.trim()) throw new Error('The agent connection ended inside an event.');
+    }
+    while(!done){
+      var chunk=await reader.read();
+      if(!current()) return;
+      consume(decoder.decode(chunk.value,{stream:!chunk.done}),chunk.done);
+      if(chunk.done) break;
+    }
+    if(!done||!result||typeof result.answer!=='string'){
+      throw new Error('The connection ended before the answer was complete. Check your conversation before trying again.');
+    }
+    if(current()) reply(win,id,result,null);
+  }catch(err){
+    if(current()) reply(win,id,null,err.name==='AbortError'
+      ?'Connection timed out. The request may still be running; check your conversation before trying again.'
+      :String(err.message||err));
+  }finally{
+    clearTimeout(timer);
+    if(reader){try{await reader.cancel()}catch(ignore){}}
+    if(current()) streams.delete(id);
+  }
+}

--- a/service/apps/testdata/agent-stream.mjs
+++ b/service/apps/testdata/agent-stream.mjs
@@ -26,6 +26,8 @@ const done={type:'done'};
   b.call(9,'agent.stream',{});
   assert.equal(b.calls.length,0,'unrelated window must not start work');
   b.call();await tick();
+  b.frameListeners.load();
+  assert.equal(b.calls[0].init.signal.aborted,false,'initial load must preserve a startup request');
   const bytes=new TextEncoder().encode(': heartbeat\r\n\r\n'+wire([identity,{type:'stream_token',text:'Hello 🌍'}]));
   for(const byte of bytes) enqueue(Uint8Array.of(byte));
   await tick();await tick();
@@ -53,7 +55,7 @@ for(const [name,response,expected] of [
 for(const action of ['load','pagehide','cancel']){
   const b=bridge((path,init)=>new Promise((resolve,reject)=>init.signal.addEventListener('abort',()=>reject(new DOMException('Aborted','AbortError')))));
   b.call();b.call();assert.equal(b.calls.length,1,'duplicate request IDs must not start duplicate work');
-  if(action==='load') b.frameListeners.load();
+  if(action==='load'){b.frameListeners.load();b.frameListeners.load();}
   if(action==='pagehide') b.listeners.pagehide();
   if(action==='cancel') b.listeners.message({source:b.win,data:{mu:'cancel',id:1}});
   await tick();

--- a/service/apps/testdata/agent-stream.mjs
+++ b/service/apps/testdata/agent-stream.mjs
@@ -1,0 +1,88 @@
+import assert from 'node:assert/strict';
+import {readFileSync} from 'node:fs';
+import vm from 'node:vm';
+const sources=JSON.parse(readFileSync(process.argv[2],'utf8'));
+const script=s=>s.replace(/^<script>\s*/, '').replace(/<\/script>\s*$/, '');
+const tick=()=>new Promise(resolve=>setImmediate(resolve));
+function bridge(fetcher){
+  const messages=[],listeners={},frameListeners={},calls=[];
+  const win={postMessage:m=>messages.push(m)};
+  const frame={contentWindow:win,addEventListener:(name,fn)=>frameListeners[name]=fn};
+  const context={Map,Number,AbortController,TextDecoder,setTimeout,clearTimeout,
+    document:{getElementById:()=>frame,cookie:'csrf_token=secret'},
+    window:{addEventListener:(name,fn)=>listeners[name]=fn},
+    fetch:(path,init)=>{calls.push({path,init});return fetcher(path,init)}};
+  vm.runInNewContext(script(sources.bridge),context);
+  return {messages,calls,frameListeners,listeners,win,
+    call:(id=1,op='agent.stream',source=win)=>listeners.message({source,data:{mu:'call',id,op,args:{body:{prompt:'Hello',context_id:'conversation'}}}})};
+}
+const wire=events=>events.map(e=>'data: '+JSON.stringify(e)+'\r\n\r\n').join('');
+const identity={type:'flow_id',flow_id:'run',thread:'conversation'};
+const final={type:'response',text:'Hello 🌍',flow_id:'run'};
+const done={type:'done'};
+{
+  let enqueue,finish;
+  const b=bridge(()=>new Response(new ReadableStream({start(c){enqueue=v=>c.enqueue(v);finish=()=>c.close()}}),{headers:{'Content-Type':'text/event-stream'}}));
+  b.call(9,'agent.stream',{});
+  assert.equal(b.calls.length,0,'unrelated window must not start work');
+  b.call();await tick();
+  const bytes=new TextEncoder().encode(': heartbeat\r\n\r\n'+wire([identity,{type:'stream_token',text:'Hello 🌍'}]));
+  for(const byte of bytes) enqueue(Uint8Array.of(byte));
+  await tick();await tick();
+  assert.equal(b.messages.at(-1).event.text,'Hello 🌍','deltas arrive before completion, including split UTF-8');
+  assert.equal(b.messages.some(m=>m.mu==='reply'),false);
+  enqueue(new TextEncoder().encode(wire([final,done])));finish();await tick();
+  assert.deepEqual(JSON.parse(JSON.stringify(b.messages.at(-1).result)),{answer:'Hello 🌍',flow_id:'run',thread:'conversation'});
+  assert.equal(b.calls[0].path,'/agent');
+  assert.equal(b.calls[0].init.headers['X-CSRF-Token'],'secret');
+  assert.equal(JSON.parse(b.calls[0].init.body).stream_text,true);
+  assert.equal(JSON.parse(b.calls[0].init.body).context_id,'conversation');
+  assert.equal(JSON.stringify(b.messages).includes('secret'),false);
+}
+for(const [name,response,expected] of [
+  ['HTTP failure',()=>new Response('{"error":"Sign in"}',{status:401}),'Sign in'],
+  ['JSON instead of SSE',()=>new Response('{}'),'did not return'],
+  ['truncated stream',()=>new Response(wire([identity,final]),{headers:{'Content-Type':'text/event-stream'}}),'before the answer was complete'],
+  ['server failure',()=>new Response(wire([{type:'error',message:'No provider'},done]),{headers:{'Content-Type':'text/event-stream'}}),'No provider'],
+  ['malformed event',()=>new Response('data: nope\n\n',{headers:{'Content-Type':'text/event-stream'}}),'JSON'],
+]){
+  const b=bridge(response);b.call();await tick();await tick();
+  assert.ok(b.messages.at(-1).error.includes(expected),name+': '+JSON.stringify(b.messages));
+  assert.equal(b.calls.length,1,'a failed stream must never rerun the prompt');
+}
+for(const action of ['load','pagehide','cancel']){
+  const b=bridge((path,init)=>new Promise((resolve,reject)=>init.signal.addEventListener('abort',()=>reject(new DOMException('Aborted','AbortError')))));
+  b.call();b.call();assert.equal(b.calls.length,1,'duplicate request IDs must not start duplicate work');
+  if(action==='load') b.frameListeners.load();
+  if(action==='pagehide') b.listeners.pagehide();
+  if(action==='cancel') b.listeners.message({source:b.win,data:{mu:'cancel',id:1}});
+  await tick();
+  assert.equal(b.calls[0].init.signal.aborted,true);
+  assert.equal(b.messages.length,0,'a detached/cancelled frame must receive no late result');
+}
+{
+  const posted=[],listeners={};
+  const parent={postMessage:m=>posted.push(m)};
+  const ctx={parent,Promise,Error,setTimeout,clearTimeout,addEventListener:(name,fn)=>listeners[name]=fn};
+  ctx.window=ctx;
+  vm.createContext(ctx);vm.runInContext(script(sources.shim),ctx);
+  const events=[];
+  const result=ctx.mu.agent.stream('Hello',{context_id:'conversation',onEvent:e=>events.push(e)});
+  const request=posted.at(-1);
+  assert.equal(request.op,'agent.stream');
+  assert.equal(request.args.body.context_id,'conversation');
+  listeners.message({source:{},data:{mu:'reply',id:request.id,result:'forged'}});
+  listeners.message({source:parent,data:{mu:'event',id:request.id,event:{type:'stream_token',text:'Hello'}}});
+  assert.equal(events.length,1);
+  listeners.message({source:parent,data:{mu:'reply',id:request.id,result:{answer:'Hello',thread:'conversation'}}});
+  assert.equal((await result).answer,'Hello');
+  const old=ctx.mu.agent('Hello');const oldRequest=posted.at(-1);
+  assert.equal(oldRequest.op,'agent');
+  listeners.message({source:parent,data:{mu:'reply',id:oldRequest.id,result:{answer:'Unchanged'}}});
+  assert.equal(await old,'Unchanged');
+  const failed=ctx.mu.agent.stream('Hello',{onEvent:()=>{throw new Error('callback failed')}});
+  const bad=posted.at(-1);
+  listeners.message({source:parent,data:{mu:'event',id:bad.id,event:{type:'stream_token',text:'Hello'}}});
+  await assert.rejects(failed,/callback failed/);
+  assert.equal(posted.at(-1).mu,'cancel');
+}

--- a/test/permissions.golden
+++ b/test/permissions.golden
@@ -56,6 +56,7 @@ images_search                needsAccount=true  destructive=false bound accountO
 images_websearch             needsAccount=true  destructive=false bound accountOnly=false optionalAuth=false
 mail_inbox                   needsAccount=true  destructive=false bound accountOnly=false optionalAuth=false
 mail_info                    needsAccount=true  destructive=false bound accountOnly=false optionalAuth=false
+mail_markread                needsAccount=true  destructive=false bound accountOnly=true  optionalAuth=false
 mail_read                    needsAccount=true  destructive=false bound accountOnly=false optionalAuth=false
 mail_search                  needsAccount=true  destructive=false bound accountOnly=false optionalAuth=false
 mail_send                    needsAccount=true  destructive=true  bound accountOnly=true  optionalAuth=false


### PR DESCRIPTION
The Assistant experiment currently waits for the entire agent response. Add mu.agent.stream(prompt, {context_id, onEvent}) through the existing sandbox bridge so apps can show answer text and tool progress as it arrives, then use the final answer and durable thread ID for follow-ups.

Text deltas on /agent are explicitly opt-in. Existing Home, landing and mu.agent() callers keep their existing final-answer behaviour. News freshness guards remain buffered. Runs still finish and record their answer if the browser disconnects; the bridge closes its connection on navigation, reports interrupted streams, and never retries a prompt automatically. Session credentials remain in the parent frame and the streaming operation has a fixed endpoint.

Validation: go build ./... passed; short tests for agent, apps, internal/ai and architecture/permissions passed. Added a local model test for opt-in/default/news behaviour and executable JavaScript tests for streamed UTF-8 chunks, progress before completion, final replacement, HTTP/SSE errors, source checks, cancellation, duplicate IDs and unchanged mu.agent().

Also refresh stale tool-count and permission snapshots for the already-merged mail_markread capability. Replace a brittle durable-record source scan with AST nesting checks; unrelated error-handling loops must not be mistaken for token callbacks.

The live Assistant app is updated separately through MCP once this runtime capability is deployed.