### PR TITLE
Remove the container box around conversation actions

### DIFF
--- a/internal/app/html/composition.css
+++ b/internal/app/html/composition.css
@@ -205,7 +205,7 @@ a.link-text {
 
 /* Home actions finish an exchange or move it to Assistant. */
 #home-agent .mu-chat-footer:has([hidden]) { display:none; }
-.conversation-actions { display:flex; align-items:center; flex-wrap:wrap; gap:8px; padding:8px; border:1px solid var(--card-border,#e8e8e8); border-radius:6px; background:white; }
+.conversation-actions { display:flex; align-items:center; flex-wrap:wrap; gap:8px; }
 .conversation-actions[hidden] { display:none; }
 .conversation-actions button { background:white; color:var(--text-secondary,#555); border:0; }
 .conversation-actions button:hover { background:#f5f5f5; }


### PR DESCRIPTION
Close and Continue in Assistant are actions on the answer, but the bordered container makes them look like a separate card.

Remove the row's border, background, rounded corners and outer padding, leaving the actions beneath the answer with their existing behavior.

Verified the CSS diff and git diff --check.