### PR TITLE
Unify Home card headings with Feed and simplify the brief

### DIFF
--- a/agent/preview.go
+++ b/agent/preview.go
@@ -30,7 +30,6 @@ package agent
 
 import (
 	"html"
-	"strconv"
 	"strings"
 	"time"
 
@@ -122,13 +121,11 @@ func Preview(accountID string) string {
 		rows = append(rows, entryOf{ID: a.ID, Name: name, Path: Path(accountID, a.ID)})
 	}
 
-	total := len(rows)
 	if len(rows) > previewShown {
 		rows = rows[:previewShown]
 	}
 
 	var b strings.Builder
-	b.WriteString(`<div class="agent-peek">`)
 	for _, a := range rows {
 		b.WriteString(`<a class="agent-peek-row" href="` + html.EscapeString(a.Path) + `">`)
 		b.WriteString(`<span class="agent-peek-name">` + html.EscapeString(a.Name) + `</span>`)
@@ -149,11 +146,7 @@ func Preview(accountID string) string {
 		}
 		b.WriteString(`</a>`)
 	}
-	b.WriteString(`</div>`)
-	if n := total - len(rows); n > 0 {
-		b.WriteString(app.SectionLink(strconv.Itoa(n)+" more", "/agents"))
-	}
-	return b.String()
+	return app.PreviewCard("home-agents-card", "Agents", "/agents", b.String())
 }
 
 // latestByAgent is the last conversation each agent actually spoke on.

--- a/home/apps.go
+++ b/home/apps.go
@@ -27,10 +27,10 @@ func appsHTML(acc *auth.Account) string {
 		apps = apps[:10]
 	}
 	var b strings.Builder
-	b.WriteString(`<nav class="home-apps page-stack" aria-label="Services">` + sectionRule("Services") + `<div class="home-apps-grid">`)
+	b.WriteString(`<div class="home-apps-grid">`)
 	for _, s := range apps {
 		b.WriteString(`<a href="` + html.EscapeString(s.Page) + `"><span class="home-app-icon"><img src="/` + html.EscapeString(s.NavIcon()) + `" alt=""></span><span>` + html.EscapeString(s.NavLabel()) + `</span></a>`)
 	}
-	b.WriteString(`</div></nav>`)
-	return b.String()
+	b.WriteString(`</div>`)
+	return `<nav class="home-apps page-stack" aria-label="Services">` + app.PreviewCard("home-services-card", "Services", "/services", b.String()) + `</nav>`
 }

--- a/home/apps_test.go
+++ b/home/apps_test.go
@@ -25,7 +25,7 @@ func TestAppsAlwaysOfferUsefulDefaults(t *testing.T) {
 				t.Errorf("missing default %s for %#v", name, acc)
 			}
 		}
-		if !strings.Contains(body, sectionRule("Services")) || strings.Contains(body, "Go to services") {
+		if !strings.Contains(body, `<a class="card-head-link" href="/services">Services</a>`) || strings.Contains(body, "Go to services") {
 			t.Error("launcher heading or catalogue link misplaced")
 		}
 	}

--- a/home/brief.go
+++ b/home/brief.go
@@ -96,29 +96,8 @@ func briefHTML(accountID string, external ...events.External) string {
 		return ""
 	}
 
-	// In a card, like the two blocks under it.
-	//
-	// It was a bare paragraph under a heading, which was right when Home was
-	// one column: the brief ran the width of the page and the border would have
-	// been a box around a single sentence. In the rail it sits directly above
-	// the inbox and the agents, both of them bordered, and the odd one out was
-	// the one at the top — three blocks under matching headings, the first
-	// looking like a caption that had escaped.
-	//
-	// brief-peek, and the class is in the same rule as inbox-peek and
-	// agent-peek in mu.css rather than beside them. Three names for one shape,
-	// kept in one place, because the whole complaint was that they had drifted.
-	//
-	// No presence line in here any more.
-	//
-	// Who else was online drew above the clauses for a while, on the argument
-	// that it is the only thing on this page that changes because somebody else
-	// did something. That was right about the fact and wrong about the place: it
-	// is exactly why it does not belong buried in the rail under a heading
-	// saying Brief. It is its own block under the box now, and it names people
-	// rather than counting them.
-	return sectionRule("Brief") + `<div class="brief-peek">` +
-		`<p class="home-brief">` + strings.Join(parts, " ") + `</p></div>`
+	// Home is a live summary, not an archived or separately navigable card.
+	return `<p class="home-brief">` + strings.Join(parts, " ") + `</p>`
 }
 
 // briefParts is the clauses, without deciding how they are set.

