### PR TITLE
Align Micro branding and center the console heading

### DIFF
--- a/agent/work/work.go
+++ b/agent/work/work.go
@@ -375,8 +375,15 @@ func deliver(r request, answer string, err error) {
 		body += "\n\n---\n[Disable or manage your morning brief](" + origin.Self() + "/events#morning-brief)."
 	}
 	messageID := "<" + uuid.NewString() + "@" + mail.ConfiguredDomain() + ">"
+	sender := agent.NameOf(r.Account, r.Agent)
+	if sender == "" {
+		sender = agent.DefaultName()
+	}
+	if sender == "" {
+		sender = "Micro"
+	}
 	delivery := mail.Delivery{
-		From: "Mu", FromID: "agent@" + mail.ConfiguredDomain(),
+		From: sender, FromID: "agent@" + mail.ConfiguredDomain(),
 		To: acc.Name, ToID: acc.ID, Tag: tag,
 		Subject: r.Title, Body: body, MessageID: messageID,
 	}

--- a/internal/app/chat.go
+++ b/internal/app/chat.go
@@ -520,8 +520,9 @@ html:has(.mu-chat-overlay) { scrollbar-gutter:stable; }
 body:has(.mu-console[open]) { overflow:hidden; }
 .mu-console::backdrop { background:rgba(0,0,0,.28); }
 .mu-console[open] { display:flex; flex-direction:column; }
-.mu-console-head { display:flex; align-items:center; justify-content:space-between; margin-bottom:12px; font-size:14px; }
-.mu-console-close { font:inherit; font-weight:400; cursor:pointer; }
+.mu-console-head { display:grid; grid-template-columns:1fr auto 1fr; align-items:center; gap:var(--space-control,8px); margin-bottom:var(--space-field,16px); font-size:14px; }
+.mu-console-head strong { grid-column:2; text-align:center; }
+.mu-console-close { grid-column:3; justify-self:end; font:inherit; font-weight:400; }
 .mu-console #mu-chat { display:flex; flex-direction:column; min-height:0; flex:1; max-width:none; }
 .mu-console #mu-chat-form { flex-shrink:0; position:static; }
 .mu-console #mu-chat #mu-chat-conv { flex:1; min-height:0; max-height:none; overflow:auto; overflow-anchor:none; }
@@ -665,7 +666,7 @@ if(overlay && input && form){
  shell.before(slot); slot.appendChild(shell);
  var dialog=document.createElement('dialog'); dialog.className='mu-console';
  dialog.setAttribute('aria-label','Micro');
- dialog.innerHTML='<div class="mu-console-head"><strong>Micro</strong><button type="button" class="mu-console-close">Close</button></div>';
+ dialog.innerHTML='<div class="mu-console-head"><strong>Micro</strong><button type="button" class="mu-console-close link-button">Close</button></div>';
  slot.appendChild(dialog);
  var closing=false;
  function openConsole(){

--- a/internal/app/html/mu.js
+++ b/internal/app/html/mu.js
@@ -120,7 +120,7 @@ self.addEventListener('push', function (e) {
   try { n = e.data ? e.data.json() : {}; } catch (err) { why = 'the payload could not be read'; }
   if (!why && !n.title) why = 'the payload had no title';
 
-  var title = n.title || 'Notification unreadable';
+  var title = 'Micro \u2014 ' + (n.title || 'Notification unreadable');
   var body = why ? ('This device woke up but could not read it: ' + why + '.') : (n.body || '');
   var tag = n.tag || 'mu';
 


### PR DESCRIPTION
Scheduled briefs still displayed Mu as their sender, and the prompt console's heading was left-aligned beside a standard Close button.

Resolve scheduled delivery's display sender from the assigned agent, falling back to the built-in agent name/Micro. Keep the existing sender address and delivery route. Prefix visible push titles with Micro while preserving the subject, body, grouping and target; the manifest already names the installed app Micro. This cannot change browser/OS-controlled origin attribution such as micro.mu.

Center the console heading using equal side columns and use the shared link-button styling for Close, retaining semantic button keyboard activation and the existing Escape/focus behaviour.

Validation: go test ./agent/work ./internal/app ./home -short passed; node --check passed; exercised the push handler with normal and malformed payloads, checking title/body/URL/tag. gofmt and git diff --check passed. No additional messages or notifications are generated.