### PR TITLE
Restore Reminder card with verse and reflection

### DIFF
--- a/home/cards.json
+++ b/home/cards.json
@@ -10,7 +10,7 @@
     },
     {
       "id": "prayer",
-      "title": "Prayer",
+      "title": "Reminder",
       "type": "prayer",
       "position": 1,
       "link": "/prayer",

--- a/service/prayer/card_test.go
+++ b/service/prayer/card_test.go
@@ -7,33 +7,18 @@ import (
 	"mu/internal/service"
 )
 
-// The home card answers the time-sensitive question in its corner — "Asr
-// 14:25" — while the verse stays the body. Before this you had to open the
-// page and scroll to find out when the next prayer was.
-//
-// This is the reader we know nothing about, which is the browser fallback. For
-// somebody who has set a place the mark is computed here instead — see
-// nextMark, and account/place.go for why that matters more for a prayer time
-// than for anything else on the screen.
-func TestHomeCardCarriesTheNextPrayer(t *testing.T) {
-	html := ReminderHTML(service.Anyone())
-	if !strings.Contains(html, `id="prayer-next"`) {
-		t.Error("home card has no slot for the next prayer")
+func TestReminderCardShowsVerseAndReflection(t *testing.T) {
+	body := renderReminderCard(&ReminderData{Verse: "Verse & reference", Message: "Reflection <script>"})
+	if !strings.Contains(body, "Verse &amp; reference") || !strings.Contains(body, "Reflection &lt;script&gt;") {
+		t.Fatal("card must retain and escape both verse and reflection")
 	}
-	if !strings.Contains(html, "card-corner") {
-		t.Error("the mark is not using the corner style")
-	}
-}
-
-// The home screen must not prompt for location. The mark fills itself in only
-// from coordinates already granted to the weather or prayer cards, and stays
-// empty otherwise — .card-corner:empty is display:none.
-func TestHomeCardNeverAsksForLocation(t *testing.T) {
-	html := ReminderHTML(service.Anyone())
-	if strings.Contains(html, "geolocation") {
-		t.Error("the home card asks for geolocation; it must only reuse cached coordinates")
-	}
-	if !strings.Contains(html, "mu_weather_lat") {
-		t.Error("the mark is not reading the shared cached coordinates")
+	reminderMutex.Lock()
+	previous := reminderHTML
+	reminderHTML = body
+	reminderMutex.Unlock()
+	defer func() { reminderMutex.Lock(); reminderHTML = previous; reminderMutex.Unlock() }()
+	got := ReminderHTML(service.Anyone())
+	if got != body {
+		t.Fatal("card must not append prayer times or location scripts")
 	}
 }

--- a/service/prayer/reflection.go
+++ b/service/prayer/reflection.go
@@ -2,7 +2,6 @@ package prayer
 
 import (
 	"encoding/json"
-	"fmt"
 	"html"
 	"io/ioutil"
 	"math"
@@ -13,7 +12,6 @@ import (
 	"time"
 
 	"mu/internal/app"
-	"mu/internal/auth"
 	"mu/internal/data"
 	"mu/internal/event"
 	"mu/internal/service"
@@ -30,11 +28,10 @@ func Load() {
 		app.Log("reminder", "service register failed: %v", err)
 	}
 
-	// Load cached HTML
-	b, err := data.LoadFile("reminder.html")
-	if err == nil {
+	// Render cached source data with the current card format at startup.
+	if rd := GetReminderData(); rd != nil {
 		reminderMutex.Lock()
-		reminderHTML = string(b)
+		reminderHTML = renderReminderCard(rd)
 		reminderMutex.Unlock()
 	}
 
@@ -72,17 +69,13 @@ func fetchReminder() {
 	// Save full JSON data
 	data.SaveFile("reminder.json", string(b))
 
-	verseText := fmt.Sprintf("%v", val["verse"])
-	// Deduplicate header when Arabic and English names match
-	// e.g. "Muhammad - Muhammad - 47:1" → "Muhammad - 47:1"
-	verseText = deduplicateVerseName(verseText)
-	// Card body is just the verse; the home card framework appends its own
-	// "More" link to /prayer, so a second link here would be redundant.
-	html := fmt.Sprintf(`<div class="item"><div class="verse">%s</div></div>`, verseText)
+	cardHTML := renderReminderCard(&ReminderData{
+		Verse: stringField(val, "verse"), Message: stringField(val, "message"),
+	})
 
 	reminderMutex.Lock()
-	reminderHTML = html
-	data.SaveFile("reminder.html", html)
+	reminderHTML = cardHTML
+	data.SaveFile("reminder.html", cardHTML)
 	reminderMutex.Unlock()
 	event.Publish(event.Event{Type: "reminder_updated"})
 
@@ -239,80 +232,25 @@ func stringField(val map[string]interface{}, key string) string {
 	return ""
 }
 
-// ReminderHTML returns the rendered reminder card HTML
-func ReminderHTML(who service.Viewer) string {
+// ReminderHTML returns the verse and reflection without personal prayer times.
+func ReminderHTML(_ service.Viewer) string {
 	reminderMutex.RLock()
-	body := reminderHTML
-	reminderMutex.RUnlock()
-	return nextMark(who.Account) + body
+	defer reminderMutex.RUnlock()
+	return reminderHTML
 }
 
-// nextMark is the next prayer, in the corner of the card.
-//
-// Computed here when this instance knows where the reader is, which it does now
-// for anybody who has set a place — see account/place.go. That is the whole
-// difference between a card that answers and one that waits: the mark used to
-// come from coordinates a browser had cached, so it was empty on a first visit,
-// empty on a second device, and empty in anything that is not a browser at all.
-//
-// A prayer time is the case that makes this worth doing rather than merely
-// tidy. It is not a convenience — it is the reason somebody opens the page, it
-// is wrong everywhere but one latitude, and it cannot be guessed.
-func nextMark(accountID string) string {
-	lat, lon, ok := auth.Located(accountID)
-	if !ok {
-		return browserMark
+func renderReminderCard(rd *ReminderData) string {
+	var b strings.Builder
+	b.WriteString(`<div class="item">`)
+	if verse := strings.TrimSpace(deduplicateVerseName(rd.Verse)); verse != "" {
+		b.WriteString(`<div class="verse pre-line">` + html.EscapeString(verse) + `</div>`)
 	}
-	zone := ""
-	if acc, err := auth.GetAccount(accountID); err == nil && acc != nil {
-		zone = acc.Zone
+	if message := strings.TrimSpace(rd.Message); message != "" {
+		b.WriteString(`<p class="pre-line">` + html.EscapeString(message) + `</p>`)
 	}
-	times, err := GetPrayerTimes(lat, lon, zone, "")
-	if err != nil || times == nil {
-		return browserMark
-	}
-	loc := time.UTC
-	if zone != "" {
-		if z, err := time.LoadLocation(zone); err == nil {
-			loc = z
-		}
-	}
-	name, at := times.Next(time.Now().In(loc))
-	if name == "" {
-		return ""
-	}
-	return `<span class="card-corner">` + html.EscapeString(name+" "+at) + `</span>`
+	b.WriteString(`</div>`)
+	return b.String()
 }
-
-// browserMark is the fallback for a reader this instance does not have a place
-// for: it fills itself in from coordinates a browser cached, and stays empty
-// when there are none.
-//
-// It puts the next prayer in the corner of the home card — "Asr
-// 14:25" — so the card answers the time-sensitive question at a glance and the
-// verse stays the body of it.
-//
-// It fills itself in from coordinates the reader has already granted elsewhere
-// (the weather and prayer cards share these keys). It never asks for location
-// itself: the home screen is not the place to prompt, and with nothing cached
-// the mark simply stays empty.
-const browserMark = `<span id="prayer-next" class="card-corner"></span>
-<script>
-(function(){
-  var el=document.getElementById('prayer-next');
-  if(!el)return;
-  var la=null,lo=null,m=null;
-  try{la=localStorage.getItem('mu_weather_lat');lo=localStorage.getItem('mu_weather_lon');
-      m=localStorage.getItem('mu_prayer_method');}catch(e){}
-  if(!la||!lo)return;
-  var tz='';try{tz=Intl.DateTimeFormat().resolvedOptions().timeZone||'';}catch(e){}
-  var u='/prayer?lat='+encodeURIComponent(la)+'&lon='+encodeURIComponent(lo)+
-        '&tz='+encodeURIComponent(tz)+(m?'&method='+encodeURIComponent(m):'');
-  fetch(u,{headers:{'Accept':'application/json'}}).then(function(r){return r.json();}).then(function(d){
-    if(d&&d.next&&d.next_at){el.textContent=d.next+' '+d.next_at;}
-  }).catch(function(){});
-})();
-</script>`
 
 // ReminderData represents the cached reminder data
 type ReminderData struct {


### PR DESCRIPTION
Rename the Feed Prayer heading to Reminder, retain the Quranic verse and show the reflection beneath it. Remove the next-prayer marker and its location lookup from the card. More still opens the full reading; prayer times remain available on the prayer page.

Render cached JSON at startup so the updated format does not wait for an upstream refresh. Escape source text in the card.

Validation: prayer and home short tests pass, including verse/reflection escaping and no appended prayer marker. Live visual rendering not verified.