### PR TITLE
Fix duplicate Todo and add persistent All services shortcut

### DIFF
--- a/home/apps.go
+++ b/home/apps.go
@@ -31,6 +31,6 @@ func appsHTML(acc *auth.Account) string {
 	for _, s := range apps {
 		b.WriteString(`<a href="` + html.EscapeString(s.Page) + `"><span class="home-app-icon"><img src="/` + html.EscapeString(s.NavIcon()) + `" alt=""></span><span>` + html.EscapeString(s.NavLabel()) + `</span></a>`)
 	}
-	b.WriteString(`</div>`)
+	b.WriteString(`<a class="home-apps-all" href="/services" aria-label="All services"><span class="home-app-icon" aria-hidden="true">→</span><span>All services</span></a></div>`)
 	return `<nav class="home-apps page-stack" aria-label="Services">` + app.PreviewCard("home-services-card", "Services", "/services", b.String()) + `</nav>`
 }

--- a/home/home.go
+++ b/home/home.go
@@ -278,7 +278,7 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		external := events.Overview(sess.Account, events.PreviewLimit)
-		app.RespondJSON(w, map[string]string{"upcoming": events.Preview(sess.Account, external), "brief": briefHTML(sess.Account, external...) + todoHTML(sess.Account)})
+		app.RespondJSON(w, map[string]string{"upcoming": events.Preview(sess.Account, external), "brief": briefHTML(sess.Account, external...), "todo": todoHTML(sess.Account)})
 		return
 	}
 	// An installed app opens on the app, not on a pitch.

--- a/home/views.js
+++ b/home/views.js
@@ -9,6 +9,8 @@
         upcoming.innerHTML = data.upcoming;
         const brief = home.querySelector("#home-brief");
         if (brief) brief.innerHTML = data.brief;
+        const todo = home.querySelector("#home-todo");
+        if (todo) todo.innerHTML = data.todo;
         upcoming.querySelectorAll('[data-event-time]').forEach(node => {
           node.textContent = new Date(node.dateTime).toLocaleString(undefined, {weekday:'short', day:'numeric', month:'short', hour:'2-digit', minute:'2-digit'});
         });

--- a/internal/app/html/composition.css
+++ b/internal/app/html/composition.css
@@ -138,19 +138,20 @@ a.btn-secondary:hover, .btn-secondary:hover {
 .compact-list-item:first-child { padding-block-start: 0; }
 .compact-list-item:last-child { padding-block-end: 0; }
 .compact-list-item + .compact-list-item { border-top: 1px solid var(--card-border, #e8e8e8); }
-/* Count shortcuts against the grid's content width, after card padding.
-   Each icon uses 56px plus a 16px gap; hidden links leave the tab order. */
+/* Reserve the last slot for the full catalogue at every available width. */
 .home-apps-grid { container: service-shortcuts / inline-size; }
-.home-apps-grid > a:nth-child(n+2) { display: none; }
-@container service-shortcuts (min-width: 128px) { .home-apps-grid > a:nth-child(2) { display: flex; } }
-@container service-shortcuts (min-width: 200px) { .home-apps-grid > a:nth-child(3) { display: flex; } }
-@container service-shortcuts (min-width: 272px) { .home-apps-grid > a:nth-child(4) { display: flex; } }
-@container service-shortcuts (min-width: 344px) { .home-apps-grid > a:nth-child(5) { display: flex; } }
-@container service-shortcuts (min-width: 416px) { .home-apps-grid > a:nth-child(6) { display: flex; } }
-@container service-shortcuts (min-width: 488px) { .home-apps-grid > a:nth-child(7) { display: flex; } }
-@container service-shortcuts (min-width: 560px) { .home-apps-grid > a:nth-child(8) { display: flex; } }
-@container service-shortcuts (min-width: 632px) { .home-apps-grid > a:nth-child(9) { display: flex; } }
-@container service-shortcuts (min-width: 704px) { .home-apps-grid > a:nth-child(10) { display: flex; } }
+.home-apps-grid > a:not(.home-apps-all) { display: none; }
+.home-apps-grid > a.home-apps-all { display: flex; }
+@container service-shortcuts (min-width: 128px) { .home-apps-grid > a:nth-child(1):not(.home-apps-all) { display: flex; } }
+@container service-shortcuts (min-width: 200px) { .home-apps-grid > a:nth-child(2):not(.home-apps-all) { display: flex; } }
+@container service-shortcuts (min-width: 272px) { .home-apps-grid > a:nth-child(3):not(.home-apps-all) { display: flex; } }
+@container service-shortcuts (min-width: 344px) { .home-apps-grid > a:nth-child(4):not(.home-apps-all) { display: flex; } }
+@container service-shortcuts (min-width: 416px) { .home-apps-grid > a:nth-child(5):not(.home-apps-all) { display: flex; } }
+@container service-shortcuts (min-width: 488px) { .home-apps-grid > a:nth-child(6):not(.home-apps-all) { display: flex; } }
+@container service-shortcuts (min-width: 560px) { .home-apps-grid > a:nth-child(7):not(.home-apps-all) { display: flex; } }
+@container service-shortcuts (min-width: 632px) { .home-apps-grid > a:nth-child(8):not(.home-apps-all) { display: flex; } }
+@container service-shortcuts (min-width: 704px) { .home-apps-grid > a:nth-child(9):not(.home-apps-all) { display: flex; } }
+@container service-shortcuts (min-width: 776px) { .home-apps-grid > a:nth-child(10):not(.home-apps-all) { display: flex; } }
 
 /* Shared compact header and preview navigation. */
 .page-stack.compact-stack { gap: var(--space-control); }


### PR DESCRIPTION
The events refresh still appended Todo to Brief after the layout move, creating a second Todo card. Return separate brief and todo fragments and update their respective containers.

Add All services as the last shortcut, always visible. Container-query thresholds reserve its 56px slot and 16px gap before revealing service shortcuts, preserving one row at mobile and desktop widths.

Validation: JS syntax check, git diff --check, and fit arithmetic for widths 56–1000px with 0–10 shortcuts. No local Go tests or browser visual verification.