--- a/home/brief_test.go
+++ b/home/brief_test.go
@@ -106,7 +106,7 @@ func TestTheBriefSeparatesWorkInHandFromWorkOwed(t *testing.T) {
 // sentence now, sitting immediately under a box you type into, and an
 // unlabelled line there reads as output from the box rather than as a block of
 // its own.
-func TestTheBriefIsLabelledLikeEverythingElse(t *testing.T) {
+func TestTheBriefIsAnUnlabelledSummary(t *testing.T) {
 	const who = "brief-shape"
 	auth.Create(&auth.Account{ID: who, Name: who, Secret: "test-secret"}) //nolint:errcheck
 	task, err := tasks.Create(who, "Something", "", tasks.Agent, time.Time{})
@@ -118,8 +118,8 @@ func TestTheBriefIsLabelledLikeEverythingElse(t *testing.T) {
 	}
 
 	got := briefHTML(who)
-	if !strings.HasPrefix(got, sectionRule("Brief")) {
-		t.Errorf("the brief is not labelled: %q", got)
+	if strings.Contains(got, "<h4>") || strings.Contains(got, "home-section") || strings.Contains(got, "brief-peek") {
+		t.Errorf("the brief has a card or heading: %q", got)
 	}
 	if !strings.Contains(got, `<p class="home-brief">`) {
 		t.Errorf("the brief is not a paragraph: %q", got)

--- a/home/card_render_test.go
+++ b/home/card_render_test.go
@@ -25,8 +25,8 @@ func TestACardKeepsItsWayThroughOnRefresh(t *testing.T) {
 	if !strings.Contains(body, "<p>A headline</p>") {
 		t.Fatalf("the card lost its contents:\n%s", body)
 	}
-	if !strings.Contains(body, `href="/news"`) {
-		t.Errorf("the card has no way through to the service:\n%s", body)
+	if strings.Contains(body, `href="/news"`) || !strings.Contains(cardHead(c), `href="/news"`) {
+		t.Errorf("navigation must live in the heading only:\n%s", body)
 	}
 }
 

--- a/home/home.go
+++ b/home/home.go
@@ -278,7 +278,7 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		external := events.Overview(sess.Account, events.PreviewLimit)
-		app.RespondJSON(w, map[string]string{"upcoming": events.Preview(sess.Account, external), "brief": todoHTML(sess.Account) + briefHTML(sess.Account, external...)})
+		app.RespondJSON(w, map[string]string{"upcoming": events.Preview(sess.Account, external), "brief": briefHTML(sess.Account, external...) + todoHTML(sess.Account)})
 		return
 	}
 	// An installed app opens on the app, not on a pitch.
@@ -452,20 +452,20 @@ function fetchW(la,lo){
 	}))
 	b.WriteString(`</div>`)
 	if viewerID != "" {
-		b.WriteString(`<div id="home-brief" class="page-stack">` + todoHTML(viewerID) + briefHTML(viewerID, events.CachedOverview(viewerID)...) + `</div>`)
+		b.WriteString(`<div id="home-brief" class="page-stack">` + briefHTML(viewerID, events.CachedOverview(viewerID)...) + todoHTML(viewerID) + `</div>`)
 	}
 	b.WriteString(appsHTML(viewerAcc))
 	if viewerID != "" {
 		if peek := inbox.Preview(viewerID); peek != "" {
-			b.WriteString(`<div id="home-inbox" class="page-stack">` + sectionRule("Inbox") + peek + `</div>`)
+			b.WriteString(`<div id="home-inbox" class="page-stack">` + peek + `</div>`)
 		}
 	}
 	b.WriteString(`</div>`)
 	if viewerID != "" {
 		b.WriteString(`<div class="home-column page-stack">`)
-		b.WriteString(`<div id="home-upcoming" class="page-stack">` + sectionRule("Upcoming") + `<div data-home-upcoming aria-live="polite" class="page-stack">` + events.Preview(viewerID, events.CachedOverview(viewerID)) + `</div>` + `</div>`)
+		b.WriteString(`<div id="home-upcoming" class="page-stack">` + `<div data-home-upcoming aria-live="polite" class="page-stack">` + events.Preview(viewerID, events.CachedOverview(viewerID)) + `</div>` + `</div>`)
 		if who := agent.Preview(viewerID); who != "" {
-			b.WriteString(`<div id="home-agents" class="page-stack">` + sectionRule("Agents") + who + `</div>`)
+			b.WriteString(`<div id="home-agents" class="page-stack">` + who + `</div>`)
 		}
 		b.WriteString(`</div>`)
 	}
@@ -564,21 +564,6 @@ function fetchW(la,lo){
 // the escaper was weaker than it looked.
 func htmlEsc(s string) string { return html.EscapeString(s) }
 
-// sectionRule is a heading that delimits: the label, then a hairline across the
-// rest of the width.
-//
-// Home is a stack of unrelated blocks — a chat, what arrived, what the tools
-// know — and it carried two words in small caps to tell them apart. That reads
-// as a caption on the thing below it rather than as a break between two things,
-// which is why the sections did not look like sections.
-func sectionRule(label string) string {
-	text := htmlEsc(label)
-	if href := map[string]string{"Todo": "/tasks", "Inbox": "/inbox", "Agents": "/agents", "Upcoming": "/events", "Services": "/services", "Account": "/account"}[label]; href != "" {
-		text = app.TextLink(text, href)
-	}
-	return `<p class="home-section"><small>` + text + `</small></p>`
-}
-
 // cardTips is the one-line explanation behind the "?" on a card.
 //
 // Package-level because both the page and the refresh build a card's title now,
@@ -593,22 +578,12 @@ var cardTips = map[string]string{
 	"images":  "A picture a day, generated here",
 }
 
-// cardBody is a card's contents as a reader sees them: what the service
-// rendered, and the way through to the whole of it.
-//
-// One builder, because there were two. The page appended the More link to
-// CachedHTML; the JSON the page polls itself with sent CachedHTML alone, and
-// the script replaces .card-body with it wholesale. So every card lost its More
-// link on the first refresh and got it back on the next full page load, which
-// is exactly what "sometimes the More buttons disappear" looks like from the
-// outside.
+// cardBody supplies the same contents to initial renders and refreshes.
+// Navigation belongs to the linked card heading.
 func cardBody(c Card, who service.Viewer) string {
 	body := strings.TrimSpace(cardRender(c, who))
 	if body == "" {
 		return ""
-	}
-	if c.Link != "" {
-		body += app.Link("More", c.Link)
 	}
 	return body
 }

--- a/home/layout_test.go
+++ b/home/layout_test.go
@@ -53,7 +53,7 @@ func TestHomeAndFeedKeepTheirOwnContent(t *testing.T) {
 		t.Fatal("missing view panels")
 	}
 	personal, feed := body[personalAt:feedAt], body[feedAt:]
-	for _, want := range []string{`id="home-agent"`, `id="home-brief"`, sectionRule("Inbox")} {
+	for _, want := range []string{`id="home-agent"`, `id="home-brief"`, `<a class="card-head-link" href="/inbox">Inbox</a>`} {
 		if !strings.Contains(personal, want) || strings.Contains(feed, want) {
 			t.Errorf("%s is not exclusive to Home", want)
 		}
@@ -154,12 +154,12 @@ func TestTheAccountBlockLooksLikeTheOtherRailBlocks(t *testing.T) {
 	}
 
 	// The heading links to the full section, like the other previews.
-	if !strings.Contains(got, sectionRule("Account")) {
+	if !strings.Contains(got, `<a class="card-head-link" href="/account">Account</a>`) {
 		t.Error("the Account heading is not sectionRule's, so it does not match " +
 			"Inbox and Agents above it")
 	}
 	// A card, sharing the class the other two are styled by.
-	if !strings.Contains(got, `class="wallet-peek"`) {
+	if !strings.Contains(got, `id="home-account-card" class="card"`) {
 		t.Error("the balance is not in a card, and both blocks above it are")
 	}
 	if strings.Contains(got, "Go to account") {

--- a/home/task_attention_test.go
+++ b/home/task_attention_test.go
@@ -38,7 +38,7 @@ func TestTaskAttentionShowsFailedAndBlockedOwnedWork(t *testing.T) {
 			t.Fatal(part)
 		}
 	}
-	for _, want := range []string{"/tasks?status=failed", "/tasks?status=blocked", "review before retrying", sectionRule("Todo")} {
+	for _, want := range []string{"/tasks?status=failed", "/tasks?status=blocked", "review before retrying", `<a class="card-head-link" href="/tasks">Todo</a>`} {
 		if !strings.Contains(out, want) {
 			t.Errorf("attention summary missing %q: %s", want, out)
 		}

--- a/home/todo.go
+++ b/home/todo.go
@@ -2,7 +2,6 @@ package home
 
 import (
 	"html"
-	"strconv"
 	"strings"
 	"time"
 
@@ -48,9 +47,5 @@ func todoHTML(accountID string) string {
 	if total == 0 {
 		return ""
 	}
-	more := ""
-	if n := total - len(rows); n > 0 {
-		more = app.SectionLink(strconv.Itoa(n)+" more", "/tasks")
-	}
-	return sectionRule("Todo") + `<div class="todo-peek">` + strings.Join(rows, "") + `</div>` + more
+	return app.PreviewCard("home-todo-card", "Todo", "/tasks", strings.Join(rows, ""))
 }

--- a/home/wallet.go
+++ b/home/wallet.go
@@ -39,6 +39,7 @@ import (
 	"strings"
 
 	"mu/account"
+	"mu/internal/app"
 	"mu/internal/quota"
 )
 
@@ -66,11 +67,9 @@ func walletHTML(accountID string) string {
 	// foot of it. "Go to account" keeps the credit ledger reachable from
 	// Home, which is the same job "Go to inbox" does above.
 	var b strings.Builder
-	b.WriteString(sectionRule("Account"))
-	b.WriteString(`<div class="wallet-peek"><h4>Balance</h4>`)
+	b.WriteString(`<h4>Balance</h4>`)
 	for _, part := range account.BalanceBody(accountID, false) {
 		b.WriteString(part)
 	}
-	b.WriteString(`</div>`)
-	return b.String()
+	return app.PreviewCard("home-account-card", "Account", "/account", b.String())
 }

--- a/inbox/preview.go
+++ b/inbox/preview.go
@@ -19,7 +19,6 @@ import (
 	"html"
 	"net/url"
 	"regexp"
-	"strconv"
 	"strings"
 
 	"mu/internal/app"
@@ -56,7 +55,6 @@ func Preview(accountID string) string {
 	}
 
 	var b strings.Builder
-	b.WriteString(`<div class="inbox-peek">`)
 	for _, t := range threads {
 		title := t.Subject
 		if title == "" {
@@ -105,11 +103,7 @@ func Preview(accountID string) string {
 			`</span><span class="peek-when">` + html.EscapeString(app.TimeAgo(t.Updated)) + `</span></span>` +
 			`<span class="peek-line">` + line + where + `</span></a>`)
 	}
-	b.WriteString(`</div>`)
-	if n := len(all) - len(threads); n > 0 {
-		b.WriteString(app.SectionLink(strconv.Itoa(n)+" more", "/inbox"))
-	}
-	return b.String()
+	return app.PreviewCard("home-inbox-card", "Inbox", "/inbox", b.String())
 }
 
 // trimTo shortens text to fit a line, on a word where it can.

--- a/inbox/preview_test.go
+++ b/inbox/preview_test.go
@@ -42,7 +42,7 @@ func TestHomeShowsWhatIsInTheInbox(t *testing.T) {
 	if !strings.Contains(out, "the total is 420") {
 		t.Errorf("the latest message is missing:\n%s", out)
 	}
-	if strings.Contains(out, `href="/inbox"`) {
+	if strings.Contains(out, `class="section-link"`) || !strings.Contains(out, `class="card-head-link" href="/inbox"`) {
 		t.Error("a complete preview has a redundant footer")
 	}
 }
@@ -75,8 +75,8 @@ func TestHomeCarriesOnlyTheMostRecentFew(t *testing.T) {
 	}
 
 	// Prefix, not the whole attribute: an unread row carries a second class.
-	if !strings.Contains(Preview(who), "6 more") {
-		t.Error("missing hidden conversation count")
+	if strings.Contains(Preview(who), "6 more") {
+		t.Error("redundant hidden conversation count")
 	}
 	if got := strings.Count(Preview(who), `class="peek-row`); got != previewShown {
 		t.Fatalf("Home shows %d conversations, want %d", got, previewShown)

--- a/internal/app/html/composition.css
+++ b/internal/app/html/composition.css
@@ -169,3 +169,9 @@ a.link-text {
 .access-notice { flex: none; padding: var(--space-control) var(--space-field); font: 14px system-ui; background: Canvas; color: CanvasText; border-bottom: 1px solid GrayText; }
 .access-notice[hidden] { display: none; }
 .access-notice .btn-quiet { color: CanvasText; border-color: GrayText; }
+
+/* The card supplies the outside inset; preview rows supply only inner gaps. */
+.preview-rows > .peek-row:first-child,
+.preview-rows > .agent-peek-row:first-child { padding-top: 0; }
+.preview-rows > .peek-row:last-child,
+.preview-rows > .agent-peek-row:last-child { padding-bottom: 0; }

--- a/internal/app/section.go
+++ b/internal/app/section.go
@@ -6,3 +6,9 @@ import "html"
 func SectionLink(label, href string) string {
 	return `<a class="section-link" href="` + html.EscapeString(href) + `">` + html.EscapeString(label) + ` →</a>`
 }
+
+// PreviewCard uses the same heading and container as Feed cards.
+func PreviewCard(id, title, href, body string) string {
+	heading := `<a class="card-head-link" href="` + html.EscapeString(href) + `">` + html.EscapeString(title) + `</a>`
+	return Card(id, heading, `<div class="preview-rows">`+body+`</div>`)
+}

--- a/service/events/preview.go
+++ b/service/events/preview.go
@@ -2,6 +2,7 @@ package events
 
 import (
 	"html"
+	"mu/internal/app"
 	"strings"
 	"time"
 )
@@ -17,7 +18,7 @@ func Preview(owner string, external []External) string {
 	now := time.Now()
 	rows := mergedRows(Upcoming(owner), external)
 	var b strings.Builder
-	b.WriteString(`<div class="card compact-list">`)
+	b.WriteString(`<div class="compact-list">`)
 	count := 0
 	for _, row := range rows {
 		href := externalURL(row.External)
@@ -45,5 +46,5 @@ func Preview(owner string, external []External) string {
 		b.WriteString(`<p class="text-muted">No upcoming events to show.</p>`)
 	}
 	b.WriteString(`</div>`)
-	return b.String()
+	return app.PreviewCard("home-events-card", "Upcoming", "/events", b.String())
 }


### PR DESCRIPTION
Home's outside section labels and preview footers drifted from Feed's linked card titles.

Use the existing Card renderer for Todo, Inbox, Agents, Upcoming, Services and Account, with linked titles inside the card. Keep individual rows clickable and remove preview count links and Feed More links, including refreshed Feed bodies. Shared preview row spacing relies on the card's outside padding, avoiding extra space at the bottom.

The live Home brief is an unlabelled paragraph immediately beneath the input, before Todo. Its source links remain. No archive, inbox messages, model calls or morning-brief delivery changes are introduced.

Validation: go test ./home ./inbox ./agent ./service/events ./internal/app -short passed. Existing render tests updated to check heading navigation, footer removal and the unlabelled brief. gofmt and git diff --check passed. Shared Card markup/styles are reused rather than a new layout.