### PR TITLE
Add Home conversation collapse/resume and clearer location state

### DIFF
--- a/home/conversation_test.go
+++ b/home/conversation_test.go
@@ -1,0 +1,48 @@
+package home
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+func TestCollapsePreservesConversation(t *testing.T) {
+	node, err := exec.LookPath("node")
+	if err != nil {
+		t.Skip("Node required")
+	}
+	raw, err := os.ReadFile("views.js")
+	if err != nil {
+		t.Fatal(err)
+	}
+	src := string(raw)
+	start, end := strings.Index(src, "  const personal="), strings.Index(src, "  const upcoming")
+	if start < 0 || end <= start {
+		t.Fatal("conversation controller missing")
+	}
+	script := `
+const assert=require('assert');
+const events={},classes=new Set(),attrs={};
+const panel={classList:{toggle(k,on){on?classes.add(k):classes.delete(k)}}};
+const transcript={textContent:'Existing answer'};
+const button={addEventListener(k,fn){this[k]=fn},setAttribute(k,v){attrs[k]=v}};
+const home={querySelector(s){return s==='#home-personal'?panel:s==='#home-conversation-toggle'?button:transcript}};
+const window={addEventListener(k,fn){events[k]=fn}};
+` + src[start:end] + `
+assert(classes.has('is-conversing'));
+button.click();
+assert(classes.has('conversation-collapsed'));
+assert.equal(transcript.textContent,'Existing answer');
+assert.equal(button.textContent,'Resume conversation');
+button.click();
+assert(classes.has('is-conversing'));
+assert.equal(transcript.textContent,'Existing answer');
+events['mu-chat-active']({detail:false});
+assert(button.hidden);
+assert(!classes.has('conversation-collapsed'));
+`
+	if out, err := exec.Command(node, "-e", script).CombinedOutput(); err != nil {
+		t.Fatalf("%v\n%s", err, out)
+	}
+}

