### PR TITLE
Restore a matching Brief card with a plain title

### DIFF
--- a/home/brief.go
+++ b/home/brief.go
@@ -96,8 +96,8 @@ func briefHTML(accountID string, external ...events.External) string {
 		return ""
 	}
 
-	// Home is a live summary, not an archived or separately navigable card.
-	return `<p class="home-brief">` + strings.Join(parts, " ") + `</p>`
+	// Match the surrounding cards, with a plain title for this live summary.
+	return app.Card("home-brief-card", "Brief", `<p class="home-brief">`+strings.Join(parts, " ")+`</p>`)
 }
 
 // briefParts is the clauses, without deciding how they are set.

--- a/home/brief_test.go
+++ b/home/brief_test.go
@@ -106,7 +106,7 @@ func TestTheBriefSeparatesWorkInHandFromWorkOwed(t *testing.T) {
 // sentence now, sitting immediately under a box you type into, and an
 // unlabelled line there reads as output from the box rather than as a block of
 // its own.
-func TestTheBriefIsAnUnlabelledSummary(t *testing.T) {
+func TestTheBriefHasAPlainCardTitle(t *testing.T) {
 	const who = "brief-shape"
 	auth.Create(&auth.Account{ID: who, Name: who, Secret: "test-secret"}) //nolint:errcheck
 	task, err := tasks.Create(who, "Something", "", tasks.Agent, time.Time{})
@@ -118,8 +118,8 @@ func TestTheBriefIsAnUnlabelledSummary(t *testing.T) {
 	}
 
 	got := briefHTML(who)
-	if strings.Contains(got, "<h4>") || strings.Contains(got, "home-section") || strings.Contains(got, "brief-peek") {
-		t.Errorf("the brief has a card or heading: %q", got)
+	if !strings.Contains(got, `<div id="home-brief-card" class="card">`) || !strings.Contains(got, "<h4>Brief</h4>") || strings.Contains(got, "card-head-link") || strings.Contains(got, "section-link") {
+		t.Errorf("the brief must have a shared card and plain title without navigation: %q", got)
 	}
 	if !strings.Contains(got, `<p class="home-brief">`) {
 		t.Errorf("the brief is not a paragraph: %q", got)


### PR DESCRIPTION
The unlabelled Home brief looked disconnected from the surrounding cards.

Wrap the existing summary in the shared Card component with a plain Brief heading. Source links remain; no heading link, footer navigation, history or delivery change is introduced. Empty briefs remain hidden.

Updated the existing rendering assertion for the shared card and plain title. git diff --check passed. Local Go tests could not run because the temporary toolchain is no longer present; CI provides the Go checks.