### PR TITLE
Use the selected provider in agent API logs

### DIFF
--- a/agent/native.go
+++ b/agent/native.go
@@ -378,7 +378,7 @@ func buildNativeAgent(accountID, prompt string, opts QueryOpts, wrappers ...gmai
 	runs := store.NewMemoryStore()
 	agentOpts := []gmagent.Option{
 		gmagent.Model(model),
-		gmagent.OnRunEvent(logRunTiming),
+		gmagent.OnRunEvent(runTimingFor(provider)),
 		gmagent.WithStore(runs),
 		// What was said before, as turns. Read-only, which is what stops the
 		// question being counted twice — go-micro adds it to memory and then

--- a/agent/timing.go
+++ b/agent/timing.go
@@ -24,3 +24,15 @@ func logRunTiming(e gmagent.RunEvent) {
 	}
 	app.RecordExternalCall(app.APILogEntry{Kind: "model", Time: e.Time, Service: e.Provider, Method: e.Kind, Model: e.Model, RunID: e.RunID, Outcome: outcome, Attempt: e.Attempt, Duration: time.Duration(e.LatencyMS) * time.Millisecond, Error: ai.ProviderErrorDetail(e.Error), ErrorKind: e.ErrorKind, InputTokens: e.Tokens.InputTokens, OutputTokens: e.Tokens.OutputTokens})
 }
+
+// runTimingFor captures the selected route, rather than the adapter's String()
+// (OpenRouter uses the OpenAI-compatible adapter). Capture per run so a config
+// change cannot relabel an in-flight request.
+func runTimingFor(provider string) func(gmagent.RunEvent) {
+	return func(e gmagent.RunEvent) {
+		if e.Kind == "model" || e.Kind == "stream" {
+			e.Provider = provider
+		}
+		logRunTiming(e)
+	}
+}

--- a/agent/timing_test.go
+++ b/agent/timing_test.go
@@ -27,3 +27,18 @@ func TestModelTimingRetainsProviderError(t *testing.T) {
 		t.Fatalf("lost provider diagnostic: %+v", got)
 	}
 }
+
+func TestModelLogUsesSelectedRoute(t *testing.T) {
+	router := runTimingFor("openrouter")
+	direct := runTimingFor("openai")
+	for _, kind := range []string{"model", "stream"} {
+		router(gmagent.RunEvent{Kind: kind, Provider: "openai", Model: "poolside/laguna", Status: "done"})
+		if got := app.APILog()[0]; got.Service != "openrouter" || got.Model != "poolside/laguna" {
+			t.Fatalf("wrong route: %+v", got)
+		}
+		direct(gmagent.RunEvent{Kind: kind, Provider: "openai", Status: "done"})
+		if got := app.APILog()[0]; got.Service != "openai" {
+			t.Fatalf("direct route relabeled: %+v", got)
+		}
+	}
+}


### PR DESCRIPTION
OpenRouter uses the OpenAI-compatible model adapter. Its String() is openai, which the runtime copies into timing events and Micro's API log. This made OpenRouter calls look like direct OpenAI calls.

Capture the resolved provider when constructing each native run and apply it to model/stream timing events. Routing and credentials are unchanged; in-flight requests retain their original provider label even if configuration changes.

Validation: targeted agent timing tests pass for both OpenRouter and direct OpenAI routes, model and stream events; gofmt and git diff --check pass. Historical log entries are not rewritten.