### PR TITLE
Complete image library API and add web_images

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 **A personal server: one Go binary you can self-host that carries a web app, an
 HTTP API, a CLI, an MCP server and an installable PWA over the same 36 services
-and 134 tools.** `go build ./...` produces it; nothing else has to be running.
+and 141 tools.** `go build ./...` produces it; nothing else has to be running.
 
 It is not a framework or a set of libraries. It is a thing that runs, that you
 sign into, and that other programs can call.

--- a/internal/imagesearch/search.go
+++ b/internal/imagesearch/search.go
@@ -1,0 +1,77 @@
+package imagesearch
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mu/internal/settings"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+type WebImage struct {
+	Title     string `json:"title"`
+	URL       string `json:"url"`
+	Source    string `json:"source"`
+	Thumbnail struct {
+		Src string `json:"src"`
+	} `json:"thumbnail"`
+	Properties struct {
+		URL string `json:"url"`
+	} `json:"properties"`
+}
+
+var imageSearchClient = &http.Client{Timeout: 12 * time.Second}
+var imageSearchURL = "https://api.search.brave.com/res/v1/images/search"
+
+func Search(ctx context.Context, query string) ([]WebImage, error) {
+	query = strings.TrimSpace(query)
+	if query == "" || len(query) > 400 || len(strings.Fields(query)) > 50 {
+		return nil, fmt.Errorf("use a search of up to 400 characters and 50 words")
+	}
+	key := settings.Get("BRAVE_API_KEY")
+	if key == "" {
+		return nil, fmt.Errorf("web image search is not configured on this instance")
+	}
+	q := url.Values{"q": {query}, "count": {"24"}, "safesearch": {"strict"}}
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, imageSearchURL+"?"+q.Encode(), nil)
+	req.Header.Set("X-Subscription-Token", key)
+	req.Header.Set("Accept", "application/json")
+	resp, err := imageSearchClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("could not reach image search")
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("image search is unavailable (%d)", resp.StatusCode)
+	}
+	var result struct {
+		Results []WebImage
+		Extra   struct {
+			MightBeOffensive bool `json:"might_be_offensive"`
+		}
+	}
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 2<<20)).Decode(&result); err != nil {
+		return nil, fmt.Errorf("could not read image search results")
+	}
+	if result.Extra.MightBeOffensive {
+		return nil, fmt.Errorf("these results were filtered; try another search")
+	}
+	var safe []WebImage
+	for _, r := range result.Results {
+		if webURL(r.URL) && webURL(r.Thumbnail.Src) && webURL(r.Properties.URL) {
+			safe = append(safe, r)
+		}
+		if len(safe) == 24 {
+			break
+		}
+	}
+	return safe, nil
+}
+func webURL(s string) bool {
+	u, e := url.Parse(s)
+	return e == nil && u.Host != "" && (u.Scheme == "https" || u.Scheme == "http")
+}

