### PR TITLE
Fix Gemini tool continuation and preserve calendar answers

### DIFF
--- a/agent/answer_guard.go
+++ b/agent/answer_guard.go
@@ -685,7 +685,7 @@ func readableFromPayload(line string) string {
 	}
 	// The fields a tool puts prose in. Ordered, so a payload carrying more than
 	// one is read the same way every time.
-	for _, key := range []string{"summary", "answer", "text", "message", "content", "result", "description"} {
+	for _, key := range []string{"summary", "answer", "text", "events", "message", "content", "result", "description"} {
 		if raw, ok := any[key]; ok {
 			var text string
 			if json.Unmarshal(raw, &text) == nil && strings.TrimSpace(text) != "" {

--- a/agent/app_stream_test.go
+++ b/agent/app_stream_test.go
@@ -51,3 +51,15 @@ func TestAnswerDeltasAreOptIn(t *testing.T) {
 		})
 	}
 }
+
+func TestCalendarFallbackKeepsReadableEvents(t *testing.T) {
+	payload := `{"items":[],"external":[],"total":1,"events":"- Fri 11 Sep 09:00 BST — Planning meeting (id: event-1)"}`
+	answer := completeToolAnswerFor("Let me check your calendar.", []string{"### events\n" + formatToolResult("events_list", payload, nil)}, false)
+	if !strings.Contains(answer, "Planning meeting") || strings.Contains(answer, "data is unavailable") {
+		t.Fatalf("discarded calendar result: %s", answer)
+	}
+	empty := completeToolAnswerFor("Let me check your calendar.", []string{"### events\n" + formatToolResult("events_list", `{"items":[],"events":"No upcoming events."}`, nil)}, false)
+	if !strings.Contains(empty, "No upcoming events") {
+		t.Fatalf("empty calendar treated as failure: %s", empty)
+	}
+}

--- a/internal/ai/gemini_schema.go
+++ b/internal/ai/gemini_schema.go
@@ -9,7 +9,7 @@ import (
 // The pinned framework's built-in plan tool omits the schema of its steps.
 // Repair that declaration at the Gemini boundary without mutating shared tools.
 func init() {
-	gmai.Register("gemini", func(opts ...gmai.Option) gmai.Model { return &geminiSchema{gemini.NewProvider(opts...)} })
+	gmai.Register("gemini", func(opts ...gmai.Option) gmai.Model { return &geminiSchema{&geminiTools{gemini.NewProvider(opts...)}} })
 }
 
 type geminiSchema struct{ gmai.Model }

--- a/internal/ai/gemini_tools.go
+++ b/internal/ai/gemini_tools.go
@@ -17,10 +17,6 @@ import (
 
 type geminiTools struct{ *gemini.Provider }
 
-func init() {
-	model.Register("gemini", func(opts ...model.Option) model.Model { return &geminiTools{gemini.NewProvider(opts...)} })
-}
-
 type geminiFunctionCall struct {
 	ID   string         `json:"id"`
 	Name string         `json:"name"`
@@ -138,6 +134,9 @@ func (p *geminiTools) Generate(ctx context.Context, req *model.Request, opts ...
 			}
 			pending, raw = followUpResp.ToolCalls, followUpRaw
 			resp.ToolCalls = append(resp.ToolCalls, followUpResp.ToolCalls...)
+			resp.Usage.InputTokens += followUpResp.Usage.InputTokens
+			resp.Usage.OutputTokens += followUpResp.Usage.OutputTokens
+			resp.Usage.TotalTokens += followUpResp.Usage.TotalTokens
 		}
 		if len(pending) > 0 {
 			return nil, fmt.Errorf("gemini exceeded tool round limit")
@@ -147,7 +146,10 @@ func (p *geminiTools) Generate(ctx context.Context, req *model.Request, opts ...
 	return resp, nil
 }
 
-func (p *geminiTools) callAPI(ctx context.Context, req map[string]any) (*model.Response, []map[string]any, error) {
+func (p *geminiTools) callAPI(ctx context.Context, req map[string]any) (*model.Response, []json.RawMessage, error) {
+	if cap := p.Options().MaxTokens; cap > 0 {
+		req["generationConfig"] = map[string]any{"maxOutputTokens": cap}
+	}
 	reqBody, err := json.Marshal(req)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to marshal request: %w", err)
@@ -176,6 +178,12 @@ func (p *geminiTools) callAPI(ctx context.Context, req map[string]any) (*model.R
 	}
 
 	var geminiResp struct {
+		Usage struct {
+			Prompt     int `json:"promptTokenCount"`
+			Candidates int `json:"candidatesTokenCount"`
+			Thoughts   int `json:"thoughtsTokenCount"`
+			Total      int `json:"totalTokenCount"`
+		} `json:"usageMetadata"`
 		Candidates []struct {
 			Content struct {
 				Parts []json.RawMessage `json:"parts"`
@@ -192,10 +200,10 @@ func (p *geminiTools) callAPI(ctx context.Context, req map[string]any) (*model.R
 	}
 
 	parts := geminiResp.Candidates[0].Content.Parts
-	response := &model.Response{}
+	response := &model.Response{Usage: model.Usage{InputTokens: geminiResp.Usage.Prompt, OutputTokens: geminiResp.Usage.Candidates + geminiResp.Usage.Thoughts, TotalTokens: geminiResp.Usage.Total}}
 
 	var replyParts []string
-	var rawParts []map[string]any
+	var rawParts []json.RawMessage
 
 	for _, raw := range parts {
 		var part struct {
@@ -206,12 +214,8 @@ func (p *geminiTools) callAPI(ctx context.Context, req map[string]any) (*model.R
 		if err := json.Unmarshal(raw, &part); err != nil {
 			return nil, nil, err
 		}
-		var original map[string]any
-		if err := json.Unmarshal(raw, &original); err != nil {
-			return nil, nil, err
-		}
 		// Return each signed part intact; thought text is never user output.
-		rawParts = append(rawParts, original)
+		rawParts = append(rawParts, raw)
 		if part.Text != "" && !part.Thought {
 			replyParts = append(replyParts, part.Text)
 		}

--- a/internal/ai/gemini_tools.go
+++ b/internal/ai/gemini_tools.go
@@ -1,0 +1,246 @@
+package ai
+
+// Mu's Gemini tool continuation adapter. Based on go-micro's Gemini provider;
+// keep the signed response parts intact and report failed follow-up calls.
+// The underlying provider still owns configuration and the plain text stream.
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"go-micro.dev/v6/model"
+	"go-micro.dev/v6/model/gemini"
+	"io"
+	"net/http"
+	"strings"
+)
+
+type geminiTools struct{ *gemini.Provider }
+
+func init() {
+	model.Register("gemini", func(opts ...model.Option) model.Model { return &geminiTools{gemini.NewProvider(opts...)} })
+}
+
+type geminiFunctionCall struct {
+	ID   string         `json:"id"`
+	Name string         `json:"name"`
+	Args map[string]any `json:"args"`
+}
+
+func geminiToolValue(result model.ToolResult) any {
+	if result.Refused != "" {
+		return map[string]any{"error": result.Refused, "message": result.Content}
+	}
+	value := result.Value
+	if value == nil && result.Content != "" {
+		if json.Unmarshal([]byte(result.Content), &value) != nil {
+			value = result.Content
+		}
+	}
+	// Gemini requires an object even when a tool returns text, a list or null.
+	raw, err := json.Marshal(value)
+	var object map[string]any
+	if err == nil && json.Unmarshal(raw, &object) == nil && object != nil {
+		return object
+	}
+	return map[string]any{"result": value}
+}
+func (p *geminiTools) Generate(ctx context.Context, req *model.Request, opts ...model.GenerateOption) (*model.Response, error) {
+	var tools []map[string]any
+	for _, t := range req.Tools {
+		tools = append(tools, map[string]any{
+			"name":        t.Name,
+			"description": t.Description,
+			"parameters": map[string]any{
+				"type":       "object",
+				"properties": t.Properties,
+			},
+		})
+	}
+
+	contents := geminiToolContents(req)
+
+	apiReq := map[string]any{
+		"contents": contents,
+	}
+
+	if req.SystemPrompt != "" {
+		apiReq["system_instruction"] = map[string]any{
+			"parts": []map[string]any{{"text": req.SystemPrompt}},
+		}
+	}
+
+	if len(tools) > 0 {
+		apiReq["tools"] = []map[string]any{
+			{"functionDeclarations": tools},
+		}
+	}
+
+	resp, rawParts, err := p.callAPI(ctx, apiReq)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(resp.ToolCalls) == 0 {
+		return resp, nil
+	}
+
+	// Tool execution loop: execute tools, send results back, and keep the
+	// function declarations on offer so the model can take the next step. A
+	// follow-up without tools asks the model to continue with its hands tied —
+	// the call it wanted comes back written out as prose — and without a loop
+	// a second step is impossible whatever the model wants. Bounded so a model
+	// that never stops asking cannot run forever.
+	if p.Options().ToolHandler != nil {
+		// Copied rather than aliased: append on a slice that shares an array
+		// with contents would overwrite it on a later round.
+		followUpContents := append([]map[string]any(nil), contents...)
+		pending := resp.ToolCalls
+		raw := rawParts
+		for round := 0; len(pending) > 0 && round < 12; round++ {
+			var resultParts []map[string]any
+			for _, tc := range pending {
+				result := geminiToolValue(p.Options().ToolHandler(ctx, tc))
+				resultParts = append(resultParts, map[string]any{
+					"functionResponse": map[string]any{
+						"name":     tc.Name,
+						"id":       tc.ID,
+						"response": result,
+					},
+				})
+			}
+
+			followUpContents = append(followUpContents,
+				map[string]any{"role": "model", "parts": raw},
+				map[string]any{"role": "user", "parts": resultParts},
+			)
+
+			followUpReq := map[string]any{
+				"contents": followUpContents,
+			}
+			if req.SystemPrompt != "" {
+				followUpReq["system_instruction"] = map[string]any{
+					"parts": []map[string]any{{"text": req.SystemPrompt}},
+				}
+			}
+			if len(tools) > 0 {
+				followUpReq["tools"] = []map[string]any{
+					{"functionDeclarations": tools},
+				}
+			}
+
+			followUpResp, followUpRaw, err := p.callAPI(ctx, followUpReq)
+			if err != nil {
+				return nil, fmt.Errorf("gemini tool follow-up: %w", err)
+			}
+			if followUpResp.Reply != "" {
+				resp.Answer = followUpResp.Reply
+			}
+			pending, raw = followUpResp.ToolCalls, followUpRaw
+			resp.ToolCalls = append(resp.ToolCalls, followUpResp.ToolCalls...)
+		}
+		if len(pending) > 0 {
+			return nil, fmt.Errorf("gemini exceeded tool round limit")
+		}
+	}
+
+	return resp, nil
+}
+
+func (p *geminiTools) callAPI(ctx context.Context, req map[string]any) (*model.Response, []map[string]any, error) {
+	reqBody, err := json.Marshal(req)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	apiURL := strings.TrimRight(p.Options().BaseURL, "/") +
+		"/v1beta/models/" + p.Options().Model + ":generateContent"
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, apiURL, bytes.NewReader(reqBody))
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("x-goog-api-key", p.Options().APIKey)
+
+	httpResp, err := http.DefaultClient.Do(httpReq)
+	if err != nil {
+		return nil, nil, fmt.Errorf("API request failed: %w", err)
+	}
+	defer httpResp.Body.Close()
+
+	respBody, _ := io.ReadAll(httpResp.Body)
+	if httpResp.StatusCode != http.StatusOK {
+		return nil, nil, model.NewHTTPError(httpResp, respBody)
+	}
+
+	var geminiResp struct {
+		Candidates []struct {
+			Content struct {
+				Parts []json.RawMessage `json:"parts"`
+			} `json:"content"`
+		} `json:"candidates"`
+	}
+
+	if err := json.Unmarshal(respBody, &geminiResp); err != nil {
+		return nil, nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	if len(geminiResp.Candidates) == 0 {
+		return nil, nil, fmt.Errorf("no response from API")
+	}
+
+	parts := geminiResp.Candidates[0].Content.Parts
+	response := &model.Response{}
+
+	var replyParts []string
+	var rawParts []map[string]any
+
+	for _, raw := range parts {
+		var part struct {
+			Text         string              `json:"text"`
+			Thought      bool                `json:"thought"`
+			FunctionCall *geminiFunctionCall `json:"functionCall"`
+		}
+		if err := json.Unmarshal(raw, &part); err != nil {
+			return nil, nil, err
+		}
+		var original map[string]any
+		if err := json.Unmarshal(raw, &original); err != nil {
+			return nil, nil, err
+		}
+		// Return each signed part intact; thought text is never user output.
+		rawParts = append(rawParts, original)
+		if part.Text != "" && !part.Thought {
+			replyParts = append(replyParts, part.Text)
+		}
+		if part.FunctionCall != nil {
+			response.ToolCalls = append(response.ToolCalls, model.ToolCall{ID: part.FunctionCall.ID, Name: part.FunctionCall.Name, Input: part.FunctionCall.Args})
+		}
+	}
+
+	if len(replyParts) > 0 {
+		response.Reply = strings.Join(replyParts, "\n")
+	}
+
+	return response, rawParts, nil
+}
+
+func geminiToolContents(req *model.Request) []map[string]any {
+	contents := make([]map[string]any, 0, len(req.Messages)+1)
+	for _, m := range req.Messages {
+		role := m.Role
+		if role == "assistant" {
+			role = "model"
+		}
+		if role == "system" || role == "" {
+			continue
+		}
+		contents = append(contents, map[string]any{"role": role, "parts": []map[string]any{{"text": fmt.Sprint(m.Content)}}})
+	}
+	if req.Prompt != "" {
+		contents = append(contents, map[string]any{"role": "user", "parts": []map[string]any{{"text": req.Prompt}}})
+	}
+	return contents
+}

--- a/internal/ai/gemini_tools_test.go
+++ b/internal/ai/gemini_tools_test.go
@@ -1,0 +1,72 @@
+package ai
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	gmai "go-micro.dev/v6/model"
+)
+
+func TestGeminiToolContinuation(t *testing.T) {
+	for _, fail := range []bool{false, true} {
+		t.Run(fmt.Sprint(fail), func(t *testing.T) {
+			calls, executed := 0, 0
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				calls++
+				var body map[string]any
+				if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+					t.Error(err)
+					return
+				}
+				w.Header().Set("Content-Type", "application/json")
+				if calls == 1 {
+					fmt.Fprint(w, `{"candidates":[{"content":{"role":"model","parts":[{"text":"private reasoning","thought":true},{"functionCall":{"name":"events_List","args":{}},"thoughtSignature":"signed-part"}]}}]}`)
+					return
+				}
+				contents := body["contents"].([]any)
+				previous := contents[len(contents)-2].(map[string]any)
+				parts := previous["parts"].([]any)
+				if len(parts) != 2 || parts[1].(map[string]any)["thoughtSignature"] != "signed-part" {
+					http.Error(w, `{"error":{"message":"Missing thoughtSignature"}}`, 400)
+					return
+				}
+				if fail {
+					http.Error(w, `{"error":{"message":"follow-up failed"}}`, 400)
+					return
+				}
+				last := contents[len(contents)-1].(map[string]any)["parts"].([]any)[0].(map[string]any)["functionResponse"].(map[string]any)
+				result, ok := last["response"].(map[string]any)
+				if !ok || !strings.Contains(fmt.Sprint(result), "Meeting at 9") {
+					t.Errorf("missing tool result: %+v", last)
+				}
+				fmt.Fprint(w, `{"candidates":[{"content":{"parts":[{"text":"Meeting at 9"}]}}]}`)
+			}))
+			defer srv.Close()
+			model := gmai.New("gemini", gmai.WithBaseURL(srv.URL), gmai.WithAPIKey("test"), gmai.WithToolHandler(func(ctx context.Context, c gmai.ToolCall) gmai.ToolResult {
+				executed++
+				return gmai.ToolResult{Content: `{"events":"Meeting at 9","items":[]}`}
+			}))
+			rsp, err := model.Generate(context.Background(), &gmai.Request{Prompt: "What's on my calendar", Tools: []gmai.Tool{{Name: "events_List"}}})
+			if executed != 1 || calls != 2 {
+				t.Fatalf("calls=%d executions=%d", calls, executed)
+			}
+			if fail {
+				if err == nil {
+					t.Fatalf("follow-up failure swallowed: %+v", rsp)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !strings.Contains(rsp.Reply+rsp.Answer, "Meeting at 9") || strings.Contains(rsp.Reply+rsp.Answer, "private reasoning") {
+				t.Fatalf("wrong final answer: %+v", rsp)
+			}
+		})
+	}
+}

--- a/internal/ai/gemini_tools_test.go
+++ b/internal/ai/gemini_tools_test.go
@@ -23,9 +23,17 @@ func TestGeminiToolContinuation(t *testing.T) {
 					t.Error(err)
 					return
 				}
+				if body["generationConfig"].(map[string]any)["maxOutputTokens"] != float64(512) {
+					t.Error("output cap lost")
+				}
+				decls := body["tools"].([]any)[0].(map[string]any)["functionDeclarations"].([]any)
+				plan := decls[1].(map[string]any)["parameters"].(map[string]any)["properties"].(map[string]any)["steps"].(map[string]any)
+				if plan["items"] == nil {
+					t.Error("plan schema repair lost")
+				}
 				w.Header().Set("Content-Type", "application/json")
 				if calls == 1 {
-					fmt.Fprint(w, `{"candidates":[{"content":{"role":"model","parts":[{"text":"private reasoning","thought":true},{"functionCall":{"name":"events_List","args":{}},"thoughtSignature":"signed-part"}]}}]}`)
+					fmt.Fprint(w, `{"usageMetadata":{"promptTokenCount":10,"candidatesTokenCount":2,"thoughtsTokenCount":3,"totalTokenCount":15},"candidates":[{"content":{"role":"model","parts":[{"text":"private reasoning","thought":true},{"functionCall":{"name":"events_List","args":{}},"thoughtSignature":"signed-part"}]}}]}`)
 					return
 				}
 				contents := body["contents"].([]any)
@@ -44,14 +52,14 @@ func TestGeminiToolContinuation(t *testing.T) {
 				if !ok || !strings.Contains(fmt.Sprint(result), "Meeting at 9") {
 					t.Errorf("missing tool result: %+v", last)
 				}
-				fmt.Fprint(w, `{"candidates":[{"content":{"parts":[{"text":"Meeting at 9"}]}}]}`)
+				fmt.Fprint(w, `{"usageMetadata":{"promptTokenCount":20,"candidatesTokenCount":3,"thoughtsTokenCount":4,"totalTokenCount":27},"candidates":[{"content":{"parts":[{"text":"Meeting at 9"}]}}]}`)
 			}))
 			defer srv.Close()
-			model := gmai.New("gemini", gmai.WithBaseURL(srv.URL), gmai.WithAPIKey("test"), gmai.WithToolHandler(func(ctx context.Context, c gmai.ToolCall) gmai.ToolResult {
+			model := gmai.New("gemini", gmai.WithBaseURL(srv.URL), gmai.WithAPIKey("test"), gmai.WithMaxTokens(512), gmai.WithToolHandler(func(ctx context.Context, c gmai.ToolCall) gmai.ToolResult {
 				executed++
 				return gmai.ToolResult{Content: `{"events":"Meeting at 9","items":[]}`}
 			}))
-			rsp, err := model.Generate(context.Background(), &gmai.Request{Prompt: "What's on my calendar", Tools: []gmai.Tool{{Name: "events_List"}}})
+			rsp, err := model.Generate(context.Background(), &gmai.Request{Prompt: "What's on my calendar", Tools: []gmai.Tool{{Name: "events_List"}, {Name: "plan", Properties: map[string]any{"steps": map[string]any{"type": "array"}}}}})
 			if executed != 1 || calls != 2 {
 				t.Fatalf("calls=%d executions=%d", calls, executed)
 			}
@@ -63,6 +71,9 @@ func TestGeminiToolContinuation(t *testing.T) {
 			}
 			if err != nil {
 				t.Fatal(err)
+			}
+			if rsp.Usage.InputTokens != 30 || rsp.Usage.OutputTokens != 12 || rsp.Usage.TotalTokens != 42 {
+				t.Fatalf("lost usage: %+v", rsp.Usage)
 			}
 			if !strings.Contains(rsp.Reply+rsp.Answer, "Meeting at 9") || strings.Contains(rsp.Reply+rsp.Answer, "private reasoning") {
 				t.Fatalf("wrong final answer: %+v", rsp)

--- a/internal/app/chat.go
+++ b/internal/app/chat.go
@@ -665,7 +665,7 @@ if(overlay && input && form){
  shell.before(slot); slot.appendChild(shell);
  var dialog=document.createElement('dialog'); dialog.className='mu-console';
  dialog.setAttribute('aria-label','Micro');
- dialog.innerHTML='<div class="mu-console-head"><span>Micro</span><button type="button" class="mu-console-close">Close</button></div>';
+ dialog.innerHTML='<div class="mu-console-head"><strong>Micro</strong><button type="button" class="mu-console-close">Close</button></div>';
  slot.appendChild(dialog);
  var closing=false;
  function openConsole(){


### PR DESCRIPTION
Gemini calendar questions can end with Mu's generic unavailable response even after a tool runs. The pinned provider reconstructs function-call parts without Gemini's required thought signatures and silently returns the initial response when the follow-up API call fails. The calendar payload also contains an events text field that our fallback reader did not recognize.

Add a Mu-local Gemini Generate adapter over the pinned provider. Preserve complete response parts during tool continuation, keep thought text out of visible answers, return follow-up failures, and supply object-shaped function results even for tools exposing Content without Value. Retain the tool-round bound and existing provider configuration/stream implementation. Recognize readable calendar events in the shared fallback formatter. No go-micro source or dependency changes.

Also make Micro bold in the Home conversation header. The separate Assistant app's Markdown rendering fix has been published through MCP using the server-rendered final response.

Validation: reproduced missing final answers and swallowed follow-up errors against the original provider; both cases pass with the adapter. Calendar regression covers real and empty schedules. Agent, AI, Home, shared UI and architecture/permission short tests passed. Build and targeted race checks run locally. The exact production provider error was not available through the connector; the regression establishes the adapter failure path matching the symptom.

Protocol reference: https://ai.google.dev/gemini-api/docs/thought-signatures