### PR TITLE
Refine card layout and remove unnecessary page-load work

### DIFF
--- a/home/apps.go
+++ b/home/apps.go
@@ -32,5 +32,5 @@ func appsHTML(acc *auth.Account) string {
 		b.WriteString(`<a href="` + html.EscapeString(s.Page) + `"><span class="home-app-icon"><img src="/` + html.EscapeString(s.NavIcon()) + `" alt=""></span><span>` + html.EscapeString(s.NavLabel()) + `</span></a>`)
 	}
 	b.WriteString(`<a class="home-apps-all" href="/services" aria-label="All services"><span class="home-app-icon" aria-hidden="true">→</span><span>See all</span></a></div>`)
-	return `<nav class="home-apps" aria-label="Services"><div class="section-card-head"><h4><a class="card-head-link" href="/services">Services</a></h4><a class="section-more" href="/services">More →</a></div>` + b.String() + `</nav>`
+	return `<nav class="home-apps" aria-label="Services"><div class="section-card-head"><h4><a class="card-head-link" href="/services">Services</a></h4></div>` + b.String() + `</nav>`
 }

--- a/home/card_render_test.go
+++ b/home/card_render_test.go
@@ -28,10 +28,10 @@ func TestACardKeepsItsWayThroughOnRefresh(t *testing.T) {
 	}
 	section := app.SectionCard(c.ID, cardHead(c), c.Link, body)
 	if !strings.Contains(section, `class="section-more" href="/news">More →</a>`) || strings.Contains(body, "More →") {
-		t.Error("More must stay above the independently refreshed body")
+		t.Error("More must remain outside the independently refreshed body")
 	}
-	if strings.Index(section, "More →") > strings.Index(section, `class="card-body"`) {
-		t.Error("navigation belongs above the card")
+	if strings.Index(section, "More →") < strings.Index(section, `class="card-body"`) {
+		t.Error("navigation belongs below the content")
 	}
 
 }
