### PR TITLE
Make Assistant a sidebar destination above Home

### DIFF
--- a/home/conversation_test.go
+++ b/home/conversation_test.go
@@ -17,7 +17,7 @@ func TestCollapsePreservesConversation(t *testing.T) {
 		t.Fatal(err)
 	}
 	src := string(raw)
-	start, end := strings.Index(src, "  const personal="), strings.Index(src, "  const upcoming")
+	start, end := strings.Index(src, "  const personal="), strings.Index(src, "  function openAssistant")
 	if start < 0 || end <= start {
 		t.Fatal("conversation controller missing")
 	}
@@ -40,7 +40,7 @@ assert(classes.has('is-conversing'));
 assert.equal(transcript.textContent,'Existing answer');
 events['mu-chat-active']({detail:false});
 assert(button.hidden);
-assert(!classes.has('conversation-collapsed'));
+assert(classes.has('conversation-collapsed'));
 `
 	if out, err := exec.Command(node, "-e", script).CombinedOutput(); err != nil {
 		t.Fatalf("%v\n%s", err, out)

--- a/home/views.js
+++ b/home/views.js
@@ -8,10 +8,10 @@
     expanded=active;
     if(personal) {
       personal.classList.toggle('is-conversing',active);
-      personal.classList.toggle('conversation-collapsed',hasConversation && !active);
+      personal.classList.toggle('conversation-collapsed',!active);
     }
     if(conversationToggle){
-      conversationToggle.hidden=!hasConversation;
+      conversationToggle.hidden=!hasConversation && !active;
       conversationToggle.textContent=active?'Collapse conversation':'Resume conversation';
       conversationToggle.setAttribute('aria-expanded',String(active));
     }
@@ -25,6 +25,32 @@
   const initial=home.querySelector('#mu-chat-conv');
   hasConversation=!!initial && !!initial.textContent.trim();
   conversation(hasConversation);
+
+  function openAssistant(){
+    const tab=document.getElementById('home-view-personal');
+    if(tab)tab.click();
+    conversation(true);
+  }
+  const composer=home.querySelector('#mu-chat-input');
+  if(composer)composer.addEventListener('focus',openAssistant);
+  const assistantLink=document.getElementById('nav-assistant');
+  if(assistantLink)assistantLink.addEventListener('click',event=>{
+    if(event.button!==0 || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey)return;
+    event.preventDefault();event.stopPropagation();
+    openAssistant();
+    if(composer)composer.focus({preventScroll:true});
+  });
+  const homeLink=document.getElementById('nav-home');
+  if(homeLink)homeLink.addEventListener('click',event=>{
+    if(event.button!==0 || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey)return;
+    event.preventDefault();event.stopPropagation();
+    const tab=document.getElementById('home-view-personal');
+    if(tab)tab.click();
+    conversation(false);
+  });
+  if(new URL(window.location.href).searchParams.get('assistant')==='1'){
+    conversation(true);
+  }
 
   const upcoming = home.querySelector('[data-home-upcoming]');
   if (upcoming) {

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -1274,7 +1274,8 @@ func navMain(acc *auth.Account) string {
 			`"><span class="label">` + label + `</span></a>`
 	}
 
-	b := item("nav-home", "/home", "/home.png", "Home")
+	b := item("nav-assistant", "/home?assistant=1", "/agent.svg", "Assistant")
+	b += item("nav-home", "/home", "/home.png", "Home")
 	// Account and Profile are not here. They are the two that are about *you*
 	// rather than about the instance, so they sit under your name at the foot
 	// beside Log out — which is where somebody looks when the question is "who

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -358,7 +358,7 @@ func TestTheSidebarIsTheProductsNouns(t *testing.T) {
 		nav = nav[:j]
 	}
 
-	want := []string{`href="/home"`, `href="/inbox"`, `href="/agents"`, `href="/services"`}
+	want := []string{`href="/home?assistant=1"`, `href="/home"`, `href="/inbox"`, `href="/agents"`, `href="/services"`}
 	at := -1
 	for _, w := range want {
 		i := strings.Index(nav, w)


### PR DESCRIPTION
Assistant is the conversation experience; Agents remains the management destination for specialists. Add Assistant above Home in the authenticated sidebar, linking to /home?assistant=1. Feed remains inside Home.

On Home, Assistant and composer focus expand the existing inline conversation. Home and Collapse return to the overview without clearing the conversation or navigating away. Modified clicks keep ordinary link behavior. Empty assistant views can also collapse.

Validation: go test ./home ./internal/app -short passed, including sidebar ordering and collapse/resume tests. No live browser visual verification.