### PR TITLE
Replace Home's focus popup with an inline conversation

### DIFF
--- a/home/frontdoor_test.go
+++ b/home/frontdoor_test.go
@@ -44,7 +44,7 @@ func TestHomeStartsWithMicro(t *testing.T) {
 			t.Errorf("Home still offers %s", control)
 		}
 	}
-	if !strings.Contains(body, `class="mu-chat-contained mu-chat-overlay"`) {
-		t.Error("Home conversation is not contained")
+	if strings.Contains(body, `class="mu-chat-contained mu-chat-overlay"`) || !strings.Contains(body, `<div id="mu-chat">`) {
+		t.Error("Home should keep conversation in page flow")
 	}
 }

--- a/home/home.go
+++ b/home/home.go
@@ -447,13 +447,10 @@ function fetchW(la,lo){
 		HideSuggestions: true,
 		Placeholder:     "What do you need?",
 		AgentName:       agent.DefaultName(),
-		Contained:       true,
-		Overlay:         true,
+		Location:        viewerID != "",
 	}))
 	b.WriteString(`</div>`)
-	if viewerID != "" {
-		b.WriteString(`<div id="home-brief" class="page-stack">` + briefHTML(viewerID, events.CachedOverview(viewerID)...) + `</div>`)
-	}
+	b.WriteString(`<div id="home-brief" class="page-stack">` + briefHTML(viewerID, events.CachedOverview(viewerID)...) + `</div>`)
 	if viewerID != "" {
 		if peek := inbox.Preview(viewerID); peek != "" {
 			b.WriteString(`<div id="home-inbox" class="page-stack">` + peek + `</div>`)

--- a/home/index.go
+++ b/home/index.go
@@ -363,7 +363,7 @@ func indexBody() string {
 
 // topRight offers one way in from the landing; signup is on the login page.
 func topRight() string {
-	return `<a href="/login">Log in</a>`
+	return `<a href="/home">Home</a> <a href="/login">Log in</a>`
 }
 
 // today is what you are given for arriving, before you ask anything.

--- a/home/landing_test.go
+++ b/home/landing_test.go
@@ -31,9 +31,9 @@ func TestTheWordmarkSaysWhatItIs(t *testing.T) {
 	}
 }
 
-func TestTheLandingOffersOneWayIn(t *testing.T) {
+func TestTheLandingOffersPublicHomeAndLogin(t *testing.T) {
 	got := topRight()
-	if got != `<a href="/login">Log in</a>` {
+	if got != `<a href="/home">Home</a> <a href="/login">Log in</a>` {
 		t.Errorf("unexpected landing navigation: %q", got)
 	}
 }

--- a/home/layout_test.go
+++ b/home/layout_test.go
@@ -215,3 +215,17 @@ func TestHomeBoundsItsExternalCalendarRead(t *testing.T) {
 		t.Fatalf("preview %d, calls %d", rec.Code, calls)
 	}
 }
+
+func TestPublicHomeDoesNotExposePersonalCards(t *testing.T) {
+	rec := httptest.NewRecorder()
+	Handler(rec, httptest.NewRequest("GET", "/home", nil))
+	body := rec.Body.String()
+	for _, id := range []string{"home-inbox", "home-todo", "home-agents", "home-upcoming", "mu-chat-location"} {
+		if strings.Contains(body, `id="`+id+`"`) {
+			t.Errorf("public Home exposes %s", id)
+		}
+	}
+	if !strings.Contains(body, `id="home-brief"`) || !strings.Contains(body, `id="home-feed"`) {
+		t.Fatal("missing public content")
+	}
+}

--- a/home/views.js
+++ b/home/views.js
@@ -1,6 +1,12 @@
 (() => {
   const home = document.getElementById('home-cards');
   if (!home) return;
+  const personal=home.querySelector('#home-personal');
+  function conversation(active){if(personal)personal.classList.toggle('is-conversing',active);}
+  window.addEventListener('mu-chat-active',event=>conversation(event.detail===true));
+  const initial=home.querySelector('#mu-chat-conv');
+  conversation(!!initial && !!initial.textContent.trim());
+
   const upcoming = home.querySelector('[data-home-upcoming]');
   if (upcoming) {
     fetch('/home?section=upcoming', {credentials: 'same-origin'})
@@ -21,7 +27,10 @@
   const positions = new Map();
   let selected = tabs.find(tab => tab.getAttribute('aria-selected') === 'true');
   function select(tab) {
-    if (tab === selected) return;
+    if (tab === selected) {
+      if(tab.id==='home-view-personal' && personal.classList.contains('is-conversing') && window.muChatNew)window.muChatNew();
+      return;
+    }
     positions.set(selected.id, window.scrollY);
     tabs.forEach(item => {
       const active = item === tab;

--- a/internal/app/chat.go
+++ b/internal/app/chat.go
@@ -46,6 +46,8 @@ func JSAttr(s string) string {
 
 // ChatConfig configures the shared chat component.
 type ChatConfig struct {
+	// Location offers approximate device sharing on authenticated surfaces.
+	Location bool
 	// FooterHTML is trusted, pre-rendered content below the conversation and
 	// composer. Callers must escape user text.
 	FooterHTML string
@@ -401,12 +403,16 @@ func ChatComponent(cfg ChatConfig) string {
 		suggestJS = []byte("[]")
 	}
 
+	locationControl := ""
+	if cfg.Location {
+		locationControl = `<button type="button" id="mu-chat-location" aria-label="Share approximate location" title="Share approximate location with Micro and its model"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true"><circle cx="12" cy="12" r="7"/><circle cx="12" cy="12" r="2"/><path d="M12 2v3m0 14v3M2 12h3m14 0h3"/></svg></button>`
+	}
 	form := `<form id="mu-chat-form">
     <textarea id="mu-chat-input" placeholder="` + htmlpkg.EscapeString(placeholder) + `" maxlength="1024" rows="1"
       onkeydown="if(event.key==='Enter'&&!event.shiftKey){event.preventDefault();document.getElementById('mu-chat-form').dispatchEvent(new Event('submit'))}"
       oninput="this.style.height='auto';this.style.height=Math.min(this.scrollHeight,140)+'px'"></textarea>
-    <button type="submit" aria-label="Send">&#x2192;</button>
-  </form><button type="button" id="mu-chat-location" class="link-button text-sm" title="Share approximate location with Micro and its model for nearby answers.">Share location</button>`
+    ` + locationControl + `<button type="submit" aria-label="Send">&#x2192;</button>
+  </form>`
 	// Read it back, beside who is answering.
 	//
 	// Next to the picker because they are the same kind of decision — how this
@@ -491,6 +497,10 @@ func ChatComponent(cfg ChatConfig) string {
    fallback and these three did not, which is why the fault appeared the moment
    the box moved to a page the token does not reach. 30px is what mu.css sets. */
 #mu-chat-form button{flex-shrink:0;width:var(--control-h,30px);height:var(--control-h,30px);min-width:var(--control-h,30px);padding:0;background:#111;color:#fff;border:none;border-radius:6px;cursor:pointer;display:flex;align-items:center;justify-content:center;font-size:16px;line-height:1}
+#mu-chat-form #mu-chat-location{background:transparent;color:var(--text-muted,#777);border-radius:50%;width:30px;min-width:30px}
+#mu-chat-form #mu-chat-location[hidden]{display:none}
+#mu-chat-form #mu-chat-location:hover{background:var(--background-hover,#f3f3f3)}
+#mu-chat-form #mu-chat-location[aria-pressed="true"]{color:var(--text-primary,#222);background:var(--background-hover,#f3f3f3)}
 #mu-chat-suggest{margin-top:16px}
 #mu-chat-suggest:empty{display:none}
 .mu-pills{display:flex;gap:8px;flex-wrap:wrap;justify-content:center}
@@ -655,8 +665,8 @@ var contained=!!document.querySelector('#mu-chat.mu-chat-contained');
 // marked data-brief takes part. Home keeps its brief in a separate column,
 // so it remains available during a conversation.
 function briefs(){return document.querySelectorAll('[data-brief]');}
-function hideBrief(){var n=briefs();for(var i=0;i<n.length;i++){n[i].hidden=true;}}
-function showBrief(){var n=briefs();for(var i=0;i<n.length;i++){n[i].hidden=false;}}
+function hideBrief(){window.dispatchEvent(new CustomEvent("mu-chat-active",{detail:true}));var n=briefs();for(var i=0;i<n.length;i++){n[i].hidden=true;}}
+function showBrief(){window.dispatchEvent(new CustomEvent("mu-chat-active",{detail:false}));var n=briefs();for(var i=0;i<n.length;i++){n[i].hidden=false;}}
 // nearBottom is the difference between "following the answer" and "reading
 // something further up". Scrolling to the bottom in the second case is the
 // thing that makes a chat unusable while a long answer streams.

--- a/internal/app/html/composition.css
+++ b/internal/app/html/composition.css
@@ -193,3 +193,19 @@ a.link-text {
   .home-workspace #home-agents { order: 5; }
   .home-workspace .home-apps { order: 6; }
 }
+
+/* Home becomes a page-flow conversation without moving its composer to a modal. */
+#home-personal.is-conversing #home-brief,
+#home-personal.is-conversing #home-inbox,
+#home-personal.is-conversing .home-apps,
+#home-personal.is-conversing #home-todo,
+#home-personal.is-conversing #home-upcoming,
+#home-personal.is-conversing #home-agents { display:none; }
+#home-personal.is-conversing #mu-chat-conv { animation:home-answer-in 180ms ease-out; }
+@keyframes home-answer-in { from { opacity:0; transform:translateY(6px); } to { opacity:1; transform:translateY(0); } }
+@media(prefers-reduced-motion:reduce) {
+ #home-personal.is-conversing #mu-chat-conv { animation:none; }
+}
+@media(min-width:1100px) {
+ .home-workspace:not(:has(#home-todo,#home-agents,#home-upcoming)) { grid-template-columns:minmax(0,1fr); }
+}

--- a/internal/app/location.js
+++ b/internal/app/location.js
@@ -1,8 +1,15 @@
+var requestClientContext=(function(){
+if(!document.getElementById('mu-chat-location'))return function(){return {};};
 // Only the opt-out flag persists; coordinates remain in this page's memory.
 var deviceLocation=null, locationBusy=false, locationEpoch=0, locationOff=false;
 try { locationOff=sessionStorage.getItem('mu-location-off')==='1'; } catch(e) {}
 var locationButton=document.getElementById('mu-chat-location');
-function locationLabel(text){if(locationButton)locationButton.textContent=text;}
+function locationLabel(text){if(locationButton){
+ var active=text.indexOf('Stop')!==-1;
+ locationButton.setAttribute('aria-pressed',String(active));
+ locationButton.setAttribute('aria-label',active?'Stop sharing approximate location':text==='Finding location…'?text:'Share approximate location');
+ locationButton.title=active?'Approximate location shared with Micro and its model. Click to stop.':'Share approximate location with Micro and its model';
+}}
 function refreshDeviceLocation(explicit){
  if(locationOff || locationBusy || !navigator.geolocation || document.hidden)return;
  var epoch=locationEpoch;
@@ -54,3 +61,6 @@ refreshDeviceLocation(false);
 document.addEventListener('visibilitychange',function(){if(!document.hidden)refreshDeviceLocation(false);});
 window.addEventListener('focus',function(){refreshDeviceLocation(false);});
 setInterval(function(){refreshDeviceLocation(false);},60000);
+
+return requestClientContext;
+})();

--- a/internal/app/testdata/location_test.cjs
+++ b/internal/app/testdata/location_test.cjs
@@ -1,5 +1,5 @@
 const fs=require('fs'),vm=require('vm'),assert=require('assert');
-let success,calls=0;const button={};const saved=new Map();
+let success,calls=0;const button={setAttribute(){}};const saved=new Map();
 const sandbox={Date,Math,Intl,document:{hidden:false,getElementById(){return button},addEventListener(){}},window:{addEventListener(){}},setInterval(){},sessionStorage:{getItem:k=>saved.get(k),setItem:(k,v)=>saved.set(k,v),removeItem:k=>saved.delete(k)},navigator:{geolocation:{getCurrentPosition(s,f){calls++;success=s;}}}};
 vm.createContext(sandbox);vm.runInContext(fs.readFileSync(require('path').join(__dirname,'../location.js'),'utf8'),sandbox);
 assert.equal(calls,0);


### PR DESCRIPTION
Home's focus-triggered modal broke continuity with the page, and the new standalone location button disrupted the composer styling.

Use the ordinary page-flow chat on Home: focus leaves it in place; asking hides the overview cards and reveals the conversation beneath the existing input. Keep the desktop composer column width, let the page scroll naturally, and use a brief answer fade-in with reduced-motion support. Clicking the selected Home tab starts a fresh overview. Existing modal support remains available to other callers.

Make location sharing opt-in per ChatConfig surface. Home enables a compact icon inside the composer only when signed in; active sharing has a visual state and accessible stop label. Landing and public Home have no control or automatic geolocation reads.

Make public Home intentional: render the same public brief source as landing, retain public Feed/services, and provide a Home link before Log in on landing. Public Home uses one column and never renders personal cards.

Validation: go test ./home ./internal/app -short passes; JavaScript syntax checks, gofmt and git diff --check pass. Updated layout/navigation assertions and added a public Home check for absence of private cards and location control. Live browser visual verification has not been performed.