### PR TITLE
Put Ask before Home in mobile navigation

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -1317,8 +1317,8 @@ func navTabs(acc *auth.Account) string {
 			`" alt=""><span>` + label + `</span></a>`
 	}
 	return `<nav id="tabs" aria-label="Main">` +
-		tab("/home", "/home.png", "Home") +
 		tab("/assistant", "/chat.png", "Ask") +
+		tab("/home", "/home.png", "Home") +
 		tab("/inbox", "/mail.png", "Inbox") +
 		tab("/agents", "/agent.svg", "Agents") +
 		tab("/services", "/services.svg", "Services") +


### PR DESCRIPTION
Match the desktop sidebar ordering: Ask, Home, Inbox, Agents, Services.

Only swaps the first two mobile navigation entries. Verified the diff and git diff --check.