### PR TITLE
Unify Home and Assistant with a resting Today overview

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,7 +67,8 @@ we build it" the measure and capped breadth at what one team can operate.
 Breadth behind one account is the value.
 
 **Keep capabilities and data intact while simplifying the app.** Everyday
-navigation is Assistant, Home, Inbox and Todo. The service and API remain
+navigation is Assistant, Inbox and Todo. Home and Assistant are one screen:
+a resting overview and a conversation beneath the same input. The service and API remain
 named tasks; Todo is the user-facing section label. Retire redundant discovery
 pages only with a working replacement; preserve protocols, API responses,
 authorisation, mutations and existing shared content links.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ handling the inbound mail on the backend. Mu attempts to do it all in a single b
 It includes:
 
 - **Micro** - your personal assistant and the default agent.
-- **Home** - a launch pad for your assistant, apps and daily work.
+- **Assistant** - your overview and conversation in one place.
 - **Inbox** - A place to keep track of everything.
 - **Clients** - Use Micro via Web, SMS, email, etc.
 - **Services** - building blocks for agents.
@@ -28,11 +28,11 @@ It includes:
 
 Mu comes with a unified inbox for mail, chat, SMS, WhatsApp, notes, tasks and agent activity, bringing communication and agent work into one place.
 
-The everyday web navigation is **Assistant**, **Home**, **Inbox** and **Todo**.
-Home shows personal context and quick questions; Assistant is the dedicated
-conversation. Agents and the service catalogue remain available as advanced
-tools. A service does not need a separate discovery page to remain available
-to agents, the API, MCP or the CLI.
+The everyday web navigation is **Assistant**, **Inbox** and **Todo**.
+Assistant opens with a concise overview of relevant information. Asking a
+question reveals the conversation beneath the same input; returning to Today
+does not clear it. `/home` remains an alias of the same experience. Agents and
+the service catalogue remain available as advanced tools.
 
 ## Agents
 

--- a/home/assistant.go
+++ b/home/assistant.go
@@ -3,36 +3,16 @@ package home
 import (
 	"net/http"
 
-	"mu/agent"
 	"mu/internal/app"
-	"mu/internal/auth"
 )
 
-// AssistantHandler offers the ongoing conversation independently of Home.
+// AssistantHandler and /home render the same assistant and conversation.
 func AssistantHandler(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		app.MethodNotAllowed(w, r)
 		return
 	}
