### PR TITLE
Use Home consistently and simplify logged-out entry

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,7 +67,7 @@ we build it" the measure and capped breadth at what one team can operate.
 Breadth behind one account is the value.
 
 **Keep capabilities and data intact while simplifying the app.** Everyday
-navigation is Assistant, Inbox and Todo. Home and Assistant are one screen:
+navigation is Home, Inbox and Todo. Home and Assistant are one screen:
 a resting overview and a conversation beneath the same input. The service and API remain
 named tasks; Todo is the user-facing section label. Retire redundant discovery
 pages only with a working replacement; preserve protocols, API responses,

--- a/README.md
+++ b/README.md
@@ -28,10 +28,10 @@ It includes:
 
 Mu comes with a unified inbox for mail, chat, SMS, WhatsApp, notes, tasks and agent activity, bringing communication and agent work into one place.
 
-The everyday web navigation is **Assistant**, **Inbox** and **Todo**.
-Assistant opens with a concise overview of relevant information. Asking a
+The everyday web navigation is **Home**, **Inbox** and **Todo**.
+Home opens the assistant with a concise overview of relevant information. Asking a
 question reveals the conversation beneath the same input; returning to Today
-does not clear it. `/home` remains an alias of the same experience. Agents and
+does not clear it. `/assistant` opens the same experience. Agents and
 the service catalogue remain available as advanced tools.
 
 ## Agents

