### PR TITLE
Simplify Home and navigation; unbox conversations and replace Nunito

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,8 @@ cron job can all reach the same account.
 ## The three things the app is
 
 **Services** are the building blocks: 36 of them, one directory each, each with
-a page, an API surface and a set of tools derived from the same Spec. Some run a
+an API surface and a set of tools derived from the same Spec. A dedicated
+page is optional: services are capabilities, not a requirement for more screens. Some run a
 protocol here — mail, chat, files, shell. Others hold an account with an upstream
 provider so the caller does not have to: news, markets, video, weather, places,
 maps, web search. Both are legitimate and the test is the same — whether the
@@ -65,9 +66,10 @@ one protocol. An earlier line said *real tools, not wrappers*, which made "did
 we build it" the measure and capped breadth at what one team can operate.
 Breadth behind one account is the value.
 
-**Keep the signed-in app intact.** It is not legacy, it is the proof the tools
-work: every capability had to render a page, which is why the services are
-coherent enough for tools to be derived from them.
+**Keep capabilities and data intact while simplifying the app.** Everyday
+navigation is Assistant, Home, Inbox and Tasks. Retire redundant discovery
+pages only with a working replacement; preserve protocols, API responses,
+authorisation, mutations and existing shared content links.
 
 ## What is true today, and what is not
 
@@ -510,6 +512,12 @@ cost; rate limits stop bots.
   repository never sees
 
 ## UI composition
+
+The UI is being reduced before adopting a maintained component library. Prefer
+plain conversation flow and unboxed sections; use cards only when a distinct
+embedded object needs a boundary. Share typography across landing, account and
+application shells. Do not add new page-specific styling or a second chat
+implementation during this migration.
 
 Use the shared components in `internal/app/form.go`, `internal/app/html/mu.css` and
 `internal/app/html/composition.css` (also loaded by the landing page).

--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ It includes:
 
 Mu comes with a unified inbox for mail, chat, SMS, WhatsApp, notes, tasks and agent activity, bringing communication and agent work into one place.
 
+The everyday web navigation is **Assistant**, **Home**, **Inbox** and **Tasks**.
+Home shows personal context and quick questions; Assistant is the dedicated
+conversation. Agents and the service catalogue remain available as advanced
+tools. A service does not need a separate discovery page to remain available
+to agents, the API, MCP or the CLI.
+
 ## Agents
 
 Mu is the runtime. Micro is the first agent and the one people meet first.

--- a/account/pages.go
+++ b/account/pages.go
@@ -72,9 +72,6 @@ var LoginTemplate = `<html lang="en">
     <title>Login | Mu</title>
     <meta name="viewport" content="width=device-width, initial-scale=1, interactive-widget=resizes-content, viewport-fit=cover" />
     <meta name="referrer" content="no-referrer"/>
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Nunito+Sans:ital,opsz,wght@0,6..12,200..1000;1,6..12,200..1000&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/mu.css?` + app.Version + `">
   </head>
   <body>
@@ -180,9 +177,6 @@ var SignupTemplate = `<html lang="en">
     <title>Signup | Mu</title>
     <meta name="viewport" content="width=device-width, initial-scale=1, interactive-widget=resizes-content, viewport-fit=cover" />
     <meta name="referrer" content="no-referrer"/>
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Nunito+Sans:ital,opsz,wght@0,6..12,200..1000;1,6..12,200..1000&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/mu.css?` + app.Version + `">
   </head>
   <body>

