### PR TITLE
Call the everyday tasks section Todo

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,7 +67,8 @@ we build it" the measure and capped breadth at what one team can operate.
 Breadth behind one account is the value.
 
 **Keep capabilities and data intact while simplifying the app.** Everyday
-navigation is Assistant, Home, Inbox and Tasks. Retire redundant discovery
+navigation is Assistant, Home, Inbox and Todo. The service and API remain
+named tasks; Todo is the user-facing section label. Retire redundant discovery
 pages only with a working replacement; preserve protocols, API responses,
 authorisation, mutations and existing shared content links.
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ It includes:
 
 Mu comes with a unified inbox for mail, chat, SMS, WhatsApp, notes, tasks and agent activity, bringing communication and agent work into one place.
 
-The everyday web navigation is **Assistant**, **Home**, **Inbox** and **Tasks**.
+The everyday web navigation is **Assistant**, **Home**, **Inbox** and **Todo**.
 Home shows personal context and quick questions; Assistant is the dedicated
 conversation. Agents and the service catalogue remain available as advanced
 tools. A service does not need a separate discovery page to remain available

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -1263,7 +1263,7 @@ func navMain(acc *auth.Account) string {
 	b := item("nav-assistant", "/assistant", "/chat.png", "Assistant")
 	b += item("nav-home", "/home", "/home.png", "Home")
 	b += item("nav-inbox", "/inbox", "/mail.png", "Inbox")
-	b += item("nav-tasks", "/tasks", "/tasks.svg", "Tasks")
+	b += item("nav-tasks", "/tasks", "/tasks.svg", "Todo")
 
 	return b
 }
@@ -1281,7 +1281,7 @@ func navTabs(acc *auth.Account) string {
 		tab("/assistant", "/chat.png", "Ask") +
 		tab("/home", "/home.png", "Home") +
 		tab("/inbox", "/mail.png", "Inbox") +
-		tab("/tasks", "/tasks.svg", "Tasks") +
+		tab("/tasks", "/tasks.svg", "Todo") +
 		`</nav>`
 }
 

--- a/service/tasks/handler.go
+++ b/service/tasks/handler.go
@@ -129,7 +129,7 @@ func listPage(w http.ResponseWriter, r *http.Request, names ...func(string, stri
 	}
 	b.WriteString(`<div class="page-stack"><div class="task-tabs">`)
 	tab(&b, "", filter, fmt.Sprintf("All (%d)", len(all)))
-	tab(&b, StatusTodo, filter, fmt.Sprintf("To do (%d)", open))
+	tab(&b, StatusTodo, filter, fmt.Sprintf("Todo (%d)", open))
 	tab(&b, StatusDoing, filter, fmt.Sprintf("Doing (%d)", doing))
 	tab(&b, StatusFailed, filter, fmt.Sprintf("Failed (%d)", failed))
 	tab(&b, StatusBlocked, filter, fmt.Sprintf("Blocked (%d)", blocked))
@@ -164,7 +164,7 @@ func listPage(w http.ResponseWriter, r *http.Request, names ...func(string, stri
 	}
 
 	b.WriteString(tasksPageCSS)
-	app.Respond(w, r, app.Response{Title: "Tasks", Description: "What is to be done", HTML: b.String()})
+	app.Respond(w, r, app.Response{Title: "Todo", Description: "What is to be done", HTML: b.String()})
 }
 
 func tab(b *strings.Builder, status, active, label string) {

--- a/service/tasks/service.go
+++ b/service/tasks/service.go
@@ -209,6 +209,7 @@ func Load() {
 
 var Spec = service.Spec{
 	Name:        "tasks",
+	Label:       "Todo",
 	Handler:     new(Server),
 	Description: "Manage tasks and assign work",
 	Page:        "/tasks",


### PR DESCRIPTION
Use the friendlier name Todo consistently in desktop/mobile navigation, the page title and open-item filter, and service metadata used by shortcuts/catalogues. Update the documented navigation naming.

The underlying tasks service, /tasks URLs, API/tool names and stored records stay compatible. Home already uses Todo.

Validation: existing internal/app, service/tasks and home short tests pass.