-	_, acc := auth.TrySession(r)
-	viewerID := ""
-	if acc != nil {
-		viewerID = acc.ID
-	}
-	ns := assistantNamespace(viewerID)
-	fromHome := r.URL.Query().Get("view") == "home"
-	if fromHome {
-		ns += ":home"
-	}
-	w.Header().Set("Cache-Control", "private, no-store")
-	body := `<main class="assistant-page"><script>window.muActiveAgent="";</script>` + app.ChatComponent(app.ChatConfig{
-		Ask: true, HideSuggestions: true, AgentName: agent.DefaultName(),
-		Placeholder: "What do you need?", Location: acc != nil, StorageNS: ns, AcceptHandoff: fromHome,
-	}) + `</main>`
-	if fromHome {
-		body = `<div class="page-stack"><div class="section-actions"><a href="/assistant">Back to main conversation</a></div>` + body + `</div>`
-	}
-	app.Respond(w, r, app.Response{Title: "Assistant", Description: "Talk to Micro", HTML: body})
+	Handler(w, r)
 }
 
 func assistantNamespace(account string) string {

--- a/home/assistant_test.go
+++ b/home/assistant_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestAssistantSeparatesAccountAndGuestConversations(t *testing.T) {
 	for _, who := range []string{"", "asstreadera", "asstreaderb"} {
-		for _, path := range []string{"/assistant", "/assistant?view=home"} {
+		for _, path := range []string{"/assistant", "/home", "/assistant?view=home"} {
 			r := httptest.NewRequest(http.MethodGet, path, nil)
 			ns := "assistant:guest"
 			if who != "" {
@@ -45,8 +45,8 @@ func TestAssistantSeparatesAccountAndGuestConversations(t *testing.T) {
 			if strings.Contains(body, `id="mu-chat-location"`) != (who != "") {
 				t.Errorf("%s: location control does not match authentication", path)
 			}
-			if strings.Contains(body, `id="home-cards"`) {
-				t.Error("Assistant depends on Home")
+			if !strings.Contains(body, `id="home-overview"`) {
+				t.Error("Assistant must include its resting overview")
 			}
 		}
 	}
@@ -60,8 +60,8 @@ func TestHomeDisclosureFollowsAnswer(t *testing.T) {
 	if form < 0 || answer <= form || toggle <= answer {
 		t.Fatal("Home input, answers, disclosure must appear in that order")
 	}
-	if !strings.Contains(body, `var CONTINUE_NS="assistant:account:homedisclose:home";`) {
-		t.Error("Home handoff must target its separate conversation")
+	if !strings.Contains(body, `var NS="assistant:account:homedisclose";`) {
+		t.Error("Home must share the main assistant namespace")
 	}
 	if !strings.Contains(body, "var stationary=true;") {
 		t.Error("Home must preserve its surrounding content")

--- a/home/conversation_test.go
+++ b/home/conversation_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 )
 
-func TestCloseEndsHomeExchange(t *testing.T) {
+func TestOverviewTogglePreservesConversation(t *testing.T) {
 	node, err := exec.LookPath("node")
 	if err != nil {
 		t.Skip("Node required")
@@ -17,26 +17,41 @@ func TestCloseEndsHomeExchange(t *testing.T) {
 		t.Fatal(err)
 	}
 	src := string(raw)
-	start, end := strings.Index(src, "  const actions="), strings.Index(src, "  const upcoming")
+	start, end := strings.Index(src, "  const actions="), strings.Index(src, "  function refreshOverview")
 	if start < 0 || end <= start {
 		t.Fatal("conversation controller missing")
 	}
 	script := `
 const assert=require('assert');
-const events={},actionBar={},transcript={textContent:'Existing answer'};
-const button={addEventListener(k,fn){this[k]=fn}};
-const home={querySelector(s){return s==='#home-conversation-actions'?actionBar:s==='#home-conversation-close'?button:transcript}};
-let resets=0;
-const window={addEventListener(k,fn){events[k]=fn},muChatNew(){resets++;transcript.textContent='';events['mu-chat-active']({detail:false})}};
-` + src[start:end] + `
+let refreshes=0;
+function refreshOverview(){refreshes++;}
+const events={},actionBar={},transcript={textContent:'Existing answer'},overview={};
+const button={addEventListener(k,fn){this[k]=fn},setAttribute(k,v){this[k]=v}};
+const home={querySelector(s){return {'#home-conversation-actions':actionBar,'#home-conversation-toggle':button,'#mu-chat-conv':transcript,'#home-overview':overview}[s]}};
+const window={addEventListener(k,fn){events[k]=fn},muChatNew(){throw Error('must not reset conversation')}};
+` + "{\n" + src[start:end] + `
+assert.equal(transcript.hidden,true);
+assert.equal(overview.hidden,false);
 assert.equal(actionBar.hidden,false);
-button.click({preventDefault(){},stopPropagation(){}});
-assert.equal(resets,1);
-assert.equal(transcript.textContent,'');
-assert.equal(actionBar.hidden,true);
+assert.equal(button.textContent,'Resume conversation');
+button.click();
+assert.equal(transcript.hidden,false);
+assert.equal(overview.hidden,true);
+assert.equal(button['aria-expanded'],'true');
+button.click();
+assert.equal(transcript.textContent,'Existing answer');
+assert.equal(refreshes,1);
+assert.equal(overview.hidden,false);
 events['mu-chat-active']({detail:true});
-assert.equal(actionBar.hidden,false);
+assert.equal(transcript.hidden,false);
+assert.equal(overview.hidden,true);
+transcript.textContent='';
+events['mu-chat-active']({detail:false});
+assert.equal(actionBar.hidden,true);
+assert.equal(overview.hidden,false);
+}
 `
+
 	if out, err := exec.Command(node, "-e", script).CombinedOutput(); err != nil {
 		t.Fatalf("%v\n%s", err, out)
 	}

--- a/home/home.go
+++ b/home/home.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	"mu/agent"
-	"mu/inbox"
 	"mu/internal/app"
 	"mu/internal/auth"
 	"mu/internal/event"
@@ -270,15 +269,18 @@ func ForceRefresh() {
 }
 
 func Handler(w http.ResponseWriter, r *http.Request) {
-	if r.URL.Query().Get("section") == "upcoming" {
+	if section := r.URL.Query().Get("section"); section == "upcoming" || section == "overview" {
 		sess, _ := auth.TrySession(r)
 		w.Header().Set("Cache-Control", "private, no-store")
 		if sess == nil {
 			http.Error(w, "Sign in to see upcoming events", http.StatusUnauthorized)
 			return
 		}
-		external := events.Overview(sess.Account, events.PreviewLimit)
-		app.RespondJSON(w, map[string]string{"upcoming": events.Preview(sess.Account, external), "brief": briefHTML(sess.Account, external...), "todo": todoHTML(sess.Account)})
+		external := events.CachedOverview(sess.Account)
+		if section == "upcoming" {
+			external = events.Overview(sess.Account, events.PreviewLimit)
+		}
+		app.RespondJSON(w, map[string]string{"upcoming": events.Preview(sess.Account, external), "brief": briefHTML(sess.Account, external...), "todo": todoHTML(sess.Account), "overview": overviewHTML(sess.Account, external...)})
 		return
 	}
 	// An installed app opens on the app, not on a pitch.
@@ -433,33 +435,23 @@ function fetchW(la,lo){
 	b.WriteString(`<div class="page-section compact-stack page-stack">` + dateHTML)
 	b.WriteString(`</div><section id="home-personal">`)
 
-	// Each column flows independently as a conversation grows.
-	b.WriteString(`<div class="home-workspace"><div class="home-column page-stack">`)
-	b.WriteString(`<div id="home-agent" class="page-stack"><script>window.muActiveAgent="";</script>`)
+	// Both entry URLs use one conversation and one resting overview.
+	ns := assistantNamespace(viewerID)
+	legacy := r.URL.Query().Get("view") == "home"
+	if legacy {
+		ns += ":home"
+	}
+	b.WriteString(`<div class="assistant-page page-stack"><div id="home-agent"><script>window.muActiveAgent="";</script>`)
 	b.WriteString(app.ChatComponent(app.ChatConfig{
-		Ask:             true,
-		HideSuggestions: true,
-		Placeholder:     "What do you need?",
-		AgentName:       agent.DefaultName(),
-		Location:        viewerID != "",
-		Stationary:      true,
-		ContinueNS:      assistantNamespace(viewerID) + ":home",
-		FooterHTML:      `<div id="home-conversation-actions" class="conversation-actions" hidden><a href="/home" id="home-conversation-close">Close</a><a href="/assistant?view=home" id="mu-chat-continue" aria-disabled="true">Continue in Assistant →</a><span id="mu-chat-transfer-error" role="status"></span></div>`,
+		Ask: true, HideSuggestions: true, Placeholder: "What do you need?",
+		AgentName: agent.DefaultName(), Location: viewerID != "", Stationary: true,
+		StorageNS: ns, AcceptHandoff: legacy,
+		FooterHTML: `<div id="home-conversation-actions" class="conversation-actions" hidden><button type="button" class="link-text" id="home-conversation-toggle" aria-controls="mu-chat-conv home-overview" aria-expanded="false">Resume conversation</button></div>`,
 	}))
 	b.WriteString(`</div>`)
-	b.WriteString(appsHTML(viewerAcc))
-	b.WriteString(`<div id="home-brief" class="page-stack">` + briefHTML(viewerID, events.CachedOverview(viewerID)...) + `</div>`)
-	if viewerID != "" {
-		if peek := inbox.Preview(viewerID); peek != "" {
-			b.WriteString(`<div id="home-inbox" class="page-stack">` + peek + `</div>`)
-		}
-	}
-	b.WriteString(`</div>`)
-	if viewerID != "" {
-		b.WriteString(`<div class="home-column page-stack">`)
-		b.WriteString(`<div id="home-todo" class="page-stack">` + todoHTML(viewerID) + `</div>`)
-		b.WriteString(`<div id="home-upcoming" class="page-stack">` + fmt.Sprintf(`<div data-home-upcoming data-fresh="%t" aria-live="polite" class="page-stack">`, events.OverviewFresh(viewerID)) + events.Preview(viewerID, events.CachedOverview(viewerID)) + `</div>` + `</div>`)
-		b.WriteString(`</div>`)
+	b.WriteString(fmt.Sprintf(`<div id="home-overview" data-fresh="%t" data-guest="%t">`, viewerID == "" || events.OverviewFresh(viewerID), viewerID == "") + overviewHTML(viewerID, events.CachedOverview(viewerID)...) + `</div>`)
+	if legacy {
+		b.WriteString(`<a href="/assistant">Back to main conversation</a>`)
 	}
 	b.WriteString(`</div>`)
 
@@ -486,7 +478,8 @@ function fetchW(la,lo){
 	// That is what a banner moving from one page into the chrome looks like
 	// when the call site it left behind is not removed. See app.renderForRequest,
 	// which is the only place any of the three banners is added.
-	app.Respond(w, r, app.Response{Title: greeting(viewerAcc), Description: "The home screen",
+	w.Header().Set("Cache-Control", "private, no-store")
+	app.Respond(w, r, app.Response{Title: greeting(viewerAcc), Description: "Your personal assistant",
 		HTML: b.String(), BodyClass: bodyClass})
 }
 

--- a/home/index.go
+++ b/home/index.go
@@ -363,7 +363,7 @@ func indexBody() string {
 
 // topRight offers one way in from the landing; signup is on the login page.
 func topRight() string {
-	return `<a href="/home">Home</a> <a href="/login">Log in</a>`
+	return `<a href="/assistant">Assistant</a> <a href="/login">Log in</a>`
 }
 
 // today is what you are given for arriving, before you ask anything.

--- a/home/landing_test.go
+++ b/home/landing_test.go
@@ -33,7 +33,7 @@ func TestTheWordmarkSaysWhatItIs(t *testing.T) {
 
 func TestTheLandingOffersPublicHomeAndLogin(t *testing.T) {
 	got := topRight()
-	if got != `<a href="/home">Home</a> <a href="/login">Log in</a>` {
+	if got != `<a href="/assistant">Assistant</a> <a href="/login">Log in</a>` {
 		t.Errorf("unexpected landing navigation: %q", got)
 	}
 }

--- a/home/layout_test.go
+++ b/home/layout_test.go
@@ -44,7 +44,7 @@ func TestHomeKeepsPersonalContext(t *testing.T) {
 	}
 	thread.Add(thread.Message{Thread: th.ID, Account: who, From: "sender@example.com", Text: "An inbox message"})
 	body := homeFor(t, who)
-	for _, want := range []string{"Welcome back, " + who, `id="home-agent"`, `id="home-brief"`, `<a class="card-head-link" href="/inbox">Inbox</a>`} {
+	for _, want := range []string{"Welcome back, " + who, `id="home-agent"`, `id="home-overview"`, `href="/inbox"`} {
 		if !strings.Contains(body, want) {
 			t.Errorf("missing %s", want)
 		}
@@ -212,7 +212,7 @@ func TestPublicHomeDoesNotExposePersonalCards(t *testing.T) {
 			t.Errorf("public Home exposes %s", id)
 		}
 	}
-	if !strings.Contains(body, `id="home-brief"`) {
+	if !strings.Contains(body, `id="home-overview"`) {
 		t.Fatal("missing public content")
 	}
 }

--- a/home/login_continuity_test.go
+++ b/home/login_continuity_test.go
@@ -19,12 +19,12 @@ func TestLandingRefreshAndLoginStartClean(t *testing.T) {
 	}
 }
 
-func TestHomeStartsWithAFreshPrompt(t *testing.T) {
+func TestHomeKeepsAssistantConversation(t *testing.T) {
 	b, err := os.ReadFile("home.go")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if strings.Contains(string(b), "StorageNS:") {
-		t.Fatal("Home restores browser chat instead of a fresh prompt")
+	if !strings.Contains(string(b), "StorageNS:") {
+		t.Fatal("Home must retain the assistant conversation")
 	}
 }

--- a/home/overview.go
+++ b/home/overview.go
@@ -1,0 +1,33 @@
+package home
+
+import (
+	"mu/internal/app"
+	"mu/service/events"
+	"mu/service/tasks"
+	"strings"
+)
+
+// overviewHTML reads owned records and the cached brief; rendering never calls a model.
+func overviewHTML(owner string, external ...events.External) string {
+	parts := briefParts(owner, external...)
+	if owner != "" {
+		attention := len(tasks.List(owner, tasks.StatusBlocked)) + len(tasks.List(owner, tasks.StatusFailed))
+		if attention > 0 {
+			parts = append(parts, app.TextLink(count(attention, "thing needs", "things need")+" your attention", "/tasks")+".")
+		}
+
+		n := 0
+		for _, task := range tasks.List(owner, tasks.StatusTodo) {
+			if task.Assignee == tasks.Me {
+				n++
+			}
+		}
+		if n > 0 {
+			parts = append(parts, "You have "+app.TextLink(count(n, "thing", "things")+" to do", "/tasks?status=todo")+".")
+		}
+	}
+	if len(parts) == 0 {
+		return `<section aria-labelledby="overview-title"><h2 id="overview-title">Today</h2><p>What would you like help with?</p></section>`
+	}
+	return `<section aria-labelledby="overview-title"><h2 id="overview-title">Today</h2><p>` + strings.Join(parts, "</p><p>") + `</p></section>`
+}

--- a/home/overview_test.go
+++ b/home/overview_test.go
@@ -1,0 +1,37 @@
+package home
+
+import (
+	"mu/service/tasks"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestOverviewSummarisesOnlyOwnedPersonalActions(t *testing.T) {
+	const owner = "overview-action-owner"
+	defer tasks.DeleteAll(owner)
+	if _, err := tasks.Create(owner, "Private errand", "", tasks.Me, time.Time{}); err != nil {
+		t.Fatal(err)
+	}
+	task, err := tasks.Create(owner, "Blocked agent request", "", tasks.Agent, time.Time{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = tasks.Update(owner, task.ID, "", "", tasks.StatusBlocked, "", "Review needed"); err != nil {
+		t.Fatal(err)
+	}
+	got := overviewHTML(owner)
+	for _, want := range []string{"1 thing needs your attention", "1 thing to do"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("missing %s: %s", want, got)
+		}
+		for _, other := range []string{"", "overview-other-owner"} {
+			if strings.Contains(overviewHTML(other), want) {
+				t.Fatal("overview crossed account boundary")
+			}
+		}
+	}
+	if strings.Contains(got, "peek-row") || strings.Contains(got, "Private errand") {
+		t.Fatal("overview became a duplicate task list")
+	}
+}

--- a/home/publicbrief_test.go
+++ b/home/publicbrief_test.go
@@ -118,11 +118,11 @@ func TestAskingTakesTheBriefOffThePage(t *testing.T) {
 	}
 }
 
-// Home's separate brief stays available while the person talks to Micro.
-func TestHomesBriefStaysAvailable(t *testing.T) {
+// The overview is available as the resting view of the assistant.
+func TestAssistantHasARestingOverview(t *testing.T) {
 	body := homeFor(t, "homebriefvisible")
-	if !strings.Contains(body, `id="home-brief" class="page-stack"`) || strings.Contains(body, `id="home-brief" data-brief`) {
-		t.Error("Home brief still steps aside during a conversation")
+	if !strings.Contains(body, `id="home-overview"`) || !strings.Contains(body, `id="home-conversation-toggle"`) {
+		t.Error("missing overview or conversation switch")
 	}
 }
 

--- a/home/views.js
+++ b/home/views.js
@@ -2,29 +2,39 @@
   const home = document.getElementById('home-cards');
   if (!home) return;
   const actions=home.querySelector('#home-conversation-actions');
-  function conversation(active){
-    if(actions)actions.hidden=!active;
+  const transcript=home.querySelector('#mu-chat-conv');
+  const overview=home.querySelector('#home-overview');
+  const toggle=home.querySelector('#home-conversation-toggle');
+  let active=false;
+  function conversation(show){
+    active=show;
+    transcript.hidden=!show;
+    overview.hidden=show;
+    actions.hidden=!show && !transcript.textContent.trim();
+    toggle.textContent=show?'Today':'Resume conversation';
+    toggle.setAttribute('aria-expanded',String(show));
   }
   window.addEventListener('mu-chat-active',event=>conversation(event.detail===true));
-  const close=home.querySelector('#home-conversation-close');
-  if(close)close.addEventListener('click',event=>{event.preventDefault();event.stopPropagation();window.muChatNew();});
-  const initial=home.querySelector('#mu-chat-conv');
-  conversation(!!initial && !!initial.textContent.trim());
+  toggle.addEventListener('click',()=>{
+    conversation(!active);
+    if(!active)refreshOverview('overview');
+  });
+  conversation(false);
 
-  const upcoming = home.querySelector('[data-home-upcoming]');
-  if (upcoming && upcoming.dataset.fresh !== 'true') {
-    fetch('/home?section=upcoming', {credentials: 'same-origin'})
-      .then(response => { if (!response.ok) throw new Error('events'); return response.json(); })
-      .then(data => {
-        upcoming.innerHTML = data.upcoming;
-        const brief = home.querySelector("#home-brief");
-        if (brief) brief.innerHTML = data.brief;
-        const todo = home.querySelector("#home-todo");
-        if (todo) todo.innerHTML = data.todo;
-        upcoming.querySelectorAll('[data-event-time]').forEach(node => {
-          node.textContent = new Date(node.dateTime).toLocaleString(undefined, {weekday:'short', day:'numeric', month:'short', hour:'2-digit', minute:'2-digit'});
-        });
-      })
-      .catch(() => { upcoming.innerHTML = '<p class="text-muted">Could not load events. <a href="/events">Open events</a></p>'; });
+  function refreshOverview(section) {
+    // Guests have no private counts or calendars to refresh.
+    if (overview.dataset.guest === 'true') return;
+    fetch('/home?section='+section, {credentials: 'same-origin'})
+      .then(response => { if (!response.ok) throw new Error('overview'); return response.json(); })
+      .then(data => { overview.innerHTML=data.overview; })
+      .catch(() => {
+        if(overview.querySelector('[data-overview-error]'))return;
+        const note=document.createElement('p');
+        note.dataset.overviewError='';
+        note.className='text-muted';
+        note.textContent='The overview could not be refreshed and may be out of date.';
+        overview.appendChild(note);
+      });
   }
+  if (overview.dataset.fresh !== 'true') refreshOverview('upcoming');
 })();

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -732,7 +732,7 @@ var Template = `
           if (u.pathname === '/video' && u.searchParams.get('id')) return;
           // Agent pages own live streams and per-thread draft/scroll state.
           // Use document navigation so pagehide saves it and listeners retire.
-          if (u.pathname === '/assistant' || location.pathname === '/assistant' || u.pathname === '/' || location.pathname === '/' || /^\/agent(?:\/|$)/.test(u.pathname) || /^\/agent(?:\/|$)/.test(location.pathname)) return;
+          if (u.pathname === '/home' || location.pathname === '/home' || u.pathname === '/assistant' || location.pathname === '/assistant' || u.pathname === '/' || location.pathname === '/' || /^\/agent(?:\/|$)/.test(u.pathname) || /^\/agent(?:\/|$)/.test(location.pathname)) return;
           e.preventDefault();
           if (u.href === location.href) return;
           go(u.href, true);
@@ -866,6 +866,7 @@ var Template = `
       // in the document — so the tab bar was never marked.
       function markNav() {
         var here = location.pathname.replace(/\/+$/, '') || '/';
+        if(here === '/home') here = '/assistant';
         if(here === '/agent' || here.indexOf('/agent/') === 0) here = '/agents';
         var groups = ['#nav a, .nav-bottom a', '#tabs a'];
         for (var g = 0; g < groups.length; g++) {
@@ -1250,7 +1251,7 @@ func VerifyBanner(r *http.Request) string {
 </div>`
 }
 
-// navMain holds the four everyday destinations, matching the mobile tabs.
+// navMain holds the three everyday destinations, matching the mobile tabs.
 func navMain(acc *auth.Account) string {
 	if acc == nil {
 		return ""
@@ -1261,7 +1262,6 @@ func navMain(acc *auth.Account) string {
 	}
 
 	b := item("nav-assistant", "/assistant", "/chat.png", "Assistant")
-	b += item("nav-home", "/home", "/home.png", "Home")
 	b += item("nav-inbox", "/inbox", "/mail.png", "Inbox")
 	b += item("nav-tasks", "/tasks", "/tasks.svg", "Todo")
 
@@ -1278,8 +1278,7 @@ func navTabs(acc *auth.Account) string {
 			`" alt=""><span>` + label + `</span></a>`
 	}
 	return `<nav id="tabs" aria-label="Main">` +
-		tab("/assistant", "/chat.png", "Ask") +
-		tab("/home", "/home.png", "Home") +
+		tab("/assistant", "/chat.png", "Assistant") +
 		tab("/inbox", "/mail.png", "Inbox") +
 		tab("/tasks", "/tasks.svg", "Todo") +
 		`</nav>`

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -253,7 +253,7 @@ func TestRenderHTMLGuestNavHidesSignedInActions(t *testing.T) {
 func TestTheSignedInRailCarriesEveryDestination(t *testing.T) {
 	result := renderWithLang("Test", "A test page", "<p>content</p>", "en", &auth.Account{ID: "alice", Pinned: []string{}})
 	for _, want := range []string{
-		`id="nav-home"`, `id="nav-account"`, `id="nav-inbox"`, `id="nav-tasks"`,
+		`id="nav-account"`, `id="nav-inbox"`, `id="nav-tasks"`,
 		`id="nav-agents"`, `id="nav-services"`,
 		`id="nav-logout"`, `@alice`,
 	} {
@@ -358,7 +358,7 @@ func TestTheSidebarIsTheProductsNouns(t *testing.T) {
 		nav = nav[:j]
 	}
 
-	want := []string{`href="/assistant"`, `href="/home"`, `href="/inbox"`, `href="/tasks"`, `href="/agents"`, `href="/services"`}
+	want := []string{`href="/assistant"`, `href="/inbox"`, `href="/tasks"`, `href="/agents"`, `href="/services"`}
 	at := -1
 	for _, w := range want {
 		i := strings.Index(nav, w)
@@ -436,11 +436,11 @@ func TestPinningNothingDrawsNoGroup(t *testing.T) {
 func TestEverydayNavigationMatchesAcrossDevices(t *testing.T) {
 	acc := &auth.Account{ID: "alice"}
 	for _, nav := range []string{navMain(acc), navTabs(acc)} {
-		if strings.Count(nav, `<a `) != 4 {
-			t.Fatal("everyday navigation must have four destinations")
+		if strings.Count(nav, `<a `) != 3 {
+			t.Fatal("everyday navigation must have three destinations")
 		}
 		at := -1
-		for _, path := range []string{"/assistant", "/home", "/inbox", "/tasks"} {
+		for _, path := range []string{"/assistant", "/inbox", "/tasks"} {
 			i := strings.Index(nav, `href="`+path+`"`)
 			if i <= at {
 				t.Fatalf("missing or misplaced destination %s", path)

--- a/internal/app/html/composition.css
+++ b/internal/app/html/composition.css
@@ -177,29 +177,7 @@ a.link-text {
 .preview-rows > .peek-row:last-child,
 .preview-rows > .agent-peek-row:last-child { padding-bottom: 0; }
 
-/* Flatten the columns on small screens so daily actions precede messages. */
-#home-todo:empty { display: none; }
-@media (max-width: 1099px) {
-  .home-workspace > .home-column { display: contents; }
-  .home-workspace #home-agent { order: 0; }
-  .home-workspace #home-brief { order: 2; }
-  .home-workspace #home-todo { order: 3; }
-  .home-workspace #home-upcoming { order: 4; }
-  .home-workspace #home-inbox { order: 5; }
-  .home-workspace #home-agents { order: 6; }
-  .home-workspace .home-apps { order: 1; }
-}
-
-#home-personal.is-conversing #mu-chat-conv { animation:home-answer-in 180ms ease-out; }
-@keyframes home-answer-in { from { opacity:0; transform:translateY(6px); } to { opacity:1; transform:translateY(0); } }
-@media(prefers-reduced-motion:reduce) {
- #home-personal.is-conversing #mu-chat-conv { animation:none; }
-}
-@media(min-width:1100px) {
- .home-workspace:not(:has(#home-todo,#home-agents,#home-upcoming)) { grid-template-columns:minmax(0,2fr) minmax(0,1fr); }
-}
-
-/* Home actions finish an exchange or move it to Assistant. */
+/* Return to the overview without resetting the conversation. */
 #home-agent .mu-chat-footer:has([hidden]) { display:none; }
 .conversation-actions { display:flex; align-items:center; justify-content:space-between; flex-wrap:wrap; gap:8px 16px; }
 .conversation-actions[hidden] { display:none; }
@@ -212,10 +190,8 @@ a.link-text {
 #home-agent #mu-chat-opts:empty, #home-agent #mu-chat-conv:empty,
 .assistant-page #mu-chat-opts:empty, .assistant-page #mu-chat-conv:empty { display:none; }
 #home-agent #mu-chat-conv > :last-child, .assistant-page #mu-chat-conv > :last-child { margin-bottom:0; }
-.home-workspace { row-gap:var(--space-field,16px); }
-.home-workspace > .home-column { gap:var(--space-field,16px); }
 .assistant-page { max-width:800px; margin:0; }
-@media(max-width:900px) { #tabs { grid-template-columns:repeat(4,minmax(0,1fr)); } }
+@media(max-width:900px) { #tabs { grid-template-columns:repeat(3,minmax(0,1fr)); } }
 
 /* Keep the Assistant composer below the fixed app header while reading. */
 .assistant-page #mu-chat-form { --mu-composer-top:58px; }
@@ -261,3 +237,13 @@ a.link-text {
 .ledger-description { min-width:0; overflow-wrap:anywhere; }
 .ledger-values { text-align:right; font-variant-numeric:tabular-nums; }
 .ledger-detail { display:block; font-size:12px; color:var(--text-muted,#707070); }
+
+/* The overview and conversation share one reading column and one fixed input position. */
+.page-home #home-cards, .page-home #page-title { max-width:760px; margin-inline:auto; }
+.page-home .assistant-page { width:100%; max-width:760px; margin-inline:auto; }
+#home-overview h2 { font-size:16px; font-weight:500; margin:0 0 8px; }
+#home-overview p { margin:0 0 16px; }
+#home-overview p:last-child { margin-bottom:0; }
+#home-overview a { font-weight:400; text-decoration:underline !important; text-underline-offset:3px; }
+#home-conversation-toggle { font:inherit; font-size:13px; font-weight:400; border:0; background:none; padding:0; cursor:pointer; }
+#home-agent #mu-chat-conv[hidden], #home-overview[hidden] { display:none; }


### PR DESCRIPTION
Home and Assistant were separate halves of the same experience. This gives them one renderer, one account-scoped in-tab conversation and one reading column.

- Primary navigation becomes Assistant, Inbox and Todo on desktop/mobile. Assistant opens the main screen, not a new conversation or voice. /home remains a compatible alias and highlights Assistant.
- Replace fixed Services/Inbox/Todo/Upcoming previews with a concise Today overview from existing brief/calendar data and owned task counts. Calendar records remain Events; they do not become Todos.
- Asking reveals the conversation beneath the same input. Today/Resume conversation switches the content without clearing history or moving the composer. Returning to Today refreshes local facts without a model call. External calendars retain the existing bounded cache refresh.
- Share the existing main Assistant storage namespace between both URLs. Preserve old ?view=home namespaces/handoff links rather than overwriting those conversations. This retains current browser-tab continuity; it does not claim a new cross-device conversation store.
- Update landing navigation, docs and regression coverage. Remove obsolete Home column ordering styles.

Validation: home, internal/app and internal/server short suites pass; JS syntax, gofmt and diff checks pass. Coverage includes account/guest isolation, shared namespaces, preserved legacy conversations, owner-only overview counts and a JS switch test that rejects conversation resets. Live browser appearance and deployment remain unverified.

Continues #1573 and #1570. This changes the current UI; React/Material UI migration remains separate in #1572.