@@ -68,10 +68,10 @@ func TestACardTitleLinksToItsService(t *testing.T) {
 // sent in the JSON and never used by the script, so a card refreshed its
 // headlines and went on claiming they were an hour old.
 func TestACardSaysHowOldItIs(t *testing.T) {
-	head := cardHead(Card{
+	head := cardBody(Card{
 		ID: "news", Title: "News", Link: "/news",
-		At: time.Now().Add(-2 * time.Hour),
-	})
+		At: time.Now().Add(-2 * time.Hour), CachedHTML: "<p>News</p>",
+	}, service.Anyone())
 	if !strings.Contains(head, "card-when") {
 		t.Errorf("a card that happened at a time does not say when:\n%s", head)
 	}

--- a/home/home.go
+++ b/home/home.go
@@ -342,8 +342,7 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Refresh cards if cache expired (2 minute TTL)
-	RefreshCards()
+	// Feed refreshes through its JSON endpoint when selected; do not block Home on it.
 
 	_, viewerAcc := auth.TrySession(r)
 
@@ -464,7 +463,7 @@ function fetchW(la,lo){
 	if viewerID != "" {
 		b.WriteString(`<div class="home-column page-stack">`)
 		b.WriteString(`<div id="home-todo" class="page-stack">` + todoHTML(viewerID) + `</div>`)
-		b.WriteString(`<div id="home-upcoming" class="page-stack">` + `<div data-home-upcoming aria-live="polite" class="page-stack">` + events.Preview(viewerID, events.CachedOverview(viewerID)) + `</div>` + `</div>`)
+		b.WriteString(`<div id="home-upcoming" class="page-stack">` + fmt.Sprintf(`<div data-home-upcoming data-fresh="%t" aria-live="polite" class="page-stack">`, events.OverviewFresh(viewerID)) + events.Preview(viewerID, events.CachedOverview(viewerID)) + `</div>` + `</div>`)
 		if who := agent.Preview(viewerID); who != "" {
 			b.WriteString(`<div id="home-agents" class="page-stack">` + who + `</div>`)
 		}
@@ -513,8 +512,7 @@ function fetchW(la,lo){
         if(el){
           var content = el.querySelector('.card-body');
           if(content) content.innerHTML = c.html;
-          // The head too, or the age on a card stands still while its
-          // contents move. c.title was sent and never used.
+          // Refresh the section title independently of the body and its timestamp.
           var head = el.querySelector('h4');
           if(head) head.innerHTML = c.title;
         }
@@ -565,26 +563,15 @@ function fetchW(la,lo){
 // the escaper was weaker than it looked.
 func htmlEsc(s string) string { return html.EscapeString(s) }
 
-// cardTips is the one-line explanation behind the "?" on a card.
-//
-// Package-level because both the page and the refresh build a card's title now,
-// and the two disagreeing about what a card is called is the bug below.
-var cardTips = map[string]string{
-	"blog":    "Microblog posts with daily AI-generated digests",
-	"news":    "Headlines from RSS feeds, sorted by time",
-	"markets": "Live crypto, futures, and commodity prices",
-	"prayer":  "Islamic prayer times, and a daily verse, saying and name",
-	"social":  "Public discussion threads",
-	"video":   "Latest videos from curated channels",
-	"images":  "A picture a day, generated here",
-}
-
 // cardBody supplies the same contents to initial renders and refreshes.
-// Navigation stays in the section header, outside the refreshed body.
+// Footer navigation stays outside the refreshed body.
 func cardBody(c Card, who service.Viewer) string {
 	body := strings.TrimSpace(cardRender(c, who))
 	if body == "" {
 		return ""
+	}
+	if c.Streamed() {
+		body = `<div class="card-meta"><span class="card-when">` + htmlEsc(app.TimeAgo(c.At)) + `</span></div>` + body
 	}
 	return body
 }
@@ -617,15 +604,6 @@ func cardHead(c Card) string {
 	title := htmlEsc(c.Title)
 	if c.Link != "" {
 		title = `<a class="card-head-link" href="` + htmlEsc(c.Link) + `">` + title + `</a>`
-	}
-	if tip, ok := cardTips[c.ID]; ok {
-		title += fmt.Sprintf(` <span class="card-tooltip" data-tip="%s" onclick="event.stopPropagation();document.querySelectorAll('.card-tooltip.show').forEach(function(e){e.classList.remove('show')});this.classList.toggle('show')">?</span>`, htmlEsc(tip))
-	}
-	// When it is from, on the card, which is the whole point of the stream:
-	// a row of headlines with no age on it reads as "now" whether it is an
-	// hour old or a week.
-	if c.Streamed() {
-		title += ` <span class="card-when">` + htmlEsc(app.TimeAgo(c.At)) + `</span>`
 	}
 	return title
 }

--- a/home/views.js
+++ b/home/views.js
@@ -12,7 +12,7 @@
   conversation(!!initial && !!initial.textContent.trim());
 
   const upcoming = home.querySelector('[data-home-upcoming]');
-  if (upcoming) {
+  if (upcoming && upcoming.dataset.fresh !== 'true') {
     fetch('/home?section=upcoming', {credentials: 'same-origin'})
       .then(response => { if (!response.ok) throw new Error('events'); return response.json(); })
       .then(data => {

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -1538,6 +1538,11 @@ func Serve() http.Handler {
 		switch {
 		case r.URL.Path == "/mu.js" || strings.HasSuffix(r.URL.Path, "/mu.js"):
 			w.Header().Set("Cache-Control", "no-cache")
+			// Page scripts carry this build's version and can be reused without
+			// a blocking revalidation. Worker update requests stay uncached.
+			if r.URL.RawQuery == Version && r.Header.Get("Service-Worker") != "script" && r.Header.Get("Sec-Fetch-Dest") != "serviceworker" {
+				w.Header().Set("Cache-Control", "public, max-age=86400")
+			}
 		case strings.HasSuffix(r.URL.Path, ".css"),
 			strings.HasSuffix(r.URL.Path, ".js"),
 			strings.HasSuffix(r.URL.Path, ".png"),

--- a/internal/app/html/composition.css
+++ b/internal/app/html/composition.css
@@ -227,7 +227,7 @@ a.link-text {
 @media(max-width:900px) { .assistant-page #mu-chat-form { top:52px; } }
 
 /* Quiet orientation, shared across desktop and mobile page shells. */
-#page-title { font-size:20px; font-weight:500; line-height:1.4; text-align:left; color:var(--text-secondary,#555); margin:0 0 16px; }
+#page-title { font-size:16px; font-weight:500; line-height:1.4; text-align:left; color:var(--text-secondary,#555); margin:0 0 8px; }
 /* Section labels and navigation sit above the bordered content. */
 .section-card { min-width:0; margin:0 0 16px; }
 .section-card-head { display:flex; align-items:baseline; justify-content:space-between; gap:16px; margin-bottom:8px; }
@@ -242,3 +242,10 @@ a.link-text {
  #home { gap:16px; }
  #home > .home-left > .section-card, #home > .home-right > .section-card { order:var(--feed-order); margin:0; }
 }
+
+@media(max-width:900px) { #page-title { text-align:center; } }
+.section-card > .card > .section-more { display:block; margin-top:8px; font-size:13px; color:var(--text-secondary,#555); text-decoration:none; }
+.section-card > .card > .section-more:hover { text-decoration:underline; }
+.section-card .card-meta { display:flex; justify-content:flex-end; margin:0 0 8px; }
+.section-card .card-meta .card-when { margin:0; font-size:12px; }
+.section-card .card-body > :last-child { margin-bottom:0; padding-bottom:0; }

--- a/internal/app/script_cache_test.go
+++ b/internal/app/script_cache_test.go
@@ -1,0 +1,20 @@
+package app
+
+import (
+	"net/http/httptest"
+	"testing"
+)
+
+func TestPageScriptCachesWithoutCachingWorkerUpdates(t *testing.T) {
+	for _, tc := range []struct{ query, worker, want string }{
+		{"", "", "no-cache"}, {Version, "", "public, max-age=86400"}, {Version, "script", "no-cache"}, {"older", "", "no-cache"},
+	} {
+		r := httptest.NewRequest("GET", "/mu.js?"+tc.query, nil)
+		r.Header.Set("Service-Worker", tc.worker)
+		w := httptest.NewRecorder()
+		Serve().ServeHTTP(w, r)
+		if got := w.Header().Get("Cache-Control"); got != tc.want {
+			t.Errorf("query %q worker %q: got %q", tc.query, tc.worker, got)
+		}
+	}
+}

--- a/internal/app/section.go
+++ b/internal/app/section.go
@@ -13,12 +13,12 @@ func PreviewCard(id, title, href, body string) string {
 	return SectionCard(id, heading, href, `<div class="preview-rows">`+body+`</div>`)
 }
 
-// SectionCard places a trusted heading and navigation above the content card.
+// SectionCard places a trusted heading and navigation outside the content card.
 // Heading and body are pre-rendered HTML; id and href are escaped here.
 func SectionCard(id, heading, href, body string) string {
 	more := ""
 	if href != "" {
 		more = `<a class="section-more" href="` + html.EscapeString(href) + `">More →</a>`
 	}
-	return `<section id="` + html.EscapeString(id) + `" class="section-card"><div class="section-card-head"><h4>` + heading + `</h4>` + more + `</div><div class="card"><div class="card-body">` + body + `</div></div></section>`
+	return `<section id="` + html.EscapeString(id) + `" class="section-card"><div class="section-card-head"><h4>` + heading + `</h4></div><div class="card"><div class="card-body">` + body + `</div>` + more + `</div></section>`
 }

--- a/service/events/overview.go
+++ b/service/events/overview.go
@@ -85,3 +85,15 @@ func Overview(owner string, limit int) []External {
 	overviewCache.Unlock()
 	return withoutLocalCopies(Upcoming(owner), entries)
 }
+
+// OverviewFresh reports whether Home can use its snapshot without a provider refresh.
+func OverviewFresh(owner string) bool {
+	if owner == "" || (ExternalConnected != nil && !HasExternal(owner)) {
+		return true
+	}
+	key := overviewKey(owner, PreviewLimit)
+	overviewCache.Lock()
+	defer overviewCache.Unlock()
+	snapshot, ok := overviewCache.values[key]
+	return ok && time.Now().Before(snapshot.expires)
+}

--- a/service/events/overview_test.go
+++ b/service/events/overview_test.go
@@ -18,8 +18,14 @@ func TestOverviewCachesByOwner(t *testing.T) {
 		return []External{{Title: owner, Start: time.Now().Add(time.Hour)}}
 	}
 	a, b := "overview-test-a", "overview-test-b"
+	if OverviewFresh(a) {
+		t.Fatal("missing snapshot marked fresh")
+	}
 	Overview(a, PreviewLimit)
 	Overview(a, PreviewLimit)
+	if !OverviewFresh(a) || OverviewFresh(b) {
+		t.Fatal("freshness crossed accounts")
+	}
 	Overview(b, PreviewLimit)
 	if calls != 2 {
 		t.Fatalf("provider calls: %d", calls)


### PR DESCRIPTION
Set page titles to 16px with 8px below, centered on mobile and left aligned on desktop. Move More from section headings to below card content, keep refreshable timestamps inside the card at top right, remove information icons, and trim trailing body spacing. Services keeps See all without a duplicate More link.

Address concrete load-path costs:
- Home no longer synchronously refreshes Feed providers before rendering the dashboard; Feed refreshes on selection via its existing JSON endpoint.
- Skip the supplemental Upcoming request when the account/calendar snapshot is fresh (or no calendar is connected). Stale snapshots still refresh asynchronously.
- Cache the current versioned mu.js page script for a day, avoiding blocking revalidation on each full navigation. Preserve no-cache for unversioned/worker-script requests and preserve execution order because the script installs CSRF hooks.

The service worker itself only intercepts images. Public timing probes from this environment showed 5.8s Assistant / 8.6s Home TTFB including network setup, which do not establish the user's browser bottleneck or an improvement figure. No claim of live-browser performance or visual verification.

Validation: go test ./home ./internal/app ./service/events -short and git diff --check passed. Coverage includes refreshed timestamp placement, persistent footer navigation, per-account calendar freshness, and page-script caching without caching worker updates.