### PR TITLE
Remove the card around Home service shortcuts

### DIFF
--- a/home/apps.go
+++ b/home/apps.go
@@ -32,5 +32,5 @@ func appsHTML(acc *auth.Account) string {
 		b.WriteString(`<a href="` + html.EscapeString(s.Page) + `"><span class="home-app-icon"><img src="/` + html.EscapeString(s.NavIcon()) + `" alt=""></span><span>` + html.EscapeString(s.NavLabel()) + `</span></a>`)
 	}
 	b.WriteString(`<a class="home-apps-all" href="/services" aria-label="All services"><span class="home-app-icon" aria-hidden="true">→</span><span>See all</span></a></div>`)
-	return `<nav class="home-apps page-stack" aria-label="Services">` + app.PreviewCard("home-services-card", "Services", "/services", b.String()) + `</nav>`
+	return `<nav class="home-apps" aria-label="Services"><div class="section-card-head"><h4><a class="card-head-link" href="/services">Services</a></h4><a class="section-more" href="/services">More →</a></div>` + b.String() + `</nav>`
 }


### PR DESCRIPTION
Services is a launcher row rather than a content preview. Render its heading and shortcuts directly in the navigation section, removing the bordered card and its padding.

Preserve the responsive single-row icon selection, See all, and heading navigation above the brief.

Validation: go test ./home -short and git diff --check passed.