--- a/internal/imagesearch/search_test.go
+++ b/internal/imagesearch/search_test.go
@@ -1,0 +1,32 @@
+package imagesearch
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestBraveImageRequestAndFiltering(t *testing.T) {
+	t.Setenv("BRAVE_API_KEY", "test-key")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("safesearch") != "strict" || r.Header.Get("X-Subscription-Token") != "test-key" {
+			t.Error("missing safe search or authentication")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"results":[{"title":"Lake","url":"https://example.org/page","thumbnail":{"src":"https://example.org/thumb"},"properties":{"url":"https://example.org/image"}},{"url":"javascript:alert(1)"}]}`))
+	}))
+	defer srv.Close()
+	old := imageSearchURL
+	imageSearchURL = srv.URL
+	defer func() { imageSearchURL = old }()
+	rows, err := Search(context.Background(), "lake")
+	if err != nil || len(rows) != 1 {
+		t.Fatalf("%v %#v", err, rows)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := Search(ctx, "lake"); err == nil {
+		t.Fatal("cancellation ignored")
+	}
+}

--- a/internal/userdb/userdb.go
+++ b/internal/userdb/userdb.go
@@ -158,6 +158,45 @@ func List(ns, caller, collection, scope string, where map[string]interface{}, so
 	return out, nil
 }
 
+// Page returns a bounded page after applying the same ownership filters as List.
+func Page(ns, caller, collection, scope string, offset, limit int) ([]Record, bool, error) {
+	k, err := key(ns, collection)
+	if err != nil {
+		return nil, false, err
+	}
+	if offset < 0 {
+		return nil, false, errors.New("invalid offset")
+	}
+	if limit <= 0 || limit > MaxListLimit {
+		limit = MaxListLimit
+	}
+	if scope == "" {
+		scope = "mine"
+	}
+	if caller == "" {
+		scope = "public"
+	}
+	mu.Lock()
+	recs := load(k)
+	mu.Unlock()
+	out := filter(recs, scope, caller, nil)
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Created.Equal(out[j].Created) {
+			return out[i].ID < out[j].ID
+		}
+		return out[i].Created.After(out[j].Created)
+	})
+	if offset >= len(out) {
+		return []Record{}, false, nil
+	}
+	end := offset + limit
+	more := end < len(out)
+	if end > len(out) {
+		end = len(out)
+	}
+	return out[offset:end], more, nil
+}
+
 // LatestBy returns the newest private record per group, applying the limit
 // after grouping. A busy conversation must not crowd every other one out of
 // a conversation list. Missing grouping fields have their string zero value.

--- a/server.json
+++ b/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "mu.micro/mu",
-  "description": "A personal agent: it has an email address and it answers. News, web search, mail, markets, weather, places, transit, files, calendar, contacts and notes behind it. 134 tools, one endpoint.",
+  "description": "A personal agent: it has an email address and it answers. News, web search, mail, markets, weather, places, transit, files, calendar, contacts and notes behind it. 141 tools, one endpoint.",
   "repository": {
     "url": "https://github.com/micro/mu",
     "source": "github"

--- a/service/images/library.go
+++ b/service/images/library.go
@@ -1,0 +1,299 @@
+package images
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"mu/internal/app"
+	"mu/internal/blob"
+	"mu/internal/service"
+	"mu/internal/userdb"
+	"strconv"
+	"strings"
+)
+
+type Image struct {
+	ID          string   `json:"id"`
+	URL         string   `json:"url"`
+	Title       string   `json:"title"`
+	Description string   `json:"description"`
+	Tags        []string `json:"tags"`
+	Prompt      string   `json:"prompt,omitempty"`
+	Source      string   `json:"source"`
+	Visibility  string   `json:"visibility"`
+	CreatedAt   string   `json:"created_at"`
+}
+
+func recordImage(r userdb.Record) Image {
+	text := func(k string) string { s, _ := r.Data[k].(string); return s }
+	tags := []string{}
+	raw, _ := json.Marshal(r.Data["tags"])
+	_ = json.Unmarshal(raw, &tags)
+	if tags == nil {
+		tags = []string{}
+	}
+	description := text("description")
+	if description == "" {
+		description = text("prompt")
+	}
+	source := "generated"
+	if r.Data["uploaded"] == true {
+		source = "uploaded"
+	}
+	visibility := "private"
+	if r.Public {
+		visibility = "public"
+	}
+	return Image{ID: r.ID, URL: AbsoluteURL(r.ID), Title: text("title"), Description: description, Tags: tags, Prompt: text("prompt"), Source: source, Visibility: visibility, CreatedAt: r.Created.Format("2006-01-02T15:04:05Z07:00")}
+}
+func dailyImage(d Daily) Image {
+	return Image{ID: "daily:" + d.Date, URL: app.PublicURL() + "/images/daily/" + d.Date, Title: d.Theme, Description: d.Prompt, Tags: []string{d.Theme}, Prompt: d.Prompt, Source: "daily", Visibility: "public", CreatedAt: d.Date}
+}
+
+type ListRequest struct {
+	Scope  string `json:"scope" description:"mine, public, all (own plus public), or daily; defaults to public"`
+	Limit  int    `json:"limit" description:"Page size, default 20, maximum 100"`
+	Cursor string `json:"cursor" description:"Next cursor from the previous page; keep query and scope unchanged"`
+}
+type ListResponse struct {
+	Items      []Image `json:"items"`
+	NextCursor string  `json:"next_cursor,omitempty"`
+}
+type GetRequest struct {
+	ID string `json:"id" required:"true"`
+}
+type ImageResponse struct {
+	Image Image `json:"image"`
+}
+type DailyRequest struct {
+	Date string `json:"date" description:"YYYY-MM-DD; omitted for the current daily image"`
+}
+
+func (Server) Daily(_ context.Context, req *DailyRequest, rsp *ImageResponse) error {
+	if req.Date == "" {
+		d := getDaily()
+		if d.Date == "" {
+			return userdb.ErrNotFound
+		}
+		rsp.Image = dailyImage(d)
+		return nil
+	}
+	if !validDate(req.Date) {
+		return fmt.Errorf("invalid date")
+	}
+	for _, d := range Archive(0) {
+		if d.Date == req.Date {
+			rsp.Image = dailyImage(d)
+			return nil
+		}
+	}
+	return userdb.ErrNotFound
+}
+func (s Server) Get(ctx context.Context, req *GetRequest, rsp *ImageResponse) error {
+	if strings.HasPrefix(req.ID, "daily:") {
+		return s.Daily(ctx, &DailyRequest{Date: strings.TrimPrefix(req.ID, "daily:")}, rsp)
+	}
+	r, err := userdb.Get(ns, service.AccountFrom(ctx), collection, req.ID)
+	if err != nil {
+		return err
+	}
+	rsp.Image = recordImage(*r)
+	return nil
+}
+func (Server) List(ctx context.Context, req *ListRequest, rsp *ListResponse) error {
+	return libraryPage(service.AccountFrom(ctx), *req, "", rsp)
+}
+func libraryPage(caller string, req ListRequest, query string, rsp *ListResponse) error {
+	scope := req.Scope
+	if scope == "" {
+		scope = "public"
+	}
+	if scope != "mine" && scope != "public" && scope != "all" && scope != "daily" {
+		return fmt.Errorf("invalid scope")
+	}
+	if scope == "mine" && caller == "" {
+		return userdb.ErrAuth
+	}
+	offset := 0
+	if req.Cursor != "" {
+		n, err := strconv.Atoi(req.Cursor)
+		if err != nil || n < 0 || n > 10000000 {
+			return fmt.Errorf("invalid cursor")
+		}
+		offset = n
+	}
+	limit := req.Limit
+	if limit <= 0 {
+		limit = 20
+	}
+	if limit > 100 {
+		limit = 100
+	}
+	rsp.Items = []Image{}
+	rsp.NextCursor = ""
+	matches := func(i Image) bool {
+		hay := strings.ToLower(i.Title + " " + i.Description + " " + i.Prompt + " " + strings.Join(i.Tags, " "))
+		for _, word := range strings.Fields(strings.ToLower(query)) {
+			if !strings.Contains(hay, word) {
+				return false
+			}
+		}
+		return true
+	}
+	if scope == "daily" {
+		all := Archive(0)
+		for i := offset; i < len(all); i++ {
+			item := dailyImage(all[i])
+			if matches(item) {
+				rsp.Items = append(rsp.Items, item)
+			}
+			if len(rsp.Items) == limit {
+				if i+1 < len(all) {
+					rsp.NextCursor = strconv.Itoa(i + 1)
+				}
+				break
+			}
+		}
+		return nil
+	}
+	for {
+		rows, more, err := userdb.Page(ns, caller, collection, scope, offset, 100)
+		if err != nil {
+			return err
+		}
+		for idx, r := range rows {
+			item := recordImage(r)
+			if matches(item) {
+				rsp.Items = append(rsp.Items, item)
+			}
+			if len(rsp.Items) == limit {
+				if idx+1 < len(rows) || more {
+					rsp.NextCursor = strconv.Itoa(offset + idx + 1)
+				}
+				return nil
+			}
+		}
+		offset += len(rows)
+		if !more {
+			return nil
+		}
+	}
+}
+
+type UpdateRequest struct {
+	ID          string    `json:"id" required:"true"`
+	Title       *string   `json:"title,omitempty"`
+	Description *string   `json:"description,omitempty"`
+	Tags        *[]string `json:"tags,omitempty"`
+}
+
+func owned(caller string, id string) (*userdb.Record, error) {
+	if caller == "" {
+		return nil, userdb.ErrAuth
+	}
+	r, err := userdb.Get(ns, caller, collection, id)
+	if err != nil {
+		return nil, err
+	}
+	if r.Owner != caller {
+		return nil, userdb.ErrNotFound
+	}
+	return r, nil
+}
+func (Server) Update(ctx context.Context, req *UpdateRequest, rsp *ImageResponse) error {
+	r, err := owned(service.AccountFrom(ctx), req.ID)
+	if err != nil {
+		return err
+	}
+	if req.Title != nil {
+		if len(*req.Title) > 200 {
+			return fmt.Errorf("title exceeds 200 characters")
+		}
+		r.Data["title"] = *req.Title
+	}
+	if req.Description != nil {
+		if len(*req.Description) > 4000 {
+			return fmt.Errorf("description exceeds 4000 characters")
+		}
+		r.Data["description"] = *req.Description
+	}
+	if req.Tags != nil {
+		if len(*req.Tags) > 30 {
+			return fmt.Errorf("too many tags")
+		}
+		for _, tag := range *req.Tags {
+			if len(tag) > 80 {
+				return fmt.Errorf("tag too long")
+			}
+		}
+		r.Data["tags"] = *req.Tags
+	}
+	r, err = userdb.Update(ns, r.Owner, collection, r.ID, r.Data, r.Public)
+	if err == nil {
+		rsp.Image = recordImage(*r)
+	}
+	return err
+}
+
+type ShareRequest struct {
+	ID     string `json:"id" required:"true"`
+	Public bool   `json:"public" description:"Explicitly publish or unpublish this image"`
+}
+
+func (Server) Share(ctx context.Context, req *ShareRequest, rsp *ImageResponse) error {
+	r, err := owned(service.AccountFrom(ctx), req.ID)
+	if err != nil {
+		return err
+	}
+	r, err = userdb.Update(ns, r.Owner, collection, r.ID, r.Data, req.Public)
+	if err == nil {
+		rsp.Image = recordImage(*r)
+	}
+	return err
+}
+
+type DeleteResponse struct {
+	Deleted bool `json:"deleted"`
+}
+
+func (Server) Delete(ctx context.Context, req *GetRequest, rsp *DeleteResponse) error {
+	r, err := owned(service.AccountFrom(ctx), req.ID)
+	if err != nil {
+		return err
+	}
+	if err = userdb.Delete(ns, r.Owner, collection, r.ID); err != nil {
+		return err
+	}
+	if key, ok := r.Data["file"].(string); ok && key != "" {
+		if err = blob.Delete(key); err != nil {
+			return fmt.Errorf("record deleted but image bytes could not be removed: %w", err)
+		}
+	}
+	rsp.Deleted = true
+	return nil
+}
+
+type UploadRequest struct {
+	Data        string `json:"data" required:"true" description:"Base64 PNG, JPEG or GIF; at most 512 KB decoded and 8 megapixels; browser uploads support 8 MB"`
+	Description string `json:"description" description:"Image caption, at most 1000 characters"`
+}
+
+func (Server) Upload(ctx context.Context, req *UploadRequest, rsp *ImageResponse) error {
+	caller := service.AccountFrom(ctx)
+	if caller == "" {
+		return userdb.ErrAuth
+	}
+	if len(req.Data) > base64.StdEncoding.EncodedLen(512<<10) {
+		return fmt.Errorf("API image exceeds 512 KB; use the browser upload for larger images")
+	}
+	raw, err := base64.StdEncoding.DecodeString(req.Data)
+	if err != nil {
+		return fmt.Errorf("invalid base64 image")
+	}
+	r, err := saveUpload(caller, raw, req.Description)
+	if err == nil {
+		rsp.Image = recordImage(*r)
+	}
+	return err
+}

--- a/service/images/library_test.go
+++ b/service/images/library_test.go
@@ -1,0 +1,103 @@
+package images
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"image"
+	"image/png"
+	"mu/internal/service"
+	"mu/internal/userdb"
+	"testing"
+)
+
+func TestLibraryOwnershipAndMetadata(t *testing.T) {
+	ctx := service.WithAccount(context.Background(), "library-owner")
+	other := service.WithAccount(context.Background(), "library-other")
+	var buf bytes.Buffer
+	if err := png.Encode(&buf, image.NewRGBA(image.Rect(0, 0, 2, 2))); err != nil {
+		t.Fatal(err)
+	}
+	var uploaded ImageResponse
+	if err := (Server{}).Upload(ctx, &UploadRequest{Data: base64.StdEncoding.EncodeToString(buf.Bytes()), Description: "lake"}, &uploaded); err != nil {
+		t.Fatal(err)
+	}
+	id := uploaded.Image.ID
+	defer userdb.Delete(ns, "library-owner", collection, id)
+	if uploaded.Image.Visibility != "private" || uploaded.Image.Source != "uploaded" {
+		t.Fatal(uploaded)
+	}
+	if err := (Server{}).Get(other, &GetRequest{ID: id}, &ImageResponse{}); err == nil {
+		t.Fatal("private image leaked")
+	}
+	title := "Mountain lake"
+	tags := []string{"dawn", "water"}
+	if err := (Server{}).Update(ctx, &UpdateRequest{ID: id, Title: &title, Tags: &tags}, &ImageResponse{}); err != nil {
+		t.Fatal(err)
+	}
+	var found SearchResponse
+	if err := (Server{}).Search(ctx, &SearchRequest{Scope: "mine", Query: "mountain dawn"}, &found); err != nil || len(found.Items) != 1 {
+		t.Fatalf("search: %v %#v", err, found)
+	}
+	if err := (Server{}).Share(ctx, &ShareRequest{ID: id, Public: true}, &ImageResponse{}); err != nil {
+		t.Fatal(err)
+	}
+	if err := (Server{}).Get(other, &GetRequest{ID: id}, &ImageResponse{}); err != nil {
+		t.Fatal(err)
+	}
+	if err := (Server{}).Update(other, &UpdateRequest{ID: id, Title: &title}, &ImageResponse{}); err == nil {
+		t.Fatal("foreign update")
+	}
+	if err := (Server{}).Share(other, &ShareRequest{ID: id, Public: false}, &ImageResponse{}); err == nil {
+		t.Fatal("foreign share")
+	}
+	if err := (Server{}).Delete(other, &GetRequest{ID: id}, &DeleteResponse{}); err == nil {
+		t.Fatal("foreign delete")
+	}
+	if err := (Server{}).Share(ctx, &ShareRequest{ID: id, Public: false}, &ImageResponse{}); err != nil {
+		t.Fatal(err)
+	}
+	if err := (Server{}).Get(other, &GetRequest{ID: id}, &ImageResponse{}); err == nil {
+		t.Fatal("unpublished image leaked")
+	}
+	if err := (Server{}).Delete(ctx, &GetRequest{ID: id}, &DeleteResponse{}); err != nil {
+		t.Fatal(err)
+	}
+	if err := (Server{}).Get(ctx, &GetRequest{ID: id}, &ImageResponse{}); err == nil {
+		t.Fatal("deleted record remains")
+	}
+}
+func TestLibraryPaginationPastStoreLimit(t *testing.T) {
+	const owner = "image-pages"
+	ctx := service.WithAccount(context.Background(), owner)
+	defer userdb.DeleteOwner(ns, owner)
+	for i := 0; i < 205; i++ {
+		if _, err := userdb.Create(ns, owner, collection, map[string]interface{}{"prompt": "page test"}, false); err != nil {
+			t.Fatal(err)
+		}
+	}
+	seen := map[string]bool{}
+	cursor := ""
+	for {
+		var rsp ListResponse
+		if err := (Server{}).List(ctx, &ListRequest{Scope: "mine", Limit: 70, Cursor: cursor}, &rsp); err != nil {
+			t.Fatal(err)
+		}
+		for _, item := range rsp.Items {
+			if seen[item.ID] {
+				t.Fatal("duplicate page item")
+			}
+			seen[item.ID] = true
+		}
+		cursor = rsp.NextCursor
+		if cursor == "" {
+			break
+		}
+	}
+	if len(seen) != 205 {
+		t.Fatalf("listed %d images", len(seen))
+	}
+	if err := (Server{}).List(context.Background(), &ListRequest{Scope: "mine"}, &ListResponse{}); err == nil {
+		t.Fatal("guest mine accepted")
+	}
+}

--- a/service/images/service.go
+++ b/service/images/service.go
@@ -3,10 +3,12 @@ package images
 import (
 	"context"
 	"fmt"
+
 	"strings"
 
 	"mu/internal/quota"
 	"mu/internal/service"
+	"mu/internal/userdb"
 )
 
 // Server is the go-micro service handler for images. Its methods are exposed as
@@ -22,7 +24,8 @@ type GenerateRequest struct {
 
 // GenerateResponse is the created image.
 type GenerateResponse struct {
-	URL string `json:"url" description:"URL of the generated image"`
+	Image *Image `json:"image,omitempty"`
+	URL   string `json:"url" description:"URL of the generated image"`
 }
 
 // Generate creates an image from a text prompt and returns its URL. It costs
@@ -39,6 +42,11 @@ func (Server) Generate(ctx context.Context, req *GenerateRequest, rsp *GenerateR
 	// chat — so it needs the full address, the same reasoning AbsoluteURL
 	// exists for.
 	if id, ok := strings.CutPrefix(url, DisplayURL("")); ok {
+		record, getErr := userdb.Get(ns, service.AccountFrom(ctx), collection, id)
+		if getErr == nil {
+			item := recordImage(*record)
+			rsp.Image = &item
+		}
 		url = AbsoluteURL(id)
 	}
 	rsp.URL = url
@@ -54,9 +62,15 @@ var Spec = service.Spec{
 	Icon:        "images.svg",
 	Card:        service.Glance(CardHTML),
 	Endpoints: map[string]service.Endpoint{
-		"Generate":  {Writes: true, Aliases: []string{"image_generate"}, Doc: "Generate an image from a text prompt and return its URL", Cost: quota.OpImageGenerate},
-		"WebSearch": {Doc: "Search the web for images with source links and strict SafeSearch", Cost: quota.OpWebSearch},
-		"Search":    {Aliases: []string{"image_search"}, Doc: "Search the public image library by description and get URLs to reuse. Cheaper than generating: look here first"},
+		"Delete":   {Doc: "Delete an image you own", Destructive: true},
+		"Share":    {Doc: "Explicitly publish or unpublish your image", Destructive: true},
+		"Update":   {Doc: "Edit metadata on an image you own", Writes: true},
+		"Upload":   {Doc: "Upload a private raster image", Writes: true},
+		"Daily":    {Doc: "Retrieve the current daily image or a date", Writes: false},
+		"Get":      {Doc: "Retrieve accessible image metadata and URL", Writes: false},
+		"List":     {Doc: "List stored images or the daily archive with pagination", Writes: false},
+		"Generate": {Writes: true, Aliases: []string{"image_generate"}, Doc: "Generate an image from a text prompt and return its URL", Cost: quota.OpImageGenerate},
+		"Search":   {Aliases: []string{"image_search"}, Doc: "Search accessible stored images by title, description, prompt and tags; public by default"},
 	},
 }
 
@@ -69,42 +83,41 @@ var Spec = service.Spec{
 // first.
 
 type SearchRequest struct {
-	Query string `json:"query" required:"true" description:"What the image should show, in words"`
-	Limit int    `json:"limit" description:"Max results (default 20)"`
+	Scope  string `json:"scope" description:"public, mine, all, or daily; defaults to public"`
+	Cursor string `json:"cursor"`
+	Query  string `json:"query" required:"true" description:"What the image should show, in words"`
+	Limit  int    `json:"limit" description:"Max results (default 20)"`
 }
 
 type SearchResponse struct {
-	Text string `json:"text" description:"Matching images: what each depicts, and a URL to reuse"`
+	Items      []Image `json:"items"`
+	NextCursor string  `json:"next_cursor,omitempty"`
+	Text       string  `json:"text,omitempty" description:"Matching images: what each depicts, and a URL to reuse"`
 }
 
 // Search looks through the public image library — images generated here and
 // shared — so an existing one can be reused instead of paying to make another.
 // @example {"query": "a lighthouse at dusk"}
-func (Server) Search(_ context.Context, req *SearchRequest, rsp *SearchResponse) error {
-	q := strings.TrimSpace(req.Query)
-	if q == "" {
+func (Server) Search(ctx context.Context, req *SearchRequest, rsp *SearchResponse) error {
+	if strings.TrimSpace(req.Query) == "" {
 		return fmt.Errorf("query is required")
 	}
-	limit := req.Limit
-	if limit <= 0 || limit > 50 {
-		limit = 20
+	if len(req.Query) > 400 {
+		return fmt.Errorf("query exceeds 400 characters")
 	}
-
-	recs := Search("", q)
-	if len(recs) == 0 {
-		rsp.Text = "No matching images in the stock pool."
-		return nil
+	page := ListResponse{}
+	if err := libraryPage(service.AccountFrom(ctx), ListRequest{Scope: req.Scope, Limit: req.Limit, Cursor: req.Cursor}, req.Query, &page); err != nil {
+		return err
 	}
-	var b strings.Builder
-	for i, rec := range recs {
-		if i >= limit {
-			break
-		}
-		prompt, _ := rec.Data["prompt"].(string)
-		// Our copy, not the provider's link: the caller is being handed a URL
-		// to keep, and the provider's expires.
-		b.WriteString(fmt.Sprintf("- %s\n  %s\n", prompt, AbsoluteURL(rec.ID)))
+	rsp.Items = page.Items
+	rsp.NextCursor = page.NextCursor
+	var text strings.Builder
+	for _, item := range page.Items {
+		fmt.Fprintf(&text, "- %s\n  %s\n", item.Description, item.URL)
 	}
-	rsp.Text = b.String()
+	rsp.Text = text.String()
+	if len(page.Items) == 0 {
+		rsp.Text = "No matching images."
+	}
 	return nil
 }

--- a/service/images/upload.go
+++ b/service/images/upload.go
@@ -2,6 +2,7 @@ package images
 
 import (
 	"bytes"
+	"fmt"
 	"html"
 	"image"
 	_ "image/gif"
@@ -47,47 +48,56 @@ func uploadHandler(w http.ResponseWriter, r *http.Request) {
 		app.BadRequest(w, r, "Choose an image up to 8 MB.")
 		return
 	}
-	cfg, _, err := image.DecodeConfig(bytes.NewReader(raw))
-	if err != nil || cfg.Width < 1 || cfg.Height < 1 || int64(cfg.Width)*int64(cfg.Height) > 8000000 {
-		app.BadRequest(w, r, "Use a PNG, JPEG or GIF up to 8 megapixels.")
-		return
-	}
-	im, _, err := image.Decode(bytes.NewReader(raw))
-	if err != nil {
-		app.BadRequest(w, r, "Could not read this image.")
-		return
-	}
-	var encoded bytes.Buffer
-	if png.Encode(&encoded, im) != nil {
-		app.BadRequest(w, r, "Could not store this image.")
-		return
-	}
 	caption := strings.TrimSpace(r.FormValue("caption"))
 	if caption == "" {
 		caption = h.Filename
 	}
-	if len(caption) > 1000 {
-		app.BadRequest(w, r, "Keep the caption under 1000 characters.")
-		return
-	}
-	rec, err := userdb.Create(ns, sess.Account, collection, map[string]interface{}{"prompt": caption, "uploaded": true}, false)
-	if err != nil {
-		app.RespondError(w, 500, "Could not save image")
-		return
-	}
-	key := genPrefix(rec.ID) + ".png"
-	if err = blob.Put(key, encoded.Bytes(), "image/png"); err == nil {
-		rec.Data["file"] = key
-		_, err = userdb.Update(ns, sess.Account, collection, rec.ID, rec.Data, false)
-	}
-	if err != nil {
-		_ = blob.Delete(key)
-		_ = userdb.Delete(ns, sess.Account, collection, rec.ID)
-		app.RespondError(w, 500, "Could not save image")
+	if _, err := saveUpload(sess.Account, raw, caption); err != nil {
+		app.BadRequest(w, r, err.Error())
 		return
 	}
 	http.Redirect(w, r, "/images", http.StatusSeeOther)
 }
 func uploadForm(r *http.Request) string {
 	return `<details class="card"><summary>Upload an image</summary><form class="form form-inline mt-3" method="POST" action="/images?upload=1" enctype="multipart/form-data">` + app.CSRFField(auth.CSRFToken(r)) + `<input type="file" name="file" accept="image/png,image/jpeg,image/gif" required><input name="caption" placeholder="Caption" maxlength="1000"><button>Upload</button></form><p class="text-sm text-muted">Private. PNG, JPEG or GIF, up to 8 MB and 8 megapixels. ` + html.EscapeString("GIF uploads keep the first frame.") + `</p></details>`
+}
+
+// saveUpload normalizes accepted raster images and creates a private record.
+func saveUpload(owner string, raw []byte, caption string) (*userdb.Record, error) {
+	if owner == "" {
+		return nil, userdb.ErrAuth
+	}
+	if len(raw) > 8<<20 {
+		return nil, fmt.Errorf("image exceeds 8 MB")
+	}
+	cfg, _, err := image.DecodeConfig(bytes.NewReader(raw))
+	if err != nil || cfg.Width < 1 || cfg.Height < 1 || int64(cfg.Width)*int64(cfg.Height) > 8000000 {
+		return nil, fmt.Errorf("Use a PNG, JPEG or GIF up to 8 megapixels.")
+	}
+	im, _, err := image.Decode(bytes.NewReader(raw))
+	if err != nil {
+		return nil, fmt.Errorf("Could not read this image.")
+	}
+	var encoded bytes.Buffer
+	if png.Encode(&encoded, im) != nil {
+		return nil, fmt.Errorf("Could not store this image.")
+	}
+	if len(caption) > 1000 {
+		return nil, fmt.Errorf("Keep the caption under 1000 characters.")
+	}
+	rec, err := userdb.Create(ns, owner, collection, map[string]interface{}{"prompt": caption, "uploaded": true}, false)
+	if err != nil {
+		return nil, fmt.Errorf("could not save image")
+	}
+	key := genPrefix(rec.ID) + ".png"
+	if err = blob.Put(key, encoded.Bytes(), "image/png"); err == nil {
+		rec.Data["file"] = key
+		_, err = userdb.Update(ns, owner, collection, rec.ID, rec.Data, false)
+	}
+	if err != nil {
+		_ = blob.Delete(key)
+		_ = userdb.Delete(ns, owner, collection, rec.ID)
+		return nil, fmt.Errorf("could not save image")
+	}
+	return rec, nil
 }

--- a/service/images/web.go
+++ b/service/images/web.go
@@ -1,95 +1,14 @@
 package images
 
 import (
-	"context"
-	"encoding/json"
-	"fmt"
 	"html"
-	"io"
 	"mu/internal/app"
 	"mu/internal/auth"
+	"mu/internal/imagesearch"
 	"mu/internal/quota"
-	"mu/internal/settings"
 	"net/http"
-	"net/url"
-	"strings"
-	"time"
 )
 
-type WebSearchRequest struct {
-	Query string `json:"query" required:"true" description:"Images to find on the web"`
-}
-type WebImage struct {
-	Title     string `json:"title"`
-	URL       string `json:"url"`
-	Source    string `json:"source"`
-	Thumbnail struct {
-		Src string `json:"src"`
-	} `json:"thumbnail"`
-	Properties struct {
-		URL string `json:"url"`
-	} `json:"properties"`
-}
-type WebSearchResponse struct {
-	Results []WebImage `json:"results"`
-}
-
-var imageSearchClient = &http.Client{Timeout: 12 * time.Second}
-var imageSearchURL = "https://api.search.brave.com/res/v1/images/search"
-
-func webImages(query string) ([]WebImage, error) {
-	query = strings.TrimSpace(query)
-	if query == "" || len(query) > 400 || len(strings.Fields(query)) > 50 {
-		return nil, fmt.Errorf("use a search of up to 400 characters and 50 words")
-	}
-	key := settings.Get("BRAVE_API_KEY")
-	if key == "" {
-		return nil, fmt.Errorf("web image search is not configured on this instance")
-	}
-	q := url.Values{"q": {query}, "count": {"24"}, "safesearch": {"strict"}}
-	req, _ := http.NewRequest(http.MethodGet, imageSearchURL+"?"+q.Encode(), nil)
-	req.Header.Set("X-Subscription-Token", key)
-	req.Header.Set("Accept", "application/json")
-	resp, err := imageSearchClient.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("could not reach image search")
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != 200 {
-		return nil, fmt.Errorf("image search is unavailable (%d)", resp.StatusCode)
-	}
-	var result struct {
-		Results []WebImage
-		Extra   struct {
-			MightBeOffensive bool `json:"might_be_offensive"`
-		}
-	}
-	if err := json.NewDecoder(io.LimitReader(resp.Body, 2<<20)).Decode(&result); err != nil {
-		return nil, fmt.Errorf("could not read image search results")
-	}
-	if result.Extra.MightBeOffensive {
-		return nil, fmt.Errorf("these results were filtered; try another search")
-	}
-	var safe []WebImage
-	for _, r := range result.Results {
-		if webURL(r.URL) && webURL(r.Thumbnail.Src) && webURL(r.Properties.URL) {
-			safe = append(safe, r)
-		}
-		if len(safe) == 24 {
-			break
-		}
-	}
-	return safe, nil
-}
-func webURL(s string) bool {
-	u, e := url.Parse(s)
-	return e == nil && u.Host != "" && (u.Scheme == "https" || u.Scheme == "http")
-}
-func (Server) WebSearch(ctx context.Context, req *WebSearchRequest, rsp *WebSearchResponse) error {
-	var err error
-	rsp.Results, err = webImages(req.Query)
-	return err
-}
 func webSearchPage(w http.ResponseWriter, r *http.Request) {
 	owner, ok := app.BillableCaller(w, r, quota.OpWebSearch)
 	if !ok {
@@ -107,7 +26,7 @@ func webSearchPage(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	results, err := webImages(r.PostFormValue("query"))
+	results, err := imagesearch.Search(r.Context(), r.PostFormValue("query"))
 	if err == nil && owner != "" {
 		err = quota.Charge(owner, quota.OpWebSearch, nil)
 	}

--- a/service/web/images.go
+++ b/service/web/images.go
@@ -1,0 +1,40 @@
+package web
+
+import (
+	"context"
+	"mu/internal/imagesearch"
+)
+
+type ImagesRequest struct {
+	Query string `json:"query" required:"true" description:"Images to find on the web"`
+	Limit int    `json:"limit" description:"Maximum results, default 24"`
+}
+type WebImage struct {
+	Title     string `json:"title"`
+	URL       string `json:"url"`
+	Thumbnail string `json:"thumbnail"`
+	SourceURL string `json:"source_url"`
+	Source    string `json:"source"`
+}
+type ImagesResponse struct {
+	Items []WebImage `json:"items"`
+}
+
+func (Server) Images(ctx context.Context, req *ImagesRequest, rsp *ImagesResponse) error {
+	rows, err := imagesearch.Search(ctx, req.Query)
+	if err != nil {
+		return err
+	}
+	limit := req.Limit
+	if limit <= 0 || limit > 24 {
+		limit = 24
+	}
+	rsp.Items = []WebImage{}
+	for _, row := range rows {
+		if len(rsp.Items) == limit {
+			break
+		}
+		rsp.Items = append(rsp.Items, WebImage{Title: row.Title, URL: row.Properties.URL, Thumbnail: row.Thumbnail.Src, SourceURL: row.URL, Source: row.Source})
+	}
+	return nil
+}

--- a/service/web/service.go
+++ b/service/web/service.go
@@ -112,6 +112,7 @@ var Spec = service.Spec{
 	// icon stays search.svg; a file name is not a user-facing string.
 	Icon: "search.svg",
 	Endpoints: map[string]service.Endpoint{
+		"Images": {Doc: "Search the web for images, thumbnails and original source pages", Cost: quota.OpWebSearch},
 		"Fetch": {
 			Aliases: []string{"search_fetch"},
 			Doc: "Fetch a web page by URL and return its cleaned readable content, " +

--- a/test/permissions.golden
+++ b/test/permissions.golden
@@ -51,9 +51,15 @@ food_search                  needsAccount=false destructive=false open accountOn
 hazards_alerts               needsAccount=false destructive=false open accountOnly=false optionalAuth=false
 hazards_floods               needsAccount=false destructive=false open accountOnly=false optionalAuth=false
 hazards_quakes               needsAccount=false destructive=false open accountOnly=false optionalAuth=false
+images_daily                 needsAccount=true  destructive=false bound accountOnly=false optionalAuth=false
+images_delete                needsAccount=true  destructive=true  bound accountOnly=false optionalAuth=false
 images_generate              needsAccount=true  destructive=false bound accountOnly=false optionalAuth=false
+images_get                   needsAccount=true  destructive=false bound accountOnly=false optionalAuth=false
+images_list                  needsAccount=true  destructive=false bound accountOnly=false optionalAuth=false
 images_search                needsAccount=true  destructive=false bound accountOnly=false optionalAuth=false
-images_websearch             needsAccount=true  destructive=false bound accountOnly=false optionalAuth=false
+images_share                 needsAccount=true  destructive=true  bound accountOnly=false optionalAuth=false
+images_update                needsAccount=true  destructive=false bound accountOnly=false optionalAuth=false
+images_upload                needsAccount=true  destructive=false bound accountOnly=false optionalAuth=false
 mail_inbox                   needsAccount=true  destructive=false bound accountOnly=false optionalAuth=false
 mail_info                    needsAccount=true  destructive=false bound accountOnly=false optionalAuth=false
 mail_markread                needsAccount=true  destructive=false bound accountOnly=true  optionalAuth=false
@@ -131,4 +137,5 @@ weather_history              needsAccount=false destructive=false open accountOn
 weather_lookup               needsAccount=false destructive=false bound accountOnly=false optionalAuth=true
 weather_marine               needsAccount=false destructive=false open accountOnly=false optionalAuth=false
 web_fetch                    needsAccount=true  destructive=false bound accountOnly=false optionalAuth=false
+web_images                   needsAccount=false destructive=false bound accountOnly=false optionalAuth=true
 web_search                   needsAccount=false destructive=false bound accountOnly=false optionalAuth=true

--- a/test/scoped_test.go
+++ b/test/scoped_test.go
@@ -45,12 +45,7 @@ var resolvesCaller = regexp.MustCompile(
 //
 // Each of these was read. None is "it looked fine".
 var exemptFromScoping = map[string]string{
-	// Passes an empty caller on purpose. images.Search("") selects scope
-	// "public", which is the stock pool — the shared images, not everyone's.
-	// Handing it the real caller would widen the search to their own private
-	// images, which is a different tool.
-	"images.Search":    "empty caller selects the public pool by design",
-	"images.WebSearch": "searches public web images only; the service gateway authenticates and charges the caller",
+	"images.Daily": "reads only the instance public daily image archive",
 
 	// Resolves the caller through sender(ctx, req), which reads
 	// service.AccountFrom and never trusts a field in the request. Matched by


### PR DESCRIPTION
Images had generation and prompt-only public search, but no API for browsing the daily archive or managing owned images. Add List, Get, Daily, Upload, Update, Share and Delete, with structured image records and searchable title/description/prompt/tags. Retain the existing Search text and Generate URL fields for compatibility.

List and Search support public, mine, all (own + public), and daily scopes with bounded offset cursors. The new userdb page reader applies ownership filtering before slicing and reaches beyond the old 200-record limit. Upload shares raster validation/storage with the browser; JSON uploads are capped at 512 KB decoded to fit the existing 1 MB gateway cap, while browser uploads remain 8 MB. Share and Delete are protected operations withheld from the autonomous model, matching existing destructive-operation policy.

Move external image search from images.WebSearch to web.Images, using a shared internal Brave client for the existing browser surface. It retains strict SafeSearch and source attribution, adds cancellation, and returns source-page, image and thumbnail URLs. This renames the MCP operation from images_websearch to web_images. Update advertised counts and the reviewed permission snapshot.

Validation: go test ./service/images ./service/web ./internal/userdb ./internal/imagesearch -short; go test ./test -short; gofmt and git diff --check. Tests cover owner/other-user reads and writes, sharing/unsharing/deletion, PNG upload, metadata search, 205-record pagination, and Brave request/filter/cancellation behavior. No paid generation or live Brave query executed. Offset cursors are intended for sequential browsing; concurrent insertions/deletions may shift page boundaries.