### PR TITLE
Make credit history mobile-friendly and distinguish unread items

### DIFF
--- a/account/balance.go
+++ b/account/balance.go
@@ -146,18 +146,20 @@ func LedgerSection(userID string) string {
 	// same reason.
 	if len(transactions) > 0 {
 		var rows strings.Builder
-		rows.WriteString(`<table class="data-table">`)
-		rows.WriteString(`<tr><th>Date</th><th>Type</th><th>Amount</th><th>Balance</th></tr>`)
+		rows.WriteString(`<ul class="ledger-list" aria-label="Credit history">`)
 		for _, tx := range transactions {
-			rows.WriteString(fmt.Sprintf(`<tr>
-				<td>%s</td>
-				<td>%s</td>
-				<td>%s</td>
-				<td>%d</td>
-			</tr>`, tx.CreatedAt.Format("2 Jan 15:04"), htmlEsc(transactionLabel(tx)),
-				transactionAmount(tx), tx.Balance))
+			amount := transactionAmount(tx)
+			if tx.Amount != 0 {
+				amount += " credits"
+			}
+			rows.WriteString(fmt.Sprintf(`<li class="ledger-entry">
+				<div class="ledger-description">%s<time class="ledger-detail" datetime="%s">%s</time></div>
+				<div class="ledger-values">%s<span class="ledger-detail">Balance %d</span></div>
+			</li>`, htmlEsc(transactionLabel(tx)), tx.CreatedAt.Format(time.RFC3339), tx.CreatedAt.Format("2 Jan 15:04"),
+				amount, tx.Balance))
 		}
-		rows.WriteString(`</table>`)
+		rows.WriteString(`</ul>`)
+
 		sb.WriteString(app.SectionID("ledger", "History", rows.String()))
 	}
 

--- a/internal/app/chat.go
+++ b/internal/app/chat.go
@@ -483,8 +483,14 @@ func ChatComponent(cfg ChatConfig) string {
 
 <style>
 #mu-chat{max-width:760px;margin:0 auto;width:100%}
-#mu-chat-form{display:flex;align-items:center;gap:0;border:1px solid #ddd;border-radius:6px;background:#fff;padding:4px 4px 4px 12px;transition:border-color .2s;position:sticky;top:8px;z-index:5}
+#mu-chat-form{display:flex;align-items:center;gap:0;border:1px solid #ddd;border-radius:6px;background:#fff;padding:4px 4px 4px 12px;transition:border-color .2s;position:sticky;top:var(--mu-composer-top,8px);z-index:5}
 #mu-chat-form:focus-within{border-color:#999}
+/* Opaque above the sticky composer, fading below it into the transcript. */
+#mu-chat-form::before,#mu-chat-form::after{content:"";position:absolute;left:-8px;right:-8px;pointer-events:none;z-index:-1}
+#mu-chat-form::before{bottom:100%;height:calc(var(--mu-composer-top,8px) + 1px);background:#fff}
+#mu-chat-form::after{top:100%;height:24px;background:linear-gradient(to bottom,#fff,rgba(255,255,255,0))}
+.mu-chat-transcript #mu-chat-form::before,.mu-chat-transcript #mu-chat-form::after,.mu-console #mu-chat-form::before,.mu-console #mu-chat-form::after{display:none}
+
 /* Reading back, beside who is answering — the same kind of decision. */
 #mu-chat-say{display:flex;align-items:center;gap:6px;cursor:pointer}
 #mu-chat-say input{margin:0}

--- a/internal/app/html/composition.css
+++ b/internal/app/html/composition.css
@@ -218,8 +218,8 @@ a.link-text {
 @media(max-width:900px) { #tabs { grid-template-columns:repeat(4,minmax(0,1fr)); } }
 
 /* Keep the Assistant composer below the fixed app header while reading. */
-.assistant-page #mu-chat-form { top:58px; }
-@media(max-width:900px) { .assistant-page #mu-chat-form { top:52px; } }
+.assistant-page #mu-chat-form { --mu-composer-top:58px; }
+@media(max-width:900px) { .assistant-page #mu-chat-form { --mu-composer-top:52px; } }
 
 /* Quiet orientation, shared across desktop and mobile page shells. */
 #page-title { font-size:16px; font-weight:500; line-height:1.4; text-align:left; color:var(--text-secondary,#555); margin:0 0 8px; }
@@ -252,3 +252,12 @@ a.link-text {
 .section-card .card-body { display:flow-root; }
 /* Align the corner mark with the unboxed content. */
 .section-card .card-corner { top:0; right:0; }
+
+/* A ledger entry keeps its description and amounts together at narrow widths. */
+.ledger-list { list-style:none; margin:0; padding:0; }
+.ledger-entry { display:grid; grid-template-columns:minmax(0,1fr) auto; gap:8px 16px; padding:16px 0; border-bottom:1px solid var(--divider,#eee); }
+.ledger-entry:first-child { padding-top:0; }
+.ledger-entry:last-child { border-bottom:0; padding-bottom:0; }
+.ledger-description { min-width:0; overflow-wrap:anywhere; }
+.ledger-values { text-align:right; font-variant-numeric:tabular-nums; }
+.ledger-detail { display:block; font-size:12px; color:var(--text-muted,#707070); }

--- a/internal/app/html/mu.css
+++ b/internal/app/html/mu.css
@@ -6011,6 +6011,7 @@ button.pill:hover {
 .ib-row:hover { text-decoration: none }
 
 .ib-row {
+  font-weight: var(--font-weight-normal, 400);
   display: flex;
   align-items: baseline;
   gap: 12px;
@@ -6093,6 +6094,7 @@ button.pill:hover {
    left a ragged gap on every row with only one, and on a phone there was never
    room for any of it. Nothing competes when nothing shares a line. */
 .ib-row {
+  font-weight: var(--font-weight-normal, 400);
   display: flex;
   flex-direction: column;
   /* Stretch, and stated rather than left to the default. The rule above sets
@@ -6114,7 +6116,7 @@ button.pill:hover {
   align-items: start;
   gap: 8px;
   font-size: 12px;
-  font-weight: var(--font-weight-medium, 500);
+  font-weight: var(--font-weight-normal, 400);
   color: var(--text-secondary, #555);
   min-width: 0;
 }
@@ -6465,6 +6467,7 @@ button.pill:hover {
 }
 
 .peek-row {
+  font-weight: var(--font-weight-normal, 400);
   display: block;
   padding: 11px 0;
   text-decoration: none;
@@ -6474,7 +6477,8 @@ button.pill:hover {
 
 .peek-row:last-of-type { border-bottom: 0 }
 /* The row, not the title — see .ib-item. */
-.peek-row { padding-left: 10px; padding-right: 10px; margin: 0 -10px;
+.peek-row {
+  font-weight: var(--font-weight-normal, 400); padding-left: 10px; padding-right: 10px; margin: 0 -10px;
   border-radius: var(--border-radius, 6px) }
 .peek-row:hover { background: var(--hover-background, #fafafa); text-decoration: none }
 .peek-row.unseen .peek-title { font-weight: var(--font-weight-bold, 700) }
@@ -6483,7 +6487,7 @@ button.pill:hover {
 
 .peek-title {
   font-size: 14px;
-  font-weight: var(--font-weight-medium, 500);
+  font-weight: var(--font-weight-normal, 400);
   color: var(--text-primary, #1a1a1a);
   overflow: hidden;
   text-overflow: ellipsis;
@@ -6492,7 +6496,7 @@ button.pill:hover {
 
 .peek-when { font-size: 11px; color: var(--text-muted, #888); margin-left: auto; white-space: nowrap; flex: none }
 .peek-line { display: block; font-size: 13px; color: var(--text-muted, #888); margin-top: 3px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap }
-.peek-who { color: var(--text-secondary, #555); font-weight: var(--font-weight-medium, 500) }
+.peek-who { color: var(--text-secondary, #555); font-weight: var(--font-weight-normal, 400) }
 
 /* The channel, last on the line the eye reads last. It was a pill, which made
    it the loudest thing in the block and usually said "Mail" three times. */

--- a/service/tasks/handler.go
+++ b/service/tasks/handler.go
@@ -331,7 +331,7 @@ const tasksPageCSS = `<style>
 .task-tab{font-size:13px;color:var(--text-muted);text-decoration:none}
 .task-tab.active{color:var(--text-primary);font-weight:600}
 .task{display:flex;flex-direction:column;gap:var(--space-control)}
-.task-title{font-weight:var(--font-weight-medium)}
+.task-title{font-weight:var(--font-weight-normal,400)}
 .task-done .task-title{text-decoration:line-through;color:var(--text-muted)}
 .task-meta{font-size:12px;color:var(--text-muted);margin:0}
 .task-context{margin:0}.task-context summary{cursor:pointer;color:var(--text-muted)}


### PR DESCRIPTION
Account History's four-column table is cramped on phones, text scrolls visibly around the sticky assistant input, and Home previews inherit bold link styling even after an item is read.

Replace the credit history table with semantic list entries: description/date alongside amount/balance. Preserve transaction labels, amounts, balances and timestamps. Add an opaque area above the sticky composer and a short white-to-transparent fade below it, with no input displacement or pointer interception. Static transcript/dialog composers do not get the overlay.

Set Inbox and Home preview rows to regular weight, including read titles and metadata. Keep the existing unread class and bold unread title rules. Todo titles are regular weight; read state and completion state remain distinct.

Validation: existing inbox, home, account, internal/app and service/tasks short suites pass; gofmt and diff checks pass. Live browser visual verification remains outstanding. This continues the current UI cleanup; it does not install React or Material UI.