--- a/home/assistant_test.go
+++ b/home/assistant_test.go
@@ -12,6 +12,9 @@ import (
 func TestAssistantSeparatesAccountAndGuestConversations(t *testing.T) {
 	for _, who := range []string{"", "asstreadera", "asstreaderb"} {
 		for _, path := range []string{"/assistant", "/home", "/assistant?view=home"} {
+			if who == "" && path == "/home" {
+				continue
+			}
 			r := httptest.NewRequest(http.MethodGet, path, nil)
 			ns := "assistant:guest"
 			if who != "" {

--- a/home/home.go
+++ b/home/home.go
@@ -283,6 +283,14 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 		app.RespondJSON(w, map[string]string{"upcoming": events.Preview(sess.Account, external), "brief": briefHTML(sess.Account, external...), "todo": todoHTML(sess.Account), "overview": overviewHTML(sess.Account, external...)})
 		return
 	}
+	// Home is an authenticated entry point. Keep machine responses separate.
+	if r.URL.Path == "/home" && (r.Method == http.MethodGet || r.Method == http.MethodHead) && !app.WantsJSON(r) {
+		if _, acc := auth.TrySession(r); acc == nil {
+			w.Header().Set("Cache-Control", "private, no-store")
+			http.Redirect(w, r, "/", http.StatusSeeOther)
+			return
+		}
+	}
 	// An installed app opens on the app, not on a pitch.
 	//
 	// The manifest's start_url was "/", so tapping the icon on a home screen

--- a/home/index.go
+++ b/home/index.go
@@ -363,7 +363,7 @@ func indexBody() string {
 
 // topRight offers one way in from the landing; signup is on the login page.
 func topRight() string {
-	return `<a href="/assistant">Assistant</a> <a href="/login">Log in</a>`
+	return `<a href="/login">Log in</a>`
 }
 
 // today is what you are given for arriving, before you ask anything.

--- a/home/landing_test.go
+++ b/home/landing_test.go
@@ -31,9 +31,9 @@ func TestTheWordmarkSaysWhatItIs(t *testing.T) {
 	}
 }
 
-func TestTheLandingOffersPublicHomeAndLogin(t *testing.T) {
+func TestTheLandingOffersOnlyLogin(t *testing.T) {
 	got := topRight()
-	if got != `<a href="/assistant">Assistant</a> <a href="/login">Log in</a>` {
+	if got != `<a href="/login">Log in</a>` {
 		t.Errorf("unexpected landing navigation: %q", got)
 	}
 }

--- a/home/layout_test.go
+++ b/home/layout_test.go
@@ -57,9 +57,18 @@ func TestHomeKeepsPersonalContext(t *testing.T) {
 }
 
 func TestOldFeedAndDisplayLinksStillShowHome(t *testing.T) {
+	const owner = "legacyhomelinks"
+	auth.Create(&auth.Account{ID: owner})
+	sess, err := auth.CreateSession(owner)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	for _, path := range []string{"/home?view=feed", "/home?mode=display"} {
 		rec := httptest.NewRecorder()
-		Handler(rec, httptest.NewRequest("GET", path, nil))
+		req := httptest.NewRequest("GET", path, nil)
+		req.AddCookie(&http.Cookie{Name: "session", Value: sess.Token})
+		Handler(rec, req)
 		body := rec.Body.String()
 		if rec.Code != http.StatusOK || !strings.Contains(body, `<section id="home-personal">`) {
 			t.Errorf("%s no longer opens Home", path)
@@ -203,16 +212,19 @@ func TestHomeBoundsItsExternalCalendarRead(t *testing.T) {
 	}
 }
 
-func TestPublicHomeDoesNotExposePersonalCards(t *testing.T) {
-	rec := httptest.NewRecorder()
-	Handler(rec, httptest.NewRequest("GET", "/home", nil))
-	body := rec.Body.String()
-	for _, id := range []string{"home-inbox", "home-todo", "home-agents", "home-upcoming", "mu-chat-location"} {
-		if strings.Contains(body, `id="`+id+`"`) {
-			t.Errorf("public Home exposes %s", id)
+func TestLoggedOutHomeRedirectsToLanding(t *testing.T) {
+	for _, path := range []string{"/home", "/home?from=app", "/home?view=feed", "/home?prompt=private"} {
+		for _, method := range []string{http.MethodGet, http.MethodHead} {
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest(method, path, nil)
+			req.AddCookie(&http.Cookie{Name: "session", Value: "expired-session"})
+			Handler(rec, req)
+			if rec.Code != http.StatusSeeOther || rec.Header().Get("Location") != "/" || rec.Header().Get("Cache-Control") != "private, no-store" {
+				t.Fatalf("%s %s: %d %v", method, path, rec.Code, rec.Header())
+			}
+			if strings.Contains(rec.Body.String(), `id="home-overview"`) {
+				t.Fatal("rendered guest Home")
+			}
 		}
-	}
-	if !strings.Contains(body, `id="home-overview"`) {
-		t.Fatal("missing public content")
 	}
 }

--- a/home/wayin_test.go
+++ b/home/wayin_test.go
@@ -30,8 +30,8 @@ func TestSignedOutHomeDoesNotOfferASecondWayIn(t *testing.T) {
 	if n := strings.Count(body, `href="/signup"`); n != 0 {
 		t.Errorf("the guest Home page offers redundant signup links: %d", n)
 	}
-	if n := strings.Count(body, `href="/login?redirect=%2Fhome"`); n != 1 {
-		t.Errorf("the guest Home page should offer Login once in the sidebar, got %d", n)
+	if rec.Header().Get("Location") != "/" {
+		t.Error("guest Home should redirect to landing")
 	}
 }
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -866,7 +866,7 @@ var Template = `
       // in the document — so the tab bar was never marked.
       function markNav() {
         var here = location.pathname.replace(/\/+$/, '') || '/';
-        if(here === '/home') here = '/assistant';
+        if(here === '/assistant') here = '/home';
         if(here === '/agent' || here.indexOf('/agent/') === 0) here = '/agents';
         var groups = ['#nav a, .nav-bottom a', '#tabs a'];
         for (var g = 0; g < groups.length; g++) {
@@ -1261,7 +1261,7 @@ func navMain(acc *auth.Account) string {
 			`"><span class="label">` + label + `</span></a>`
 	}
 
-	b := item("nav-assistant", "/assistant", "/chat.png", "Assistant")
+	b := item("nav-home", "/home", "/home.png", "Home")
 	b += item("nav-inbox", "/inbox", "/mail.png", "Inbox")
 	b += item("nav-tasks", "/tasks", "/tasks.svg", "Todo")
 
@@ -1278,7 +1278,7 @@ func navTabs(acc *auth.Account) string {
 			`" alt=""><span>` + label + `</span></a>`
 	}
 	return `<nav id="tabs" aria-label="Main">` +
-		tab("/assistant", "/chat.png", "Assistant") +
+		tab("/home", "/home.png", "Home") +
 		tab("/inbox", "/mail.png", "Inbox") +
 		tab("/tasks", "/tasks.svg", "Todo") +
 		`</nav>`

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -253,7 +253,7 @@ func TestRenderHTMLGuestNavHidesSignedInActions(t *testing.T) {
 func TestTheSignedInRailCarriesEveryDestination(t *testing.T) {
 	result := renderWithLang("Test", "A test page", "<p>content</p>", "en", &auth.Account{ID: "alice", Pinned: []string{}})
 	for _, want := range []string{
-		`id="nav-account"`, `id="nav-inbox"`, `id="nav-tasks"`,
+		`id="nav-home"`, `id="nav-account"`, `id="nav-inbox"`, `id="nav-tasks"`,
 		`id="nav-agents"`, `id="nav-services"`,
 		`id="nav-logout"`, `@alice`,
 	} {
@@ -358,7 +358,7 @@ func TestTheSidebarIsTheProductsNouns(t *testing.T) {
 		nav = nav[:j]
 	}
 
-	want := []string{`href="/assistant"`, `href="/inbox"`, `href="/tasks"`, `href="/agents"`, `href="/services"`}
+	want := []string{`href="/home"`, `href="/inbox"`, `href="/tasks"`, `href="/agents"`, `href="/services"`}
 	at := -1
 	for _, w := range want {
 		i := strings.Index(nav, w)
@@ -440,7 +440,7 @@ func TestEverydayNavigationMatchesAcrossDevices(t *testing.T) {
 			t.Fatal("everyday navigation must have three destinations")
 		}
 		at := -1
-		for _, path := range []string{"/assistant", "/inbox", "/tasks"} {
+		for _, path := range []string{"/home", "/inbox", "/tasks"} {
 			i := strings.Index(nav, `href="`+path+`"`)
 			if i <= at {
 				t.Fatalf("missing or misplaced destination %s", path)

--- a/internal/app/chat.go
+++ b/internal/app/chat.go
@@ -487,7 +487,7 @@ func ChatComponent(cfg ChatConfig) string {
 #mu-chat-form:focus-within{border-color:#999}
 /* Opaque above the sticky composer, fading below it into the transcript. */
 #mu-chat-form::before,#mu-chat-form::after{content:"";position:absolute;left:-8px;right:-8px;pointer-events:none;z-index:-1}
-#mu-chat-form::before{bottom:100%;height:calc(var(--mu-composer-top,8px) + 1px);background:#fff}
+#mu-chat-form::before{bottom:100%;height:8px;background:#fff}
 #mu-chat-form::after{top:100%;height:24px;background:linear-gradient(to bottom,#fff,rgba(255,255,255,0))}
 .mu-chat-transcript #mu-chat-form::before,.mu-chat-transcript #mu-chat-form::after,.mu-console #mu-chat-form::before,.mu-console #mu-chat-form::after{display:none}
 


### PR DESCRIPTION
The combined overview/conversation screen is Home, linked at /home in both desktop and mobile navigation. There is no separate Assistant navigation entry. Existing /assistant URLs still resolve to the shared renderer and highlight Home.

Logged-out HTML visits to /home redirect to / with private, no-store caching, including expired sessions and installed-app entry URLs. Query text is not copied to the destination. Preserve signed-in Home and machine/section endpoint contracts. Remove the redundant Assistant link from the landing corner, leaving Log in.

Shorten the composer's upper white backdrop to 8px: using its sticky offset as the backdrop height obscured Welcome back before scrolling. Keep the fade below the input.

Validation: home and internal/app short suites pass, with updated redirect, navigation and landing expectations. Live browser visual verification remains outstanding.