### PR TITLE
Match Todo section to Inbox and Agents styling

### DIFF
--- a/home/task_attention_test.go
+++ b/home/task_attention_test.go
@@ -38,7 +38,7 @@ func TestTaskAttentionShowsFailedAndBlockedOwnedWork(t *testing.T) {
 			t.Fatal(part)
 		}
 	}
-	for _, want := range []string{"/tasks?status=failed", "/tasks?status=blocked", "review before retrying", sectionRule("To do")} {
+	for _, want := range []string{"/tasks?status=failed", "/tasks?status=blocked", "review before retrying", sectionRule("Todo")} {
 		if !strings.Contains(out, want) {
 			t.Errorf("attention summary missing %q: %s", want, out)
 		}

--- a/home/todo.go
+++ b/home/todo.go
@@ -25,7 +25,7 @@ func todoHTML(accountID string) string {
 			if len(rows) == 5 {
 				continue
 			}
-			label := "To do"
+			label := "Todo"
 			switch status {
 			case tasks.StatusBlocked:
 				label = "Blocked · review what is needed"
@@ -40,12 +40,12 @@ func todoHTML(accountID string) string {
 					}
 				}
 			}
-			link := app.TextLink(html.EscapeString(task.Title), "/tasks?status="+status+"#task-"+task.ID)
-			rows = append(rows, "<li>"+link+` <span class="text-muted">`+html.EscapeString(label)+"</span></li>")
+			link := "/tasks?status=" + status + "#task-" + task.ID
+			rows = append(rows, `<a class="peek-row" href="`+html.EscapeString(link)+`"><span class="peek-head"><span class="peek-title">`+html.EscapeString(task.Title)+`</span></span><span class="peek-line">`+html.EscapeString(label)+`</span></a>`)
 		}
 	}
 	if total == 0 {
 		return ""
 	}
-	return sectionRule("To do") + `<div class="brief-peek"><ul>` + strings.Join(rows, "") + `</ul>` + app.TextLink("View all tasks", "/tasks") + `</div>`
+	return sectionRule("Todo") + `<div class="todo-peek">` + strings.Join(rows, "") + `</div>` + app.SectionLink("Go to tasks", "/tasks")
 }

--- a/internal/app/html/mu.css
+++ b/internal/app/html/mu.css
@@ -6422,6 +6422,7 @@ button.pill:hover {
    caption that had escaped its card. */
 .brief-peek,
 .inbox-peek,
+.todo-peek,
 .agent-peek,
 .wallet-peek {
   border: var(--border-width, 1px) solid var(--card-border, #e8e8e8);


### PR DESCRIPTION
The Todo section used a bulleted list inside the Brief card, so its indentation, spacing and footer differed from Inbox and Agents.

Rename the heading to Todo. Reuse Inbox's clickable preview rows, title/status lines and SectionLink footer; add the Todo card to the existing shared preview-card rule. Task selection and direct task links are unchanged.

Validation: existing Home tests pass; gofmt and git diff --check pass. This is a small markup/style correction with no new layout system.