### PR TITLE
Use normal-weight answer links and match spacing around the card

### DIFF
--- a/home/home.go
+++ b/home/home.go
@@ -449,7 +449,7 @@ function fetchW(la,lo){
 		Location:        viewerID != "",
 		Stationary:      true,
 		ContinueNS:      assistantNamespace(viewerID) + ":home",
-		FooterHTML:      `<div id="home-conversation-actions" class="conversation-actions" hidden><a href="/home" id="home-conversation-close">Close</a><a href="/assistant?view=home" id="mu-chat-continue" aria-disabled="true">Continue in Assistant</a><span id="mu-chat-transfer-error" role="status"></span></div>`,
+		FooterHTML:      `<div id="home-conversation-actions" class="conversation-actions" hidden><a href="/home" id="home-conversation-close">Close</a><a href="/assistant?view=home" id="mu-chat-continue" aria-disabled="true">Continue in Assistant →</a><span id="mu-chat-transfer-error" role="status"></span></div>`,
 	}))
 	b.WriteString(`</div>`)
 	b.WriteString(appsHTML(viewerAcc))

--- a/internal/app/html/composition.css
+++ b/internal/app/html/composition.css
@@ -205,9 +205,9 @@ a.link-text {
 
 /* Home actions finish an exchange or move it to Assistant. */
 #home-agent .mu-chat-footer:has([hidden]) { display:none; }
-.conversation-actions { display:flex; align-items:center; flex-wrap:wrap; gap:8px; }
+.conversation-actions { display:flex; align-items:center; justify-content:space-between; flex-wrap:wrap; gap:8px 16px; }
 .conversation-actions[hidden] { display:none; }
-.conversation-actions a { padding:0; font-size:13px; line-height:1.5; color:var(--text-secondary,#555); text-decoration:underline; text-underline-offset:3px; }
+.conversation-actions a { padding:0; font-weight:400; font-size:13px; line-height:1.5; color:var(--text-secondary,#555); text-decoration:underline; text-underline-offset:3px; }
 .conversation-actions a[aria-disabled="true"] { opacity:.5; cursor:default; }
 #mu-chat-transfer-error:empty { display:none; }
 /* One gap owner for the composer, answers and disclosure; empty slots take no space. */
@@ -246,3 +246,8 @@ a.link-text {
 .section-card .card-meta { display:flex; justify-content:flex-end; margin:0 0 8px; }
 .section-card .card-meta .card-when { margin:0; font-size:12px; }
 .section-card .card-body > :last-child { margin-bottom:0; padding-bottom:0; }
+
+/* Match the byline-to-answer gap below the final answer as well. */
+#home-agent #mu-chat .mu-by { margin-bottom:8px; }
+#home-agent #mu-chat .mu-agent:last-child .card:last-child { margin-bottom:0; }
+#mu-chat-transfer-error { flex-basis:100%; }


### PR DESCRIPTION
Close and Continue inherited bold link styling and the final answer card retained its 12px bottom margin in addition to the conversation gap.

Set both actions to weight 400, put them at opposite ends of the row with wrapping on narrow screens, and add an arrow to Continue in Assistant. Remove the last answer card's extra bottom margin and use an 8px gap above and below the answer to match the Micro byline. Keep transfer errors on their own row.

Verified the scoped CSS and markup diff and git diff --check. No interaction changes or live-browser visual verification.