### PR TITLE
Restore cards, put the public Brief on Feed and soften questions

### DIFF
--- a/home/home.go
+++ b/home/home.go
@@ -461,7 +461,6 @@ function fetchW(la,lo){
 	}))
 	b.WriteString(`</div>`)
 	b.WriteString(appsHTML(viewerAcc))
-	b.WriteString(`<div id="home-brief" class="page-stack">` + briefHTML(viewerID, events.CachedOverview(viewerID)...) + `</div>`)
 	if viewerID != "" {
 		if peek := inbox.Preview(viewerID); peek != "" {
 			b.WriteString(`<div id="home-inbox" class="page-stack">` + peek + `</div>`)
@@ -480,6 +479,9 @@ function fetchW(la,lo){
 	b.WriteString(`</div>`)
 
 	b.WriteString(`</section><section id="home-feed" role="tabpanel" aria-labelledby="home-view-feed"` + panelHidden(!feed) + `><div class="home-main full">`)
+	if summary := happening(); summary != "" {
+		b.WriteString(app.SectionCard("feed-brief", "Brief", "", `<p class="home-brief">`+summary+`</p>`))
+	}
 	cards := CardsHTML(r, viewerAcc)
 	if cards == "" {
 		cards = `<p class="text-muted">No feed items yet.</p>`

--- a/home/layout_test.go
+++ b/home/layout_test.go
@@ -53,7 +53,7 @@ func TestHomeAndFeedKeepTheirOwnContent(t *testing.T) {
 		t.Fatal("missing view panels")
 	}
 	personal, feed := body[personalAt:feedAt], body[feedAt:]
-	for _, want := range []string{`id="home-agent"`, `id="home-brief"`, `<a class="card-head-link" href="/inbox">Inbox</a>`} {
+	for _, want := range []string{`id="home-agent"`, `<a class="card-head-link" href="/inbox">Inbox</a>`} {
 		if !strings.Contains(personal, want) || strings.Contains(feed, want) {
 			t.Errorf("%s is not exclusive to Home", want)
 		}

--- a/home/publicbrief_test.go
+++ b/home/publicbrief_test.go
@@ -118,11 +118,21 @@ func TestAskingTakesTheBriefOffThePage(t *testing.T) {
 	}
 }
 
-// Home's separate brief stays available while the person talks to Micro.
-func TestHomesBriefStaysAvailable(t *testing.T) {
+// Personal summaries belong to Home's actionable sections, not a mixed brief.
+func TestHomeDoesNotCarryAMixedBrief(t *testing.T) {
 	body := homeFor(t, "homebriefvisible")
-	if !strings.Contains(body, `id="home-brief" class="page-stack"`) || strings.Contains(body, `id="home-brief" data-brief`) {
-		t.Error("Home brief still steps aside during a conversation")
+	if strings.Contains(body, `id="home-brief"`) {
+		t.Error("the mixed personal and public brief remains on Home")
+	}
+	feedAt := strings.Index(body, `<section id="home-feed"`)
+	if feedAt < 0 {
+		t.Fatal("missing Feed")
+	}
+	if strings.Contains(body[:feedAt], `id="feed-brief"`) {
+		t.Error("public brief is outside Feed")
+	}
+	if happening() != "" && !strings.Contains(body[feedAt:], `id="feed-brief"`) {
+		t.Error("Feed is missing the public brief")
 	}
 }
 

--- a/internal/app/chat.go
+++ b/internal/app/chat.go
@@ -589,7 +589,7 @@ body:has(.mu-console[open]) { overflow:hidden; }
   overflow-y:auto;overscroll-behavior:contain;
   margin:0 0 12px;padding-right:4px
 }
-.mu-user{margin:0 0 16px;padding:16px;border:1px solid var(--border-color,#ddd);border-radius:6px;background:var(--bg-primary,#fff);font-size:16px;font-weight:400;color:#111;white-space:pre-wrap;scroll-margin-top:64px}
+.mu-user{margin:0 0 16px;padding:8px 12px;border:0;border-radius:4px;background:#f5f5f5;font-size:16px;font-weight:400;color:#111;white-space:pre-wrap;scroll-margin-top:64px}
 .mu-agent{margin-bottom:24px;scroll-margin-top:64px}
 /* Who answered. The same shape as the rail's section headings, because it is
    the same kind of thing — a label over a block, not a line of the block. */

--- a/internal/app/html/composition.css
+++ b/internal/app/html/composition.css
@@ -200,8 +200,8 @@ a.link-text {
 /* Quiet orientation, shared across desktop and mobile page shells. */
 #page-title { font-size:16px; font-weight:500; line-height:1.4; text-align:left; color:var(--text-secondary,#555); margin:0 0 8px; }
 /* Subtle rules distinguish unboxed sections without adding card chrome. */
-.section-card { min-width:0; margin:0 0 24px; border-top:1px solid var(--divider,#e8e8e8); padding-top:16px; }
-.section-card-head { display:flex; align-items:baseline; justify-content:space-between; gap:16px; margin-bottom:8px; }
+.section-card { min-width:0; margin:0 0 24px; border:1px solid var(--divider,#e8e8e8); border-radius:6px; padding:16px; background:var(--bg-primary,#fff); }
+.section-card-head { display:flex; align-items:baseline; justify-content:space-between; gap:16px; margin-bottom:16px; }
 .section-card-head h4 { margin:0; min-width:0; font-size:14px; font-weight:500; line-height:1.5; color:var(--text-secondary,#555); }
 .section-card-head .card-head-link, .section-card-head .card-head-link:visited { color:inherit; font-weight:inherit; text-decoration:none; }
 .section-card-head .card-head-link:hover { text-decoration:underline; }
@@ -274,6 +274,6 @@ a.link-text {
 .home-workspace { column-gap:48px; row-gap:24px; }
 .home-column.page-stack { gap:24px; }
 #home { column-gap:48px; }
-.home-apps { border-top:1px solid var(--divider,#e8e8e8); padding-top:16px; }
+.home-apps { border:0; padding-top:0; }
 @media(max-width:1099px) { .home-workspace { gap:24px; } }
 @media(max-width:900px) { #home { gap:24px; } }

--- a/internal/app/section.go
+++ b/internal/app/section.go
@@ -13,7 +13,7 @@ func PreviewCard(id, title, href, body string) string {
 	return SectionCard(id, heading, href, `<div class="preview-rows">`+body+`</div>`)
 }
 
-// SectionCard places a trusted heading and navigation outside the content card.
+// SectionCard groups a trusted heading, navigation and body inside one bordered section.
 // Heading and body are pre-rendered HTML; id and href are escaped here.
 func SectionCard(id, heading, href, body string) string {
 	more := ""


### PR DESCRIPTION
Home remains the personal overview with Inbox, Todo, Upcoming and Agents. Remove its mixed brief and render only the shared public summary above Feed content; this adds no model calls.

Restore subtle borders and 16px padding to shared section cards, enclosing titles, More links and content. Services shortcuts remain unboxed. Retain the wider column gutter and aligned agent cards.

Replace outlined user questions with a light grey background, regular text and 8px by 12px padding throughout the shared chat component.

Validation: Home and shared app short tests pass. Updated layout assertions for Brief placement. Live visual verification remains outstanding.