### PR TITLE
Preserve restricted authority across apps and background work

### DIFF
--- a/agent/commands.go
+++ b/agent/commands.go
@@ -118,6 +118,9 @@ func executeCommandRun(ctx context.Context, account string, call service.Command
 		opts.Stream.ToolStart(run)
 	}
 	start := time.Now()
+	if len(opts.Tools) > 0 || opts.Public {
+		ctx = service.WithRestrictedCaller(ctx)
+	}
 	result, err := service.CallDynamic(service.WithAccount(ctx, account), call.Service, call.Method, call.Args)
 	text := ""
 	if err == nil {

--- a/agent/inject_account_test.go
+++ b/agent/inject_account_test.go
@@ -9,6 +9,21 @@ import (
 	gmai "go-micro.dev/v6/model"
 )
 
+func TestRestrictedAgentCannotLoseItsDelegationBoundary(t *testing.T) {
+	called := false
+	h := func(ctx context.Context, _ gmai.ToolCall) gmai.ToolResult {
+		called = true
+		if !service.RestrictedCaller(ctx) || service.AccountFrom(ctx) != "alice" {
+			t.Fatal("restricted identity lost")
+		}
+		return gmai.ToolResult{}
+	}
+	injectAccount("alice", true)(h)(context.Background(), gmai.ToolCall{Input: map[string]any{"restricted": false, "account_id": "bob"}})
+	if !called {
+		t.Fatal("handler not exercised")
+	}
+}
+
 // TestInjectAccountBindsCallerToContext is a security regression test. The
 // identity account-scoped tools act on must always be the authenticated
 // caller's, and it must travel on the call context — never in the arguments,

--- a/agent/native.go
+++ b/agent/native.go
@@ -119,7 +119,7 @@ func filterServices(all, allow []string) []string {
 // because it means nothing now and so a handler can never start trusting it.
 // For a run with no account the identity is empty, which clears any inherited account instead
 // of borrowing the previous caller's.
-func injectAccount(accountID string) gmai.ToolWrapper {
+func injectAccount(accountID string, restricted ...bool) gmai.ToolWrapper {
 	return func(next gmai.ToolHandler) gmai.ToolHandler {
 		return func(ctx context.Context, call gmai.ToolCall) gmai.ToolResult {
 			delete(call.Input, "account_id")
@@ -129,6 +129,9 @@ func injectAccount(accountID string) gmai.ToolWrapper {
 			// the account is: a handler that needs to know cannot be given a
 			// field the caller could set. See service.InAgentRun.
 			ctx = service.WithAgentRun(service.WithAccount(ctx, accountID))
+			if len(restricted) > 0 && restricted[0] {
+				ctx = service.WithRestrictedCaller(ctx)
+			}
 			return next(ctx, call)
 		}
 	}
@@ -353,7 +356,7 @@ func buildNativeAgent(accountID, prompt string, opts QueryOpts, wrappers ...gmai
 	// Use a fresh named agent for each request. Some go-micro providers keep
 	// per-agent conversation state keyed by name, so reusing a stable "assistant"
 	// name can leak prior independent prompts into fresh requests.
-	toolWrappers := append([]gmai.ToolWrapper{acceptToolNamesWeAdvertise(), blockDestructiveTools(), injectAccount(accountID), dedupeNativeToolCalls(), retainEvidence(accountID, opts)}, wrappers...)
+	toolWrappers := append([]gmai.ToolWrapper{acceptToolNamesWeAdvertise(), blockDestructiveTools(), injectAccount(accountID, len(opts.Tools) > 0 || opts.Public), dedupeNativeToolCalls(), retainEvidence(accountID, opts)}, wrappers...)
 	if opts.Stream.wants() {
 		toolWrappers = append([]gmai.ToolWrapper{streamToolReporter(opts.Stream)}, toolWrappers...)
 	}

--- a/agent/roster.go
+++ b/agent/roster.go
@@ -28,6 +28,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"strconv"
@@ -39,6 +40,9 @@ import (
 	"mu/internal/userdb"
 	"mu/service/mail"
 )
+
+// Serialize roster mutations with credential issuance and revocation.
+var rosterMutation sync.Mutex
 
 const (
 	ns         = "agents"
@@ -232,6 +236,8 @@ func plural(n int) string {
 // each call site. A caller that never reads this package still cannot escape
 // the scope, because the check lives at the MCP boundary.
 func CreateAgent(owner, name, kind, prompt, description string, services []string, withToken bool) (*Agent, string, error) {
+	rosterMutation.Lock()
+	defer rosterMutation.Unlock()
 	if owner == "" {
 		return nil, "", fmt.Errorf("sign in to create an agent")
 	}
@@ -356,6 +362,8 @@ func (a *Agent) save() error {
 // Tags are assigned oldest first so the shortest name wins the unadorned tag,
 // rather than whichever agent happened to be loaded first.
 func EnsureTags(owner string) {
+	rosterMutation.Lock()
+	defer rosterMutation.Unlock()
 	all := Agents(owner)
 	var missing []*Agent
 	for _, a := range all {
@@ -433,6 +441,8 @@ func NameOf(owner, id string) string {
 // working would be the worst of both: gone from the page that would have told
 // you it existed, and still able to call.
 func RemoveAgent(owner, id string) error {
+	rosterMutation.Lock()
+	defer rosterMutation.Unlock()
 	a := For(owner, id)
 	if a == nil {
 		return fmt.Errorf("no such agent")
@@ -576,6 +586,8 @@ func without(list []string, tag string) []string {
 
 // UpdateAgent rewrites an agent the owner owns, keeping its id and token.
 func UpdateAgent(owner, id, name, prompt, description string, services []string) (*Agent, error) {
+	rosterMutation.Lock()
+	defer rosterMutation.Unlock()
 	selected := validServices(services)
 	if len(services) > 0 && len(selected) == 0 {
 		return nil, fmt.Errorf("none of the selected services are available")
@@ -634,6 +646,8 @@ func UpdateAgent(owner, id, name, prompt, description string, services []string)
 // the person who could fix it is the one who chose it — at the moment they
 // chose it. See ai.Offered.
 func SetModel(owner, id, model string) error {
+	rosterMutation.Lock()
+	defer rosterMutation.Unlock()
 	a := For(owner, id)
 	if a == nil {
 		return fmt.Errorf("no such agent")
@@ -652,6 +666,8 @@ func SetModel(owner, id, model string) error {
 // run somewhere else, and because the secret can only be shown once — so it has
 // to be an action somebody takes deliberately rather than a side effect.
 func IssueToken(owner, id string) (string, error) {
+	rosterMutation.Lock()
+	defer rosterMutation.Unlock()
 	a := For(owner, id)
 	if a == nil {
 		return "", fmt.Errorf("no such agent")
@@ -665,6 +681,7 @@ func IssueToken(owner, id string) (string, error) {
 	}
 	a.TokenID = tok.ID
 	if err := a.save(); err != nil {
+		_ = auth.DeleteToken(tok.ID, owner)
 		return "", err
 	}
 	return secret, nil

--- a/agent/roster.go
+++ b/agent/roster.go
@@ -261,7 +261,11 @@ func CreateAgent(owner, name, kind, prompt, description string, services []strin
 			max, plural(max), len(existing))
 	}
 
+	requestedScope := len(services) > 0
 	services = validServices(services)
+	if requestedScope && len(services) == 0 {
+		return nil, "", fmt.Errorf("none of the selected services are available")
+	}
 
 	a := &Agent{
 		Owner:       owner,
@@ -572,6 +576,10 @@ func without(list []string, tag string) []string {
 
 // UpdateAgent rewrites an agent the owner owns, keeping its id and token.
 func UpdateAgent(owner, id, name, prompt, description string, services []string) (*Agent, error) {
+	selected := validServices(services)
+	if len(services) > 0 && len(selected) == 0 {
+		return nil, fmt.Errorf("none of the selected services are available")
+	}
 	all := Agents(owner)
 	var a *Agent
 	for _, x := range all {
@@ -593,7 +601,17 @@ func UpdateAgent(owner, id, name, prompt, description string, services []string)
 	}
 	a.Prompt = strings.TrimSpace(prompt)
 	a.Description = strings.TrimSpace(description)
-	a.Services = validServices(services)
+	if a.TokenID != "" && strings.Join(a.Services, ",") != strings.Join(selected, ",") {
+		if _, err := auth.TokenByID(a.TokenID); err == nil {
+			if err := auth.DeleteToken(a.TokenID, owner); err != nil {
+				return nil, err
+			}
+		}
+		// Existing credentials cannot retain the old grant after a scope edit.
+		// The owner can issue a replacement with the new scope.
+		a.TokenID = ""
+	}
+	a.Services = selected
 	// a.save(), not a bare Update with public:false — editing an agent must not
 	// silently unpublish it.
 	if err := a.save(); err != nil {

--- a/agent/scope_failclosed_test.go
+++ b/agent/scope_failclosed_test.go
@@ -1,0 +1,52 @@
+package agent
+
+import (
+	"mu/internal/auth"
+	"testing"
+)
+
+func TestEditingScopeRevokesTheOldCredential(t *testing.T) {
+	probes(t)
+	id := owner(t, "scope_revoke_owner")
+	a, secret, err := CreateAgent(id, "Reader", External, "", "", []string{"probealpha", "probebeta"}, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	updated, err := UpdateAgent(id, a.ID, "Reader", "", "", []string{"probealpha"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated.TokenID != "" {
+		t.Fatal("old token still attached")
+	}
+	if _, err := auth.ValidatePAT(secret); err == nil {
+		t.Fatal("old broad credential still works")
+	}
+}
+
+func TestUnavailableScopeDoesNotCreateUnrestrictedAgent(t *testing.T) {
+	id := owner(t, "invalidscopeowner")
+	a, secret, err := CreateAgent(id, "Restricted", External, "", "", []string{"unavailable-service"}, true)
+	if err == nil || a != nil || secret != "" {
+		t.Fatalf("invalid scope created agent: %v %v", a, err)
+	}
+	if len(Agents(id)) != 0 {
+		t.Fatal("failed creation persisted an agent")
+	}
+}
+
+func TestUnavailableScopeDoesNotWidenExistingAgent(t *testing.T) {
+	probes(t)
+	id := owner(t, "invalidscopeedit")
+	a, _, err := CreateAgent(id, "Restricted", Hosted, "", "", []string{"probealpha"}, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := UpdateAgent(id, a.ID, "Changed", "", "", []string{"unavailable-service"}); err == nil {
+		t.Fatal("invalid scope accepted")
+	}
+	got := Agents(id)
+	if len(got) != 1 || got[0].Unscoped() || got[0].Name != "Restricted" {
+		t.Fatalf("failed update changed agent: %+v", got)
+	}
+}

--- a/agent/scope_failclosed_test.go
+++ b/agent/scope_failclosed_test.go
@@ -2,8 +2,47 @@ package agent
 
 import (
 	"mu/internal/auth"
+	"sync"
 	"testing"
 )
+
+func TestConcurrentScopeEditAndIssuanceCannotLeaveBroadToken(t *testing.T) {
+	probes(t)
+	id := owner(t, "scope_concurrent_owner")
+	a, _, err := CreateAgent(id, "Reader", External, "", "", []string{"probealpha", "probebeta"}, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 12; i++ {
+		if _, err := UpdateAgent(id, a.ID, "Reader", "", "", []string{"probealpha", "probebeta"}); err != nil {
+			t.Fatal(err)
+		}
+		start := make(chan struct{})
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			<-start
+			if _, err := IssueToken(id, a.ID); err != nil {
+				t.Error(err)
+			}
+		}()
+		go func() {
+			defer wg.Done()
+			<-start
+			if _, err := UpdateAgent(id, a.ID, "Reader", "", "", []string{"probealpha"}); err != nil {
+				t.Error(err)
+			}
+		}()
+		close(start)
+		wg.Wait()
+		for _, token := range auth.ListTokens(id) {
+			if token.AllowsService("probebeta") {
+				t.Fatal("concurrent edit left a live broad token")
+			}
+		}
+	}
+}
 
 func TestEditingScopeRevokesTheOldCredential(t *testing.T) {
 	probes(t)

--- a/internal/api/mcp.go
+++ b/internal/api/mcp.go
@@ -351,6 +351,9 @@ func callContext(r *http.Request) context.Context {
 		return context.Background()
 	}
 	ctx := r.Context()
+	if token := auth.TokenFromRequest(r); token != nil && token.Scoped() {
+		ctx = service.WithRestrictedCaller(ctx)
+	}
 	for _, h := range idempotencyHeaders {
 		if v := strings.TrimSpace(r.Header.Get(h)); v != "" {
 			return service.WithRequest(ctx, v)

--- a/internal/api/scope_test.go
+++ b/internal/api/scope_test.go
@@ -55,6 +55,9 @@ func TestAScopedTokenIsRefusedToolsOutsideItsScope(t *testing.T) {
 
 	r, _ := http.NewRequest("POST", "/mcp", nil)
 	r.Header.Set("Authorization", "Bearer "+secret)
+	if !service.RestrictedCaller(callContext(r)) {
+		t.Fatal("token restriction lost before service dispatch")
+	}
 
 	if err := checkTokenScope(r, "scopeallowed_list"); err != nil {
 		t.Errorf("a token was refused the service it names: %v", err)

--- a/internal/auth/scope.go
+++ b/internal/auth/scope.go
@@ -61,13 +61,23 @@ func (t *Token) Services() []string {
 }
 
 // Scoped reports whether this token is confined at all.
-func (t *Token) Scoped() bool { return len(t.Services()) > 0 }
+func (t *Token) Scoped() bool {
+	if t == nil {
+		return false
+	}
+	for _, p := range t.Permissions {
+		if strings.HasPrefix(p, ScopePrefix) {
+			return true
+		}
+	}
+	return false
+}
 
 // AllowsService reports whether a token may reach a service. An unscoped token
 // allows everything; a scoped one allows only what it names.
 func (t *Token) AllowsService(name string) bool {
 	scope := t.Services()
-	if len(scope) == 0 {
+	if !t.Scoped() {
 		return true
 	}
 	name = service.CanonicalName(name)

--- a/internal/auth/scope_test.go
+++ b/internal/auth/scope_test.go
@@ -6,6 +6,13 @@ import (
 	"time"
 )
 
+func TestEmptyScopeMarkerDoesNotGrantEverything(t *testing.T) {
+	tok := &Token{Permissions: []string{ScopePrefix}}
+	if !tok.Scoped() || tok.AllowsService("mail") || tok.AllowsService("") {
+		t.Fatal("an empty restriction became an unrestricted credential")
+	}
+}
+
 // Every token ever issued before scopes existed has no scope, and must go on
 // reaching everything. A confinement that silently applied to old credentials
 // would break every working integration on upgrade.

--- a/internal/server/browser_write.go
+++ b/internal/server/browser_write.go
@@ -1,0 +1,40 @@
+package server
+
+import (
+	"net/http"
+	"net/url"
+	"strings"
+
+	"mu/internal/auth"
+)
+
+// Browser cookies are ambient credentials. An Authorization header or an MCP
+// path does not exempt a request that actually authenticated with a cookie.
+// Older first-party pages without a CSRF token may prove their origin instead.
+func browserWriteAllowed(r *http.Request) bool {
+	if r.Method == "GET" || r.Method == "HEAD" || r.Method == "OPTIONS" {
+		return true
+	}
+	cookie, err := r.Cookie("session")
+	if err != nil {
+		return true
+	}
+	if _, err := auth.ParseToken(cookie.Value); err != nil {
+		return true
+	}
+	if auth.StrictCSRF(r) {
+		return true
+	}
+	if origin := r.Header.Get("Origin"); origin != "" {
+		u, err := url.Parse(origin)
+		if err != nil || u.User != nil || u.Path != "" || u.RawQuery != "" || u.Fragment != "" {
+			return false
+		}
+		scheme := "http"
+		if r.TLS != nil || r.Header.Get("X-Forwarded-Proto") == "https" {
+			scheme = "https"
+		}
+		return u.Scheme == scheme && strings.EqualFold(u.Host, r.Host)
+	}
+	return r.Header.Get("Sec-Fetch-Site") == "same-origin"
+}

--- a/internal/server/browser_write_test.go
+++ b/internal/server/browser_write_test.go
@@ -1,0 +1,52 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"mu/internal/auth"
+)
+
+func TestCookieWritesRequireTokenOrFirstPartyOrigin(t *testing.T) {
+	const owner = "browser_write_owner"
+	if err := auth.Create(&auth.Account{ID: owner, Name: owner, Secret: "test"}); err != nil {
+		t.Fatal(err)
+	}
+	session, err := auth.CreateSession(owner)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, tc := range []struct {
+		origin, site, token string
+		want                bool
+	}{
+		{"", "", "", false},
+		{"null", "cross-site", "", false},
+		{"https://attacker.test", "cross-site", "", false},
+		{"https://micro.test.attacker.test", "", "", false},
+		{"http://micro.test", "", "", false},
+		{"https://micro.test", "same-origin", "", true},
+		{"", "same-origin", "", true},
+		{"", "same-site", "", false},
+		{"https://attacker.test", "cross-site", "valid", true},
+	} {
+		for _, path := range []string{"/mcp", "/agent", "/apps/demo/sdk/service", "/mail", "/anything/webhook"} {
+			r := httptest.NewRequest("POST", "https://micro.test"+path, nil)
+			r.AddCookie(&http.Cookie{Name: "session", Value: session.Token})
+			r.Header.Set("Origin", tc.origin)
+			r.Header.Set("Sec-Fetch-Site", tc.site)
+			// An arbitrary header cannot exempt ambient cookie authentication.
+			r.Header.Set("Authorization", "Bearer invalid")
+			if tc.token == "valid" {
+				r.Header.Set("X-CSRF-Token", auth.CSRFToken(r))
+			}
+			if got := browserWriteAllowed(r); got != tc.want {
+				t.Errorf("%s %+v: got %v", path, tc, got)
+			}
+		}
+	}
+	if !browserWriteAllowed(httptest.NewRequest("POST", "/mcp", nil)) {
+		t.Fatal("non-cookie client blocked")
+	}
+}

--- a/internal/server/serve.go
+++ b/internal/server/serve.go
@@ -57,6 +57,14 @@ func serve(addr string) {
 			}
 
 			setSecurityHeaders(w)
+			if !browserWriteAllowed(r) {
+				http.Error(w, "Cross-origin account action refused", http.StatusForbidden)
+				return
+			}
+			if !scopedRequestAllowed(r) {
+				http.Error(w, "Scoped tokens must use the MCP or service API endpoint", http.StatusForbidden)
+				return
+			}
 
 			// Set Onion-Location header for Tor Browser discovery
 			if onion := os.Getenv("TOR_ONION"); onion != "" {

--- a/internal/server/token_scope.go
+++ b/internal/server/token_scope.go
@@ -15,8 +15,9 @@ func scopedRequestAllowed(r *http.Request) bool {
 	if token == nil || !token.Scoped() {
 		return true
 	}
-	if path.Clean(r.URL.Path) != r.URL.Path {
+	p := strings.TrimSuffix(r.URL.Path, "/")
+	if path.Clean(p) != p {
 		return false
 	}
-	return r.URL.Path == "/mcp" || strings.HasPrefix(r.URL.Path, "/api/v1/")
+	return p == "/mcp" || p == "/api/v1" || strings.HasPrefix(p, "/api/v1/")
 }

--- a/internal/server/token_scope.go
+++ b/internal/server/token_scope.go
@@ -1,0 +1,22 @@
+package server
+
+import (
+	"net/http"
+	"path"
+	"strings"
+
+	"mu/internal/auth"
+)
+
+// Service scopes are enforced by the MCP/REST tool dispatcher. Other doors
+// authenticate an account, but cannot preserve a restricted caller's grant.
+func scopedRequestAllowed(r *http.Request) bool {
+	token := auth.TokenFromRequest(r)
+	if token == nil || !token.Scoped() {
+		return true
+	}
+	if path.Clean(r.URL.Path) != r.URL.Path {
+		return false
+	}
+	return r.URL.Path == "/mcp" || strings.HasPrefix(r.URL.Path, "/api/v1/")
+}

--- a/internal/server/token_scope_test.go
+++ b/internal/server/token_scope_test.go
@@ -1,0 +1,39 @@
+package server
+
+import (
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"mu/internal/auth"
+)
+
+func TestScopedCredentialCannotUseAccountDoors(t *testing.T) {
+	owner := "scope_door_owner"
+	if err := auth.Create(&auth.Account{ID: owner, Name: owner, Secret: "test"}); err != nil {
+		t.Fatal(err)
+	}
+	_, secret, err := auth.CreateToken(owner, "restricted", auth.ScopeFor([]string{"news"}), time.Time{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, header := range []string{"Authorization", "X-Micro-Token"} {
+		for _, path := range []string{"/mail", "/agent", "/agent/run", "/account", "/apps/example/sdk/service", "/files/private.pdf", "/mcp/../mail", "/api/v1x/mail/inbox", "/api/v1/../../mail", "/api/v1/%2e%2e/%2e%2e/mail"} {
+			r := httptest.NewRequest("POST", path, nil)
+			r.Header.Set(header, secret)
+			if scopedRequestAllowed(r) {
+				t.Errorf("%s reached %s", header, path)
+			}
+		}
+		for _, path := range []string{"/mcp", "/api/v1/news/list"} {
+			r := httptest.NewRequest("POST", path, nil)
+			r.Header.Set(header, secret)
+			if !scopedRequestAllowed(r) {
+				t.Errorf("%s denied %s", header, path)
+			}
+		}
+	}
+	if !scopedRequestAllowed(httptest.NewRequest("GET", "/agent", nil)) {
+		t.Fatal("browser route blocked")
+	}
+}

--- a/internal/server/token_scope_test.go
+++ b/internal/server/token_scope_test.go
@@ -25,7 +25,7 @@ func TestScopedCredentialCannotUseAccountDoors(t *testing.T) {
 				t.Errorf("%s reached %s", header, path)
 			}
 		}
-		for _, path := range []string{"/mcp", "/api/v1/news/list"} {
+		for _, path := range []string{"/mcp", "/mcp/", "/api/v1", "/api/v1/", "/api/v1/news/list", "/api/v1/news/list/"} {
 			r := httptest.NewRequest("POST", path, nil)
 			r.Header.Set(header, secret)
 			if !scopedRequestAllowed(r) {

--- a/internal/service/restricted.go
+++ b/internal/service/restricted.go
@@ -1,0 +1,19 @@
+package service
+
+import (
+	"context"
+	"go-micro.dev/v6/metadata"
+)
+
+const restrictedKey = "Mu-Restricted-Caller"
+
+// WithRestrictedCaller marks a grant narrower than the account. Durable work
+// must not exchange that grant for the account's unrestricted agent authority.
+func WithRestrictedCaller(ctx context.Context) context.Context {
+	return metadata.Set(ctx, restrictedKey, "true")
+}
+
+func RestrictedCaller(ctx context.Context) bool {
+	v, _ := metadata.Get(ctx, restrictedKey)
+	return v == "true"
+}

--- a/service/apps/sandbox.go
+++ b/service/apps/sandbox.go
@@ -396,7 +396,7 @@ func appBridgeJS(slug string) string {
     // The iframe cannot authorize use of the viewer's account. This prompt
     // belongs to the trusted parent and is deliberately per request: an app
     // can change after publication, and its own Send button is untrusted code.
-    var personal=op==='agent'||op==='agent.stream'||op==='chat'||op==='blog.create'||op==='user'||op==='sdk:service';
+    var personal=op==='user'||(OPS[op]&&OPS[op].m==='POST')||op==='sdk:service'||op==='sdk:ai'||op==='sdk:fetch';
     if(personal){
       var detail=JSON.stringify(args);
       if(detail.length>16000){reply(e.source,m.id,null,'Request too large to review');return;}

--- a/service/apps/sandbox.go
+++ b/service/apps/sandbox.go
@@ -393,6 +393,17 @@ func appBridgeJS(slug string) string {
     if(m.mu==='cancel'){cancelStream(m.id);return;}
 
     var op=String(m.op||''), args=m.args||{};
+    // The iframe cannot authorize use of the viewer's account. This prompt
+    // belongs to the trusted parent and is deliberately per request: an app
+    // can change after publication, and its own Send button is untrusted code.
+    var personal=op==='agent'||op==='agent.stream'||op==='chat'||op==='blog.create'||op==='user'||op==='sdk:service';
+    if(personal){
+      var detail=JSON.stringify(args);
+      if(detail.length>16000){reply(e.source,m.id,null,'Request too large to review');return;}
+      if(!window.confirm('Allow '+SLUG+' to use your account for '+op+'?\n\nThe result will be visible to this app. Agent requests may send private data to the configured AI provider and take actions using your tools.\n\n'+detail)){
+        reply(e.source,m.id,null,'Request declined');return;
+      }
+    }
 
     // The server-side proxy: caller bound from the session, app named in the
     // path. These were never the problem.
@@ -416,6 +427,7 @@ func appBridgeJS(slug string) string {
     if(spec.q){ path=path+query(args.query); }
 
     var init={headers:{'Accept':j}};
+    if(spec.m==='GET'&&op!=='user') init.credentials='omit';
     if(spec.m==='POST'){
       init.method='POST';
       init.headers['Content-Type']=j;

--- a/service/apps/testdata/agent-stream.mjs
+++ b/service/apps/testdata/agent-stream.mjs
@@ -4,13 +4,13 @@ import vm from 'node:vm';
 const sources=JSON.parse(readFileSync(process.argv[2],'utf8'));
 const script=s=>s.replace(/^<script>\s*/, '').replace(/<\/script>\s*$/, '');
 const tick=()=>new Promise(resolve=>setImmediate(resolve));
-function bridge(fetcher){
+function bridge(fetcher,confirm=()=>true){
   const messages=[],listeners={},frameListeners={},calls=[];
   const win={postMessage:m=>messages.push(m)};
   const frame={contentWindow:win,addEventListener:(name,fn)=>frameListeners[name]=fn};
   const context={Map,Number,AbortController,TextDecoder,setTimeout,clearTimeout,
     document:{getElementById:()=>frame,cookie:'csrf_token=secret'},
-    window:{addEventListener:(name,fn)=>listeners[name]=fn},
+    window:{confirm,addEventListener:(name,fn)=>listeners[name]=fn},
     fetch:(path,init)=>{calls.push({path,init});return fetcher(path,init)}};
   vm.runInNewContext(script(sources.bridge),context);
   return {messages,calls,frameListeners,listeners,win,
@@ -87,4 +87,23 @@ for(const action of ['load','pagehide','cancel']){
   listeners.message({source:parent,data:{mu:'event',id:bad.id,event:{type:'stream_token',text:'Hello'}}});
   await assert.rejects(failed,/callback failed/);
   assert.equal(posted.at(-1).mu,'cancel');
+}
+
+// Untrusted app requests cannot authorize themselves, including the legacy
+// synchronous agent path and generic service dispatch.
+for (const op of ['agent', 'agent.stream', 'chat', 'blog.create', 'user', 'sdk:service']) {
+  const prompts=[];
+  const b=bridge(()=>{throw new Error('unauthorized fetch')}, text=>{prompts.push(text);return false});
+  b.call(1,op); await tick();
+  assert.equal(b.calls.length,0,op);
+  assert.equal(prompts.length,1,op);
+  assert.match(prompts[0],/Hello/);
+  assert.match(b.messages.at(-1).error,/declined/);
+  b.call(2,op,{});
+  assert.equal(prompts.length,1,'unrelated frames cannot prompt');
+}
+{
+ const b=bridge(()=>Promise.resolve(new Response('{}')));
+ b.call(1,'blog.list'); await tick();
+ assert.equal(b.calls[0].init.credentials,'omit','public reads cannot borrow the viewer');
 }

--- a/service/apps/testdata/agent-stream.mjs
+++ b/service/apps/testdata/agent-stream.mjs
@@ -91,7 +91,7 @@ for(const action of ['load','pagehide','cancel']){
 
 // Untrusted app requests cannot authorize themselves, including the legacy
 // synchronous agent path and generic service dispatch.
-for (const op of ['agent', 'agent.stream', 'chat', 'blog.create', 'user', 'sdk:service']) {
+for (const op of ['agent', 'agent.stream', 'chat', 'blog.create', 'user', 'sdk:service', 'sdk:ai', 'sdk:fetch', 'places.search', 'places.nearby']) {
   const prompts=[];
   const b=bridge(()=>{throw new Error('unauthorized fetch')}, text=>{prompts.push(text);return false});
   b.call(1,op); await tick();

--- a/service/events/restricted_test.go
+++ b/service/events/restricted_test.go
@@ -1,0 +1,27 @@
+package events
+
+import (
+	"context"
+	"mu/internal/service"
+	"testing"
+	"time"
+)
+
+func TestRestrictedCallerCannotScheduleAnUnrestrictedAgent(t *testing.T) {
+	ctx := service.WithRestrictedCaller(service.WithAccount(context.Background(), "restricted-owner"))
+	var rsp CreateResponse
+	req := &CreateRequest{Title: "Appointment", When: time.Now().Add(time.Hour).Format(time.RFC3339), Prompt: "Read private mail"}
+	if err := (Server{}).Create(ctx, req, &rsp); err == nil {
+		t.Fatal("restricted caller scheduled work")
+	}
+	req.Prompt = ""
+	if err := (Server{}).Create(ctx, req, &rsp); err != nil {
+		t.Fatal(err)
+	}
+	defer Cancel("restricted-owner", rsp.Item.ID)
+	prompt := "Read private mail"
+	var updated UpdateResponse
+	if err := (Server{}).Update(ctx, &UpdateRequest{ID: rsp.Item.ID, Prompt: &prompt}, &updated); err == nil {
+		t.Fatal("restricted caller upgraded reminder to agent work")
+	}
+}

--- a/service/events/service.go
+++ b/service/events/service.go
@@ -41,6 +41,9 @@ type CreateResponse struct {
 // whenever the user asks to be reminded of something or to schedule an event.
 // @example {"title": "Call the dentist", "when": "2026-07-22T15:00:00+01:00"}
 func (Server) Create(ctx context.Context, req *CreateRequest, rsp *CreateResponse) error {
+	if service.RestrictedCaller(ctx) && strings.TrimSpace(req.Prompt) != "" {
+		return fmt.Errorf("a restricted caller cannot schedule background agent work")
+	}
 	when, err := parseWhen(req.When)
 	if err != nil {
 		return err

--- a/service/events/update.go
+++ b/service/events/update.go
@@ -36,6 +36,9 @@ func (Server) Update(ctx context.Context, req *UpdateRequest, rsp *UpdateRespons
 	if old == nil || old.Owner != owner {
 		return fmt.Errorf("event not found")
 	}
+	if service.RestrictedCaller(ctx) && (old.Prompt != "" || (req.Prompt != nil && strings.TrimSpace(*req.Prompt) != "")) {
+		return fmt.Errorf("a restricted caller cannot change background agent work")
+	}
 	next := *old
 	if req.Title != nil {
 		next.Title = strings.TrimSpace(*req.Title)

--- a/service/tasks/restricted_test.go
+++ b/service/tasks/restricted_test.go
@@ -11,8 +11,10 @@ func TestRestrictedCallerCannotBorrowBackgroundAgent(t *testing.T) {
 	setupTasks(t)
 	ctx := service.WithRestrictedCaller(service.WithAccount(context.Background(), "someone"))
 	var rsp TaskResponse
-	if err := (Server{}).Create(ctx, &CreateRequest{Title: "Read private mail", Assignee: Agent}, &rsp); err == nil {
-		t.Fatal("restricted caller started work")
+	for _, assignee := range []string{Agent, "bot", "ai", "mu", " BOT "} {
+		if err := (Server{}).Create(ctx, &CreateRequest{Title: "Read private mail", Assignee: assignee}, &rsp); err == nil {
+			t.Fatalf("restricted caller started work with %q", assignee)
+		}
 	}
 	if len(List("someone", "")) != 0 {
 		t.Fatal("refused task persisted")

--- a/service/tasks/restricted_test.go
+++ b/service/tasks/restricted_test.go
@@ -1,0 +1,34 @@
+package tasks
+
+import (
+	"context"
+	"mu/internal/service"
+	"testing"
+	"time"
+)
+
+func TestRestrictedCallerCannotBorrowBackgroundAgent(t *testing.T) {
+	setupTasks(t)
+	ctx := service.WithRestrictedCaller(service.WithAccount(context.Background(), "someone"))
+	var rsp TaskResponse
+	if err := (Server{}).Create(ctx, &CreateRequest{Title: "Read private mail", Assignee: Agent}, &rsp); err == nil {
+		t.Fatal("restricted caller started work")
+	}
+	if len(List("someone", "")) != 0 {
+		t.Fatal("refused task persisted")
+	}
+	if err := (Server{}).Create(ctx, &CreateRequest{Title: "Personal reminder", Assignee: Me}, &rsp); err != nil {
+		t.Fatal(err)
+	}
+	task, err := Create("someone", "Existing work", "", Agent, time.Time{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := (Server{}).Update(ctx, &UpdateRequest{ID: task.ID, Detail: "Read private mail"}, &rsp); err == nil {
+		t.Fatal("restricted caller changed agent instructions")
+	}
+	got, _ := Get("someone", task.ID)
+	if got.Detail != "" {
+		t.Fatal("refused update persisted")
+	}
+}

--- a/service/tasks/service.go
+++ b/service/tasks/service.go
@@ -69,6 +69,9 @@ type DeleteResponse struct {
 // Create adds a task to the caller's list.
 // @example {"title": "Summarise the week's AI news", "assignee": "agent"}
 func (Server) Create(ctx context.Context, req *CreateRequest, rsp *TaskResponse) error {
+	if service.RestrictedCaller(ctx) && strings.EqualFold(strings.TrimSpace(req.Assignee), Agent) {
+		return fmt.Errorf("a restricted caller cannot start background agent work")
+	}
 	owner := service.AccountFrom(ctx)
 	due, err := ParseDue(req.Due)
 	if err != nil {
@@ -139,6 +142,15 @@ func (Server) Next(ctx context.Context, _ *NextRequest, rsp *TaskResponse) error
 // Update changes a task — its state, or what came of it.
 // @example {"id": "abc123", "status": "done", "result": "Mailed the summary"}
 func (Server) Update(ctx context.Context, req *UpdateRequest, rsp *TaskResponse) error {
+	if service.RestrictedCaller(ctx) {
+		t, err := Get(service.AccountFrom(ctx), req.ID)
+		if err != nil {
+			return err
+		}
+		if t.Assignee == Agent {
+			return fmt.Errorf("a restricted caller cannot change background agent work")
+		}
+	}
 	t, err := Update(service.AccountFrom(ctx), req.ID, req.Title, req.Detail, req.Status, "", req.Result)
 	if err != nil {
 		return err

--- a/service/tasks/service.go
+++ b/service/tasks/service.go
@@ -3,7 +3,6 @@ package tasks
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
 	"mu/internal/app"
@@ -69,7 +68,8 @@ type DeleteResponse struct {
 // Create adds a task to the caller's list.
 // @example {"title": "Summarise the week's AI news", "assignee": "agent"}
 func (Server) Create(ctx context.Context, req *CreateRequest, rsp *TaskResponse) error {
-	if service.RestrictedCaller(ctx) && strings.EqualFold(strings.TrimSpace(req.Assignee), Agent) {
+	assignee := normaliseAssignee(req.Assignee)
+	if service.RestrictedCaller(ctx) && assignee == Agent {
 		return fmt.Errorf("a restricted caller cannot start background agent work")
 	}
 	owner := service.AccountFrom(ctx)
@@ -77,7 +77,7 @@ func (Server) Create(ctx context.Context, req *CreateRequest, rsp *TaskResponse)
 	if err != nil {
 		return err
 	}
-	t, err := Create(owner, req.Title, req.Detail, req.Assignee, due)
+	t, err := Create(owner, req.Title, req.Detail, assignee, due)
 	if err != nil {
 		return err
 	}
@@ -100,7 +100,7 @@ func (Server) Create(ctx context.Context, req *CreateRequest, rsp *TaskResponse)
 	// In the background, because this call should return the task rather than
 	// wait for the work: Run marks it doing and announces, and /tasks is the
 	// progress indicator.
-	if strings.EqualFold(strings.TrimSpace(req.Assignee), Agent) && !service.InAgentRun(ctx) {
+	if assignee == Agent && !service.InAgentRun(ctx) {
 		go func() {
 			if err := Run(owner, t.ID); err != nil {
 				app.Log("tasks", "starting %s for %s: %v", t.ID, owner, err)


### PR DESCRIPTION
Restricted access must remain restricted whichever interface a caller uses. This hardens token, browser, app and scheduled-work boundaries before adding provider write permissions.

- Confine service-scoped tokens to the MCP/REST dispatchers that enforce their grants, including normalized-path checks.
- Reject unavailable-only agent scopes and revoke old credentials when the service scope changes.
- Carry a restricted-caller marker through tool dispatch; refuse creation or editing of unrestricted background agent work from restricted callers. Ordinary reminders and personal tasks remain available.
- Require a CSRF token or first-party browser origin for cookie-authenticated writes before routing, including requests carrying an Authorization header.
- Require per-request confirmation in the trusted app parent before agent/account operations. Public bridge reads omit credentials. This is an interim boundary, not a persistent app permission model.

Validation: full short suite and binary build passed. Targeted boundary suites passed. A wider race run exposed a go-micro RPC codec Close/ReadHeader race during the existing command lifecycle test; recorded as unresolved, not suppressed or treated as a pass. The new security regressions cover invalid scopes, token routing, ambient-cookie writes and background escalation; executable JS tests cover denial before dispatch and streaming compatibility.

This is not certification of the entire runtime. Cloud-model disclosure policy, isolated app/content hosting, comprehensive output authorization and host/key isolation remain separate review work. No Google write grant or user data migration is introduced.