### PR TITLE
Keep app-test sessions temporary, including concurrent login saves

### DIFF
--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -166,6 +166,9 @@ func init() {
 	json.Unmarshal(b, &accounts)
 	b, _ = data.LoadFile("sessions.json")
 	json.Unmarshal(b, &sessions)
+	// Older versions could serialize an in-flight internal dispatch when a
+	// login happened concurrently. Such credentials must never resume at boot.
+	sessions = persistentSessions(sessions)
 	b, _ = data.LoadFile("tokens.json")
 	json.Unmarshal(b, &tokens)
 	for _, t := range tokens {
@@ -381,7 +384,7 @@ func DeleteAccount(id string) error {
 	}
 
 	data.SaveJSON("accounts.json", accounts)
-	data.SaveJSON("sessions.json", sessions)
+	data.SaveJSON("sessions.json", persistentSessions(sessions))
 	data.SaveJSON("tokens.json", tokens)
 
 	// And the SSH keys, which are the same kind of thing as a token: a
@@ -453,7 +456,7 @@ func Login(id, secret string) (*Session, error) {
 
 	// store the session
 	sessions[guid] = sess
-	data.SaveJSON("sessions.json", sessions)
+	data.SaveJSON("sessions.json", persistentSessions(sessions))
 
 	return sess, nil
 }
@@ -480,7 +483,7 @@ func CreateSession(id string) (*Session, error) {
 	}
 
 	sessions[guid] = sess
-	data.SaveJSON("sessions.json", sessions)
+	data.SaveJSON("sessions.json", persistentSessions(sessions))
 
 	return sess, nil
 }
@@ -493,7 +496,7 @@ func Logout(tk string) error {
 
 	mutex.Lock()
 	delete(sessions, sess.ID)
-	data.SaveJSON("sessions.json", sessions)
+	data.SaveJSON("sessions.json", persistentSessions(sessions))
 	mutex.Unlock()
 
 	return nil

--- a/internal/auth/internal_session.go
+++ b/internal/auth/internal_session.go
@@ -63,3 +63,17 @@ func EndSession(tk string) {
 	delete(sessions, id.String())
 	mutex.Unlock()
 }
+
+// persistentSessions is the disk representation, both on save and on load.
+// Internal sessions share the lookup map with logins, but never their lifetime:
+// another goroutine logging in or out must not persist a temporary credential.
+// The caller holds mutex when reading the live sessions map.
+func persistentSessions(all map[string]*Session) map[string]*Session {
+	out := make(map[string]*Session, len(all))
+	for id, sess := range all {
+		if sess != nil && sess.Type != "internal" {
+			out[id] = sess
+		}
+	}
+	return out
+}

--- a/internal/auth/internal_session_test.go
+++ b/internal/auth/internal_session_test.go
@@ -1,6 +1,10 @@
 package auth
 
-import "testing"
+import (
+	"testing"
+
+	"mu/internal/data"
+)
 
 // TestInternalSessionsLeaveNothingBehind is the leak this replaced.
 //
@@ -49,5 +53,59 @@ func TestInternalSessionsLeaveNothingBehind(t *testing.T) {
 
 	if _, err := InternalSession("nobody"); err == nil {
 		t.Error("minted a session for an account that does not exist")
+	}
+}
+
+func TestInternalSessionDoesNotSurviveAConcurrentLoginSave(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	mutex.Lock()
+	previousAccounts, previousSessions := accounts, sessions
+	accounts = map[string]*Account{"probe": {ID: "probe"}}
+	sessions = map[string]*Session{}
+	mutex.Unlock()
+	t.Cleanup(func() {
+		mutex.Lock()
+		accounts, sessions = previousAccounts, previousSessions
+		mutex.Unlock()
+	})
+
+	temporary, err := InternalSession("probe")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer EndSession(temporary.Token)
+	login, err := CreateSession("probe")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var saved map[string]*Session
+	if err := data.LoadJSON("sessions.json", &saved); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := saved[temporary.ID]; ok {
+		t.Fatal("an unrelated login persisted the in-flight internal session")
+	}
+	if _, ok := saved[login.ID]; !ok {
+		t.Fatal("ordinary login was not saved")
+	}
+	// The internal identity remains valid for the rest of its dispatch.
+	if _, err := ParseToken(temporary.Token); err != nil {
+		t.Fatalf("saving logins invalidated the in-flight call: %v", err)
+	}
+}
+
+func TestPersistedSessionsDiscardLegacyInternalCredentials(t *testing.T) {
+	stored := map[string]*Session{
+		"temporary": {ID: "temporary", Type: "internal"},
+		"login":     {ID: "login", Type: "account"},
+		"legacy":    {ID: "legacy"},
+		"null":      nil,
+	}
+	loaded := persistentSessions(stored)
+	if len(loaded) != 2 || loaded["login"] == nil || loaded["legacy"] == nil {
+		t.Fatal("loading sessions did not preserve only durable login credentials")
+	}
+	if stored["temporary"] == nil {
+		t.Fatal("filtering the disk representation mutated live internal sessions")
 	}
 }

--- a/service/apps/test.go
+++ b/service/apps/test.go
@@ -148,11 +148,12 @@ func extractSDKCalls(html string) []sdkCall {
 func executeSDKCall(sc sdkCall, authorID string) APITestResult {
 	tr := APITestResult{Call: sc.call, Path: sc.path}
 
-	sess, err := auth.CreateSession(authorID)
+	sess, err := auth.InternalSession(authorID)
 	if err != nil {
 		tr.Error = "auth failed"
 		return tr
 	}
+	defer auth.EndSession(sess.Token)
 
 	req, _ := http.NewRequest("GET", sc.path, nil)
 	req.AddCookie(&http.Cookie{Name: "session", Value: sess.Token})

--- a/service/apps/test_session_test.go
+++ b/service/apps/test_session_test.go
@@ -1,0 +1,100 @@
+package apps
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"mu/internal/auth"
+	"mu/internal/data"
+)
+
+// SDK probes are internal dispatches, not logins. A failed test must not leave
+// a working credential behind, including when a handler panics or another
+// login saves sessions while the probe is in flight.
+func TestSDKProbeSessionLifetime(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	const owner = "app_probe_owner"
+	if err := auth.Create(&auth.Account{ID: owner, Secret: "test-only"}); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = auth.DeleteAccount(owner) })
+	previous := http.DefaultServeMux
+	t.Cleanup(func() { http.DefaultServeMux = previous })
+
+	for _, outcome := range []string{"success", "http failure", "panic"} {
+		t.Run(outcome, func(t *testing.T) {
+			var probeToken string
+			http.DefaultServeMux = http.NewServeMux()
+			http.DefaultServeMux.HandleFunc("/news", func(w http.ResponseWriter, r *http.Request) {
+				sess, err := auth.GetSession(r)
+				if err != nil || sess.Account != owner {
+					t.Fatalf("probe did not retain its caller identity: %v", err)
+				}
+				probeToken = sess.Token
+				if sess.Type != "internal" {
+					t.Errorf("probe minted a persistent login instead of an internal session")
+				}
+				// A normal login can happen before this handler returns. It must
+				// not serialize the probe's temporary authority along with it.
+				login, err := auth.CreateSession(owner)
+				if err != nil {
+					t.Fatal(err)
+				}
+				defer auth.Logout(login.Token)
+				var saved map[string]*auth.Session
+				if err := data.LoadJSON("sessions.json", &saved); err != nil {
+					t.Fatal(err)
+				}
+				if _, ok := saved[sess.ID]; ok {
+					t.Error("temporary probe credential reached persistent storage")
+				}
+				if _, ok := saved[login.ID]; !ok {
+					t.Error("ordinary login was not persisted")
+				}
+				switch outcome {
+				case "http failure":
+					http.Error(w, "unavailable", http.StatusServiceUnavailable)
+				case "panic":
+					panic("probe handler failed")
+				default:
+					_ = json.NewEncoder(w).Encode(map[string]any{"feed": []any{}})
+				}
+			})
+			var panicked bool
+			var result APITestResult
+			func() {
+				defer func() { panicked = recover() != nil }()
+				result = executeSDKCall(sdkCall{call: "mu.news()", api: "news", path: "/news"}, owner)
+			}()
+			if panicked != (outcome == "panic") {
+				t.Fatalf("unexpected panic state: %v", panicked)
+			}
+			if probeToken == "" {
+				t.Fatal("probe was not dispatched")
+			}
+			if _, err := auth.ParseToken(probeToken); err == nil {
+				t.Error("probe credential still works after dispatch ended")
+			}
+			if outcome == "success" && (result.Status != http.StatusOK || result.Error != "") {
+				t.Errorf("successful probe changed: %+v", result)
+			}
+			if outcome == "http failure" && (result.Status != http.StatusServiceUnavailable || result.Error == "") {
+				t.Errorf("failed probe was not reported: %+v", result)
+			}
+		})
+	}
+}
+
+func TestSDKProbeRejectsMissingCaller(t *testing.T) {
+	previous := http.DefaultServeMux
+	t.Cleanup(func() { http.DefaultServeMux = previous })
+	http.DefaultServeMux = http.NewServeMux()
+	http.DefaultServeMux.HandleFunc("/news", func(http.ResponseWriter, *http.Request) {
+		t.Fatal("probe dispatched without a valid caller")
+	})
+	result := executeSDKCall(sdkCall{call: "mu.news()", api: "news", path: "/news"}, "missing-probe-owner")
+	if result.Error != "auth failed" {
+		t.Fatalf("invalid identity did not fail closed: %+v", result)
+	}
+}


### PR DESCRIPTION
Bounded harness-security prerequisite from #1646, also related to #1653. Does not close the app verification queue.

`apps_test` used `auth.CreateSession` for each SDK probe and never ended it. Each probe left a durable working login credential, including on HTTP error. Use the existing internal-session lifecycle with deferred cleanup instead.

Regression testing exposed a second part of the same lifetime defect: InternalSession shares the session lookup map, so a normal login/logout could serialize an in-flight internal token. Filter internal entries from every session save and from startup loading (discarding internal credentials serialized by older versions). Ordinary account sessions remain durable and active internal calls retain their identity.

Coverage dispatches real test HTTP handlers for success, HTTP failure and panic, validates the caller while executing, interleaves a normal login/save, and rejects the temporary token after return. Missing callers fail closed. Auth tests cover durable-login preservation and filtering legacy internal entries.

The new regressions failed on main for persisted/leaked credentials and pass with this patch. Full short suite, targeted race suites and binary build are in progress. Local build uses `-buildvcs=false` because Go's VCS discovery selects the outer workspace rather than the linked worktree; production CI retains normal stamping.

No app HTML edits, publication, browser-policy bypass or dependency changes. This does not claim static API probes verify interactive app behavior or eliminate all security gaps.