### PR TITLE
Arrange Home around Todo, Upcoming and Inbox

### DIFF
--- a/home/home.go
+++ b/home/home.go
@@ -452,17 +452,18 @@ function fetchW(la,lo){
 	}))
 	b.WriteString(`</div>`)
 	if viewerID != "" {
-		b.WriteString(`<div id="home-brief" class="page-stack">` + briefHTML(viewerID, events.CachedOverview(viewerID)...) + todoHTML(viewerID) + `</div>`)
+		b.WriteString(`<div id="home-brief" class="page-stack">` + briefHTML(viewerID, events.CachedOverview(viewerID)...) + `</div>`)
 	}
-	b.WriteString(appsHTML(viewerAcc))
 	if viewerID != "" {
 		if peek := inbox.Preview(viewerID); peek != "" {
 			b.WriteString(`<div id="home-inbox" class="page-stack">` + peek + `</div>`)
 		}
 	}
+	b.WriteString(appsHTML(viewerAcc))
 	b.WriteString(`</div>`)
 	if viewerID != "" {
 		b.WriteString(`<div class="home-column page-stack">`)
+		b.WriteString(`<div id="home-todo" class="page-stack">` + todoHTML(viewerID) + `</div>`)
 		b.WriteString(`<div id="home-upcoming" class="page-stack">` + `<div data-home-upcoming aria-live="polite" class="page-stack">` + events.Preview(viewerID, events.CachedOverview(viewerID)) + `</div>` + `</div>`)
 		if who := agent.Preview(viewerID); who != "" {
 			b.WriteString(`<div id="home-agents" class="page-stack">` + who + `</div>`)

--- a/internal/app/html/composition.css
+++ b/internal/app/html/composition.css
@@ -179,3 +179,16 @@ a.link-text {
 .preview-rows > .agent-peek-row:first-child { padding-top: 0; }
 .preview-rows > .peek-row:last-child,
 .preview-rows > .agent-peek-row:last-child { padding-bottom: 0; }
+
+/* Flatten the columns on small screens so daily actions precede messages. */
+#home-todo:empty { display: none; }
+@media (max-width: 1099px) {
+  .home-workspace > .home-column { display: contents; }
+  .home-workspace #home-agent { order: 0; }
+  .home-workspace #home-brief { order: 1; }
+  .home-workspace #home-todo { order: 2; }
+  .home-workspace #home-upcoming { order: 3; }
+  .home-workspace #home-inbox { order: 4; }
+  .home-workspace #home-agents { order: 5; }
+  .home-workspace .home-apps { order: 6; }
+}


### PR DESCRIPTION
Move Todo to the top of the right column, followed by Upcoming and Agents. Keep Brief, Inbox and Services in the main column below the prompt. At the existing single-column breakpoint, flatten the column wrappers and display Brief, Todo, Upcoming, Inbox, Agents and Services in that order after the prompt. Empty Todo remains hidden.

Validation: inspected markup and CSS at the existing 1100px breakpoint; git diff --check passed. No local Go or browser visual tests run for this small layout change. CSS visual ordering on mobile retains desktop DOM/tab order.