### PR TITLE
Make Home focus open a conversation with a bottom composer

### DIFF
--- a/agent/recent.go
+++ b/agent/recent.go
@@ -1,0 +1,41 @@
+package agent
+
+import (
+	"html"
+	"net/url"
+	"strings"
+
+	"mu/internal/app"
+	"mu/internal/thread"
+)
+
+// RecentConversations is a small, account-scoped preview of chats started here.
+func RecentConversations(accountID string) string {
+	if accountID == "" {
+		return ""
+	}
+	var b strings.Builder
+	for i, t := range chatThreads(accountID, "", false) {
+		if i == 3 {
+			break
+		}
+		title := t.Subject
+		if title == "" {
+			title = "Conversation"
+		}
+		b.WriteString(`<a class="peek-row" href="/agent?session=` + url.QueryEscape(t.ID) + `"><span class="peek-main"><span class="peek-title">` + html.EscapeString(title) + `</span>`)
+		messages := thread.Messages(accountID, t.ID, 1)
+		if len(messages) > 0 {
+			text := []rune(messages[len(messages)-1].Text)
+			if len(text) > 140 {
+				text = append(text[:140], '…')
+			}
+			b.WriteString(`<span class="text-muted">` + html.EscapeString(string(text)) + `</span>`)
+		}
+		b.WriteString(`</span></a>`)
+	}
+	if b.Len() == 0 {
+		return ""
+	}
+	return app.PreviewCard("home-recent", "Recent conversations", "/agent", b.String())
+}

--- a/agent/recent_test.go
+++ b/agent/recent_test.go
@@ -1,0 +1,25 @@
+package agent
+
+import (
+	"mu/internal/thread"
+	"strings"
+	"testing"
+)
+
+func TestRecentConversationsAreOwnStartedChats(t *testing.T) {
+	const owner = "recent-preview-owner"
+	mine := thread.Open(owner, thread.WebClient, "recent-owned")
+	thread.Add(thread.Message{Thread: mine.ID, Account: owner, Text: "My recent question"})
+	other := thread.Open("recent-preview-other", thread.WebClient, "recent-other")
+	thread.Add(thread.Message{Thread: other.ID, Account: "recent-preview-other", Text: "Private other question"})
+	got := RecentConversations(owner)
+	if !strings.Contains(got, mine.ID) || !strings.Contains(got, "My recent question") {
+		t.Fatal("missing own recent chat")
+	}
+	if strings.Contains(got, other.ID) || strings.Contains(got, "Private other question") {
+		t.Fatal("other account exposed")
+	}
+	if RecentConversations("") != "" {
+		t.Fatal("guest must not have recent chats")
+	}
+}

--- a/home/conversation_test.go
+++ b/home/conversation_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 )
 