--- a/home/home.go
+++ b/home/home.go
@@ -436,7 +436,7 @@ function fetchW(la,lo){
 	if r.URL.Query().Get("q") != "" || r.URL.Query().Get("prompt") != "" {
 		feed = false
 	}
-	b.WriteString(homeViews(feed) + `</div>`)
+	b.WriteString(homeViews(feed) + `<button type="button" id="home-conversation-toggle" class="link-button text-sm" aria-controls="mu-chat-conv" hidden>Collapse conversation</button></div>`)
 	b.WriteString(`<section id="home-personal" role="tabpanel" aria-labelledby="home-view-personal"` + panelHidden(feed) + `>`)
 
 	// Each column flows independently as a conversation grows.

--- a/home/views.js
+++ b/home/views.js
@@ -2,10 +2,29 @@
   const home = document.getElementById('home-cards');
   if (!home) return;
   const personal=home.querySelector('#home-personal');
-  function conversation(active){if(personal)personal.classList.toggle('is-conversing',active);}
-  window.addEventListener('mu-chat-active',event=>conversation(event.detail===true));
+  const conversationToggle=home.querySelector('#home-conversation-toggle');
+  let hasConversation=false, expanded=false;
+  function conversation(active){
+    expanded=active;
+    if(personal) {
+      personal.classList.toggle('is-conversing',active);
+      personal.classList.toggle('conversation-collapsed',hasConversation && !active);
+    }
+    if(conversationToggle){
+      conversationToggle.hidden=!hasConversation;
+      conversationToggle.textContent=active?'Collapse conversation':'Resume conversation';
+      conversationToggle.setAttribute('aria-expanded',String(active));
+    }
+  }
+  window.addEventListener('mu-chat-active',event=>{
+    if(event.detail===true)hasConversation=true;
+    else hasConversation=false;
+    conversation(event.detail===true);
+  });
+  if(conversationToggle)conversationToggle.addEventListener('click',()=>conversation(!expanded));
   const initial=home.querySelector('#mu-chat-conv');
-  conversation(!!initial && !!initial.textContent.trim());
+  hasConversation=!!initial && !!initial.textContent.trim();
+  conversation(hasConversation);
 
   const upcoming = home.querySelector('[data-home-upcoming]');
   if (upcoming) {
@@ -28,7 +47,7 @@
   let selected = tabs.find(tab => tab.getAttribute('aria-selected') === 'true');
   function select(tab) {
     if (tab === selected) {
-      if(tab.id==='home-view-personal' && personal.classList.contains('is-conversing') && window.muChatNew)window.muChatNew();
+      if(tab.id==='home-view-personal' && expanded)conversation(false);
       return;
     }
     positions.set(selected.id, window.scrollY);

--- a/internal/app/chat.go
+++ b/internal/app/chat.go
@@ -497,10 +497,12 @@ func ChatComponent(cfg ChatConfig) string {
    fallback and these three did not, which is why the fault appeared the moment
    the box moved to a page the token does not reach. 30px is what mu.css sets. */
 #mu-chat-form button{flex-shrink:0;width:var(--control-h,30px);height:var(--control-h,30px);min-width:var(--control-h,30px);padding:0;background:#111;color:#fff;border:none;border-radius:6px;cursor:pointer;display:flex;align-items:center;justify-content:center;font-size:16px;line-height:1}
-#mu-chat-form #mu-chat-location{background:transparent;color:var(--text-muted,#777);border-radius:50%;width:30px;min-width:30px}
+#mu-chat-form:has(#mu-chat-location){gap:var(--space-field,16px)}
+#mu-chat-form #mu-chat-location{background:transparent;color:var(--text-muted,#777);border-radius:50%;width:30px;min-width:30px;position:relative}
 #mu-chat-form #mu-chat-location[hidden]{display:none}
 #mu-chat-form #mu-chat-location:hover{background:var(--background-hover,#f3f3f3)}
-#mu-chat-form #mu-chat-location[aria-pressed="true"]{color:var(--text-primary,#222);background:var(--background-hover,#f3f3f3)}
+#mu-chat-form #mu-chat-location[aria-pressed="true"]{color:#166534;background:#dcfce7;box-shadow:inset 0 0 0 1px #86efac}
+#mu-chat-form #mu-chat-location[aria-pressed="true"]::after{content:"";position:absolute;right:2px;top:2px;width:6px;height:6px;border-radius:50%;background:#15803d}
 #mu-chat-suggest{margin-top:16px}
 #mu-chat-suggest:empty{display:none}
 .mu-pills{display:flex;gap:8px;flex-wrap:wrap;justify-content:center}

--- a/internal/app/html/composition.css
+++ b/internal/app/html/composition.css
@@ -207,5 +207,8 @@ a.link-text {
  #home-personal.is-conversing #mu-chat-conv { animation:none; }
 }
 @media(min-width:1100px) {
- .home-workspace:not(:has(#home-todo,#home-agents,#home-upcoming)) { grid-template-columns:minmax(0,1fr); }
+ .home-workspace:not(:has(#home-todo,#home-agents,#home-upcoming)) { grid-template-columns:minmax(0,2fr) minmax(0,1fr); }
 }
+
+#home-personal.conversation-collapsed #mu-chat-conv { display:none; }
+#home-conversation-toggle[hidden] { display:none; }


### PR DESCRIPTION
Home lost its way back after removing the modal. Add a visible Collapse conversation / Resume conversation control that only changes visibility: transcript, current thread, draft and pending stream remain intact. Clicking the selected Home tab collapses instead of starting a fresh session.

Separate location and Send using the shared spacing token. Active location sharing is green with a dot and retains the accessible pressed/stop state. Keep public Home's composer/brief/services at the same desktop column width as signed-in Home, with the same responsive single-column behavior.

Validation: Home and shared app package tests pass, plus a new Node-backed controller test proving collapse/resume retains the transcript and reset clears the toggle state. JS syntax and git diff --check pass. No live browser visual verification. App naming is unchanged per the latest user instruction.