--- a/home/apps.go
+++ b/home/apps.go
@@ -17,7 +17,7 @@ func appsHTML(acc *auth.Account) string {
 	for _, s := range apps {
 		seen[s.Name] = true
 	}
-	for _, s := range service.Pinned([]string{"news", "video", "web", "mail", "notes", "tasks", "events", "maps", "weather", "markets"}) {
+	for _, s := range service.Pinned([]string{"events", "notes", "docs", "files", "contacts", "maps", "apps"}) {
 		if !seen[s.Name] {
 			apps = append(apps, s)
 			seen[s.Name] = true

--- a/home/apps_test.go
+++ b/home/apps_test.go
@@ -6,21 +6,22 @@ import (
 
 	"mu/internal/auth"
 	"mu/internal/service"
-	"mu/service/mail"
-	"mu/service/news"
+	"mu/service/docs"
+	"mu/service/events"
+	"mu/service/files"
+	"mu/service/notes"
 	"mu/service/video"
-	"mu/service/web"
 )
 
 func TestAppsAlwaysOfferUsefulDefaults(t *testing.T) {
-	for _, spec := range []service.Spec{news.Spec, video.Spec, web.Spec, mail.Spec} {
+	for _, spec := range []service.Spec{events.Spec, notes.Spec, docs.Spec, files.Spec, video.Spec} {
 		if err := service.Register(spec); err != nil {
 			t.Fatal(err)
 		}
 	}
 	for _, acc := range []*auth.Account{nil, {}, {Pinned: []string{}}, {Pinned: []string{"removed-service"}}} {
 		body := appsHTML(acc)
-		for _, name := range []string{"news", "video", "web", "mail"} {
+		for _, name := range []string{"events", "notes", "docs", "files"} {
 			if !strings.Contains(body, `href="/`+name+`"`) {
 				t.Errorf("missing default %s for %#v", name, acc)
 			}
@@ -30,7 +31,7 @@ func TestAppsAlwaysOfferUsefulDefaults(t *testing.T) {
 		}
 	}
 	body := appsHTML(&auth.Account{Pinned: []string{"video"}})
-	if strings.Index(body, `href="/video"`) < 0 || strings.Index(body, `href="/video"`) > strings.Index(body, `href="/news"`) {
+	if strings.Index(body, `href="/video"`) < 0 || strings.Index(body, `href="/video"`) > strings.Index(body, `href="/events"`) {
 		t.Error("explicit pins were not placed first")
 	}
 }

--- a/home/home.go
+++ b/home/home.go
@@ -431,12 +431,7 @@ function fetchW(la,lo){
 
 	// Date + invite/settings above the input
 	b.WriteString(`<div class="page-section compact-stack page-stack">` + dateHTML)
-	feed := r.URL.Query().Get("view") == "feed" || r.URL.Query().Get("mode") == "display"
-	if r.URL.Query().Get("q") != "" || r.URL.Query().Get("prompt") != "" {
-		feed = false
-	}
-	b.WriteString(homeViews(feed) + `</div>`)
-	b.WriteString(`<section id="home-personal" role="tabpanel" aria-labelledby="home-view-personal"` + panelHidden(feed) + `>`)
+	b.WriteString(`</div><section id="home-personal">`)
 
 	// Each column flows independently as a conversation grows.
 	b.WriteString(`<div class="home-workspace"><div class="home-column page-stack">`)
@@ -464,65 +459,11 @@ function fetchW(la,lo){
 		b.WriteString(`<div class="home-column page-stack">`)
 		b.WriteString(`<div id="home-todo" class="page-stack">` + todoHTML(viewerID) + `</div>`)
 		b.WriteString(`<div id="home-upcoming" class="page-stack">` + fmt.Sprintf(`<div data-home-upcoming data-fresh="%t" aria-live="polite" class="page-stack">`, events.OverviewFresh(viewerID)) + events.Preview(viewerID, events.CachedOverview(viewerID)) + `</div>` + `</div>`)
-		if who := agent.Preview(viewerID); who != "" {
-			b.WriteString(`<div id="home-agents" class="page-stack">` + who + `</div>`)
-		}
 		b.WriteString(`</div>`)
 	}
 	b.WriteString(`</div>`)
 
-	b.WriteString(`</section><section id="home-feed" role="tabpanel" aria-labelledby="home-view-feed"` + panelHidden(!feed) + `><div class="home-main full">`)
-	cards := CardsHTML(r, viewerAcc)
-	if cards == "" {
-		cards = `<p class="text-muted">No feed items yet.</p>`
-	}
-	b.WriteString(cards)
-	b.WriteString(`</div></section></div><script>` + viewsJS + `</script>`)
-
-	// Auto-refresh: poll every 2 minutes, update card content in-place
-	displayMode := r.URL.Query().Get("mode") == "display"
-	refreshInterval := 120000 // 2 minutes
-	if displayMode {
-		refreshInterval = 60000 // 1 minute in display mode
-	}
-	wakeLockJS := ""
-	if displayMode {
-		wakeLockJS = `
-  // Screen Wake Lock — keep display on in kiosk mode
-  if('wakeLock' in navigator){
-    var wl=null;
-    function reqWake(){navigator.wakeLock.request('screen').then(function(l){wl=l;l.addEventListener('release',function(){setTimeout(reqWake,1000)})}).catch(function(){})}
-    reqWake();document.addEventListener('visibilitychange',function(){if(document.visibilityState==='visible')reqWake()});
-  }`
-	}
-	b.WriteString(fmt.Sprintf(`<script>
-(function(){
-  var interval = %d;
-  var updating = false;
-  var feed = document.getElementById('home-feed');
-  function refreshFeed(){
-    if(!feed || !feed.isConnected || feed.hidden || document.hidden || updating) return;
-    updating = true;
-    fetch('/', {headers:{Accept:'application/json'}})
-    .then(function(r){return r.json()})
-    .then(function(cards){
-      if(!feed.isConnected) return;
-      cards.forEach(function(c){
-        var el = document.getElementById(c.id);
-        if(el){
-          var content = el.querySelector('.card-body');
-          if(content) content.innerHTML = c.html;
-          // Refresh the section title independently of the body and its timestamp.
-          var head = el.querySelector('h4');
-          if(head) head.innerHTML = c.title;
-        }
-      });
-    }).catch(function(){}).finally(function(){updating = false;});
-  }
-  feed.addEventListener('home-feed-shown', refreshFeed);
-  setInterval(refreshFeed, interval);%s
-})();
-</script>`, refreshInterval, wakeLockJS))
+	b.WriteString(`</section></div><script>` + viewsJS + `</script>`)
 
 	// Deep-link prefill: /?q=... or /home?prompt=... seeds the agent and submits
 	// it, so a shared link lands on the home screen with the answer already coming.
@@ -534,11 +475,7 @@ function fetchW(la,lo){
 		b.WriteString(`<script>(function(){var v=` + app.JSString(prefill) + `;var f=function(){if(window.muChatAsk){window.muChatAsk(v);history.replaceState(null,'','` + r.URL.Path + `');}else{setTimeout(f,60);}};f();})()</script>`)
 	}
 
-	// Display mode: hide nav, header, footer for kiosk/wall display
 	bodyClass := ` class="page-home"`
-	if displayMode {
-		bodyClass = ` class="page-home display-mode"`
-	}
 
 	// No ConnectBanner here. This page prepended one itself, from when it was
 	// the only page that carried the invitation — and the shell prepends it to

--- a/home/layout_test.go
+++ b/home/layout_test.go
@@ -35,8 +35,8 @@ func homeFor(t *testing.T, accountID string, names ...string) string {
 	return rec.Body.String()
 }
 
-// Home is the personal workspace; Feed holds the existing service cards.
-func TestHomeAndFeedKeepTheirOwnContent(t *testing.T) {
+// Home renders personal context without a second discovery feed.
+func TestHomeKeepsPersonalContext(t *testing.T) {
 	const who = "homefeedreader"
 	th := thread.Open(who, "mail", "sender@example.com")
 	if th == nil {
@@ -44,41 +44,28 @@ func TestHomeAndFeedKeepTheirOwnContent(t *testing.T) {
 	}
 	thread.Add(thread.Message{Thread: th.ID, Account: who, From: "sender@example.com", Text: "An inbox message"})
 	body := homeFor(t, who)
-	if !strings.Contains(body, "Welcome back, "+who) {
-		t.Error("missing personal greeting")
-	}
-	personalAt := strings.Index(body, `<section id="home-personal"`)
-	feedAt := strings.Index(body, `<section id="home-feed"`)
-	if personalAt < 0 || feedAt <= personalAt {
-		t.Fatal("missing view panels")
-	}
-	personal, feed := body[personalAt:feedAt], body[feedAt:]
-	for _, want := range []string{`id="home-agent"`, `id="home-brief"`, `<a class="card-head-link" href="/inbox">Inbox</a>`} {
-		if !strings.Contains(personal, want) || strings.Contains(feed, want) {
-			t.Errorf("%s is not exclusive to Home", want)
+	for _, want := range []string{"Welcome back, " + who, `id="home-agent"`, `id="home-brief"`, `<a class="card-head-link" href="/inbox">Inbox</a>`} {
+		if !strings.Contains(body, want) {
+			t.Errorf("missing %s", want)
 		}
 	}
-	if strings.Contains(personal, `class="home-main`) || !strings.Contains(feed, `class="home-main full"`) {
-		t.Error("service cards are not exclusive to Feed")
-	}
-	if !strings.Contains(body, `id="home-view-personal" href="/home" role="tab" aria-controls="home-personal" aria-selected="true"`) {
-		t.Error("Home is not the default")
-	}
-	if !strings.Contains(body, `id="home-feed" role="tabpanel" aria-labelledby="home-view-feed" hidden`) {
-		t.Error("Feed is initially visible")
+	for _, gone := range []string{`id="home-feed"`, `role="tabpanel"`, `id="home-agents"`, "refreshFeed", "wakeLock"} {
+		if strings.Contains(body, gone) {
+			t.Errorf("Home still includes %s", gone)
+		}
 	}
 }
 
-func TestFeedLinksAndDisplayMode(t *testing.T) {
+func TestOldFeedAndDisplayLinksStillShowHome(t *testing.T) {
 	for _, path := range []string{"/home?view=feed", "/home?mode=display"} {
 		rec := httptest.NewRecorder()
 		Handler(rec, httptest.NewRequest("GET", path, nil))
 		body := rec.Body.String()
-		if !strings.Contains(body, `id="home-personal" role="tabpanel" aria-labelledby="home-view-personal" hidden`) {
-			t.Errorf("%s did not hide Home", path)
+		if rec.Code != http.StatusOK || !strings.Contains(body, `<section id="home-personal">`) {
+			t.Errorf("%s no longer opens Home", path)
 		}
-		if strings.Contains(body, `id="home-feed" role="tabpanel" aria-labelledby="home-view-feed" hidden`) {
-			t.Errorf("%s hid Feed", path)
+		if strings.Contains(body, `class="page-home display-mode"`) || strings.Contains(body, `id="home-feed"`) {
+			t.Errorf("%s revived a retired view", path)
 		}
 	}
 }
@@ -225,7 +212,7 @@ func TestPublicHomeDoesNotExposePersonalCards(t *testing.T) {
 			t.Errorf("public Home exposes %s", id)
 		}
 	}
-	if !strings.Contains(body, `id="home-brief"`) || !strings.Contains(body, `id="home-feed"`) {
+	if !strings.Contains(body, `id="home-brief"`) {
 		t.Fatal("missing public content")
 	}
 }

--- a/home/views.go
+++ b/home/views.go
@@ -1,30 +1,11 @@
 package home
 
 import (
-	"fmt"
 	"html"
 	"strings"
 
 	"mu/internal/auth"
 )
-
-func panelHidden(hidden bool) string {
-	if hidden {
-		return ` hidden`
-	}
-	return ""
-}
-
-func homeViews(feed bool) string {
-	homeTab, feedTab := 0, -1
-	if feed {
-		homeTab, feedTab = -1, 0
-	}
-	return fmt.Sprintf(`<nav class="view-switch" role="tablist" aria-label="Home views">
-<a id="home-view-personal" href="/home" role="tab" aria-controls="home-personal" aria-selected="%t" tabindex="%d">Home</a>
-<a id="home-view-feed" href="/home?view=feed" role="tab" aria-controls="home-feed" aria-selected="%t" tabindex="%d">Feed</a>
-</nav>`, !feed, homeTab, feed, feedTab)
-}
 
 // greeting avoids using the server timezone for a person's local time of day.
 func greeting(acc *auth.Account) string {

--- a/home/views.js
+++ b/home/views.js
@@ -27,47 +27,4 @@
       })
       .catch(() => { upcoming.innerHTML = '<p class="text-muted">Could not load events. <a href="/events">Open events</a></p>'; });
   }
-  const tabs = [...home.querySelectorAll('.view-switch [role="tab"]')];
-  const positions = new Map();
-  let selected = tabs.find(tab => tab.getAttribute('aria-selected') === 'true');
-  function select(tab) {
-    if (tab === selected) {
-      return;
-    }
-    positions.set(selected.id, window.scrollY);
-    tabs.forEach(item => {
-      const active = item === tab;
-      item.setAttribute('aria-selected', String(active));
-      item.tabIndex = active ? 0 : -1;
-      document.getElementById(item.getAttribute('aria-controls')).hidden = !active;
-    });
-    selected = tab;
-    if (tab.id === 'home-view-feed') {
-      document.getElementById('home-feed').dispatchEvent(new Event('home-feed-shown'));
-    }
-    const url = new URL(location.href);
-    if (tab.id === 'home-view-feed') url.searchParams.set('view', 'feed');
-    else url.searchParams.delete('view');
-    history.replaceState(history.state, '', url);
-    window.scrollTo({top: positions.get(tab.id) || 0, behavior: 'instant'});
-  }
-  tabs.forEach((tab, index) => {
-    tab.addEventListener('click', event => {
-      if (event.button !== 0 || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return;
-      event.preventDefault();
-      event.stopPropagation();
-      select(tab);
-    });
-    tab.addEventListener('keydown', event => {
-      let next;
-      if (event.key === 'ArrowRight') next = tabs[(index + 1) % tabs.length];
-      if (event.key === 'ArrowLeft') next = tabs[(index + tabs.length - 1) % tabs.length];
-      if (event.key === 'Home') next = tabs[0];
-      if (event.key === 'End') next = tabs[tabs.length - 1];
-      if (!next) return;
-      event.preventDefault();
-      next.focus();
-      select(next);
-    });
-  });
 })();

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"mu/internal/auth"
+	"mu/internal/service"
 
 	"github.com/gomarkdown/markdown"
 	"github.com/gomarkdown/markdown/ast"
@@ -375,9 +376,6 @@ var Template = `
     <link rel="preload" href="/account.png?` + Version + `" as="image">
     <link rel="preload" href="/weather.png?` + Version + `" as="image">
     <link rel="preload" href="/prayer.svg?` + Version + `" as="image">
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Nunito+Sans:ital,opsz,wght@0,6..12,200..1000;1,6..12,200..1000&display=swap" rel="stylesheet">
     <link rel="manifest" href="/manifest.webmanifest">
     <link rel="stylesheet" href="/mu.css?` + Version + `">
  <link rel="stylesheet" href="/composition.css?` + Version + `">
@@ -1252,19 +1250,7 @@ func VerifyBanner(r *http.Request) string {
 </div>`
 }
 
-// navMain is the menu: every destination, in one flat list.
-//
-// It was two lists. Four links here — Home, Inbox, Agents, Services — and five
-// more behind a disclosure triangle under your own name: Account, Profile,
-// Wallet, Tokens, Admin. The split was by ownership, "what is yours" under your
-// name, which is a true distinction and the wrong one to hide behind a click.
-// Your wallet and your tokens are not less reachable than the services
-// catalogue; they were one interaction further away than a list of nineteen
-// things you do not own.
-//
-// A menu is a list of destinations and this is the list. The account's own —
-// Account, Profile, Tokens, Wallet — appear only when there is an account, and
-// Admin only for an admin, and the main destinations require a signed-in account.
+// navMain holds the four everyday destinations, matching the mobile tabs.
 func navMain(acc *auth.Account) string {
 	if acc == nil {
 		return ""
@@ -1276,38 +1262,13 @@ func navMain(acc *auth.Account) string {
 
 	b := item("nav-assistant", "/assistant", "/chat.png", "Assistant")
 	b += item("nav-home", "/home", "/home.png", "Home")
-	// Account and Profile are not here. They are the two that are about *you*
-	// rather than about the instance, so they sit under your name at the foot
-	// beside Log out — which is where somebody looks when the question is "who
-	// am I signed in as and what is mine".
-	//
-	// Admin belongs below Account in navBottom.
-
 	b += item("nav-inbox", "/inbox", "/mail.png", "Inbox")
-	b += item("nav-agents", "/agents", "/agent.svg", "Agents")
-	b += item("nav-services", "/services", "/services.svg", "Services")
+	b += item("nav-tasks", "/tasks", "/tasks.svg", "Tasks")
 
 	return b
 }
 
-// navTabs is the four hubs along the bottom of a phone.
-//
-// The rail is behind a hamburger at phone width, which puts every destination
-// two taps away and none of them in reach of a thumb. The workaround was an
-// envelope in the top bar — one of the seven, promoted because it was the one
-// people missed most, at the far corner from where a hand holds a phone. This
-// is the general answer to what that patch was a special case of.
-//
-// Four, and they are the four navMain shows a signed-out visitor: Home, Inbox,
-// Agents, Services. A tab bar holds four or five before the labels stop being
-// readable, and these are the four this product is — where you land, what
-// arrived, who works for you, what they can reach. The rest of the rail stays
-// behind the hamburger, which is the right place for Tokens, Wallet and Admin:
-// things somebody touches monthly, and the reason not to spend a tab on them.
-//
-// Signed in only. Signed out, the shell is a landing page whose job is one
-// button, and a fixed bar across the bottom of it competes with that button
-// while offering the same four links its footer already carries.
+// navTabs keeps everyday destinations in thumb reach on phones.
 func navTabs(acc *auth.Account) string {
 	if acc == nil {
 		return ""
@@ -1320,9 +1281,18 @@ func navTabs(acc *auth.Account) string {
 		tab("/assistant", "/chat.png", "Ask") +
 		tab("/home", "/home.png", "Home") +
 		tab("/inbox", "/mail.png", "Inbox") +
-		tab("/agents", "/agent.svg", "Agents") +
-		tab("/services", "/services.svg", "Services") +
+		tab("/tasks", "/tasks.svg", "Tasks") +
 		`</nav>`
+}
+
+// navAdvanced separates runtime management from everyday assistant use.
+func navAdvanced(acc *auth.Account) string {
+	if acc == nil {
+		return ""
+	}
+	return `<div class="nav-group"><div class="nav-heading">Advanced</div>
+<a id="nav-agents" href="/agents"><img src="/agent.svg?` + Version + `"><span class="label">Agents</span></a>
+<a id="nav-services" href="/services"><img src="/services.svg?` + Version + `"><span class="label">Services</span></a></div>`
 }
 
 // TopUpConfigured reports whether this instance can take a payment, filled in
@@ -1342,26 +1312,12 @@ func navAdmin(acc *auth.Account) string {
 	return `<a id="nav-admin" href="/admin"><img src="/admin.svg?` + Version + `"><span class="label">Admin</span></a>`
 }
 
-// navPinned is the reader's own services, under a heading of their own.
-//
-// The sidebar went from nineteen alphabetical services — which put Wallet
-// eighteenth, between Video and Weather — to none of them, because the three
-// levels are what the product is and a list of nineteen buried them. That was
-// right for arriving and wrong for using: somebody who wanted Video reached for
-// the sidebar, found nothing, and had to go to the catalogue and hunt.
-//
-// The way back is not the old list. This one is chosen, so it is short, it is
-// ordered by the person who made it, and it is empty until somebody pins
-// something — which means the view a developer arrives at is unchanged. The
-// group scrolls if it grows; the account group below it does not move, because
-// signing out is not something to scroll for.
-//
-// Home and the sidebar use the same shortcuts, including defaults for new accounts.
+// navPinned contains only services the reader explicitly pinned.
 func navPinned(acc *auth.Account) string {
 	if acc == nil {
 		return ""
 	}
-	pinned := ServiceShortcuts(acc)
+	pinned := service.Pinned(acc.Pinned)
 	if len(pinned) == 0 {
 		return ""
 	}
@@ -1811,7 +1767,7 @@ func renderShell(lang, title, desc, bodyAttr, body string, acc *auth.Account, pa
 		lang, title, desc, bodyAttr,
 		headCorner(acc, here),
 		navMain(acc),
-		navPinned(acc),
+		navPinned(acc)+navAdvanced(acc),
 		navBottom(acc, here),
 		title, body, footerFor(acc), navTabs(acc))
 }

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -253,7 +253,7 @@ func TestRenderHTMLGuestNavHidesSignedInActions(t *testing.T) {
 func TestTheSignedInRailCarriesEveryDestination(t *testing.T) {
 	result := renderWithLang("Test", "A test page", "<p>content</p>", "en", &auth.Account{ID: "alice", Pinned: []string{}})
 	for _, want := range []string{
-		`id="nav-home"`, `id="nav-account"`, `id="nav-inbox"`,
+		`id="nav-home"`, `id="nav-account"`, `id="nav-inbox"`, `id="nav-tasks"`,
 		`id="nav-agents"`, `id="nav-services"`,
 		`id="nav-logout"`, `@alice`,
 	} {
@@ -358,7 +358,7 @@ func TestTheSidebarIsTheProductsNouns(t *testing.T) {
 		nav = nav[:j]
 	}
 
-	want := []string{`href="/assistant"`, `href="/home"`, `href="/inbox"`, `href="/agents"`, `href="/services"`}
+	want := []string{`href="/assistant"`, `href="/home"`, `href="/inbox"`, `href="/tasks"`, `href="/agents"`, `href="/services"`}
 	at := -1
 	for _, w := range want {
 		i := strings.Index(nav, w)
@@ -383,7 +383,7 @@ func TestTheSidebarIsTheProductsNouns(t *testing.T) {
 	if strings.Contains(nav, `href="/tools"`) {
 		t.Error("Tools is back in the sidebar")
 	}
-	for _, gone := range []string{`href="/apps"`, `href="/tasks"`, `href="/events"`, `href="/news"`} {
+	for _, gone := range []string{`href="/apps"`, `href="/events"`, `href="/news"`} {
 		if strings.Contains(result, gone) {
 			t.Errorf("%s is in the sidebar of an account that pinned nothing", gone)
 		}
@@ -428,9 +428,25 @@ func (PinProbe) List(ctx context.Context, req *struct{}, rsp *struct {
 // Nothing pinned draws no group at all. An empty heading over an empty list is
 // a worse answer than no heading when the reader has unpinned everything.
 func TestPinningNothingDrawsNoGroup(t *testing.T) {
-	result := renderWithLang("Test", "d", "<p>c</p>", "en", &auth.Account{ID: "alice", Pinned: []string{}})
-	if strings.Contains(result, "nav-group") || strings.Contains(result, "nav-heading") {
+	if got := navPinned(&auth.Account{ID: "alice", Pinned: []string{}}); got != "" {
 		t.Error("an account that pinned nothing was given a Services group")
+	}
+}
+
+func TestEverydayNavigationMatchesAcrossDevices(t *testing.T) {
+	acc := &auth.Account{ID: "alice"}
+	for _, nav := range []string{navMain(acc), navTabs(acc)} {
+		if strings.Count(nav, `<a `) != 4 {
+			t.Fatal("everyday navigation must have four destinations")
+		}
+		at := -1
+		for _, path := range []string{"/assistant", "/home", "/inbox", "/tasks"} {
+			i := strings.Index(nav, `href="`+path+`"`)
+			if i <= at {
+				t.Fatalf("missing or misplaced destination %s", path)
+			}
+			at = i
+		}
 	}
 }
 

--- a/internal/app/chat.go
+++ b/internal/app/chat.go
@@ -589,7 +589,7 @@ body:has(.mu-console[open]) { overflow:hidden; }
   overflow-y:auto;overscroll-behavior:contain;
   margin:0 0 12px;padding-right:4px
 }
-.mu-user{margin:0 0 12px;padding:10px 14px;background:#f5f5f5;border-radius:8px;font-size:14px;color:#333;scroll-margin-top:64px}
+.mu-user{margin:0 0 16px;padding:0;font-size:16px;font-weight:500;color:#111;scroll-margin-top:64px}
 .mu-agent{margin-bottom:24px;scroll-margin-top:64px}
 /* Who answered. The same shape as the rail's section headings, because it is
    the same kind of thing — a label over a block, not a line of the block. */
@@ -622,7 +622,7 @@ body:has(.mu-console[open]) { overflow:hidden; }
 #mu-chat-conv pre{overflow-x:auto;max-width:100%}
 #mu-chat-conv table{display:block;overflow-x:auto;max-width:100%}
 #mu-chat-conv img{max-width:100%;height:auto}
-#mu-chat .card{max-width:100%;border:1px solid #e0e0e0;border-radius:8px;padding:16px 18px;margin-bottom:12px;background:#fff;box-shadow:0 1px 2px rgba(0,0,0,.04)}
+#mu-chat .card{max-width:100%;border:0;border-radius:0;padding:0;margin-bottom:16px;background:transparent;box-shadow:none}
 #mu-chat .card h4{margin:0 0 8px;font-size:1em;font-weight:600}
 #mu-chat .card a,#mu-chat .link,#mu-chat a.link{color:#111}
 /* Self-contained typography so rendered answers look right anywhere. */

--- a/internal/app/html/composition.css
+++ b/internal/app/html/composition.css
@@ -53,10 +53,6 @@
 .page-stack, .page-section { display: flex; flex-direction: column; gap: var(--space-field); min-width: 0; }
 .page-section { margin-block: 0 var(--space-section); }
 .form.page-section { margin-block-end: var(--space-section); }
-/* An in-page view switch. Panels keep their own content and state. */
-.view-switch { display: flex; gap: var(--space-field); border-bottom: 1px solid var(--card-border, #e8e8e8); margin-block: 0 var(--space-section); }
-.view-switch [role=tab] { box-sizing: border-box; display: inline-flex; align-items: center; min-height: 44px; padding: var(--space-control); border-bottom: 2px solid transparent; color: var(--text-muted, #707070); font-weight: 400; text-decoration: none; }
-.view-switch [role=tab][aria-selected=true] { color: var(--text-primary, #3c3c3c); border-bottom-color: currentColor; }
 .page-stack > *, .page-section > * { margin-block: 0; min-width: 0; }
 .section-actions, .check-label { display: flex; flex-wrap: wrap; align-items: center; gap: var(--space-control); }
 .section-actions { font-size: 14px; }
@@ -219,7 +215,7 @@ a.link-text {
 .home-workspace { row-gap:var(--space-field,16px); }
 .home-workspace > .home-column { gap:var(--space-field,16px); }
 .assistant-page { max-width:800px; margin:0; }
-@media(max-width:900px) { #tabs { grid-template-columns:repeat(5,minmax(0,1fr)); } }
+@media(max-width:900px) { #tabs { grid-template-columns:repeat(4,minmax(0,1fr)); } }
 
 /* Keep the Assistant composer below the fixed app header while reading. */
 .assistant-page #mu-chat-form { top:58px; }
@@ -235,7 +231,7 @@ a.link-text {
 .section-card-head .card-head-link:hover { text-decoration:underline; }
 .section-card-head .section-more { flex:none; font-size:13px; font-weight:400; color:var(--text-secondary,#555); text-decoration:none; }
 .section-card-head .section-more:hover { text-decoration:underline; }
-.section-card > .card, .section-card > .card:hover { min-width:0; margin:0; padding:16px; border-radius:4px; box-shadow:none; }
+.section-card > .card, .section-card > .card:hover { min-width:0; margin:0; padding:0; border:0; border-radius:0; background:transparent; box-shadow:none; }
 
 @media(max-width:900px) {
  #home { gap:16px; }
@@ -254,5 +250,5 @@ a.link-text {
 
 /* Contain floated timestamps without reserving a full row above the content. */
 .section-card .card-body { display:flow-root; }
-/* The information icon is gone; align prayer's mark with the card padding. */
-.section-card .card-corner { top:16px; right:16px; }
+/* Align the corner mark with the unboxed content. */
+.section-card .card-corner { top:0; right:0; }

--- a/internal/app/html/mu.css
+++ b/internal/app/html/mu.css
@@ -130,7 +130,7 @@ html, body {
   width: 100%;
   margin: 0;
   padding: 0;
-  font-family: "Nunito Sans", sans-serif;
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   font-size: 14px;
   box-sizing: border-box;
   overflow-x: hidden;
@@ -959,9 +959,8 @@ a.btn-plain:hover {
   height: 100%;
 }
 
-/* Home and Feed share the page width, but never compete for it. */
-#home-personal, #home-feed, .home-rail, .home-main { min-width: 0; }
-#home-personal[hidden], #home-feed[hidden] { display: none !important; }
+/* Keep personal content within its column. */
+#home-personal, .home-rail, .home-main { min-width: 0; }
 #home-personal { display: grid; gap: var(--space-section, 24px); }
 .home-workspace { display: grid; gap: var(--space-section, 24px); align-items: start; }
 .home-column { min-width: 0; gap: var(--space-section, 24px); }
@@ -4174,7 +4173,7 @@ a.btn-primary:hover, .btn-primary:hover {
 }
 
 .blog-form textarea {
-  font-family: 'Nunito Sans', sans-serif;
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   resize: vertical;
   min-height: 150px;
 }
@@ -4242,7 +4241,7 @@ a.btn-primary:hover, .btn-primary:hover {
 }
 
 .mail-form textarea {
-  font-family: 'Nunito Sans', sans-serif;
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   resize: vertical;
   min-height: 200px;
 }
@@ -4251,7 +4250,7 @@ a.btn-primary:hover, .btn-primary:hover {
   padding: 15px;
   border: 1px solid #ddd;
   border-radius: 4px;
-  font-family: 'Nunito Sans', sans-serif;
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   font-size: inherit;
   min-height: 100px;
   outline: none;
@@ -5612,44 +5611,6 @@ a.card-hover:hover {
   }
 }
 
-/* ============================================
-   DISPLAY / KIOSK MODE
-   Activated via ?mode=display on /home
-   Hides nav, header, footer for wall-mounted displays
-   ============================================ */
-body.display-mode #head,
-body.display-mode #nav-container,
-body.display-mode #nav-overlay,
-body.display-mode #footer,
-body.display-mode #menu-toggle,
-body.display-mode #page-title,
-body.display-mode #tabs {
-  display: none !important;
-}
-
-body.display-mode #container {
-  margin: 0;
-  padding: 0;
-  max-width: 100%;
-}
-
-body.display-mode #content {
-  margin: 0;
-  padding: 16px;
-  max-width: 100%;
-}
-
-body.display-mode #home {
-  gap: 16px;
-}
-
-body.display-mode .card {
-  font-size: 15px;
-}
-
-body.display-mode .card h4 {
-  font-size: 16px;
-}
 @keyframes typingBounce {
   0%, 60%, 100% { opacity: 0.3; transform: translateY(0); }
   30% { opacity: 1; transform: translateY(-4px); }

--- a/internal/app/index.go
+++ b/internal/app/index.go
@@ -64,14 +64,11 @@ func RenderIndex(l Index) string {
 <meta property="og:title" content="` + l.Title + `">
 <meta property="og:description" content="` + l.Description + `">
 ` + ogImage + `
-<link rel="preconnect" href="https://fonts.googleapis.com">
-<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Nunito+Sans:ital,opsz,wght@0,6..12,200..1000;1,6..12,200..1000&display=swap" rel="stylesheet">
 ` + icons + `
 <link rel="stylesheet" href="/composition.css?` + Version + `">
 <style>
 *{margin:0;padding:0;box-sizing:border-box}
-body{font-family:'Nunito Sans',sans-serif;background:#fff;color:#111;min-height:100vh;display:flex;flex-direction:column}
+body{font-family:system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;background:#fff;color:#111;min-height:100vh;display:flex;flex-direction:column}
 .index-page{flex:1;display:flex;flex-direction:column;align-items:center;justify-content:flex-start;padding:0 20px 40px;position:relative;width:100%}
 /* The same header the app has: name centred, the way in on the right.
  *

--- a/internal/app/shortcuts.go
+++ b/internal/app/shortcuts.go
@@ -13,5 +13,5 @@ func ServiceShortcuts(acc *auth.Account) []service.Spec {
 			return pinned
 		}
 	}
-	return service.Pinned([]string{"news", "video", "web", "mail"})
+	return service.Pinned([]string{"events", "notes", "docs", "files"})
 }

--- a/internal/auth/oauth.go
+++ b/internal/auth/oauth.go
@@ -394,7 +394,7 @@ func authorizePage(clientID, redirectURI, state, codeChallenge, codeChallengeMet
 <html><head><title>Authorize</title>
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <style>
-body{font-family:'Nunito Sans',sans-serif;max-width:400px;margin:50px auto;padding:0 20px}
+body{font-family:system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;max-width:400px;margin:50px auto;padding:0 20px}
 h2{margin-bottom:4px}
 p{color:#666;font-size:14px}
 input{width:100%;padding:10px;margin:6px 0;border:1px solid #ddd;border-radius:6px;font-size:14px;box-sizing:border-box;font-family:inherit}

--- a/internal/server/helpers.go
+++ b/internal/server/helpers.go
@@ -60,7 +60,7 @@ func setSecurityHeaders(w http.ResponseWriter) {
 	h.Set("Content-Security-Policy", strings.Join([]string{
 		"default-src 'self'",
 		"script-src 'self' 'unsafe-inline'",
-		// The page template pulls Nunito Sans from Google Fonts.
+		// Retained for existing embedded app themes that use Google Fonts.
 		"style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
 		"font-src 'self' data: https://fonts.gstatic.com",
 		"img-src 'self' data: blob: https:",


### PR DESCRIPTION
The everyday assistant experience has accumulated competing destinations, a second feed and repeated card styling. This starts the agreed surface reduction before moving retained screens to a maintained UI library.

- Make Assistant, Home, Inbox and Tasks the four primary destinations on desktop and mobile. Keep Agents and Services in an Advanced group; sidebar pins are explicit choices.
- Remove Home's Feed tab, feed rendering/polling, kiosk wake lock/styles and agent roster. Old feed/display URLs still render Home. Preserve the card API and underlying services.
- Default Home shortcuts to Events, Notes, Docs and Files while preserving explicit pins and See all.
- Remove the card borders, backgrounds, shadows and padding from conversation turns and Home sections; retain headings, content links and conversation controls.
- Replace Nunito with native system sans-serif across the app, landing, login and consent shells; remove external font stylesheet requests.
- Update README and development guidance to allow services without dedicated pages.

This is the first cleanup, not complete page retirement or a frontend-library installation. Remaining consolidation is tracked in #1573 and the React/Material UI recommendation in #1572. APIs, protocols, records and shared links are preserved; mixed page/API handlers have not been blindly redirected.

Validation: go test ./home ./internal/app ./account ./internal/auth ./internal/server -short passed; JavaScript syntax, gofmt and git diff --check passed. Updated coverage checks the four destinations, public/private Home content, old feed URLs, explicit pins and shortcut defaults. No live browser visual verification or deployment confirmation.