### PR TITLE
Keep Home continuations separate from the main Assistant conversation

### DIFF
--- a/home/assistant.go
+++ b/home/assistant.go
@@ -20,11 +20,18 @@ func AssistantHandler(w http.ResponseWriter, r *http.Request) {
 		viewerID = acc.ID
 	}
 	ns := assistantNamespace(viewerID)
+	fromHome := r.URL.Query().Get("view") == "home"
+	if fromHome {
+		ns += ":home"
+	}
 	w.Header().Set("Cache-Control", "private, no-store")
 	body := `<main class="assistant-page"><script>window.muActiveAgent="";</script>` + app.ChatComponent(app.ChatConfig{
 		Ask: true, HideSuggestions: true, AgentName: agent.DefaultName(),
-		Placeholder: "What do you need?", Location: acc != nil, StorageNS: ns,
+		Placeholder: "What do you need?", Location: acc != nil, StorageNS: ns, AcceptHandoff: fromHome,
 	}) + `</main>`
+	if fromHome {
+		body = `<div class="page-stack"><div class="section-actions"><a href="/assistant">Back to main conversation</a></div>` + body + `</div>`
+	}
 	app.Respond(w, r, app.Response{Title: "Assistant", Description: "Talk to Micro", HTML: body})
 }
 

--- a/home/assistant_test.go
+++ b/home/assistant_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestAssistantSeparatesAccountAndGuestConversations(t *testing.T) {
 	for _, who := range []string{"", "asstreadera", "asstreaderb"} {
-		for _, path := range []string{"/assistant"} {
+		for _, path := range []string{"/assistant", "/assistant?view=home"} {
 			r := httptest.NewRequest(http.MethodGet, path, nil)
 			ns := "assistant:guest"
 			if who != "" {
@@ -23,6 +23,10 @@ func TestAssistantSeparatesAccountAndGuestConversations(t *testing.T) {
 				r.AddCookie(&http.Cookie{Name: "session", Value: sess.Token})
 				ns = "assistant:account:" + who
 			}
+			fromHome := strings.Contains(path, "view=home")
+			if fromHome {
+				ns += ":home"
+			}
 			w := httptest.NewRecorder()
 			AssistantHandler(w, r)
 			body := w.Body.String()
@@ -31,6 +35,12 @@ func TestAssistantSeparatesAccountAndGuestConversations(t *testing.T) {
 			}
 			if !strings.Contains(body, `var NS="`+ns+`"`) {
 				t.Errorf("%s: missing isolated namespace %s", path, ns)
+			}
+			if strings.Contains(body, `href="/assistant">Back to main conversation</a>`) != fromHome {
+				t.Error("return link must appear on the separate Home conversation")
+			}
+			if strings.Contains(body, "var handoff=true?") != fromHome {
+				t.Error("main conversation must not consume handoffs")
 			}
 			if strings.Contains(body, `id="mu-chat-location"`) != (who != "") {
 				t.Errorf("%s: location control does not match authentication", path)
@@ -49,6 +59,9 @@ func TestHomeDisclosureFollowsAnswer(t *testing.T) {
 	toggle := strings.Index(body, `id="home-conversation-actions"`)
 	if form < 0 || answer <= form || toggle <= answer {
 		t.Fatal("Home input, answers, disclosure must appear in that order")
+	}
+	if !strings.Contains(body, `var CONTINUE_NS="assistant:account:homedisclose:home";`) {
+		t.Error("Home handoff must target its separate conversation")
 	}
 	if !strings.Contains(body, "var stationary=true;") {
 		t.Error("Home must preserve its surrounding content")

--- a/home/home.go
+++ b/home/home.go
@@ -449,7 +449,7 @@ function fetchW(la,lo){
 		AgentName:       agent.DefaultName(),
 		Location:        viewerID != "",
 		Stationary:      true,
-		ContinueNS:      assistantNamespace(viewerID),
+		ContinueNS:      assistantNamespace(viewerID) + ":home",
 		FooterHTML:      `<div id="home-conversation-actions" class="conversation-actions" hidden><button type="button" id="home-conversation-close">Close</button><button type="button" id="mu-chat-continue" disabled>Continue in Assistant</button><span id="mu-chat-transfer-error" role="status"></span></div>`,
 	}))
 	b.WriteString(`</div>`)

--- a/internal/app/chat.go
+++ b/internal/app/chat.go
@@ -48,6 +48,8 @@ func JSAttr(s string) string {
 type ChatConfig struct {
 	// ContinueNS is the account-scoped Assistant destination for a Home exchange.
 	ContinueNS string
+	// AcceptHandoff allows this surface to consume an explicitly transferred exchange.
+	AcceptHandoff bool
 	// Stationary keeps an embedded composer in place and surrounding content visible.
 	Stationary bool
 	// Location offers approximate device sharing on authenticated surfaces.
@@ -801,7 +803,7 @@ var history=[];
 // conversation instead of starting a new one.
 if(!SESSION && PERSIST){
   try{
-    var handoff=sessionStorage.getItem('mu_chat_handoff:'+NS);
+    var handoff=` + boolJS(cfg.AcceptHandoff) + `?sessionStorage.getItem('mu_chat_handoff:'+NS):null;
     if(handoff){
       var exchange=JSON.parse(handoff);
       sessionStorage.setItem(CKEY,exchange.html);
@@ -1200,7 +1202,7 @@ if(transfer && CONTINUE_NS)transfer.addEventListener('click',function(){
   if(transfer.disabled)return;
   try{
     sessionStorage.setItem('mu_chat_handoff:'+CONTINUE_NS,JSON.stringify({html:conv.innerHTML,history:history,context:contextId||'',draft:input.value||''}));
-    window.location.assign('/assistant');
+    window.location.assign('/assistant?view=home');
   }catch(e){document.getElementById('mu-chat-transfer-error').textContent='Could not move this conversation. Please try again.';}
 });
 

--- a/internal/app/chat_transfer_test.go
+++ b/internal/app/chat_transfer_test.go
@@ -11,7 +11,7 @@ func TestContinueTransfersExchangeWithoutWordsInURL(t *testing.T) {
 	if err != nil {
 		t.Skip("Node required")
 	}
-	body := ChatComponent(ChatConfig{Ask: true, ContinueNS: "assistant:account:alice"})
+	body := ChatComponent(ChatConfig{Ask: true, ContinueNS: "assistant:account:alice:home"})
 	start, end := strings.Index(body, "// Move a completed exchange"), strings.Index(body, "// Start a fresh session")
 	if start < 0 || end <= start {
 		t.Fatal("missing transfer controller")
@@ -21,11 +21,11 @@ const assert=require('assert');
 let click,url,stored;
 const button={disabled:false,addEventListener(_,fn){click=fn}},status={};
 const document={getElementById(id){return id==='mu-chat-continue'?button:status}};
-const CONTINUE_NS='assistant:account:alice',conv={innerHTML:'<div>Private answer</div>'},history=[{prompt:'Private question',answer:'Private answer'}],contextId='original-thread',input={value:'Follow up'};
+const CONTINUE_NS='assistant:account:alice:home',conv={innerHTML:'<div>Private answer</div>'},history=[{prompt:'Private question',answer:'Private answer'}],contextId='original-thread',input={value:'Follow up'};
 const sessionStorage={setItem(key,value){stored={key,value}}};
 const window={location:{assign(value){url=value}}};
 ` + body[start:end] + `
-click();assert.equal(url,'/assistant');assert.equal(stored.key,'mu_chat_handoff:assistant:account:alice');
+click();assert.equal(url,'/assistant?view=home');assert.equal(stored.key,'mu_chat_handoff:assistant:account:alice:home');
 const exchange=JSON.parse(stored.value);assert.equal(exchange.context,'original-thread');assert.deepEqual(exchange.history,history);assert.equal(exchange.html,conv.innerHTML);assert.equal(exchange.draft,'Follow up');
 url=undefined;button.disabled=true;click();assert.equal(url,undefined);
 button.disabled=false;sessionStorage.setItem=()=>{throw Error('storage unavailable')};click();assert.equal(url,undefined);assert(status.textContent.includes('Could not move'));


### PR DESCRIPTION
Continue in Assistant was overwriting the active main conversation's browser state. Although server history remained, there was no route back to it in Assistant.

Route Home continuations to /assistant?view=home with a separate account-scoped storage namespace and a Back to main conversation link. The main /assistant screen keeps its existing namespace and explicitly refuses incoming handoffs. Sidebar Assistant and mobile Ask still open the main conversation.

The Home exchange retains its own server thread ID and history. This preserves the main conversation going forward; it does not recover browser state already overwritten by the previous behavior. The separate Home view holds the latest continued Home exchange, not a new thread-management interface. Persistence remains within the browser tab.

Validation: go test ./home ./internal/app -short and git diff --check passed. Tests cover separate namespaces and handoff acceptance for accounts/guests, return navigation, and Home's transfer destination.