### PR TITLE
Place More above cards and make Home conversation actions links

### DIFF
--- a/home/card_render_test.go
+++ b/home/card_render_test.go
@@ -30,8 +30,8 @@ func TestACardKeepsItsWayThroughOnRefresh(t *testing.T) {
 	if !strings.Contains(section, `class="section-more" href="/news">More →</a>`) || strings.Contains(body, "More →") {
 		t.Error("More must remain outside the independently refreshed body")
 	}
-	if strings.Index(section, "More →") < strings.Index(section, `class="card-body"`) {
-		t.Error("navigation belongs below the content")
+	if strings.Index(section, "More →") > strings.Index(section, `class="card-body"`) {
+		t.Error("navigation belongs above the card")
 	}
 
 }

--- a/home/conversation_test.go
+++ b/home/conversation_test.go
@@ -30,7 +30,7 @@ let resets=0;
 const window={addEventListener(k,fn){events[k]=fn},muChatNew(){resets++;transcript.textContent='';events['mu-chat-active']({detail:false})}};
 ` + src[start:end] + `
 assert.equal(actionBar.hidden,false);
-button.click();
+button.click({preventDefault(){},stopPropagation(){}});
 assert.equal(resets,1);
 assert.equal(transcript.textContent,'');
 assert.equal(actionBar.hidden,true);

--- a/home/home.go
+++ b/home/home.go
@@ -449,7 +449,7 @@ function fetchW(la,lo){
 		Location:        viewerID != "",
 		Stationary:      true,
 		ContinueNS:      assistantNamespace(viewerID) + ":home",
-		FooterHTML:      `<div id="home-conversation-actions" class="conversation-actions" hidden><button type="button" id="home-conversation-close">Close</button><button type="button" id="mu-chat-continue" disabled>Continue in Assistant</button><span id="mu-chat-transfer-error" role="status"></span></div>`,
+		FooterHTML:      `<div id="home-conversation-actions" class="conversation-actions" hidden><a href="/home" id="home-conversation-close">Close</a><a href="/assistant?view=home" id="mu-chat-continue" aria-disabled="true">Continue in Assistant</a><span id="mu-chat-transfer-error" role="status"></span></div>`,
 	}))
 	b.WriteString(`</div>`)
 	b.WriteString(appsHTML(viewerAcc))

--- a/home/views.js
+++ b/home/views.js
@@ -7,7 +7,7 @@
   }
   window.addEventListener('mu-chat-active',event=>conversation(event.detail===true));
   const close=home.querySelector('#home-conversation-close');
-  if(close)close.addEventListener('click',()=>window.muChatNew());
+  if(close)close.addEventListener('click',event=>{event.preventDefault();event.stopPropagation();window.muChatNew();});
   const initial=home.querySelector('#mu-chat-conv');
   conversation(!!initial && !!initial.textContent.trim());
 

