### PR TITLE
Replace redundant Home footer links with linked headings

### DIFF
--- a/agent/preview.go
+++ b/agent/preview.go
@@ -30,6 +30,7 @@ package agent
 
 import (
 	"html"
+	"strconv"
 	"strings"
 	"time"
 
@@ -121,6 +122,7 @@ func Preview(accountID string) string {
 		rows = append(rows, entryOf{ID: a.ID, Name: name, Path: Path(accountID, a.ID)})
 	}
 
+	total := len(rows)
 	if len(rows) > previewShown {
 		rows = rows[:previewShown]
 	}
@@ -148,7 +150,9 @@ func Preview(accountID string) string {
 		b.WriteString(`</a>`)
 	}
 	b.WriteString(`</div>`)
-	b.WriteString(app.SectionLink("Go to agents", "/agents"))
+	if n := total - len(rows); n > 0 {
+		b.WriteString(app.SectionLink(strconv.Itoa(n)+" more", "/agents"))
+	}
 	return b.String()
 }
 

--- a/home/apps.go
+++ b/home/apps.go
@@ -31,6 +31,6 @@ func appsHTML(acc *auth.Account) string {
 	for _, s := range apps {
 		b.WriteString(`<a href="` + html.EscapeString(s.Page) + `"><span class="home-app-icon"><img src="/` + html.EscapeString(s.NavIcon()) + `" alt=""></span><span>` + html.EscapeString(s.NavLabel()) + `</span></a>`)
 	}
-	b.WriteString(`</div>` + app.SectionLink("Go to services", "/services") + `</nav>`)
+	b.WriteString(`</div></nav>`)
 	return b.String()
 }

--- a/home/apps_test.go
+++ b/home/apps_test.go
@@ -25,7 +25,7 @@ func TestAppsAlwaysOfferUsefulDefaults(t *testing.T) {
 				t.Errorf("missing default %s for %#v", name, acc)
 			}
 		}
-		if !strings.Contains(body, sectionRule("Services")) || !strings.Contains(body, `</div><a class="section-link" href="/services">Go to services →</a>`) {
+		if !strings.Contains(body, sectionRule("Services")) || strings.Contains(body, "Go to services") {
 			t.Error("launcher heading or catalogue link misplaced")
 		}
 	}

--- a/home/home.go
+++ b/home/home.go
@@ -572,7 +572,11 @@ func htmlEsc(s string) string { return html.EscapeString(s) }
 // as a caption on the thing below it rather than as a break between two things,
 // which is why the sections did not look like sections.
 func sectionRule(label string) string {
-	return `<p class="home-section"><small>` + htmlEsc(label) + `</small></p>`
+	text := htmlEsc(label)
+	if href := map[string]string{"Todo": "/tasks", "Inbox": "/inbox", "Agents": "/agents", "Upcoming": "/events", "Services": "/services", "Account": "/account"}[label]; href != "" {
+		text = app.TextLink(text, href)
+	}
+	return `<p class="home-section"><small>` + text + `</small></p>`
 }
 
 // cardTips is the one-line explanation behind the "?" on a card.

--- a/home/layout_test.go
+++ b/home/layout_test.go
@@ -153,7 +153,7 @@ func TestTheAccountBlockLooksLikeTheOtherRailBlocks(t *testing.T) {
 		t.Fatal("account card has wrong label or destination")
 	}
 
