### PR TITLE
Restore More links on Feed cards

### DIFF
--- a/home/card_render_test.go
+++ b/home/card_render_test.go
@@ -25,8 +25,8 @@ func TestACardKeepsItsWayThroughOnRefresh(t *testing.T) {
 	if !strings.Contains(body, "<p>A headline</p>") {
 		t.Fatalf("the card lost its contents:\n%s", body)
 	}
-	if strings.Contains(body, `href="/news"`) || !strings.Contains(cardHead(c), `href="/news"`) {
-		t.Errorf("navigation must live in the heading only:\n%s", body)
+	if !strings.Contains(body, `href="/news"`) || !strings.Contains(body, "More →") || !strings.Contains(cardHead(c), `href="/news"`) {
+		t.Errorf("the heading and More link must both reach the service:\n%s", body)
 	}
 }
 

--- a/home/home.go
+++ b/home/home.go
@@ -580,11 +580,14 @@ var cardTips = map[string]string{
 }
 
 // cardBody supplies the same contents to initial renders and refreshes.
-// Navigation belongs to the linked card heading.
+// Keep the explicit More link on both initial renders and live refreshes.
 func cardBody(c Card, who service.Viewer) string {
 	body := strings.TrimSpace(cardRender(c, who))
 	if body == "" {
 		return ""
+	}
+	if c.Link != "" {
+		body += app.Link("More", htmlEsc(c.Link))
 	}
 	return body
 }


### PR DESCRIPTION
Feed needs an explicit invitation to explore beyond each preview. Restore More → beneath nonempty Feed cards with a destination, retaining the clickable titles. Use the shared cardBody renderer so links survive live refreshes; escape destinations before rendering.

Updated the existing navigation regression assertion. git diff --check passed. Local Go toolchain unavailable, so Go tests have not been run locally. Home preview cards are unchanged.