### PR TITLE
Separate Home sections and compact Agents and Inbox

### DIFF
--- a/agent/roster_page.go
+++ b/agent/roster_page.go
@@ -161,7 +161,7 @@ func RosterHandler(w http.ResponseWriter, r *http.Request) {
 	// Remove, because neither is a thing you can do to it.
 	EnsureTags(owner)
 	roster := Agents(owner)
-	b.WriteString(`<div class="col">`)
+	b.WriteString(`<div class="collection-grid">`)
 	// The default carries the same sign of life as the rest. It is the one most
 	// accounts have actually used, so a roster where every row but that one says
 	// when it last spoke is a roster missing the row that would say the most.
@@ -334,7 +334,7 @@ type entry struct {
 // the feature rather than offering it.
 func entryRow(e entry) string {
 	var b strings.Builder
-	b.WriteString(`<div class="agent-row card-hover"><div class="grow min-w-0">`)
+	b.WriteString(`<div class="agent-row"><div class="grow min-w-0">`)
 	// The name, and how long ago it last spoke out to the right of it — the
 	// same pair, in the same places, as a row in the inbox.
 	b.WriteString(`<div class="agent-head">`)
@@ -569,18 +569,15 @@ const agentsCSS = `<style>
 .agent-row .agent-seen{white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
 /* Top-aligned, not centred. A row is three or four lines tall now, and
    centring left Remove floating in the middle of the card beside nothing. */
-.agent-row{display:flex;align-items:flex-start;gap:12px;border:1px solid #eee;border-radius:8px;padding:12px 14px}
-/* No :hover here either. This filled its background grey, which is a row's
-   answer — .thread-preview in the inbox — and these are not rows, they are
-   bordered cards in a column, the same object as a tile on /services and a
-   card on home. They lift now, from .card-hover in mu.css. */
+.agent-row{display:flex;align-items:flex-start;gap:16px;min-width:0;border:1px solid var(--divider,#e8e8e8);border-radius:4px;padding:16px}
+/* Only the links are interactive; the card itself does not lift on hover. */
 /* One size, one colour, one weight for every link on a row.
    They were three: 12px grey in the link strip, 13px green or amber for the
    scope, 13px for the buttons beside them, and the name at 14px semibold. A
    row is one thing to read, so the parts that are the same rank look the
    same. */
-.agent-links{display:flex;flex-wrap:wrap;align-items:center;gap:14px;margin-top:8px}
-.agent-links a{font-size:13px;color:#666;text-decoration:none}
+.agent-links{display:flex;flex-wrap:wrap;align-items:center;gap:8px 16px;margin-top:8px}
+.agent-links a{font-size:13px;font-weight:400;color:var(--text-secondary,#555);text-decoration:underline !important;text-underline-offset:3px}
 .agent-links a:hover{color:var(--text-primary,#111);text-decoration:underline}
 /* The form holding Remove is one item in the strip, not a block that breaks it. */
 .agent-links form{display:inline;margin:0}
@@ -593,7 +590,7 @@ const agentsCSS = `<style>
 .agent-mail code{font-size:12px;color:#666;background:#f5f5f5;border-radius:3px;padding:1px 5px}
 /* The agent's name is the way into it, and it looks like body text rather
    than one more small grey control. */
-.agent-name{display:inline-block;font-weight:600;font-size:14px;color:var(--text-primary,#111);text-decoration:none}
+.agent-name{display:inline-block;font-weight:500;font-size:14px;color:var(--text-primary,#111);text-decoration:none;min-width:0;overflow-wrap:anywhere}
 /* No underline: the row behind it is the affordance now, and two of them at
    once is one too many.
    Stated on :hover rather than left to the rule above, which is the whole
@@ -623,23 +620,12 @@ const agentsCSS = `<style>
    where they are reachable with a thumb, and the endpoint scrolls inside its own
    line rather than pushing the page sideways. */
 @media(max-width:600px){
-  /* The strip's tap targets stand taller than their labels, so the card gives
-     back the space below them — see .agent-links. */
-  .agent-row{flex-direction:column;align-items:stretch;gap:8px;padding:12px 14px 4px}
+  /* Preserve the same outside inset at phone width. */
+  .agent-row{flex-direction:column;align-items:stretch;gap:8px;padding:16px}
   .agent-name{font-size:15px}
     .agent-meta{white-space:normal;overflow-wrap:anywhere}
-  /* Every action in the strip is a tap target, so they are all one height.
-     Buttons take min-height from the mobile rule in mu.css and links did not,
-     so Remove stood 16px taller than Chat beside it and the strip grew to fit
-     it.
-
-     A 14px label centred in a 32px target carries 9px of its own space above
-     and below. That is the spacing, not an addition to it: with a margin on
-     top of it the description sat 21px clear of Chat where the desktop row
-     sits 8px clear, which is the gap you can see before the buttons. The
-     margin and the card's bottom padding give theirs back and the target
-     keeps its height. */
-  .agent-links{gap:16px;margin-top:0}
+  /* Links and buttons share a touch target and baseline. */
+  .agent-links{gap:8px 16px;margin-top:8px}
   .agent-links a,.agent-act,.agent-remove{
     display:inline-flex;align-items:center;min-height:32px;font-size:14px;padding:0}
 }

--- a/home/card_render_test.go
+++ b/home/card_render_test.go
@@ -64,16 +64,14 @@ func TestACardTitleLinksToItsService(t *testing.T) {
 	}
 }
 
-// The age moves when the contents do. It is built into the title, the title was
-// sent in the JSON and never used by the script, so a card refreshed its
-// headlines and went on claiming they were an hour old.
-func TestACardSaysHowOldItIs(t *testing.T) {
+// Feed keeps source timestamps without adding another age for the whole card.
+func TestFeedCardDoesNotAddADuplicateTimestamp(t *testing.T) {
 	head := cardBody(Card{
 		ID: "news", Title: "News", Link: "/news",
-		At: time.Now().Add(-2 * time.Hour), CachedHTML: "<p>News</p>",
+		At: time.Now().Add(-2 * time.Hour), CachedHTML: "<p>News <time>2 hours ago</time></p>",
 	}, service.Anyone())
-	if !strings.Contains(head, "card-when") {
-		t.Errorf("a card that happened at a time does not say when:\n%s", head)
+	if strings.Contains(head, "card-when") || !strings.Contains(head, "<time>2 hours ago</time>") {
+		t.Errorf("feed must retain source times without adding a card timestamp: %s", head)
 	}
 
 	// A standing view has no age — markets is how things are, not something

--- a/home/context_test.go
+++ b/home/context_test.go
@@ -221,10 +221,9 @@ func TestACardRendersInTheColumnItIsConfiguredInto(t *testing.T) {
 	if strings.Index(right, `id="video"`) > strings.Index(right, `id="markets"`) {
 		t.Error("the right column lost the file's order")
 	}
-	// A card that knows when its contents are from still says so, wherever it
-	// renders — that is what Streamed() is for now that it does not pick sides.
-	if !strings.Contains(right, "card-when") {
-		t.Error("video knows when it is from and was not stamped with it")
+	// Feed does not add a second timestamp around content that has its own.
+	if strings.Contains(right, "card-when") {
+		t.Error("feed added a duplicate card timestamp")
 	}
 	if strings.Contains(left[strings.Index(left, `id="prayer"`):], "card-when") {
 		t.Error("a card showing how things are was given a time")

--- a/home/home.go
+++ b/home/home.go
@@ -579,9 +579,7 @@ func cardBody(c Card, who service.Viewer) string {
 	if body == "" {
 		return ""
 	}
-	if c.Streamed() {
-		body = `<div class="card-meta"><span class="card-when">` + htmlEsc(app.TimeAgo(c.At)) + `</span></div>` + body
-	}
+
 	return body
 }
 

--- a/internal/app/html/composition.css
+++ b/internal/app/html/composition.css
@@ -199,8 +199,8 @@ a.link-text {
 
 /* Quiet orientation, shared across desktop and mobile page shells. */
 #page-title { font-size:16px; font-weight:500; line-height:1.4; text-align:left; color:var(--text-secondary,#555); margin:0 0 8px; }
-/* Section labels and navigation sit above the bordered content. */
-.section-card { min-width:0; margin:0 0 16px; }
+/* Subtle rules distinguish unboxed sections without adding card chrome. */
+.section-card { min-width:0; margin:0 0 24px; border-top:1px solid var(--divider,#e8e8e8); padding-top:16px; }
 .section-card-head { display:flex; align-items:baseline; justify-content:space-between; gap:16px; margin-bottom:8px; }
 .section-card-head h4 { margin:0; min-width:0; font-size:14px; font-weight:500; line-height:1.5; color:var(--text-secondary,#555); }
 .section-card-head .card-head-link, .section-card-head .card-head-link:visited { color:inherit; font-weight:inherit; text-decoration:none; }
@@ -268,3 +268,12 @@ a.link-text {
 
 
 #home-personal[hidden], #home-feed[hidden] { display:none !important; }
+
+/* A shared directory layout keeps short entries from spanning the whole page. */
+.collection-grid { display:grid; grid-template-columns:repeat(auto-fill,minmax(min(100%,320px),1fr)); gap:16px; align-items:start; max-width:960px; }
+.home-workspace { column-gap:48px; row-gap:24px; }
+.home-column.page-stack { gap:24px; }
+#home { column-gap:48px; }
+.home-apps { border-top:1px solid var(--divider,#e8e8e8); padding-top:16px; }
+@media(max-width:1099px) { .home-workspace { gap:24px; } }
+@media(max-width:900px) { #home { gap:24px; } }

--- a/internal/app/html/mu.css
+++ b/internal/app/html/mu.css
@@ -553,7 +553,7 @@ td {
   font-weight: var(--font-weight-normal) !important;
   text-decoration: none;
   padding: 10px 14px;
-  border-radius: var(--border-radius);
+  border-radius: 0;
   display: flex;
   align-items: center;
   transition: all var(--transition-fast);
@@ -576,7 +576,7 @@ td {
 #nav a.active {
   background: var(--active-background, var(--hover-background));
   font-weight: var(--font-weight-normal) !important;
-  box-shadow: inset 3px 0 0 var(--accent-color, currentColor);
+  box-shadow: none;
 }
 
 #nav img {
@@ -5847,7 +5847,7 @@ button.pill:hover {
    subject and its snippet clearing the timestamp instead of wrapping under it.
    The reading measure that 760 was reaching for belongs on the message, which
    has one — see .ib-msg — not on the list of them. */
-.ib { max-width: none }
+.ib { width:100%; max-width:960px; }
 
 /* The top of the mailbox: what this list is, and what you do from here.
  *
@@ -5900,7 +5900,7 @@ button.pill:hover {
    It wraps on a phone, where the two sets stack and the rule turns into the
    space above the second one — a vertical rule on a wrapped flex row draws in
    the wrong place, so there is not one. */
-.ib-filters { display: flex; flex-wrap: wrap; align-items: center; gap: 6px 14px; margin: 0 0 14px }
+.ib-filters { display: flex; flex-wrap: wrap; align-items: center; gap: 8px 16px; margin: 0 0 16px; padding-bottom:16px; border-bottom:1px solid var(--divider,#eee); }
 /* The axis each set of chips filters on, in front of them rather than over
    them. Two headings stacked over two one-line rows was the thing that was too
    heavy; the words were not. */
@@ -5923,7 +5923,7 @@ button.pill:hover {
   border-left: 1px solid var(--border, #e5e5e5);
 }
 @media only screen and (max-width: 600px) {
-  .ib-filters .ib-kinds { padding-left: 0 }
+  .ib-filters .ib-kinds { padding-left: 0; flex-basis:100%; }
   .ib-filters .ib-kinds::before { display: none }
 }
 /* What is being written, above the compose form. See inbox.newKinds.


### PR DESCRIPTION
The restored dashboard needs clearer boundaries now that sections are unboxed. Agents also stretches short entries across the page, action links inherit bold styling, and sidebar selection uses unrelated rounded chrome.

- Use a 48px desktop gutter and 24px section rhythm, with shared subtle section rules on Home and Feed.
- Remove card-level Feed timestamps while retaining timestamps in source content, including refreshed responses.
- Make sidebar selection plain grey without rounded corners or the inset accent stripe.
- Render the agent roster through a responsive collection grid, preserving mobile stacking and equal card insets. Use regular-weight, visibly underlined action links. Cards themselves no longer lift as if clickable.
- Bound Inbox to a readable width, separate its filters from rows and stack filter groups cleanly on phones. Preserve unread state and existing selection controls.

Home/Feed structure, navigation and service/agent behaviour stay intact.

Validation: home, agent, inbox and internal/app short tests pass; gofmt and diff checks pass. Updated Feed coverage checks source timestamps are preserved without duplicate card metadata. Live browser visual verification is outstanding.