--- a/internal/app/chat.go
+++ b/internal/app/chat.go
@@ -887,7 +887,7 @@ function showSuggestions(){
 
 function save(){
   var transfer=document.getElementById('mu-chat-continue');
-  if(transfer)transfer.disabled=!history.length || !!conv.querySelector('.mu-think,.mu-cursor');
+  if(transfer)transfer.setAttribute('aria-disabled',String(!history.length || !!conv.querySelector('.mu-think,.mu-cursor')));
   if(SESSION||!PERSIST)return; // server owns reopened sessions; ephemeral surfaces don't save
   try{
     sessionStorage.setItem(CKEY,conv.innerHTML);
@@ -1198,8 +1198,9 @@ window.addEventListener('popstate',function(e){
 
 // Move a completed exchange as one bundle; never put its words in a URL.
 var transfer=document.getElementById('mu-chat-continue');
-if(transfer && CONTINUE_NS)transfer.addEventListener('click',function(){
-  if(transfer.disabled)return;
+if(transfer && CONTINUE_NS)transfer.addEventListener('click',function(event){
+  event.preventDefault();event.stopPropagation();
+  if(transfer.getAttribute('aria-disabled')==='true')return;
   try{
     sessionStorage.setItem('mu_chat_handoff:'+CONTINUE_NS,JSON.stringify({html:conv.innerHTML,history:history,context:contextId||'',draft:input.value||''}));
     window.location.assign('/assistant?view=home');

--- a/internal/app/chat_transfer_test.go
+++ b/internal/app/chat_transfer_test.go
@@ -19,16 +19,16 @@ func TestContinueTransfersExchangeWithoutWordsInURL(t *testing.T) {
 	script := `
 const assert=require('assert');
 let click,url,stored;
-const button={disabled:false,addEventListener(_,fn){click=fn}},status={};
+const button={disabled:false,getAttribute(){return String(this.disabled)},addEventListener(_,fn){click=fn}},status={};
 const document={getElementById(id){return id==='mu-chat-continue'?button:status}};
 const CONTINUE_NS='assistant:account:alice:home',conv={innerHTML:'<div>Private answer</div>'},history=[{prompt:'Private question',answer:'Private answer'}],contextId='original-thread',input={value:'Follow up'};
 const sessionStorage={setItem(key,value){stored={key,value}}};
 const window={location:{assign(value){url=value}}};
 ` + body[start:end] + `
-click();assert.equal(url,'/assistant?view=home');assert.equal(stored.key,'mu_chat_handoff:assistant:account:alice:home');
+click({preventDefault(){},stopPropagation(){}});assert.equal(url,'/assistant?view=home');assert.equal(stored.key,'mu_chat_handoff:assistant:account:alice:home');
 const exchange=JSON.parse(stored.value);assert.equal(exchange.context,'original-thread');assert.deepEqual(exchange.history,history);assert.equal(exchange.html,conv.innerHTML);assert.equal(exchange.draft,'Follow up');
-url=undefined;button.disabled=true;click();assert.equal(url,undefined);
-button.disabled=false;sessionStorage.setItem=()=>{throw Error('storage unavailable')};click();assert.equal(url,undefined);assert(status.textContent.includes('Could not move'));
+url=undefined;button.disabled=true;click({preventDefault(){},stopPropagation(){}});assert.equal(url,undefined);
+button.disabled=false;sessionStorage.setItem=()=>{throw Error('storage unavailable')};click({preventDefault(){},stopPropagation(){}});assert.equal(url,undefined);assert(status.textContent.includes('Could not move'));
 `
 	if out, err := exec.Command(node, "-e", script).CombinedOutput(); err != nil {
 		t.Fatalf("%v\n%s", err, out)

--- a/internal/app/html/composition.css
+++ b/internal/app/html/composition.css
@@ -207,9 +207,8 @@ a.link-text {
 #home-agent .mu-chat-footer:has([hidden]) { display:none; }
 .conversation-actions { display:flex; align-items:center; flex-wrap:wrap; gap:8px; }
 .conversation-actions[hidden] { display:none; }
-.conversation-actions button { background:white; color:var(--text-secondary,#555); border:0; }
-.conversation-actions button:hover { background:#f5f5f5; }
-.conversation-actions button:disabled { opacity:.5; cursor:default; }
+.conversation-actions a { padding:0; font-size:13px; line-height:1.5; color:var(--text-secondary,#555); text-decoration:underline; text-underline-offset:3px; }
+.conversation-actions a[aria-disabled="true"] { opacity:.5; cursor:default; }
 #mu-chat-transfer-error:empty { display:none; }
 /* One gap owner for the composer, answers and disclosure; empty slots take no space. */
 #home-agent #mu-chat, .assistant-page #mu-chat { display:flex; flex-direction:column; gap:var(--space-control,8px); }
@@ -244,8 +243,6 @@ a.link-text {
 }
 
 @media(max-width:900px) { #page-title { text-align:center; } }
-.section-card > .card > .section-more { display:block; margin-top:8px; font-size:13px; color:var(--text-secondary,#555); text-decoration:none; }
-.section-card > .card > .section-more:hover { text-decoration:underline; }
 .section-card .card-meta { display:flex; justify-content:flex-end; margin:0 0 8px; }
 .section-card .card-meta .card-when { margin:0; font-size:12px; }
 .section-card .card-body > :last-child { margin-bottom:0; padding-bottom:0; }

--- a/internal/app/section.go
+++ b/internal/app/section.go
@@ -20,5 +20,5 @@ func SectionCard(id, heading, href, body string) string {
 	if href != "" {
 		more = `<a class="section-more" href="` + html.EscapeString(href) + `">More →</a>`
 	}
-	return `<section id="` + html.EscapeString(id) + `" class="section-card"><div class="section-card-head"><h4>` + heading + `</h4></div><div class="card"><div class="card-body">` + body + `</div>` + more + `</div></section>`
+	return `<section id="` + html.EscapeString(id) + `" class="section-card"><div class="section-card-head"><h4>` + heading + `</h4>` + more + `</div><div class="card"><div class="card-body">` + body + `</div></div></section>`
 }


### PR DESCRIPTION
Move More back to the top-right of each section heading, outside the card. Keep timestamps inside cards and Services with only See all.

Render Close and Continue in Assistant as underlined text links without button padding or minimum height, aligned with the answer and retaining the compact 8px content gap. Services remains separated by the existing larger section gap. Keep Close's local reset and Continue's account-scoped handoff; prevent normal navigation until the handoff is ready or when storage fails, using aria-disabled on the link.

Validation: go test ./home ./internal/app -short and git diff --check passed, including updated link interaction and transfer tests. Live visual appearance not verified.