### PR TITLE
Separate Home actions from the brief and stop repeated app agent prompts

### DIFF
--- a/home/brief.go
+++ b/home/brief.go
@@ -142,12 +142,6 @@ func briefParts(accountID string, external ...events.External) []string {
 		if s := working(accountID); s != "" {
 			parts = append(parts, s)
 		}
-		if s := taskAttention(accountID); s != "" {
-			parts = append(parts, s)
-		}
-		if s := owed(accountID); s != "" {
-			parts = append(parts, s)
-		}
 		// What is actually on today, before the world's line.
 		//
 		// The brief said what was waiting, what the agent was doing and what
@@ -207,55 +201,6 @@ func working(accountID string) string {
 		out += ", the longest since " + html.EscapeString(app.TimeAgo(oldest.Updated))
 	}
 	return out + "."
-}
-
-// taskAttention points to work that needs a decision, not another automatic run.
-func taskAttention(accountID string) string {
-	var parts []string
-	for _, status := range []string{tasks.StatusFailed, tasks.StatusBlocked} {
-		if n := len(tasks.List(accountID, status)); n > 0 {
-			parts = append(parts, app.TextLink(count(n, "task", "tasks")+" "+status, "/tasks?status="+status))
-		}
-	}
-	if len(parts) == 0 {
-		return ""
-	}
-	return strings.Join(parts, " and ") + "; review before retrying."
-}
-
-// owed is what is waiting on you: due today, then everything else open.
-//
-// Overdue first and separately, because a task that has passed its date is the
-// one fact on this line somebody may need to act on today, and burying it in a
-// total is how it stops being one.
-func owed(accountID string) string {
-	todo := tasks.List(accountID, tasks.StatusTodo)
-	if len(todo) == 0 {
-		return ""
-	}
-
-	now := time.Now()
-	late, today := 0, 0
-	for _, t := range todo {
-		switch {
-		case t.Due.IsZero():
-		case t.Due.Before(now):
-			late++
-		case sameDay(t.Due, now):
-			today++
-		}
-	}
-
-	switch {
-	case late > 0 && today > 0:
-		return app.TextLink(count(late, "task", "tasks"), "/tasks") + " overdue and " +
-			strconv.Itoa(today) + " due today."
-	case late > 0:
-		return app.TextLink(count(late, "task", "tasks"), "/tasks") + " overdue."
-	case today > 0:
-		return app.TextLink(count(today, "task", "tasks"), "/tasks") + " due today."
-	}
-	return app.TextLink(count(len(todo), "task", "tasks"), "/tasks") + " open."
 }
 
 // happening is what the world did today, in agent/brief's words.

