### PR TITLE
Make brief links recognizable without hover

### DIFF
--- a/home/index.go
+++ b/home/index.go
@@ -335,7 +335,6 @@ func indexBody() string {
    is two sentences, which is short enough to centre without the ragged edge
    that makes centred prose hard to track. */
 .lbrief{font-size:15px;color:#444;line-height:1.65}
-.lbrief a{color:#444;text-decoration:underline;text-underline-offset:2px}
 /* Numbers, so they are set as numbers: tabular, quiet, one line. */
 .lmarkets{font-size:13px;font-variant-numeric:tabular-nums}
 .lmarkets a{color:#777;text-decoration:none}

--- a/internal/app/html/composition.css
+++ b/internal/app/html/composition.css
@@ -155,3 +155,12 @@ a.btn-secondary:hover, .btn-secondary:hover {
 .section-link:hover { text-decoration:underline; }
 
 @media(max-width:640px){#home-cards .view-switch{justify-content:center;}}
+
+/* Inline actions remain recognizable without hover, including on touch screens. */
+a.link-text {
+  color: var(--link-color, #0066cc);
+  text-decoration: underline !important;
+  text-decoration-thickness: 1.5px;
+  text-underline-offset: 3px;
+}
+.link-text:hover, .link-text:focus-visible { text-decoration-thickness: 2px; }

--- a/internal/app/html/mu.css
+++ b/internal/app/html/mu.css
@@ -2478,17 +2478,6 @@ a.btn-plain:hover {
   text-decoration: none;
 }
 
-/* A link inside a sentence. See app.TextLink: .link is display:block, so used
-   in prose it breaks the line where it sits. */
-.link-text {
-  color: inherit;
-  text-decoration: underline;
-  text-underline-offset: 2px;
-}
-
-.link-text:hover {
-  color: var(--accent-color, #000);
-}
 
 .category,
 .highlight,
@@ -6830,10 +6819,8 @@ textarea.ib-field { resize: vertical; line-height: var(--line-height, 1.6) }
    already applies; this is only about not having them read as body text. */
 .home-brief a {
   font-weight: var(--font-weight-medium, 500);
-  color: var(--text-primary, #1a1a1a);
 }
 
-.home-brief a:hover { text-decoration: underline }
 
 /* A real browser, at /browser. See service/browser/page.go. */
 .browser-page { max-width: var(--page-width) }


### PR DESCRIPTION
Brief links looked like ordinary text, especially on mobile. The global anchor reset forces away underlines, and landing/home overrides also muted their colour.

Move inline-link presentation into the shared composition stylesheet, give it the existing blue link colour and a persistent underline, and remove conflicting brief-specific overrides. Navigation and card links keep their existing treatment.

Verified the actual CSS cascade in Chromium at 390px and 1440px: inline links remain blue and underlined both at rest and on hover. This is a presentation-only change.