### PR TITLE
Recognize imported calendar copies without Google write access

### DIFF
--- a/internal/server/hooks.go
+++ b/internal/server/hooks.go
@@ -137,7 +137,7 @@ func wireHooks() {
 			out := make([]events.External, 0, len(entries))
 			for _, e := range entries {
 				out = append(out, events.External{
-					URL: e.URL, Title: e.Title, Start: e.Start, End: e.End,
+					UID: e.UID, URL: e.URL, Title: e.Title, Start: e.Start, End: e.End,
 					Location: e.Location, AllDay: e.AllDay, Source: events.ExternalName,
 				})
 			}

--- a/service/events/copies_test.go
+++ b/service/events/copies_test.go
@@ -1,0 +1,61 @@
+package events
+
+import (
+	"testing"
+	"time"
+)
+
+func TestOnlyUnchangedCalendarIdentityIsCollapsed(t *testing.T) {
+	e := &Event{ID: "local", Title: "Webinar", When: day(12, 0)}
+	copy := External{UID: "local@mu", Title: e.Title, Start: e.When, End: e.When.Add(e.Length())}
+	if got := withoutLocalCopies([]*Event{e}, []External{copy}); len(got) != 0 {
+		t.Fatal("unchanged imported occurrence duplicated")
+	}
+	for _, mutate := range []func(*External){
+		func(x *External) { x.UID = "" },
+		func(x *External) { x.UID = "other@mu" },
+		func(x *External) { x.Start = x.Start.Add(time.Hour) },
+		func(x *External) { x.End = x.End.Add(time.Hour) },
+		func(x *External) { x.Title = "Edited webinar" },
+		func(x *External) { x.Location = "Meeting room" },
+		func(x *External) { x.AllDay = true },
+	} {
+		x := copy
+		mutate(&x)
+		if got := withoutLocalCopies([]*Event{e}, []External{x}); len(got) != 1 {
+			t.Fatalf("ambiguous or changed occurrence hidden: %+v", x)
+		}
+	}
+	if got := withoutLocalCopies(nil, []External{copy}); len(got) != 1 {
+		t.Fatal("another owner's event was used to collapse a copy")
+	}
+}
+
+func TestExternalCopiesUseOnlyTheCallersUpcomingEvents(t *testing.T) {
+	when := time.Now().Add(time.Hour).Truncate(time.Second)
+	e, err := Create("copy-owner", "Webinar", when, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { Cancel(e.Owner, e.ID) })
+	old := ExternalEntries
+	t.Cleanup(func() { ExternalEntries = old })
+	ExternalEntries = func(string, time.Time, time.Time, int) []External {
+		return []External{{UID: e.ID + "@mu", Title: e.Title, Start: e.When, End: e.When.Add(e.Length())}}
+	}
+	if got := ExternalEvents(e.Owner, when, when.Add(time.Hour), 0); len(got) != 0 {
+		t.Fatal("owner sees duplicate imported occurrence")
+	}
+	if got := ExternalEvents("different-owner", when, when.Add(time.Hour), 0); len(got) != 1 {
+		t.Fatal("another owner's local event affected the result")
+	}
+	if got := Overview(e.Owner, PreviewLimit); len(got) != 0 {
+		t.Fatal("overview duplicated imported occurrence")
+	}
+	if err := Cancel(e.Owner, e.ID); err != nil {
+		t.Fatal(err)
+	}
+	if got := CachedOverview(e.Owner); len(got) != 1 {
+		t.Fatal("cached merge hid the independently surviving calendar copy")
+	}
+}

--- a/service/events/external.go
+++ b/service/events/external.go
@@ -21,6 +21,7 @@ import "time"
 // External is one entry on a calendar Mu does not own. Read-only by
 // construction: there is no id here to cancel by, because Mu cannot cancel it.
 type External struct {
+	UID      string    `json:"-"` // iCalendar identity, never an authorization grant.
 	URL      string    `json:"url,omitempty"`
 	Title    string    `json:"title"`
 	Start    time.Time `json:"start"`
@@ -75,10 +76,37 @@ func externalBusy(owner string, from, to time.Time) ([]Slot, error) {
 // ExternalEvents reads the owner's connected calendars within a window.
 // A positive limit bounds the result; zero reads the full window.
 func ExternalEvents(owner string, from, to time.Time, limit int) []External {
+	return withoutLocalCopies(Upcoming(owner), externalEvents(owner, from, to, limit))
+}
+
+func externalEvents(owner string, from, to time.Time, limit int) []External {
 	if ExternalEntries == nil || owner == "" {
 		return nil
 	}
 	return ExternalEntries(owner, from, to, limit)
+}
+
+// An exported ICS retains ID@mu when imported by another calendar. Collapse
+// only an unchanged occurrence with that identity; a template link, matching
+// title alone, moved occurrence or edited duration is not proof of a copy.
+// Caller supplies only this owner's local events. No provider writes occur.
+func withoutLocalCopies(local []*Event, external []External) []External {
+	byUID := make(map[string]*Event, len(local))
+	for _, e := range local {
+		if e.ID != "" && e.Kind != "brief" && e.Prompt == "" {
+			byUID[e.ID+"@mu"] = e
+		}
+	}
+	result := make([]External, 0, len(external))
+	for _, x := range external {
+		e := byUID[x.UID]
+		if e != nil && !x.AllDay && x.Title == e.Title && x.Location == "" &&
+			x.Start.Equal(e.When) && x.End.Equal(e.When.Add(e.Length())) {
+			continue
+		}
+		result = append(result, x)
+	}
+	return result
 }
 
 // HasExternal reports whether this owner has an outside calendar attached.

--- a/service/events/overview.go
+++ b/service/events/overview.go
@@ -37,7 +37,7 @@ func CachedOverview(owner string) []External {
 	key := overviewKey(owner, PreviewLimit)
 	overviewCache.Lock()
 	defer overviewCache.Unlock()
-	return futureEntries(overviewCache.values[key].entries)
+	return withoutLocalCopies(Upcoming(owner), futureEntries(overviewCache.values[key].entries))
 }
 
 func futureEntries(entries []External) []External {
@@ -62,7 +62,7 @@ func Overview(owner string, limit int) []External {
 	snapshot, ok := overviewCache.values[key]
 	if ok && time.Now().Before(snapshot.expires) {
 		overviewCache.Unlock()
-		return futureEntries(snapshot.entries)
+		return withoutLocalCopies(Upcoming(owner), futureEntries(snapshot.entries))
 	}
 	if ready := overviewCache.pending[key]; ready != nil {
 		overviewCache.Unlock()
@@ -74,12 +74,14 @@ func Overview(owner string, limit int) []External {
 	overviewCache.Unlock()
 	defer func() { overviewCache.Lock(); delete(overviewCache.pending, key); close(ready); overviewCache.Unlock() }()
 	now := time.Now()
-	entries := ExternalEvents(owner, now, now.Add(30*24*time.Hour), limit)
+	// Cache provider entries, not the merge: cancelling or editing a local
+	// reminder must reveal its independent calendar copy immediately.
+	entries := externalEvents(owner, now, now.Add(30*24*time.Hour), limit)
 	overviewCache.Lock()
 	if len(overviewCache.values) >= 512 {
 		overviewCache.values = make(map[string]overviewSnapshot)
 	}
 	overviewCache.values[key] = overviewSnapshot{entries: append([]External(nil), entries...), expires: time.Now().Add(2 * time.Minute)}
 	overviewCache.Unlock()
-	return entries
+	return withoutLocalCopies(Upcoming(owner), entries)
 }


### PR DESCRIPTION
Mu exports an iCalendar UID as event-ID@mu, but the Google adapter drops that identity before local and external calendars are combined. Importing the ICS can therefore show the same unchanged occurrence twice.

Carry the provider UID into the events layer and omit a copy only when it matches this owner's upcoming local event by UID, exact start/end and title, with no additional external location or all-day semantics. Do not merge by title or approximate time. Provider snapshots retain the raw entries; merging uses current local state, so cancelling or editing a local reminder immediately reveals the independent Google entry.

Tests cover exact copies, ambiguous identities, moved/edited entries, all-day/location differences, owner isolation and cancellation against a populated overview cache. Events, Google and server short suites pass.

No provider writes or new OAuth scope. This resolves the ICS-import case only: the existing Google template link does not preserve the local UID, so those copies still require explicit association or a different export flow. Related #1569 and #1653.