### PR TITLE
Even out Todo card vertical padding

### DIFF
--- a/internal/app/html/mu.css
+++ b/internal/app/html/mu.css
@@ -6432,6 +6432,10 @@ button.pill:hover {
   margin: 0;
 }
 
+/* Todo rows already supply their own vertical padding. Keep the outer
+   inset equal above the first row and below the last. */
+.todo-peek { padding-block: 4px; }
+
 /* The brief's own padding is even, unlike the two below it. Theirs is 4px at
    the top because their first child is a row carrying 11px of its own; this
    holds a paragraph, and 4px above a sentence with 12px under it sits it


### PR DESCRIPTION
Todo inherited 4px top and 12px bottom padding from the preview card rule, in addition to its rows' symmetric 11px padding. This left eight extra pixels below the last item.

Set Todo's outer vertical padding to 4px on both sides. Existing shared row, horizontal spacing and footer styles remain in use.

Verified the CSS cascade and git diff --check. No new tests for this CSS-only correction.