-	// The heading is the same plain one the others use, not a link.
+	// The heading links to the full section, like the other previews.
 	if !strings.Contains(got, sectionRule("Account")) {
 		t.Error("the Account heading is not sectionRule's, so it does not match " +
 			"Inbox and Agents above it")
@@ -162,11 +162,10 @@ func TestTheAccountBlockLooksLikeTheOtherRailBlocks(t *testing.T) {
 	if !strings.Contains(got, `class="wallet-peek"`) {
 		t.Error("the balance is not in a card, and both blocks above it are")
 	}
-	// And the way to the page, where the others put it.
-	if !strings.Contains(got, `href="/account" class="link"`) {
-		t.Error("no `Go to account` link — every other rail block ends with one, " +
-			"and it is the only route to /wallet from Home")
+	if strings.Contains(got, "Go to account") {
+		t.Error("redundant account footer")
 	}
+
 }
 
 func TestGreetingTreatsDisplayNamesAsText(t *testing.T) {

--- a/home/todo.go
+++ b/home/todo.go
@@ -2,6 +2,7 @@ package home
 
 import (
 	"html"
+	"strconv"
 	"strings"
 	"time"
 
@@ -47,5 +48,9 @@ func todoHTML(accountID string) string {
 	if total == 0 {
 		return ""
 	}
-	return sectionRule("Todo") + `<div class="todo-peek">` + strings.Join(rows, "") + `</div>` + app.SectionLink("Go to tasks", "/tasks")
+	more := ""
+	if n := total - len(rows); n > 0 {
+		more = app.SectionLink(strconv.Itoa(n)+" more", "/tasks")
+	}
+	return sectionRule("Todo") + `<div class="todo-peek">` + strings.Join(rows, "") + `</div>` + more
 }

--- a/home/wallet.go
+++ b/home/wallet.go
@@ -71,7 +71,6 @@ func walletHTML(accountID string) string {
 	for _, part := range account.BalanceBody(accountID, false) {
 		b.WriteString(part)
 	}
-	b.WriteString(`<a href="/account" class="link">Go to account &rarr;</a>`)
 	b.WriteString(`</div>`)
 	return b.String()
 }

--- a/inbox/preview.go
+++ b/inbox/preview.go
@@ -19,6 +19,7 @@ import (
 	"html"
 	"net/url"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"mu/internal/app"
@@ -105,7 +106,9 @@ func Preview(accountID string) string {
 			`<span class="peek-line">` + line + where + `</span></a>`)
 	}
 	b.WriteString(`</div>`)
-	b.WriteString(app.SectionLink("Go to inbox", "/inbox"))
+	if n := len(all) - len(threads); n > 0 {
+		b.WriteString(app.SectionLink(strconv.Itoa(n)+" more", "/inbox"))
+	}
 	return b.String()
 }
 

--- a/inbox/preview_test.go
+++ b/inbox/preview_test.go
@@ -42,8 +42,8 @@ func TestHomeShowsWhatIsInTheInbox(t *testing.T) {
 	if !strings.Contains(out, "the total is 420") {
 		t.Errorf("the latest message is missing:\n%s", out)
 	}
-	if !strings.Contains(out, `href="/inbox"`) {
-		t.Error("no way through to the inbox itself")
+	if strings.Contains(out, `href="/inbox"`) {
+		t.Error("a complete preview has a redundant footer")
 	}
 }
 
@@ -75,6 +75,9 @@ func TestHomeCarriesOnlyTheMostRecentFew(t *testing.T) {
 	}
 
 	// Prefix, not the whole attribute: an unread row carries a second class.
+	if !strings.Contains(Preview(who), "6 more") {
+		t.Error("missing hidden conversation count")
+	}
 	if got := strings.Count(Preview(who), `class="peek-row`); got != previewShown {
 		t.Fatalf("Home shows %d conversations, want %d", got, previewShown)
 	}

--- a/service/events/preview.go
+++ b/service/events/preview.go
@@ -2,7 +2,6 @@ package events
 
 import (
 	"html"
-	"mu/internal/app"
 	"strings"
 	"time"
 )
@@ -45,6 +44,6 @@ func Preview(owner string, external []External) string {
 	if count == 0 {
 		b.WriteString(`<p class="text-muted">No upcoming events to show.</p>`)
 	}
-	b.WriteString(`</div>` + app.SectionLink("Go to events", "/events"))
+	b.WriteString(`</div>`)
 	return b.String()
 }

--- a/service/events/preview_test.go
+++ b/service/events/preview_test.go
@@ -31,7 +31,7 @@ func TestPreviewCombinesOwnedAndExternalEventsAndLimitsRows(t *testing.T) {
 		}
 	}
 	body := Preview(owner, ExternalEvents(owner, now, now.Add(30*24*time.Hour), PreviewLimit))
-	for _, want := range []string{"Earlier &lt;meeting&gt;", "Local reminder", "Later meeting", "Go to events"} {
+	for _, want := range []string{"Earlier &lt;meeting&gt;", "Local reminder", "Later meeting"} {
 		if !strings.Contains(body, want) {
 			t.Errorf("missing %q", want)
 		}


### PR DESCRIPTION
Home repeated Go to links beneath previews whose items already open directly.

Link Todo, Inbox, Agents, Upcoming, Services and Account headings to their full sections. Remove unconditional Go to footer links. Todo, Inbox and Agents show N more only when their known lists contain omitted items; Upcoming has no invented total for provider-limited results.

Validation: go test ./home ./inbox ./agent ./service/events -short passed; existing preview assertions updated for complete versus truncated lists. gofmt and git diff --check passed.

The proposed action-detection loop is recorded in #1577, and the remaining session agenda in #1585. No background scanning or new model usage is enabled by this change.