### PR TITLE
Soften page titles and put Home and Feed headings above cards

### DIFF
--- a/home/brief.go
+++ b/home/brief.go
@@ -97,7 +97,7 @@ func briefHTML(accountID string, external ...events.External) string {
 	}
 
 	// Match the surrounding cards, with a plain title for this live summary.
-	return app.Card("home-brief-card", "Brief", `<p class="home-brief">`+strings.Join(parts, " ")+`</p>`)
+	return app.SectionCard("home-brief-card", "Brief", "", `<p class="home-brief">`+strings.Join(parts, " ")+`</p>`)
 }
 
 // briefParts is the clauses, without deciding how they are set.

--- a/home/brief_test.go
+++ b/home/brief_test.go
@@ -118,7 +118,7 @@ func TestTheBriefHasAPlainCardTitle(t *testing.T) {
 	}
 
 	got := briefHTML(who)
-	if !strings.Contains(got, `<div id="home-brief-card" class="card">`) || !strings.Contains(got, "<h4>Brief</h4>") || strings.Contains(got, "card-head-link") || strings.Contains(got, "section-link") {
+	if !strings.Contains(got, `<section id="home-brief-card" class="section-card">`) || !strings.Contains(got, "<h4>Brief</h4>") || strings.Contains(got, "card-head-link") || strings.Contains(got, "section-link") {
 		t.Errorf("the brief must have a shared card and plain title without navigation: %q", got)
 	}
 	if !strings.Contains(got, `<p class="home-brief">`) {

--- a/home/card_render_test.go
+++ b/home/card_render_test.go
@@ -6,6 +6,7 @@ package home
 // that vanished a minute after the page loaded.
 
 import (
+	"mu/internal/app"
 	"mu/internal/service"
 	"strings"
 	"testing"
@@ -25,9 +26,14 @@ func TestACardKeepsItsWayThroughOnRefresh(t *testing.T) {
 	if !strings.Contains(body, "<p>A headline</p>") {
 		t.Fatalf("the card lost its contents:\n%s", body)
 	}
-	if !strings.Contains(body, `href="/news"`) || !strings.Contains(body, "More →") || !strings.Contains(cardHead(c), `href="/news"`) {
-		t.Errorf("the heading and More link must both reach the service:\n%s", body)
+	section := app.SectionCard(c.ID, cardHead(c), c.Link, body)
+	if !strings.Contains(section, `class="section-more" href="/news">More →</a>`) || strings.Contains(body, "More →") {
+		t.Error("More must stay above the independently refreshed body")
 	}
+	if strings.Index(section, "More →") > strings.Index(section, `class="card-body"`) {
+		t.Error("navigation belongs above the card")
+	}
+
 }
 
 // A card with nothing to show is not a card. Both renders have to agree about

--- a/home/home.go
+++ b/home/home.go
@@ -580,14 +580,11 @@ var cardTips = map[string]string{
 }
 
 // cardBody supplies the same contents to initial renders and refreshes.
-// Keep the explicit More link on both initial renders and live refreshes.
+// Navigation stays in the section header, outside the refreshed body.
 func cardBody(c Card, who service.Viewer) string {
 	body := strings.TrimSpace(cardRender(c, who))
 	if body == "" {
 		return ""
-	}
-	if c.Link != "" {
-		body += app.Link("More", htmlEsc(c.Link))
 	}
 	return body
 }
@@ -673,7 +670,13 @@ func CardsHTML(r *http.Request, viewerAcc *auth.Account) string {
 		if body == "" {
 			continue
 		}
-		rendered := fmt.Sprintf(app.CardTemplate, card.ID, card.ID, cardHead(card), body)
+		// The section, including its heading, is now the mobile ordering unit.
+		order := len(leftHTML)*2 + 1
+		if card.column() != "left" {
+			order = len(rightHTML)*2 + 2
+		}
+		rendered := app.SectionCard(card.ID, cardHead(card), card.Link, body)
+		rendered = strings.Replace(rendered, `class="section-card"`, fmt.Sprintf(`class="section-card" style="--feed-order:%d"`, order), 1)
 		if card.column() == "left" {
 			leftHTML = append(leftHTML, rendered)
 		} else {

--- a/home/layout_test.go
+++ b/home/layout_test.go
@@ -159,7 +159,7 @@ func TestTheAccountBlockLooksLikeTheOtherRailBlocks(t *testing.T) {
 			"Inbox and Agents above it")
 	}
 	// A card, sharing the class the other two are styled by.
-	if !strings.Contains(got, `id="home-account-card" class="card"`) {
+	if !strings.Contains(got, `id="home-account-card" class="section-card"`) {
 		t.Error("the balance is not in a card, and both blocks above it are")
 	}
 	if strings.Contains(got, "Go to account") {

--- a/internal/app/html/composition.css
+++ b/internal/app/html/composition.css
@@ -225,3 +225,20 @@ a.link-text {
 /* Keep the Assistant composer below the fixed app header while reading. */
 .assistant-page #mu-chat-form { top:58px; }
 @media(max-width:900px) { .assistant-page #mu-chat-form { top:52px; } }
+
+/* Quiet orientation, shared across desktop and mobile page shells. */
+#page-title { font-size:20px; font-weight:500; line-height:1.4; text-align:left; color:var(--text-secondary,#555); margin:0 0 16px; }
+/* Section labels and navigation sit above the bordered content. */
+.section-card { min-width:0; margin:0 0 16px; }
+.section-card-head { display:flex; align-items:baseline; justify-content:space-between; gap:16px; margin-bottom:8px; }
+.section-card-head h4 { margin:0; min-width:0; font-size:14px; font-weight:500; line-height:1.5; color:var(--text-secondary,#555); }
+.section-card-head .card-head-link, .section-card-head .card-head-link:visited { color:inherit; font-weight:inherit; text-decoration:none; }
+.section-card-head .card-head-link:hover { text-decoration:underline; }
+.section-card-head .section-more { flex:none; font-size:13px; font-weight:400; color:var(--text-secondary,#555); text-decoration:none; }
+.section-card-head .section-more:hover { text-decoration:underline; }
+.section-card > .card, .section-card > .card:hover { min-width:0; margin:0; padding:16px; border-radius:4px; box-shadow:none; }
+
+@media(max-width:900px) {
+ #home { gap:16px; }
+ #home > .home-left > .section-card, #home > .home-right > .section-card { order:var(--feed-order); margin:0; }
+}

--- a/internal/app/section.go
+++ b/internal/app/section.go
@@ -10,5 +10,15 @@ func SectionLink(label, href string) string {
 // PreviewCard uses the same heading and container as Feed cards.
 func PreviewCard(id, title, href, body string) string {
 	heading := `<a class="card-head-link" href="` + html.EscapeString(href) + `">` + html.EscapeString(title) + `</a>`
-	return Card(id, heading, `<div class="preview-rows">`+body+`</div>`)
+	return SectionCard(id, heading, href, `<div class="preview-rows">`+body+`</div>`)
+}
+
+// SectionCard places a trusted heading and navigation above the content card.
+// Heading and body are pre-rendered HTML; id and href are escaped here.
+func SectionCard(id, heading, href, body string) string {
+	more := ""
+	if href != "" {
+		more = `<a class="section-more" href="` + html.EscapeString(href) + `">More →</a>`
+	}
+	return `<section id="` + html.EscapeString(id) + `" class="section-card"><div class="section-card-head"><h4>` + heading + `</h4>` + more + `</div><div class="card"><div class="card-body">` + body + `</div></div></section>`
 }


### PR DESCRIPTION
Page titles are visually heavy and section labels compete with the items they describe. Trial one shared treatment across Home and Feed.

Use smaller medium-weight, left-aligned page titles. Add a shared SectionCard renderer with the heading and explicit More link above the content card. Home previews and Feed use it; Brief has a plain heading without a fabricated destination. Cards use a light border, slight rounding and no shadow. Existing title links and item links remain usable.

Feed refresh still updates only body content and the heading text; More stays in the section header. Responsive interleaving now orders the entire section so headings stay with their cards. General service cards retain their existing renderer.

Validation: go test ./home ./internal/app ./inbox ./service/events -short passed, with Home/app rechecked after responsive ordering changes. git diff --check passed. No live browser visual verification. This is a styling trial, not a change to app architecture or replaceable launchers.