-func TestCloseEndsHomeExchange(t *testing.T) {
+func TestClosePreservesHomeExchange(t *testing.T) {
 	node, err := exec.LookPath("node")
 	if err != nil {
 		t.Skip("Node required")
@@ -27,13 +27,13 @@ const events={},actionBar={},transcript={textContent:'Existing answer'};
 const button={addEventListener(k,fn){this[k]=fn}};
 const home={querySelector(s){return s==='#home-conversation-actions'?actionBar:s==='#home-conversation-close'?button:transcript}};
 let resets=0;
-const window={addEventListener(k,fn){events[k]=fn},muChatNew(){resets++;transcript.textContent='';events['mu-chat-active']({detail:false})}};
+const window={addEventListener(k,fn){events[k]=fn},muChatClose(){resets++}};
 ` + src[start:end] + `
 assert.equal(actionBar.hidden,false);
 button.click({preventDefault(){},stopPropagation(){}});
 assert.equal(resets,1);
-assert.equal(transcript.textContent,'');
-assert.equal(actionBar.hidden,true);
+assert.equal(transcript.textContent,'Existing answer');
+assert.equal(actionBar.hidden,false);
 events['mu-chat-active']({detail:true});
 assert.equal(actionBar.hidden,false);
 `

--- a/home/frontdoor_test.go
+++ b/home/frontdoor_test.go
@@ -44,7 +44,7 @@ func TestHomeStartsWithMicro(t *testing.T) {
 			t.Errorf("Home still offers %s", control)
 		}
 	}
-	if strings.Contains(body, `class="mu-chat-contained mu-chat-overlay"`) || !strings.Contains(body, `<div id="mu-chat">`) {
-		t.Error("Home should keep conversation in page flow")
+	if !strings.Contains(body, `class="mu-chat-contained mu-chat-overlay"`) {
+		t.Error("Home should open a focused conversation")
 	}
 }

--- a/home/home.go
+++ b/home/home.go
@@ -456,11 +456,13 @@ function fetchW(la,lo){
 		AgentName:       agent.DefaultName(),
 		Location:        viewerID != "",
 		Stationary:      true,
+		Overlay:         true,
 		ContinueNS:      assistantNamespace(viewerID) + ":home",
 		FooterHTML:      `<div id="home-conversation-actions" class="conversation-actions" hidden><a href="/home" id="home-conversation-close">Close</a><a href="/assistant?view=home" id="mu-chat-continue" aria-disabled="true">Continue in Assistant →</a><span id="mu-chat-transfer-error" role="status"></span></div>`,
 	}))
 	b.WriteString(`</div>`)
 	b.WriteString(appsHTML(viewerAcc))
+	b.WriteString(agent.RecentConversations(viewerID))
 	if viewerID != "" {
 		if peek := inbox.Preview(viewerID); peek != "" {
 			b.WriteString(`<div id="home-inbox" class="page-stack">` + peek + `</div>`)

--- a/home/views.js
+++ b/home/views.js
@@ -3,11 +3,11 @@
   if (!home) return;
   const actions=home.querySelector('#home-conversation-actions');
   function conversation(active){
-    if(actions)actions.hidden=!active;
+    if(actions)actions.hidden=false;
   }
   window.addEventListener('mu-chat-active',event=>conversation(event.detail===true));
   const close=home.querySelector('#home-conversation-close');
-  if(close)close.addEventListener('click',event=>{event.preventDefault();event.stopPropagation();window.muChatNew();});
+  if(close)close.addEventListener('click',event=>{event.preventDefault();event.stopPropagation();if(window.muChatClose)window.muChatClose();});
   const initial=home.querySelector('#mu-chat-conv');
   conversation(!!initial && !!initial.textContent.trim());
 

--- a/internal/app/chat.go
+++ b/internal/app/chat.go
@@ -537,17 +537,23 @@ func ChatComponent(cfg ChatConfig) string {
 }
 #mu-chat.mu-chat-overlay #mu-chat-conv { margin-top:var(--space-control,8px); }
 #mu-chat.mu-chat-overlay:not(.mu-console-open) #mu-chat-conv { display:none; }
-.mu-console { box-sizing:border-box; width:min(880px,calc(100% - 32px)); height:min(800px,calc(100dvh - 48px)); max-height:none; max-width:none; padding:16px; border:1px solid var(--card-border,#ddd); border-radius:12px; background:var(--background-color,#fff); color:var(--text-primary,#222); }
+.mu-console { box-sizing:border-box; width:min(880px,calc(100% - 32px)); height:min(800px,calc(100dvh - 48px)); max-height:none; max-width:none; padding:16px; border:1px solid var(--card-border,#ddd); border-radius:6px; background:var(--background-color,#fff); color:var(--text-primary,#222); }
 html:has(.mu-chat-overlay) { scrollbar-gutter:stable; }
 body:has(.mu-console[open]) { overflow:hidden; }
 .mu-console::backdrop { background:rgba(0,0,0,.28); }
 .mu-console[open] { display:flex; flex-direction:column; }
 .mu-console-head { display:grid; grid-template-columns:1fr auto 1fr; align-items:center; gap:var(--space-control,8px); margin-bottom:var(--space-field,16px); font-size:14px; }
+.mu-console-head[hidden] { display:none; }
 .mu-console-head strong { grid-column:2; text-align:center; }
 .mu-console-close { grid-column:3; justify-self:end; font:inherit; font-weight:400; }
 .mu-console #mu-chat { display:flex; flex-direction:column; min-height:0; flex:1; max-width:none; }
-.mu-console #mu-chat-form { flex-shrink:0; position:static; }
-.mu-console #mu-chat #mu-chat-conv { flex:1; min-height:0; max-height:none; overflow:auto; overflow-anchor:none; }
+.mu-console #mu-chat-form { flex-shrink:0; position:static; order:3; }
+.mu-console #mu-chat-opts { order:4; flex:none; }
+.mu-console #mu-chat-suggest { order:2; flex:none; }
+.mu-console .mu-chat-footer { flex:none; margin:0 0 16px; }
+.mu-console .conversation-actions { margin:0; padding:0; display:flex; justify-content:space-between; gap:16px; }
+.mu-chat-overlay:not(.mu-console-open) .mu-chat-footer { display:none; }
+.mu-console #mu-chat #mu-chat-conv { flex:1; min-height:0; max-height:none; overflow:auto; overflow-anchor:none; order:1; margin:0 0 16px; }
 @media(max-width:600px){.mu-console{width:100%;height:100dvh;margin:0;border:0;border-radius:0;padding:12px;}}
 /* A conversation, not a box.
 
@@ -684,6 +690,8 @@ function nearBottom(){
   return (conv.scrollTop+conv.clientHeight)>=(conv.scrollHeight-nearEnough);
 }
 var nearEnough=120;
+var followOverlay=true;
+if(overlay&&conv)conv.addEventListener("scroll",function(){followOverlay=nearBottom();});
 if(overlay && input && form){
  var shell=document.getElementById('mu-chat');
  var slot=document.createElement('div');
@@ -692,18 +700,22 @@ if(overlay && input && form){
  dialog.setAttribute('aria-label','Micro');
  dialog.innerHTML='<div class="mu-console-head"><strong>Micro</strong><button type="button" class="mu-console-close link-button">Close</button></div>';
  slot.appendChild(dialog);
+ var footer=shell.querySelector('.mu-chat-footer');
+ if(footer)dialog.querySelector('.mu-console-head').hidden=true;
  var closing=false;
  function openConsole(){
   if(closing || dialog.open || !shell.isConnected)return;
   slot.style.minHeight=shell.getBoundingClientRect().height+'px';
+  if(footer)dialog.appendChild(footer);
   dialog.appendChild(shell);shell.classList.add('mu-console-open');
-  dialog.showModal();fitConv();input.focus({preventScroll:true});
+  dialog.showModal();fitConv();input.focus({preventScroll:true});toBottom(true);
  }
  function closeConsole(){if(dialog.open)dialog.close();}
+ window.muChatClose=closeConsole;
  dialog.querySelector('button').addEventListener('click',closeConsole);
  dialog.addEventListener('click',function(e){if(e.target===dialog){var r=dialog.getBoundingClientRect();if(e.clientX<r.left||e.clientX>r.right||e.clientY<r.top||e.clientY>r.bottom)closeConsole();}});
  dialog.addEventListener('close',function(){
-  closing=true;shell.classList.remove('mu-console-open');slot.insertBefore(shell,dialog);
+  closing=true;shell.classList.remove('mu-console-open');if(footer)shell.appendChild(footer);slot.insertBefore(shell,dialog);
   slot.style.minHeight='';
   if(window.matchMedia('(pointer:coarse)').matches){input.blur();}else{input.focus({preventScroll:true});}setTimeout(function(){closing=false;},0);
  });
@@ -713,6 +725,7 @@ if(overlay && input && form){
 }
 
 function revealQuestion(node){
+  if(overlay){toBottom(false);return;}
   if(transcript){toBottom(false);return;}
   requestAnimationFrame(function(){
     if(!node||!node.isConnected)return;
@@ -723,8 +736,9 @@ function revealQuestion(node){
   });
 }
 function toBottom(force,smooth){
-  if(overlay||(!transcript&&!contained)) return;
-  if(!force && !nearBottom()) return;
+  if(!overlay&&!transcript&&!contained) return;
+  if(overlay){if(force)followOverlay=true;if(!followOverlay)return;}
+  else if(!force && !nearBottom()) return;
   requestAnimationFrame(function(){
     conv.scrollTo({top:conv.scrollHeight,behavior:smooth?'smooth':'auto'});
   });
@@ -988,7 +1002,7 @@ function ask(q){
   //
   // In a box the exchange is anchored under the input instead, which is what
   // Home wants: you typed at the top and the answer appears under it.
-  if(transcript){ toBottom(true,true); } else {
+  if(transcript||overlay){ toBottom(true,true); } else {
     revealQuestion(u);
     // Re-align after the mobile keyboard has finished shrinking the viewport.
     if(touchInput)setTimeout(function(){if(epoch===viewEpoch)revealQuestion(u);},350);

--- a/internal/app/chat_scroll_test.go
+++ b/internal/app/chat_scroll_test.go
@@ -18,7 +18,7 @@ func TestInlineQuestionScrollClearsStickyInput(t *testing.T) {
 	}
 	script := `
 const assert=require('assert');
-const stationary=true,transcript=false,contained=false;
+const stationary=true,transcript=false,contained=false,overlay=false;
 const form={getBoundingClientRect(){return {height:42}}};
 const window={getComputedStyle(){return {top:'58px'}},matchMedia(){return {matches:false}}};
 const requestAnimationFrame=fn=>fn();

--- a/internal/app/html/composition.css
+++ b/internal/app/html/composition.css
@@ -249,7 +249,7 @@ a.link-text {
 @media (max-width: 1099px) {
   .home-workspace > .home-column { display: contents; }
   .home-workspace #home-agent { order: 0; }
-  .home-workspace #home-brief { order: 2; }
+  .home-workspace #home-recent { order: 2; }
   .home-workspace #home-todo { order: 3; }
   .home-workspace #home-upcoming { order: 4; }
   .home-workspace #home-inbox { order: 5; }


### PR DESCRIPTION
Home still used inline chat after we discussed a focused experience. Enable the shared modal chat on focus, preserve the Home input slot, and dim the background. Put Close and Continue in Assistant at the top; messages scroll above a bottom composer with visual-viewport sizing for the mobile keyboard. Close preserves the current exchange, and focus reopens it. Follow new questions and streamed responses, pausing when the reader scrolls away.

Add a three-item Recent conversations preview beneath service shortcuts. It reuses account-scoped started-chat selection and links to existing sessions, without adding inbox records.

Validation: Home, agent and internal/app short tests pass, including close preservation and recent-chat account isolation. Live browser/keyboard verification and deployment confirmation remain outstanding.