### PR TITLE
Keep the Assistant input visible beneath the fixed header

### DIFF
--- a/internal/app/html/composition.css
+++ b/internal/app/html/composition.css
@@ -221,3 +221,7 @@ a.link-text {
 .home-workspace > .home-column { gap:var(--space-field,16px); }
 .assistant-page { max-width:800px; margin:0; }
 @media(max-width:900px) { #tabs { grid-template-columns:repeat(5,minmax(0,1fr)); } }
+
+/* Keep the Assistant composer below the fixed app header while reading. */
+.assistant-page #mu-chat-form { top:58px; }
+@media(max-width:900px) { .assistant-page #mu-chat-form { top:52px; } }


### PR DESCRIPTION
Assistant inherits the landing composer's sticky top:8px, but the app has a fixed header above it. Scrolling the conversation therefore obscures the input behind that header.

Set Assistant's sticky offset to 58px on desktop (50px header plus 8px) and 52px on mobile (44px plus 8px). The existing question scroll calculation reads this offset, so questions also clear the visible composer.

Validation: go test ./internal/app -short and git diff --check passed. No live browser visual verification.