--- a/home/brief_split_test.go
+++ b/home/brief_split_test.go
@@ -39,11 +39,11 @@ func TestTheBriefIsAboutYouAndNotTheWorld(t *testing.T) {
 	// A line about the world exists and is being published.
 	line := brief.Line()
 
-	got := briefHTML(who)
+	got := todoHTML(who)
 	if got == "" {
 		t.Fatal("an account with an overdue task gets no brief at all")
 	}
-	if !strings.Contains(got, "overdue") {
+	if !strings.Contains(got, "Overdue") {
 		t.Errorf("the brief does not say what is owed:\n%s", got)
 	}
 	if line != "" && strings.Contains(got, line) {

--- a/home/brief_test.go
+++ b/home/brief_test.go
@@ -90,7 +90,7 @@ func TestTheBriefSeparatesWorkInHandFromWorkOwed(t *testing.T) {
 	if !strings.Contains(got, "The agent is on") || !strings.Contains(got, "1 thing") {
 		t.Errorf("work in hand is not reported:\n%s", got)
 	}
-	if !strings.Contains(got, "1 task") || !strings.Contains(got, "overdue") {
+	if strings.Contains(got, "overdue") || !strings.Contains(todoHTML(who), "Overdue") {
 		t.Errorf("an overdue task is not called out:\n%s", got)
 	}
 	if !strings.Contains(got, `href="/tasks"`) {
@@ -109,7 +109,11 @@ func TestTheBriefSeparatesWorkInHandFromWorkOwed(t *testing.T) {
 func TestTheBriefIsLabelledLikeEverythingElse(t *testing.T) {
 	const who = "brief-shape"
 	auth.Create(&auth.Account{ID: who, Name: who, Secret: "test-secret"}) //nolint:errcheck
-	if _, err := tasks.Create(who, "Something", "", tasks.Me, time.Time{}); err != nil {
+	task, err := tasks.Create(who, "Something", "", tasks.Agent, time.Time{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tasks.Update(who, task.ID, "", "", tasks.StatusDoing, "", ""); err != nil {
 		t.Fatal(err)
 	}
 

--- a/home/home.go
+++ b/home/home.go
@@ -278,7 +278,7 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		external := events.Overview(sess.Account, events.PreviewLimit)
-		app.RespondJSON(w, map[string]string{"upcoming": events.Preview(sess.Account, external), "brief": briefHTML(sess.Account, external...)})
+		app.RespondJSON(w, map[string]string{"upcoming": events.Preview(sess.Account, external), "brief": todoHTML(sess.Account) + briefHTML(sess.Account, external...)})
 		return
 	}
 	// An installed app opens on the app, not on a pitch.
@@ -452,7 +452,7 @@ function fetchW(la,lo){
 	}))
 	b.WriteString(`</div>`)
 	if viewerID != "" {
-		b.WriteString(`<div id="home-brief" class="page-stack">` + briefHTML(viewerID, events.CachedOverview(viewerID)...) + `</div>`)
+		b.WriteString(`<div id="home-brief" class="page-stack">` + todoHTML(viewerID) + briefHTML(viewerID, events.CachedOverview(viewerID)...) + `</div>`)
 	}
 	b.WriteString(appsHTML(viewerAcc))
 	if viewerID != "" {

--- a/home/task_attention_test.go
+++ b/home/task_attention_test.go
@@ -20,13 +20,30 @@ func TestTaskAttentionShowsFailedAndBlockedOwnedWork(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	out := taskAttention(who)
-	for _, want := range []string{"/tasks?status=failed", "/tasks?status=blocked", "review before retrying"} {
+	if _, err := tasks.Create(who, "<script>personal</script>", "", tasks.Me, time.Time{}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tasks.Create(who, "Queued agent work", "", tasks.Agent, time.Time{}); err != nil {
+		t.Fatal(err)
+	}
+	out := todoHTML(who)
+	if strings.Contains(out, "<script>") || strings.Contains(out, "Queued agent work") {
+		t.Fatal(out)
+	}
+	if !strings.Contains(out, "&lt;script&gt;personal") {
+		t.Fatal(out)
+	}
+	for _, part := range briefParts(who) {
+		if strings.Contains(part, "retry") || strings.Contains(part, "blocked") || strings.Contains(part, "open.") {
+			t.Fatal(part)
+		}
+	}
+	for _, want := range []string{"/tasks?status=failed", "/tasks?status=blocked", "review before retrying", sectionRule("To do")} {
 		if !strings.Contains(out, want) {
 			t.Errorf("attention summary missing %q: %s", want, out)
 		}
 	}
-	if taskAttention("unrelated-owner") != "" || taskAttention("") != "" {
+	if todoHTML("unrelated-owner") != "" || todoHTML("") != "" {
 		t.Fatal("task attention crossed ownership")
 	}
 }

--- a/home/todo.go
+++ b/home/todo.go
@@ -1,0 +1,51 @@
+package home
+
+import (
+	"html"
+	"strings"
+	"time"
+
+	"mu/internal/app"
+	"mu/service/tasks"
+)
+
+// todoHTML uses current owned records; the brief never invents action items.
+func todoHTML(accountID string) string {
+	if accountID == "" {
+		return ""
+	}
+	var rows []string
+	total := 0
+	for _, status := range []string{tasks.StatusBlocked, tasks.StatusFailed, tasks.StatusTodo} {
+		for _, task := range tasks.List(accountID, status) {
+			if status == tasks.StatusTodo && task.Assignee != tasks.Me {
+				continue
+			}
+			total++
+			if len(rows) == 5 {
+				continue
+			}
+			label := "To do"
+			switch status {
+			case tasks.StatusBlocked:
+				label = "Blocked · review what is needed"
+			case tasks.StatusFailed:
+				label = "Failed · review before retrying"
+			default:
+				if !task.Due.IsZero() {
+					if task.Due.Before(time.Now()) {
+						label = "Overdue"
+					} else if sameDay(task.Due, time.Now()) {
+						label = "Due today"
+					}
+				}
+			}
+			link := app.TextLink(html.EscapeString(task.Title), "/tasks?status="+status+"#task-"+task.ID)
+			rows = append(rows, "<li>"+link+` <span class="text-muted">`+html.EscapeString(label)+"</span></li>")
+		}
+	}
+	if total == 0 {
+		return ""
+	}
+	return sectionRule("To do") + `<div class="brief-peek"><ul>` + strings.Join(rows, "") + `</ul>` + app.TextLink("View all tasks", "/tasks") + `</div>`
+}

--- a/internal/app/html/composition.css
+++ b/internal/app/html/composition.css
@@ -164,3 +164,8 @@ a.link-text {
   text-underline-offset: 3px;
 }
 .link-text:hover, .link-text:focus-visible { text-decoration-thickness: 2px; }
+
+/* Permission notices sit outside untrusted content and use ordinary actions. */
+.access-notice { flex: none; padding: var(--space-control) var(--space-field); font: 14px system-ui; background: Canvas; color: CanvasText; border-bottom: 1px solid GrayText; }
+.access-notice[hidden] { display: none; }
+.access-notice .btn-quiet { color: CanvasText; border-color: GrayText; }

--- a/service/apps/sandbox.go
+++ b/service/apps/sandbox.go
@@ -133,27 +133,30 @@ const sandboxCSP = "sandbox allow-scripts allow-forms allow-popups allow-modals;
 const appShimJS = `<script>
 (function(){
   var seq=0, waiting={};
-  window.addEventListener('message', function(e){
+  var channel=new MessageChannel(), connection=channel.port1;
+  connection.onmessage=function(e){
     var m=e.data;
-    if(e.source!==parent||!m||!waiting[m.id]) return;
+    if(!m||!waiting[m.id]) return;
     var w=waiting[m.id];
     if(m.mu==='event'){
       if(w.onEvent){try{w.onEvent(m.event)}catch(err){
         delete waiting[m.id]; clearTimeout(w.timer);
-        parent.postMessage({mu:'cancel',id:m.id},'*'); w.reject(err);
+        connection.postMessage({mu:'cancel',id:m.id}); w.reject(err);
       }}
       return;
     }
     if(m.mu!=='reply') return;
     delete waiting[m.id]; clearTimeout(w.timer);
     if(m.error){ w.reject(new Error(m.error)); } else { w.resolve(m.result); }
-  });
+  };
+  connection.start();
+  parent.postMessage({mu:'connect'},'*',[channel.port2]);
   function ask(op, args, onEvent){
     return new Promise(function(resolve,reject){
       var id=++seq; waiting[id]={resolve:resolve,reject:reject,onEvent:onEvent};
-      parent.postMessage({mu:'call', id:id, op:op, args:args||{}}, '*');
+      connection.postMessage({mu:'call', id:id, op:op, args:args||{}});
       waiting[id].timer=setTimeout(function(){ if(waiting[id]){
-        delete waiting[id]; parent.postMessage({mu:'cancel',id:id},'*');
+        delete waiting[id]; connection.postMessage({mu:'cancel',id:id});
         reject(new Error('Connection timed out. The request may still be running; check your conversation before trying again.'));
       } }, op==='agent.stream'?360000:60000);
     });
@@ -399,12 +402,25 @@ func appBridgeJS(slug string) string {
     return parts.length?('?'+parts.join('&')):'';
   }
 
+  var connection;
   window.addEventListener('message', function(e){
-    var m=e.data;
-    if(!m||(m.mu!=='call'&&m.mu!=='cancel')) return;
-    // Only the frame we created. A sandboxed frame has a null origin, so the
-    // window identity is the check that means anything.
+    // A WindowProxy survives navigation. A MessagePort belongs to one
+    // document, so its replacement must connect and revoke before any call.
     if(!frame||e.source!==frame.contentWindow) return;
+    if(!e.data||e.data.mu!=='connect'||!e.ports||e.ports.length!==1) return;
+    revokeAgent();
+    if(connection) connection.close();
+    var port=e.ports[0];connection=port;
+    var target={postMessage:function(message){port.postMessage(message)}};
+    port.onmessage=function(event){
+      if(connection!==port) return;
+      handle(event.data,target);
+    };
+    port.start();
+  });
+
+  function handle(m,target){
+    if(!m||(m.mu!=='call'&&m.mu!=='cancel')) return;
     if(m.mu==='cancel'){cancelStream(m.id);return;}
 
     var op=String(m.op||''), args=m.args||{};
@@ -412,16 +428,16 @@ func appBridgeJS(slug string) string {
     // for this open page, never localStorage or a grant shared with other apps.
     // All other account operations still require their own approval.
     var agentOp=op==='agent'||op==='agent.stream';
-    if(agentOp&&csrf()!==pageCSRF){revokeAgent();reply(e.source,m.id,null,'Your sign-in changed. Reload this app before continuing.');return;}
+    if(agentOp&&csrf()!==pageCSRF){revokeAgent();reply(target,m.id,null,'Your sign-in changed. Reload this app before continuing.');return;}
     var personal=op==='user'||(OPS[op]&&OPS[op].m==='POST')||op==='sdk:service'||op==='sdk:ai'||op==='sdk:fetch';
     if(personal&&!(agentOp&&agentAllowed)){
       var detail=JSON.stringify(args);
-      if(detail.length>16000){reply(e.source,m.id,null,'Request too large to review');return;}
+      if(detail.length>16000){reply(target,m.id,null,'Request too large to review');return;}
       var question=agentOp
         ? 'Allow '+SLUG+' to use your agent while this page is open?\n\nThis app can send requests, receive answers, use your credits, and ask the agent to access private data or take actions with its tools. Data may go to the configured AI provider. Only allow an app you trust. You can revoke access at the top of this page.\n\nFirst request: '+detail
         : 'Allow '+SLUG+' to use your account for '+op+'?\n\nThe result will be visible to this app. Requests may send private data to the configured AI provider and take actions using your tools.\n\n'+detail;
       if(!window.confirm(question)){
-        reply(e.source,m.id,null,'Request declined');return;
+        reply(target,m.id,null,'Request declined');return;
       }
       if(agentOp){agentAllowed=true;if(access) access.hidden=false;}
     }
@@ -430,18 +446,18 @@ func appBridgeJS(slug string) string {
     // path. These were never the problem.
     if(op.indexOf('sdk:')===0){
       var sub=op.slice(4);
-      if(PROXY.indexOf(sub)<0){ reply(e.source,m.id,null,'unknown operation'); return; }
+      if(PROXY.indexOf(sub)<0){ reply(target,m.id,null,'unknown operation'); return; }
       fetch('/apps/'+encodeURIComponent(SLUG)+'/sdk/'+sub,{
         method:'POST',headers:{'Content-Type':j,'Accept':j,'X-CSRF-Token':csrf()},
         body:JSON.stringify(args)})
         .then(function(r){return r.json()})
-        .then(function(d){reply(e.source,m.id,d,null)})
-        .catch(function(err){reply(e.source,m.id,null,String(err))});
+        .then(function(d){reply(target,m.id,d,null)})
+        .catch(function(err){reply(target,m.id,null,String(err))});
       return;
     }
 
     var spec=OPS[op];
-    if(!spec){ reply(e.source,m.id,null,'this app asked for something it is not allowed to do: '+op); return; }
+    if(!spec){ reply(target,m.id,null,'this app asked for something it is not allowed to do: '+op); return; }
 
     var path=spec.p;
     if(spec.s){ path=path+segment(args.suffix); }
@@ -456,7 +472,7 @@ func appBridgeJS(slug string) string {
       init.body=JSON.stringify(args.body||{});
     }
     if(op==='agent.stream'){
-      streamAgent(e.source,m.id,path,args.body||{},init);
+      streamAgent(target,m.id,path,args.body||{},init);
       return;
     }
     var generation=accessGeneration, controller;
@@ -464,10 +480,10 @@ func appBridgeJS(slug string) string {
     function current(){return !agentOp||generation===accessGeneration;}
     fetch(path,init)
       .then(function(r){return r.json().catch(function(){return {}})})
-      .then(function(d){if(current()) reply(e.source,m.id,d,null)})
-      .catch(function(err){if(current()) reply(e.source,m.id,null,String(err))})
+      .then(function(d){if(current()) reply(target,m.id,d,null)})
+      .catch(function(err){if(current()) reply(target,m.id,null,String(err))})
       .finally(function(){if(controller) agentRequests.delete(controller)});
-  });
+  }
 })();
 </script>`
 }
@@ -496,14 +512,12 @@ func sandboxPage(slug, title string) string {
 	// Canvas is the system background and color-scheme is what tells the
 	// browser which one to use. Two words, no media query, and it follows the
 	// reader rather than a guess made here.
+	b.WriteString(`<link rel="stylesheet" href="/composition.css">`)
 	b.WriteString(`<style>html,body{margin:0;padding:0;height:100%;background:Canvas;color-scheme:light dark}
 body{display:flex;flex-direction:column}
-#app-agent-access{flex:none;padding:8px 12px;font:14px system-ui;background:Canvas;color:CanvasText;border-bottom:1px solid GrayText}
-#app-agent-access[hidden]{display:none}
-#app-agent-revoke{margin-left:8px;font:inherit}
 #app-frame{display:block;width:100%;flex:1;min-height:0;border:0;background:Canvas}</style>`)
 	b.WriteString(`</head><body>`)
-	b.WriteString(`<div id="app-agent-access" hidden>Agent access allowed for this page. <button id="app-agent-revoke" type="button">Revoke access</button></div>`)
+	b.WriteString(`<div id="app-agent-access" class="access-notice section-actions" hidden><span>Agent access allowed for this page.</span><button id="app-agent-revoke" class="btn btn-quiet" type="button">Revoke access</button></div>`)
 	// The app itself, not /run. That word is retired — see embed.go — and the
 	// document is at the app's own address with raw=1.
 	b.WriteString(`<iframe id="app-frame" src="/apps/` + html.EscapeString(slug) +

--- a/service/apps/sandbox.go
+++ b/service/apps/sandbox.go
@@ -368,11 +368,15 @@ func appBridgeJS(slug string) string {
   var frame=document.getElementById('app-frame');
   var j='application/json';
   var agentAllowed=false;
+  var agentRequests=new Set();
+  var accessGeneration=0;
   var pageCSRF=csrf();
   var access=document.getElementById('app-agent-access');
   var revoke=document.getElementById('app-agent-revoke');
   function revokeAgent(){
     agentAllowed=false;
+    accessGeneration++;
+    agentRequests.forEach(function(c){c.abort()});agentRequests.clear();
     if(access) access.hidden=true;
     cancelStreams();
   }
@@ -455,10 +459,14 @@ func appBridgeJS(slug string) string {
       streamAgent(e.source,m.id,path,args.body||{},init);
       return;
     }
+    var generation=accessGeneration, controller;
+    if(agentOp){controller=new AbortController();agentRequests.add(controller);init.signal=controller.signal;}
+    function current(){return !agentOp||generation===accessGeneration;}
     fetch(path,init)
       .then(function(r){return r.json().catch(function(){return {}})})
-      .then(function(d){reply(e.source,m.id,d,null)})
-      .catch(function(err){reply(e.source,m.id,null,String(err))});
+      .then(function(d){if(current()) reply(e.source,m.id,d,null)})
+      .catch(function(err){if(current()) reply(e.source,m.id,null,String(err))})
+      .finally(function(){if(controller) agentRequests.delete(controller)});
   });
 })();
 </script>`

--- a/service/apps/sandbox.go
+++ b/service/apps/sandbox.go
@@ -367,6 +367,17 @@ func appBridgeJS(slug string) string {
   var SLUG=` + jsString(slug) + `;
   var frame=document.getElementById('app-frame');
   var j='application/json';
+  var agentAllowed=false;
+  var pageCSRF=csrf();
+  var access=document.getElementById('app-agent-access');
+  var revoke=document.getElementById('app-agent-revoke');
+  function revokeAgent(){
+    agentAllowed=false;
+    if(access) access.hidden=true;
+    cancelStreams();
+  }
+  if(revoke) revoke.addEventListener('click',revokeAgent);
+
   ` + appAgentStreamJS + `
 
   function csrf(){var m=document.cookie.match(/(?:^|; )csrf_token=([^;]+)/);return m?decodeURIComponent(m[1]):'';}
@@ -393,16 +404,22 @@ func appBridgeJS(slug string) string {
     if(m.mu==='cancel'){cancelStream(m.id);return;}
 
     var op=String(m.op||''), args=m.args||{};
-    // The iframe cannot authorize use of the viewer's account. This prompt
-    // belongs to the trusted parent and is deliberately per request: an app
-    // can change after publication, and its own Send button is untrusted code.
+    // Only the trusted parent can grant account access. Agent access lasts
+    // for this open page, never localStorage or a grant shared with other apps.
+    // All other account operations still require their own approval.
+    var agentOp=op==='agent'||op==='agent.stream';
+    if(agentOp&&csrf()!==pageCSRF){revokeAgent();reply(e.source,m.id,null,'Your sign-in changed. Reload this app before continuing.');return;}
     var personal=op==='user'||(OPS[op]&&OPS[op].m==='POST')||op==='sdk:service'||op==='sdk:ai'||op==='sdk:fetch';
-    if(personal){
+    if(personal&&!(agentOp&&agentAllowed)){
       var detail=JSON.stringify(args);
       if(detail.length>16000){reply(e.source,m.id,null,'Request too large to review');return;}
-      if(!window.confirm('Allow '+SLUG+' to use your account for '+op+'?\n\nThe result will be visible to this app. Agent requests may send private data to the configured AI provider and take actions using your tools.\n\n'+detail)){
+      var question=agentOp
+        ? 'Allow '+SLUG+' to use your agent while this page is open?\n\nThis app can send requests, receive answers, use your credits, and ask the agent to access private data or take actions with its tools. Data may go to the configured AI provider. Only allow an app you trust. You can revoke access at the top of this page.\n\nFirst request: '+detail
+        : 'Allow '+SLUG+' to use your account for '+op+'?\n\nThe result will be visible to this app. Requests may send private data to the configured AI provider and take actions using your tools.\n\n'+detail;
+      if(!window.confirm(question)){
         reply(e.source,m.id,null,'Request declined');return;
       }
+      if(agentOp){agentAllowed=true;if(access) access.hidden=false;}
     }
 
     // The server-side proxy: caller bound from the session, app named in the
@@ -431,7 +448,7 @@ func appBridgeJS(slug string) string {
     if(spec.m==='POST'){
       init.method='POST';
       init.headers['Content-Type']=j;
-      init.headers['X-CSRF-Token']=csrf();
+      init.headers['X-CSRF-Token']=agentOp?pageCSRF:csrf();
       init.body=JSON.stringify(args.body||{});
     }
     if(op==='agent.stream'){
@@ -472,8 +489,13 @@ func sandboxPage(slug, title string) string {
 	// browser which one to use. Two words, no media query, and it follows the
 	// reader rather than a guess made here.
 	b.WriteString(`<style>html,body{margin:0;padding:0;height:100%;background:Canvas;color-scheme:light dark}
-#app-frame{display:block;width:100%;height:100%;border:0;background:Canvas}</style>`)
+body{display:flex;flex-direction:column}
+#app-agent-access{flex:none;padding:8px 12px;font:14px system-ui;background:Canvas;color:CanvasText;border-bottom:1px solid GrayText}
+#app-agent-access[hidden]{display:none}
+#app-agent-revoke{margin-left:8px;font:inherit}
+#app-frame{display:block;width:100%;flex:1;min-height:0;border:0;background:Canvas}</style>`)
 	b.WriteString(`</head><body>`)
+	b.WriteString(`<div id="app-agent-access" hidden>Agent access allowed for this page. <button id="app-agent-revoke" type="button">Revoke access</button></div>`)
 	// The app itself, not /run. That word is retired — see embed.go — and the
 	// document is at the app's own address with raw=1.
 	b.WriteString(`<iframe id="app-frame" src="/apps/` + html.EscapeString(slug) +

--- a/service/apps/static/agent-stream.js
+++ b/service/apps/static/agent-stream.js
@@ -9,10 +9,10 @@ var frameLoaded=false;
 if(frame) frame.addEventListener('load',function(){
   // An inline app script can start work before its first load event. That
   // event finishes initialization; only subsequent loads leave a document.
-  if(frameLoaded) cancelStreams();
+  if(frameLoaded) revokeAgent();
   frameLoaded=true;
 });
-window.addEventListener('pagehide',cancelStreams);
+window.addEventListener('pagehide',revokeAgent);
 
 async function streamAgent(win,id,path,body,init){
   if(!Number.isSafeInteger(id)||streams.has(id)) return;

--- a/service/apps/testdata/agent-stream.mjs
+++ b/service/apps/testdata/agent-stream.mjs
@@ -9,7 +9,7 @@ function bridge(fetcher,confirm=()=>true){
   const win={postMessage:m=>messages.push(m)};
   const frame={contentWindow:win,addEventListener:(name,fn)=>frameListeners[name]=fn};
   const access={hidden:true},revoke={addEventListener:(name,fn)=>listeners.revoke=fn};
-  const context={Map,Number,AbortController,TextDecoder,setTimeout,clearTimeout,
+  const context={Map,Set,Number,AbortController,TextDecoder,setTimeout,clearTimeout,
     document:{getElementById:id=>id==='app-frame'?frame:id==='app-agent-access'?access:revoke,cookie:'csrf_token=secret'},
     window:{confirm,addEventListener:(name,fn)=>listeners[name]=fn},
     fetch:(path,init)=>{calls.push({path,init});return fetcher(path,init)}};
@@ -136,4 +136,14 @@ for (const op of ['agent', 'agent.stream', 'chat', 'blog.create', 'user', 'sdk:s
  assert.equal(b.calls.length,1,'page consent cannot follow an account switch');
  assert.match(b.messages.at(-1).error,/sign-in changed/);
  assert.equal(b.access.hidden,true);
+}
+
+{
+ let finish;
+ const b=bridge(()=>new Promise(resolve=>finish=resolve));
+ b.call(1,'agent');
+ b.listeners.revoke();
+ assert.equal(b.calls[0].init.signal.aborted,true,'revocation aborts legacy agent requests too');
+ finish(new Response('{}')); await tick();await tick();
+ assert.equal(b.messages.length,0,'late answers are not delivered after revocation');
 }

--- a/service/apps/testdata/agent-stream.mjs
+++ b/service/apps/testdata/agent-stream.mjs
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
 import {readFileSync} from 'node:fs';
 import vm from 'node:vm';
+import {MessageChannel as NativeMessageChannel} from 'node:worker_threads';
 const sources=JSON.parse(readFileSync(process.argv[2],'utf8'));
 const script=s=>s.replace(/^<script>\s*/, '').replace(/<\/script>\s*$/, '');
 const tick=()=>new Promise(resolve=>setImmediate(resolve));
@@ -14,8 +15,16 @@ function bridge(fetcher,confirm=()=>true){
     window:{confirm,addEventListener:(name,fn)=>listeners[name]=fn},
     fetch:(path,init)=>{calls.push({path,init});return fetcher(path,init)}};
   vm.runInNewContext(script(sources.bridge),context);
-  return {messages,calls,frameListeners,listeners,win,access,document:context.document,
-    call:(id=1,op='agent.stream',source=win)=>listeners.message({source,data:{mu:'call',id,op,args:{body:{prompt:'Hello',context_id:'conversation'}}}})};
+  let port;
+  function connect(){
+    port={postMessage:m=>messages.push(m),start(){},close(){}};
+    listeners.message({source:win,data:{mu:'connect'},ports:[port]});
+    return port;
+  }
+  connect();
+  return {messages,calls,frameListeners,listeners,win,access,document:context.document,connect,
+    cancel:id=>port.onmessage({data:{mu:'cancel',id}}),
+    call:(id=1,op='agent.stream',source=win)=>source===win?port.onmessage({data:{mu:'call',id,op,args:{body:{prompt:'Hello',context_id:'conversation'}}}}):listeners.message({source,data:{mu:'call',id,op}})};
 }
 const wire=events=>events.map(e=>'data: '+JSON.stringify(e)+'\r\n\r\n').join('');
 const identity={type:'flow_id',flow_id:'run',thread:'conversation'};
@@ -59,7 +68,7 @@ for(const action of ['load','pagehide','cancel','revoke']){
   if(action==='load'){b.frameListeners.load();b.frameListeners.load();}
   if(action==='pagehide') b.listeners.pagehide();
   if(action==='revoke') b.listeners.revoke();
-  if(action==='cancel') b.listeners.message({source:b.win,data:{mu:'cancel',id:1}});
+  if(action==='cancel') b.cancel(1);
   await tick();
   assert.equal(b.calls[0].init.signal.aborted,true);
   assert.equal(b.messages.length,0,'a detached/cancelled frame must receive no late result');
@@ -67,7 +76,9 @@ for(const action of ['load','pagehide','cancel','revoke']){
 {
   const posted=[],listeners={};
   const parent={postMessage:m=>posted.push(m)};
-  const ctx={parent,Promise,Error,setTimeout,clearTimeout,addEventListener:(name,fn)=>listeners[name]=fn};
+  let receiver;
+  class MessageChannel {constructor(){this.port1={postMessage:m=>posted.push(m),start(){}};this.port2={};receiver=this.port1;}}
+  const ctx={MessageChannel,parent,Promise,Error,setTimeout,clearTimeout,addEventListener:(name,fn)=>listeners[name]=fn};
   ctx.window=ctx;
   vm.createContext(ctx);vm.runInContext(script(sources.shim),ctx);
   const events=[];
@@ -75,18 +86,18 @@ for(const action of ['load','pagehide','cancel','revoke']){
   const request=posted.at(-1);
   assert.equal(request.op,'agent.stream');
   assert.equal(request.args.body.context_id,'conversation');
-  listeners.message({source:{},data:{mu:'reply',id:request.id,result:'forged'}});
-  listeners.message({source:parent,data:{mu:'event',id:request.id,event:{type:'stream_token',text:'Hello'}}});
+  assert.equal(listeners.message,undefined,'the shim does not accept window messages as replies');
+  receiver.onmessage({data:{mu:'event',id:request.id,event:{type:'stream_token',text:'Hello'}}});
   assert.equal(events.length,1);
-  listeners.message({source:parent,data:{mu:'reply',id:request.id,result:{answer:'Hello',thread:'conversation'}}});
+  receiver.onmessage({data:{mu:'reply',id:request.id,result:{answer:'Hello',thread:'conversation'}}});
   assert.equal((await result).answer,'Hello');
   const old=ctx.mu.agent('Hello');const oldRequest=posted.at(-1);
   assert.equal(oldRequest.op,'agent');
-  listeners.message({source:parent,data:{mu:'reply',id:oldRequest.id,result:{answer:'Unchanged'}}});
+  receiver.onmessage({data:{mu:'reply',id:oldRequest.id,result:{answer:'Unchanged'}}});
   assert.equal(await old,'Unchanged');
   const failed=ctx.mu.agent.stream('Hello',{onEvent:()=>{throw new Error('callback failed')}});
   const bad=posted.at(-1);
-  listeners.message({source:parent,data:{mu:'event',id:bad.id,event:{type:'stream_token',text:'Hello'}}});
+  receiver.onmessage({data:{mu:'event',id:bad.id,event:{type:'stream_token',text:'Hello'}}});
   await assert.rejects(failed,/callback failed/);
   assert.equal(posted.at(-1).mu,'cancel');
 }
@@ -146,4 +157,35 @@ for (const op of ['agent', 'agent.stream', 'chat', 'blog.create', 'user', 'sdk:s
  assert.equal(b.calls[0].init.signal.aborted,true,'revocation aborts legacy agent requests too');
  finish(new Response('{}')); await tick();await tick();
  assert.equal(b.messages.length,0,'late answers are not delivered after revocation');
+}
+
+// A replacement document connects before load. It cannot inherit consent,
+// even though its WindowProxy is exactly the same object.
+{
+ let prompts=0;
+ const b=bridge(()=>Promise.resolve(new Response('{}')),()=>{prompts++;return true});
+ b.call(1,'agent'); await tick(); assert.equal(prompts,1);
+ const old=b.connect();
+ b.call(2,'agent'); await tick(); assert.equal(prompts,2);
+ b.connect();
+ old.onmessage({data:{mu:'call',id:3,op:'agent',args:{}}});
+ assert.equal(b.calls.length,2,'a superseded document port cannot send requests');
+ b.listeners.message({source:b.win,data:{mu:'call',id:4,op:'agent',args:{}}});
+ assert.equal(b.calls.length,2,'raw window calls cannot borrow a page grant');
+}
+
+// Exercise the full shim/parent path using real transferable message ports.
+{
+ const channels=[];
+ const b=bridge(()=>Promise.resolve(new Response(wire([identity,final,done]),{headers:{'Content-Type':'text/event-stream'}})));
+ class MessageChannel extends NativeMessageChannel {constructor(){super();channels.push(this)}}
+ const parent={postMessage:(data,origin,ports)=>b.listeners.message({source:b.win,data,ports})};
+ const ctx={MessageChannel,parent,Promise,Error,setTimeout,clearTimeout,addEventListener(){}};
+ ctx.window=ctx;
+ vm.runInNewContext(script(sources.shim),ctx);
+ try {
+  const result=await ctx.mu.agent.stream('Hello');
+  assert.equal(result.answer,'Hello 🌍');
+  assert.equal(result.thread,'conversation');
+ } finally {for(const c of channels){c.port1.close();c.port2.close()}}
 }

--- a/service/apps/testdata/agent-stream.mjs
+++ b/service/apps/testdata/agent-stream.mjs
@@ -8,12 +8,13 @@ function bridge(fetcher,confirm=()=>true){
   const messages=[],listeners={},frameListeners={},calls=[];
   const win={postMessage:m=>messages.push(m)};
   const frame={contentWindow:win,addEventListener:(name,fn)=>frameListeners[name]=fn};
+  const access={hidden:true},revoke={addEventListener:(name,fn)=>listeners.revoke=fn};
   const context={Map,Number,AbortController,TextDecoder,setTimeout,clearTimeout,
-    document:{getElementById:()=>frame,cookie:'csrf_token=secret'},
+    document:{getElementById:id=>id==='app-frame'?frame:id==='app-agent-access'?access:revoke,cookie:'csrf_token=secret'},
     window:{confirm,addEventListener:(name,fn)=>listeners[name]=fn},
     fetch:(path,init)=>{calls.push({path,init});return fetcher(path,init)}};
   vm.runInNewContext(script(sources.bridge),context);
-  return {messages,calls,frameListeners,listeners,win,
+  return {messages,calls,frameListeners,listeners,win,access,document:context.document,
     call:(id=1,op='agent.stream',source=win)=>listeners.message({source,data:{mu:'call',id,op,args:{body:{prompt:'Hello',context_id:'conversation'}}}})};
 }
 const wire=events=>events.map(e=>'data: '+JSON.stringify(e)+'\r\n\r\n').join('');
@@ -52,11 +53,12 @@ for(const [name,response,expected] of [
   assert.ok(b.messages.at(-1).error.includes(expected),name+': '+JSON.stringify(b.messages));
   assert.equal(b.calls.length,1,'a failed stream must never rerun the prompt');
 }
-for(const action of ['load','pagehide','cancel']){
+for(const action of ['load','pagehide','cancel','revoke']){
   const b=bridge((path,init)=>new Promise((resolve,reject)=>init.signal.addEventListener('abort',()=>reject(new DOMException('Aborted','AbortError')))));
   b.call();b.call();assert.equal(b.calls.length,1,'duplicate request IDs must not start duplicate work');
   if(action==='load'){b.frameListeners.load();b.frameListeners.load();}
   if(action==='pagehide') b.listeners.pagehide();
+  if(action==='revoke') b.listeners.revoke();
   if(action==='cancel') b.listeners.message({source:b.win,data:{mu:'cancel',id:1}});
   await tick();
   assert.equal(b.calls[0].init.signal.aborted,true);
@@ -106,4 +108,32 @@ for (const op of ['agent', 'agent.stream', 'chat', 'blog.create', 'user', 'sdk:s
  const b=bridge(()=>Promise.resolve(new Response('{}')));
  b.call(1,'blog.list'); await tick();
  assert.equal(b.calls[0].init.credentials,'omit','public reads cannot borrow the viewer');
+}
+
+// A page grant covers only agent requests and remains under parent control.
+{
+ let prompts=0;
+ const b=bridge(()=>Promise.resolve(new Response('{}')),()=>{prompts++;return true});
+ b.call(1,'agent'); b.call(2,'agent'); await tick();
+ assert.equal(prompts,1);
+ assert.equal(b.access.hidden,false);
+ b.call(3,'sdk:service'); await tick(); assert.equal(prompts,2);
+ b.listeners.revoke(); assert.equal(b.access.hidden,true);
+ b.call(4,'agent'); await tick(); assert.equal(prompts,3);
+ b.frameListeners.load(); b.frameListeners.load();
+ b.call(5,'agent'); await tick(); assert.equal(prompts,4);
+ b.listeners.pagehide();
+ b.call(6,'agent'); await tick(); assert.equal(prompts,5);
+ const other=bridge(()=>Promise.resolve(new Response('{}')),()=>{prompts++;return true});
+ other.call(1,'agent'); await tick(); assert.equal(prompts,6);
+}
+
+{
+ const b=bridge(()=>Promise.resolve(new Response('{}')));
+ b.call(1,'agent'); await tick();
+ b.document.cookie='csrf_token=another-session';
+ b.call(2,'agent'); await tick();
+ assert.equal(b.calls.length,1,'page consent cannot follow an account switch');
+ assert.match(b.messages.at(-1).error,/sign-in changed/);
+ assert.equal(b.access.hidden,true);
 }

--- a/service/tasks/handler.go
+++ b/service/tasks/handler.go
@@ -202,7 +202,7 @@ func taskCard(t *Task, csrf, label string, actionURL func(string) string) string
 	if !t.Open() {
 		class += " task-done"
 	}
-	fmt.Fprintf(&b, `<div class="%s" data-task-id="%s" data-task-status="%s">`, class, html.EscapeString(t.ID), html.EscapeString(t.Status))
+	fmt.Fprintf(&b, `<div class="%s" id="task-%s" data-task-id="%s" data-task-status="%s">`, class, html.EscapeString(t.ID), html.EscapeString(t.ID), html.EscapeString(t.Status))
 
 	fmt.Fprintf(&b, `<div class="task-title">%s</div>`, html.EscapeString(t.Title))
 


### PR DESCRIPTION
Home buried failed, blocked and pending tasks in the briefing sentence, while Assistant asked for account permission on every message.

This change gives Home a separate To do section populated from current owned task records. It shows up to five task titles, prioritises blocked/failed work for review, includes personal pending tasks, and links directly to task cards. Task actions are removed from brief prose, including its refreshed response. Titles are escaped and queued agent work is not presented as the user's to-do.

The trusted app parent now asks explicitly for agent access for the current open page. Subsequent agent messages use that consent, with a persistent Revoke access control. Other account operations still require individual confirmation. Consent is memory-only, clears on iframe reload/page exit, and is bound to the original session's CSRF token so it cannot follow an account switch. Revocation aborts active streams; it cannot undo actions already performed.

This is an explicit grant to use the account's existing agent, including its tools and credits, not a new reduced-permission agent or persistent app capability system. The initial consent describes that authority and model disclosure. Broader capability isolation remains tracked in #1653.

Validation: go test ./home ./service/apps ./service/tasks -short passed with Node present, including bridge execution covering repeat messages, rejection, unrelated operations/windows, revoke, iframe navigation, page exit and account change. Home tests cover ownership, escaping and separation from the brief. gofmt and git diff --check passed. No claim of final interactive verification/publication of the separate Copy candidate (#1646).