### PR TITLE
Unify Home conversation continuity and shared account experience

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -546,3 +546,10 @@ CSS for ordinary fields, select lists, buttons, and action rows. Use the shared
 in their existing components. Check narrow mobile and desktop, with the sidebar
 open and closed, including revealed and collapsed controls when changing these
 shared rules.
+
+Home and Feed share one stationary prompt above their view panels. Focusing it
+must not relocate it or open a modal. Replies grow beneath it; Close preserves
+the exchange. Continue in Assistant reopens the same account-owned saved thread.
+Assistant uses the shared saved-chat renderer and history, while Agents manages
+agent identities, scopes and activity. Do not create separate transcript stores
+for these entry points. Recent conversations are shortcuts to saved threads.

--- a/account/google_oauth.go
+++ b/account/google_oauth.go
@@ -90,6 +90,10 @@ func startGoogle(w http.ResponseWriter, r *http.Request, link bool) {
 		Name: "g_link", Value: linkVal, Path: "/", MaxAge: linkAge,
 		HttpOnly: true, Secure: secure, SameSite: http.SameSiteLaxMode,
 	})
+	http.SetCookie(w, &http.Cookie{
+		Name: "g_return", Value: url.QueryEscape(safeRedirect(r)), Path: "/", MaxAge: 600,
+		HttpOnly: true, Secure: secure, SameSite: http.SameSiteLaxMode,
+	})
 	q := url.Values{}
 	q.Set("client_id", googleClientID())
 	q.Set("redirect_uri", googleRedirectURI(r))
@@ -180,7 +184,14 @@ func GoogleCallback(w http.ResponseWriter, r *http.Request) {
 		Name: "session", Value: sess.Token, Path: "/", MaxAge: 2592000,
 		HttpOnly: true, Secure: requestSecure(r), SameSite: http.SameSiteLaxMode,
 	})
-	http.Redirect(w, r, "/home", http.StatusFound)
+	destination := "/home"
+	if c, err := r.Cookie("g_return"); err == nil {
+		if decoded, err := url.QueryUnescape(c.Value); err == nil {
+			destination = SafeRedirectTo(decoded)
+		}
+	}
+	http.SetCookie(w, &http.Cookie{Name: "g_return", Value: "", Path: "/", MaxAge: -1, HttpOnly: true, Secure: requestSecure(r), SameSite: http.SameSiteLaxMode})
+	http.Redirect(w, r, destination, http.StatusFound)
 }
 
 // googleExchange trades an authorization code for an access token.

--- a/account/journey_test.go
+++ b/account/journey_test.go
@@ -1,0 +1,48 @@
+package account
+
+import (
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+func TestAccountErrorsPreserveOnlyNonSecretFields(t *testing.T) {
+	form := url.Values{"id": {`bad"><script>alert(1)</script>`}, "name": {"A name"}, "secret": {"never-reflect-this-password"}}
+	r := httptest.NewRequest("POST", "/signup?redirect=%2Fassistant", strings.NewReader(form.Encode()))
+	r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	page := accountFormValues(renderSignup("Please try again"), r)
+	if strings.Contains(page, "never-reflect-this-password") || strings.Contains(page, `<script>alert(1)</script>`) {
+		t.Fatal("unescaped field or password reflected")
+	}
+	if !strings.Contains(page, `value="A name"`) || !strings.Contains(page, `href="/login?redirect=%2Fassistant"`) {
+		t.Fatal("form values or destination lost")
+	}
+	for _, want := range []string{"/composition.css?", `autocomplete="new-password"`, `class="field-label"`, ">Micro</a>"} {
+		if !strings.Contains(page, want) {
+			t.Errorf("missing %s", want)
+		}
+	}
+}
+
+func TestGoogleSignInKeepsOnlyASafeReturnDestination(t *testing.T) {
+	withGoogle(t)
+	for _, tc := range []struct{ to, want string }{{"/tasks", "/tasks"}, {"https://example.com", "/home"}, {"//example.com", "/home"}} {
+		r := httptest.NewRequest("GET", "https://micro.mu/oauth2/google?redirect="+url.QueryEscape(tc.to), nil)
+		w := httptest.NewRecorder()
+		startGoogle(w, r, false)
+		found := false
+		for _, c := range w.Result().Cookies() {
+			if c.Name == "g_return" {
+				found = true
+				got, _ := url.QueryUnescape(c.Value)
+				if got != tc.want || !c.HttpOnly || !c.Secure {
+					t.Fatalf("unsafe or lost return cookie: %#v", c)
+				}
+			}
+		}
+		if !found {
+			t.Fatal("missing return destination")
+		}
+	}
+}

--- a/account/pages.go
+++ b/account/pages.go
@@ -69,28 +69,30 @@ func SignupRateLimit(ip string) bool {
 
 var LoginTemplate = `<html lang="en">
   <head>
-    <title>Login | Mu</title>
+    <title>Login | Micro</title>
     <meta name="viewport" content="width=device-width, initial-scale=1, interactive-widget=resizes-content, viewport-fit=cover" />
     <meta name="referrer" content="no-referrer"/>
     <link rel="stylesheet" href="/mu.css?` + app.Version + `">
+    <link rel="stylesheet" href="/composition.css?` + app.Version + `">
   </head>
-  <body>
+  <body class="auth-page">
     <div id="head">
       <div id="brand">
-        <a href="/">Mu</a>
+        <a href="/">Micro</a>
       </div>
     </div>
     <div id="container">
       <div id="content">
-	<form id="login" action="/login%s" method="POST">
+	<p id="auth-status" role="status"></p><form id="login" action="/login%s" method="POST" class="form page-stack">
 	  <h1>Log in</h1>
 	  %s
 	  %s
-	  <input id="id" name="id" placeholder="Username" required>
-	  <input id="secret" name="secret" type="password" placeholder="Password" required>
-	  <br>
-	  <button>Login</button>
+	  <label class="field-label">Username<input id="id" name="id" autocomplete="username" required></label>
+	  <label class="field-label">Password<input id="secret" name="secret" type="password" autocomplete="current-password" required></label>
+
+	  <button>Log in</button>
 	</form>
+	<details class="disclosure auth-help"><summary>Having trouble signing in?</summary><p>If you joined with Google, use Continue with Google. If you still have a signed-in device, you can set a password in Account. Otherwise, <a href="/contact">contact the server operator</a> for help. Automatic password reset is not available.</p></details>
 	<div id="passkey-login" class="d-none text-center mt-5">
 	  <p class="text-muted">or</p>
 	  <button onclick="loginWithPasskey()">Login with Passkey</button>
@@ -159,10 +161,10 @@ var LoginTemplate = `<html lang="en">
 	    if (result.success) {
 	      window.location.href = result.redirect || '/home';
 	    } else {
-	      alert('Login failed');
+	      document.getElementById('auth-status').textContent='Sign-in failed. Please try another sign-in method.';
 	    }
 	  } catch (e) {
-	    if (e.name !== 'NotAllowedError') alert('Error: ' + e.message);
+	    if (e.name !== 'NotAllowedError') document.getElementById('auth-status').textContent='Unable to sign in. Please try again.';
 	  }
 	}
 	</script>
@@ -174,30 +176,31 @@ var LoginTemplate = `<html lang="en">
 
 var SignupTemplate = `<html lang="en">
   <head>
-    <title>Signup | Mu</title>
+    <title>Signup | Micro</title>
     <meta name="viewport" content="width=device-width, initial-scale=1, interactive-widget=resizes-content, viewport-fit=cover" />
     <meta name="referrer" content="no-referrer"/>
     <link rel="stylesheet" href="/mu.css?` + app.Version + `">
+    <link rel="stylesheet" href="/composition.css?` + app.Version + `">
   </head>
-  <body>
+  <body class="auth-page">
     <div id="head">
       <div id="brand">
-        <a href="/">Mu</a>
+        <a href="/">Micro</a>
       </div>
     </div>
     <div id="container">
       <div id="content">
-	<form id="signup" action="/signup%s" method="POST">
+	<form id="signup" action="/signup%s" method="POST" class="form page-stack">
 	  <h1>Create your account</h1>
 	  %s
 	  %s
-	  <input id="id" name="id" placeholder="Username (4-24 chars, lowercase)" required>
-	  <input id="name" name="name" placeholder="Name (optional)">
-  	  <input id="secret" name="secret" type="password" placeholder="Password (min 6 chars)" required>
+	  <label class="field-label">Username<input id="id" name="id" autocomplete="username" minlength="4" maxlength="24" pattern="[a-z][a-z0-9_]{3,23}" aria-describedby="username-help" required></label><small id="username-help" class="text-muted">4–24 characters. Start with a letter; use lowercase letters, numbers or underscores.</small>
+	  <label class="field-label">Name (optional)<input id="name" name="name" autocomplete="name"></label>
+	  <label class="field-label">Password<input id="secret" name="secret" type="password" autocomplete="new-password" minlength="6" aria-describedby="password-help" required></label><small id="password-help" class="text-muted">At least 6 characters.</small>
 	  %s
 	  %s
-	  <br>
-	  <button>Signup</button>
+
+	  <button>Create account</button>
 	</form>
 	<p class="text-center mt-5"><a href="/login">Log in</a> if you have an account</p>
       </div>
@@ -355,13 +358,15 @@ func RequestInvite(w http.ResponseWriter, r *http.Request) {
 
 // Login handler
 func Login(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Cache-Control", "private, no-store")
+	renderLogin := func(to, msg string) string { return accountFormValues(loginPage(to, msg), r) }
 	if r.Method == "GET" {
 		// Preserve redirect parameter in form action
 		redirectParam := ""
 		if redirect := r.URL.Query().Get("redirect"); redirect != "" {
 			redirectParam = "?redirect=" + url.QueryEscape(redirect)
 		}
-		w.Write([]byte(loginPage(redirectParam, "")))
+		w.Write([]byte(renderLogin(redirectParam, "")))
 		return
 	}
 
@@ -378,17 +383,17 @@ func Login(w http.ResponseWriter, r *http.Request) {
 		}
 
 		if len(id) == 0 {
-			w.Write([]byte(loginPage(redirectParam, `<p class="text-error">Username is required</p>`)))
+			w.Write([]byte(renderLogin(redirectParam, `<p class="text-error">Username is required</p>`)))
 			return
 		}
 		if len(secret) == 0 {
-			w.Write([]byte(loginPage(redirectParam, `<p class="text-error">Password is required</p>`)))
+			w.Write([]byte(renderLogin(redirectParam, `<p class="text-error">Password is required</p>`)))
 			return
 		}
 
 		sess, err := auth.Login(id, secret)
 		if err != nil {
-			w.Write([]byte(loginPage(redirectParam, `<p class="text-error">Invalid username or password</p>`)))
+			w.Write([]byte(renderLogin(redirectParam, `<p class="text-error">Invalid username or password</p>`)))
 			return
 		}
 
@@ -427,7 +432,7 @@ func Signup(w http.ResponseWriter, r *http.Request) {
 	}
 	// Keep referral state on this request, never shared between visitors.
 	render := func(errHTML, redirectParam string) string {
-		return renderSignupInvite(errHTML, redirectParam, invCode)
+		return accountFormValues(renderSignupInvite(errHTML, redirectParam, invCode), r)
 	}
 
 	// Carried through every render so the POST keeps it — see renderSignupTo.
@@ -1268,4 +1273,20 @@ func handleVerifyStart(w http.ResponseWriter, r *http.Request, acc *auth.Account
 	}
 	app.Log("auth", "Sent verification email to %s for account %s", email, acc.ID)
 	http.Redirect(w, r, "/account", http.StatusSeeOther)
+}
+
+// Preserve non-secret form fields on errors and the destination between auth pages.
+func accountFormValues(page string, r *http.Request) string {
+	if r.Method == "POST" {
+		for _, name := range []string{"id", "name"} {
+			marker := `id="` + name + `" name="` + name + `"`
+			page = strings.Replace(page, marker, marker+` value="`+htmlpkg.EscapeString(r.FormValue(name))+`"`, 1)
+		}
+	}
+	if to := r.URL.Query().Get("redirect"); to != "" {
+		for _, route := range []string{"/login", "/signup", "/oauth2/google"} {
+			page = strings.ReplaceAll(page, `href="`+route+`"`, `href="`+route+`?redirect=`+htmlpkg.EscapeString(url.QueryEscape(SafeRedirectTo(to)))+`"`)
+		}
+	}
+	return page
 }

--- a/agent/activity.go
+++ b/agent/activity.go
@@ -1,0 +1,75 @@
+package agent
+
+import (
+	"html"
+	"mu/internal/ai"
+	"mu/service/tasks"
+	"strings"
+	"time"
+)
+
+// activity describes work for this account, not a global online presence.
+func activity(accountID, agentID string) string {
+	canonical := func(id string) string {
+		if id == DefaultPlatformAgent || id == DefaultSlug {
+			return ""
+		}
+		return id
+	}
+	agentID = canonical(agentID)
+	running, blocked, failed, queued := false, false, false, false
+	for _, task := range tasks.List(accountID, "") {
+		if task.Assignee != tasks.Agent || canonical(task.Agent) != agentID {
+			continue
+		}
+		switch task.Status {
+		case tasks.StatusDoing:
+			running = true
+		case tasks.StatusBlocked:
+			blocked = true
+		case tasks.StatusFailed:
+			failed = true
+		case tasks.StatusTodo:
+			queued = true
+		}
+	}
+	flowMu.RLock()
+	var last *Flow
+	for _, f := range flowStore {
+		if f.AccountID != accountID || canonical(f.Agent) != agentID {
+			continue
+		}
+		if f.Status == "running" {
+			running = true
+		}
+		if last == nil || f.CreatedAt.After(last.CreatedAt) {
+			last = f
+		}
+	}
+	lastFailed := last != nil && last.Status == "error" && time.Since(last.CreatedAt) < 24*time.Hour
+	flowMu.RUnlock()
+	var states []string
+	if running {
+		states = append(states, "Working")
+	}
+	if blocked {
+		states = append(states, "Needs input")
+	}
+	if failed || lastFailed {
+		states = append(states, "Needs attention")
+	}
+	if queued {
+		states = append(states, "Queued")
+	}
+	if len(states) > 0 {
+		return strings.Join(states, " · ")
+	}
+	if !ai.Configured() {
+		return "Not configured"
+	}
+	return "Idle"
+}
+
+func activityHTML(accountID, agentID string) string {
+	return `<span class="activity-status">` + html.EscapeString(activity(accountID, agentID)) + `</span>`
+}

--- a/agent/activity_test.go
+++ b/agent/activity_test.go
@@ -1,0 +1,35 @@
+package agent
+
+import (
+	"mu/service/tasks"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestActivityIsScopedAndReflectsWork(t *testing.T) {
+	const owner = "activity-owner"
+	flowMu.Lock()
+	flowStore["activity-test"] = &Flow{ID: "activity-test", AccountID: owner, Agent: "", Status: "running", CreatedAt: time.Now()}
+	flowMu.Unlock()
+	t.Cleanup(func() { flowMu.Lock(); delete(flowStore, "activity-test"); flowMu.Unlock() })
+	if got := activity(owner, DefaultPlatformAgent); got != "Working" {
+		t.Fatalf("default activity: %s", got)
+	}
+	if got := activity("activity-other", DefaultPlatformAgent); strings.Contains(got, "Working") {
+		t.Fatal("another account's activity leaked")
+	}
+	if got := activity(owner, "specialist"); strings.Contains(got, "Working") {
+		t.Fatal("another agent's activity leaked")
+	}
+	task, err := tasks.CreateOn(owner, "", "", "Needs a decision", "", tasks.Agent, time.Time{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = tasks.Update(owner, task.ID, "", "", tasks.StatusBlocked, "", "", nil); err != nil {
+		t.Fatal(err)
+	}
+	if got := activity(owner, ""); !strings.Contains(got, "Working") || !strings.Contains(got, "Needs input") {
+		t.Fatalf("simultaneous work and blocked task lost: %s", got)
+	}
+}

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -344,6 +344,8 @@ func servePage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	accountID := acc.ID
+	assistant := r.URL.Path == "/assistant"
+	w.Header().Set("Cache-Control", "private, no-store")
 
 	// Reopen a saved session (?session=, or legacy ?continue=).
 	sessionID := r.URL.Query().Get("session")
@@ -414,6 +416,11 @@ func servePage(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	if sessionID != "" && !reopened {
+		app.NotFound(w, r, "Conversation not found")
+		return
+	}
+
 	// The chat switcher requests only its account-owned transcript.
 	if r.Header.Get("X-Mu-Transcript") == "1" {
 		w.Header().Set("Cache-Control", "no-store")
@@ -472,13 +479,16 @@ func servePage(w http.ResponseWriter, r *http.Request) {
 	if reopened {
 		// A reopened conversation decides its own agent; the rail filters to it.
 		selAgent = reopenAgent
-	} else if (selAgent != "" || named) && prefill == "" && cfg.Attachment == "" && r.URL.Query().Get("new") != "1" {
+	} else if (selAgent != "" || named || assistant) && prefill == "" && cfg.Attachment == "" && r.URL.Query().Get("new") != "1" {
 		// Land in the last conversation with this agent, if there is one.
 		if last := latestThreadFor(accountID, selAgent, named); last != "" {
 			cfg.ContextID = last
 			cfg.InitialConvHTML = renderThreadTurns(accountID, last)
 			cfg.Pending = Pending(accountID, last)
 			activeRoot = last
+			if th := thread.Get(accountID, last); th != nil {
+				selAgent = th.Agent
+			}
 		}
 	}
 
@@ -492,6 +502,12 @@ func servePage(w http.ResponseWriter, r *http.Request) {
 	// title uses, so the page and the answer cannot disagree about which agent
 	// this is.
 	cfg.AgentName = agentTitle(accountID, selAgent)
+	chatBase := chatPath(accountID, selAgent)
+	if assistant {
+		chatBase = "/assistant"
+		cfg.HideSuggestions = true
+		cfg.Location = true
+	}
 
 	// One panel beside the conversation: the conversations. On a phone it folds
 	// away behind the bar below and the chat is the first thing on the page —
@@ -513,7 +529,7 @@ func servePage(w http.ResponseWriter, r *http.Request) {
 	rail := `<div class="chat-side">` +
 		`<div class="chat-pane" id="pane-chats">` +
 		renderSessionsRail(accountID, activeRoot, selAgent, named,
-			"") + `</div></div>`
+			"", chatBase) + `</div></div>`
 
 	// The bar above the conversation: how you got here, and how to see the
 	// other conversations on a phone. Nothing else.
@@ -537,7 +553,7 @@ func servePage(w http.ResponseWriter, r *http.Request) {
 	// only exists here put a row of chrome above the conversation to say
 	// something the nav already says.
 	chip := `<div class="agent-bar">` +
-		`<a class="btn chat-open-list" href="` + chatPath(accountID, selAgent) + `?new=1">New</a>` +
+		`<a class="btn chat-open-list" href="` + chatBase + `?new=1">New</a>` +
 		`<button type="button" class="btn chat-open-list" onclick="muPane('chats')">Chats</button>` +
 		`</div>` + paneJS
 
@@ -581,14 +597,14 @@ func servePage(w http.ResponseWriter, r *http.Request) {
 	// non-empty left the tab's remembered selection in charge on a bare /agent:
 	// the rail listed every agent's conversations while the next message went to
 	// whichever agent the tab remembered. The URL is the state.
-	content += `<script>window.addEventListener('mu-chat-thread',function(e){history.replaceState(null,'',` + app.JSString(chatPath(accountID, selAgent)) + `+'?session='+encodeURIComponent(e.detail));});</script>`
+	content += `<script>window.addEventListener('mu-chat-thread',function(e){history.replaceState(null,'',` + app.JSString(chatBase) + `+'?session='+encodeURIComponent(e.detail));});</script>`
 	content += resumeMicroJS(accountID, selAgent, cfg.ContextID)
 	if r.URL.Path == "/" {
 		content += HandoffHTML(r)
 	}
 	content += `<script>window.muSeedAgent(` + app.JSString(selAgent) + `);</script>`
 	if prefill != "" {
-		content += `<script>(function(){var i=document.getElementById('mu-chat-input');if(i&&window.muChatAsk){i.value=` + app.JSString(prefill) + `;window.muChatAsk(i.value);}history.replaceState(null,'',` + app.JSString(chatPath(accountID, selAgent)) + `);})()</script>`
+		content += `<script>(function(){var i=document.getElementById('mu-chat-input');if(i&&window.muChatAsk){i.value=` + app.JSString(prefill) + `;window.muChatAsk(i.value);}history.replaceState(null,'',` + app.JSString(chatBase) + `);})()</script>`
 	}
 
 	// The agent's own name, because this page is about one agent.
@@ -598,6 +614,9 @@ func servePage(w http.ResponseWriter, r *http.Request) {
 	// you talk to an agent — so the title was the clearest possible statement
 	// that the two had not been told apart.
 	title := agentTitle(accountID, selAgent)
+	if assistant {
+		title = "Assistant"
+	}
 	desc := "Talk to " + title + ", and the address it answers on"
 	app.Respond(w, r, app.Response{Title: title, Description: desc, HTML: content})
 }
@@ -732,7 +751,7 @@ func inboxAddress(accountID, agentID string) string {
 // and whatever else that agent has. extra is appended inside the one scroll
 // region — see the note on .chat-sess-scroll, which exists because two lists
 // with their own overflow in a fixed-height column draw over each other.
-func renderSessionsRail(accountID, currentID, agentID string, named bool, extra string) string {
+func renderSessionsRail(accountID, currentID, agentID string, named bool, extra string, routes ...string) string {
 	sessions := chatThreads(accountID, agentID, named)
 	// A new chat with the agent whose rail this is. It used to rewrite the URL
 	// to a bare /agent, which dropped the agent out of the address bar while
@@ -743,6 +762,9 @@ func renderSessionsRail(accountID, currentID, agentID string, named bool, extra 
 	// holds what arrived, so a link from one to the other lands somewhere that
 	// does not have the conversation in it.
 	base := chatPath(accountID, agentID)
+	if len(routes) > 0 && routes[0] != "" {
+		base = routes[0]
+	}
 	newURL := base + "?new=1"
 	if agentID != "" && base == "/agent/"+DefaultSlug {
 		// An id that resolves to nothing in the roster. Keep it in the URL
@@ -845,7 +867,7 @@ function muSessionDelete(id,ev){
 window.muSessionStarted=function(id,title){
   var list=document.querySelector('.chat-sess-list');if(!list)return;
   var empty=list.querySelector('.chat-sess-empty');if(empty)empty.remove();
-  var href='/agent?session='+id;
+  var href=(location.pathname==='/assistant'?'/assistant':'/agent')+'?session='+encodeURIComponent(id);
   if(list.querySelector('a[href="'+href+'"]'))return;
   title=(title||'Untitled').trim();
   if(title.length>60)title=title.slice(0,60)+'…';

--- a/agent/handoff.go
+++ b/agent/handoff.go
@@ -88,7 +88,8 @@ function finish(id){
  if(draft)sessionStorage.setItem('mu_chat_draft:'+ns+':'+id,draft);
  ['hist','conv','ctx','draft'].forEach(function(k){sessionStorage.removeItem('mu_chat_'+k+':landing');});
  }catch(e){return;}
- // Keep the person on Home; the imported conversation is in chat history.
+ if(id){if(draft)sessionStorage.setItem('mu_chat_continue_draft:'+id,draft);window.location.replace('/assistant?session='+encodeURIComponent(id));}
+ else if(draft){sessionStorage.setItem('mu_chat_draft:'+ns+':',draft);window.location.replace('/assistant?new=1');}
 }
 if(!turns.length){finish('');return;}
 fetch('/agent/handoff',{method:'POST',credentials:'same-origin',headers:{'Content-Type':'application/json','X-CSRF-Token':` + app.JSString(auth.CSRFToken(r)) + `},body:JSON.stringify({turns:turns})})

--- a/agent/preview.go
+++ b/agent/preview.go
@@ -130,6 +130,7 @@ func Preview(accountID string) string {
 		b.WriteString(`<a class="agent-peek-row" href="` + html.EscapeString(a.Path) + `">`)
 		b.WriteString(`<span class="agent-peek-name">` + html.EscapeString(a.Name) + `</span>`)
 
+		b.WriteString(activityHTML(accountID, a.ID))
 		if s, ok := latest[a.ID]; ok {
 			what := s.subject
 			if what == "" {

--- a/agent/recent.go
+++ b/agent/recent.go
@@ -23,19 +23,19 @@ func RecentConversations(accountID string) string {
 		if title == "" {
 			title = "Conversation"
 		}
-		b.WriteString(`<a class="peek-row" href="/agent?session=` + url.QueryEscape(t.ID) + `"><span class="peek-main"><span class="peek-title">` + html.EscapeString(title) + `</span>`)
+		b.WriteString(`<a class="peek-row" href="/assistant?session=` + url.QueryEscape(t.ID) + `"><span class="peek-main"><span class="peek-title">` + html.EscapeString(title) + `</span>`)
 		messages := thread.Messages(accountID, t.ID, 1)
 		if len(messages) > 0 {
 			text := []rune(messages[len(messages)-1].Text)
 			if len(text) > 140 {
 				text = append(text[:140], '…')
 			}
-			b.WriteString(`<span class="text-muted">` + html.EscapeString(string(text)) + `</span>`)
+			b.WriteString(`<span class="peek-snippet">` + html.EscapeString(string(text)) + `</span>`)
 		}
 		b.WriteString(`</span></a>`)
 	}
 	if b.Len() == 0 {
 		return ""
 	}
-	return app.PreviewCard("home-recent", "Recent conversations", "/agent", b.String())
+	return app.PreviewCard("home-recent", "Recent conversations", "/assistant", b.String())
 }

--- a/agent/roster_page.go
+++ b/agent/roster_page.go
@@ -322,8 +322,9 @@ type entry struct {
 	// everywhere else. It was one string reading "Last: Tuesday · 2 hours ago",
 	// which put a label nobody needs in front of the only interesting word and
 	// buried the timestamp mid-sentence.
-	Seen string
-	When string
+	Seen   string
+	When   string
+	Status string
 }
 
 // entryRow draws one.
@@ -343,6 +344,9 @@ func entryRow(e entry) string {
 		b.WriteString(`<span class="agent-when">` + html.EscapeString(e.When) + `</span>`)
 	}
 	b.WriteString(`</div>`)
+	if e.Status != "" {
+		b.WriteString(`<div class="activity-status">` + html.EscapeString(e.Status) + `</div>`)
+	}
 	if e.For != "" {
 		b.WriteString(`<div class="agent-for">` + html.EscapeString(e.For) + `</div>`)
 	}
@@ -422,15 +426,16 @@ func agentRow(a *Agent, csrf, base string) string {
 	open, chat := Path(a.Owner, a.ID), Path(a.Owner, a.ID)
 
 	return entryRow(entry{
-		Name:  a.Name,
-		Path:  open,
-		Chat:  chat,
-		For:   for_,
-		Seen:  seenLine(a.Owner, a.ID),
-		When:  seenWhen(a.Owner, a.ID),
-		ID:    a.ID,
-		Admin: true,
-		Extra: extra,
+		Name:   a.Name,
+		Status: activity(a.Owner, a.ID),
+		Path:   open,
+		Chat:   chat,
+		For:    for_,
+		Seen:   seenLine(a.Owner, a.ID),
+		When:   seenWhen(a.Owner, a.ID),
+		ID:     a.ID,
+		Admin:  true,
+		Extra:  extra,
 	})
 }
 
@@ -442,6 +447,7 @@ func agentRow(a *Agent, csrf, base string) string {
 // in, where "last used 2 hours ago" would be a fact about a stranger.
 func platformSeenRow(name, accountID string) string {
 	row := platformRow(name)
+	row = strings.Replace(row, `</div>`, `</div>`+activityHTML(accountID, name), 1)
 
 	// How long ago, beside the name.
 	if when := seenWhen(accountID, name); when != "" {

--- a/home/assistant.go
+++ b/home/assistant.go
@@ -19,20 +19,17 @@ func AssistantHandler(w http.ResponseWriter, r *http.Request) {
 	if acc != nil {
 		viewerID = acc.ID
 	}
-	ns := assistantNamespace(viewerID)
-	fromHome := r.URL.Query().Get("view") == "home"
-	if fromHome {
-		ns += ":home"
+	if acc != nil {
+		auth.SetCSRFCookie(w, r)
+		agent.Handler(w, r)
+		return
 	}
 	w.Header().Set("Cache-Control", "private, no-store")
-	body := `<main class="assistant-page"><script>window.muActiveAgent="";</script>` + app.ChatComponent(app.ChatConfig{
-		Ask: true, HideSuggestions: true, AgentName: agent.DefaultName(),
-		Placeholder: "What do you need?", Location: acc != nil, StorageNS: ns, AcceptHandoff: fromHome,
+	body := `<main class="assistant-page">` + app.ChatComponent(app.ChatConfig{
+		Ask: true, HideSuggestions: true, AgentName: agent.DefaultName(), Transcript: true,
+		Placeholder: "What do you need?", StorageNS: assistantNamespace(viewerID),
 	}) + `</main>`
-	if fromHome {
-		body = `<div class="page-stack"><div class="section-actions"><a href="/assistant">Back to main conversation</a></div>` + body + `</div>`
-	}
-	app.Respond(w, r, app.Response{Title: "Assistant", Description: "Talk to Micro", HTML: body})
+	app.Respond(w, r, app.Response{Title: "Assistant", HTML: body})
 }
 
 func assistantNamespace(account string) string {

--- a/home/assistant_continuity_test.go
+++ b/home/assistant_continuity_test.go
@@ -1,0 +1,41 @@
+package home
+
+import (
+	"mu/internal/auth"
+	"mu/internal/thread"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestAssistantReopensOwnedConversation(t *testing.T) {
+	const owner = "asstcontinuity"
+	if err := auth.Create(&auth.Account{ID: owner, Name: owner}); err != nil {
+		t.Fatal(err)
+	}
+	sess, err := auth.CreateSession(owner)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mine := thread.Open(owner, thread.WebClient, "assistant-continuity")
+	thread.Add(thread.Message{Account: owner, Thread: mine.ID, Text: "My preserved question"})
+	other := thread.Open("another-reader", thread.WebClient, "assistant-private")
+	for _, tc := range []struct {
+		id   string
+		want int
+	}{{mine.ID, 200}, {other.ID, 404}, {"nonexistent", 404}} {
+		r := httptest.NewRequest("GET", "/assistant?session="+tc.id, nil)
+		r.AddCookie(&http.Cookie{Name: "session", Value: sess.Token})
+		w := httptest.NewRecorder()
+		AssistantHandler(w, r)
+		if w.Code != tc.want {
+			t.Fatalf("%s: got %d want %d", tc.id, w.Code, tc.want)
+		}
+		if tc.want == 200 {
+			if !strings.Contains(w.Body.String(), "My preserved question") || !strings.Contains(w.Body.String(), `href="/assistant?session=`) {
+				t.Fatal("saved conversation/history not rendered in Assistant")
+			}
+		}
+	}
+}

--- a/home/assistant_test.go
+++ b/home/assistant_test.go
@@ -21,11 +21,7 @@ func TestAssistantSeparatesAccountAndGuestConversations(t *testing.T) {
 					t.Fatal(err)
 				}
 				r.AddCookie(&http.Cookie{Name: "session", Value: sess.Token})
-				ns = "assistant:account:" + who
-			}
-			fromHome := strings.Contains(path, "view=home")
-			if fromHome {
-				ns += ":home"
+				ns = "agent-" + who + "-"
 			}
 			w := httptest.NewRecorder()
 			AssistantHandler(w, r)
@@ -36,11 +32,8 @@ func TestAssistantSeparatesAccountAndGuestConversations(t *testing.T) {
 			if !strings.Contains(body, `var NS="`+ns+`"`) {
 				t.Errorf("%s: missing isolated namespace %s", path, ns)
 			}
-			if strings.Contains(body, `href="/assistant">Back to main conversation</a>`) != fromHome {
-				t.Error("return link must appear on the separate Home conversation")
-			}
-			if strings.Contains(body, "var handoff=true?") != fromHome {
-				t.Error("main conversation must not consume handoffs")
+			if who != "" && (!strings.Contains(body, `class="chat-sess-list"`) || !strings.Contains(body, `mu-chat-transcript`)) {
+				t.Error("Assistant must show saved conversations and a transcript")
 			}
 			if strings.Contains(body, `id="mu-chat-location"`) != (who != "") {
 				t.Errorf("%s: location control does not match authentication", path)

--- a/home/chat_test.go
+++ b/home/chat_test.go
@@ -51,7 +51,7 @@ func TestAnExpiredSessionIsOfferedTheWayBackIn(t *testing.T) {
 	// answered outright — see agent.Handler — and this branch is what is left
 	// for an instance that has turned strangers off, or one whose session
 	// expired mid-conversation. Both ways on carry the question.
-	for _, want := range []string{"/archive?q=", "/agent?q="} {
+	for _, want := range []string{"/login?redirect=", "mu_chat_continue_draft:"} {
 		if !strings.Contains(html, want) {
 			t.Errorf("the chat has no %s for a caller whose session has gone", want)
 		}

--- a/home/conversation_test.go
+++ b/home/conversation_test.go
@@ -24,16 +24,18 @@ func TestClosePreservesHomeExchange(t *testing.T) {
 	script := `
 const assert=require('assert');
 const events={},actionBar={},transcript={textContent:'Existing answer'};
-const button={addEventListener(k,fn){this[k]=fn}};
-const home={querySelector(s){return s==='#home-conversation-actions'?actionBar:s==='#home-conversation-close'?button:transcript}};
+const button={addEventListener(k,fn){this[k]=fn}},prompt={addEventListener(k,fn){this[k]=fn}};
+const home={querySelector(s){return s==='#home-conversation-actions'?actionBar:s==='#home-conversation-close'?button:s==='#mu-chat-input'?prompt:transcript}};
 let resets=0;
 const window={addEventListener(k,fn){events[k]=fn},muChatClose(){resets++}};
 ` + src[start:end] + `
 assert.equal(actionBar.hidden,false);
 button.click({preventDefault(){},stopPropagation(){}});
-assert.equal(resets,1);
+assert.equal(resets,0);
+assert.equal(transcript.hidden,true);
 assert.equal(transcript.textContent,'Existing answer');
-assert.equal(actionBar.hidden,false);
+assert.equal(actionBar.hidden,true);
+prompt.focus();assert.equal(transcript.hidden,false);
 events['mu-chat-active']({detail:true});
 assert.equal(actionBar.hidden,false);
 `

--- a/home/frontdoor_test.go
+++ b/home/frontdoor_test.go
@@ -44,7 +44,7 @@ func TestHomeStartsWithMicro(t *testing.T) {
 			t.Errorf("Home still offers %s", control)
 		}
 	}
-	if !strings.Contains(body, `class="mu-chat-contained mu-chat-overlay"`) {
-		t.Error("Home should open a focused conversation")
+	if strings.Contains(body, `class="mu-chat-contained mu-chat-overlay"`) || !strings.Contains(body, `<div id="mu-chat">`) {
+		t.Error("Home prompt must remain in place")
 	}
 }

--- a/home/home.go
+++ b/home/home.go
@@ -352,6 +352,7 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 
 	// Feed refreshes through its JSON endpoint when selected; do not block Home on it.
 
+	auth.SetCSRFCookie(w, r)
 	_, viewerAcc := auth.TrySession(r)
 
 	var b strings.Builder
@@ -443,11 +444,7 @@ function fetchW(la,lo){
 	if r.URL.Query().Get("q") != "" || r.URL.Query().Get("prompt") != "" {
 		feed = false
 	}
-	b.WriteString(homeViews(feed) + `</div>`)
-	b.WriteString(`<section id="home-personal" role="tabpanel" aria-labelledby="home-view-personal"` + panelHidden(feed) + `>`)
-
-	// Each column flows independently as a conversation grows.
-	b.WriteString(`<div class="home-workspace"><div class="home-column page-stack">`)
+	b.WriteString(`</div>`)
 	b.WriteString(`<div id="home-agent" class="page-stack"><script>window.muActiveAgent="";</script>`)
 	b.WriteString(app.ChatComponent(app.ChatConfig{
 		Ask:             true,
@@ -456,13 +453,18 @@ function fetchW(la,lo){
 		AgentName:       agent.DefaultName(),
 		Location:        viewerID != "",
 		Stationary:      true,
-		Overlay:         true,
 		ContinueNS:      assistantNamespace(viewerID) + ":home",
-		FooterHTML:      `<div id="home-conversation-actions" class="conversation-actions" hidden><a href="/home" id="home-conversation-close">Close</a><a href="/assistant?view=home" id="mu-chat-continue" aria-disabled="true">Continue in Assistant →</a><span id="mu-chat-transfer-error" role="status"></span></div>`,
+		FooterHTML:      `<div id="home-conversation-actions" class="conversation-actions" hidden><a href="/home" id="home-conversation-close">Close</a><a href="/assistant" id="mu-chat-continue" aria-disabled="true">Continue in Assistant →</a><span id="mu-chat-transfer-error" role="status"></span></div>`,
 	}))
 	b.WriteString(`</div>`)
+	b.WriteString(homeViews(feed))
+	b.WriteString(`<section id="home-personal" role="tabpanel" aria-labelledby="home-view-personal"` + panelHidden(feed) + `><div class="home-workspace"><div class="home-column page-stack">`)
 	b.WriteString(appsHTML(viewerAcc))
-	b.WriteString(agent.RecentConversations(viewerID))
+	recent := agent.RecentConversations(viewerID)
+	b.WriteString(recent)
+	if recent == "" && inbox.Preview(viewerID) == "" && todoHTML(viewerID) == "" {
+		b.WriteString(app.SectionCard("home-start", "Get started", "", `<p>Ask Micro a question above, add something to <a href="/tasks">Todo</a>, or see your <a href="/events">upcoming events</a>. Your recent conversations will appear here.</p>`))
+	}
 	if viewerID != "" {
 		if peek := inbox.Preview(viewerID); peek != "" {
 			b.WriteString(`<div id="home-inbox" class="page-stack">` + peek + `</div>`)
@@ -489,7 +491,7 @@ function fetchW(la,lo){
 		cards = `<p class="text-muted">No feed items yet.</p>`
 	}
 	b.WriteString(cards)
-	b.WriteString(`</div></section></div><script>` + viewsJS + `</script>`)
+	b.WriteString(`</div></section></div><script>` + viewsJS + `</script>` + agent.HandoffHTML(r))
 
 	// Auto-refresh: poll every 2 minutes, update card content in-place
 	displayMode := r.URL.Query().Get("mode") == "display"

--- a/home/index.go
+++ b/home/index.go
@@ -243,7 +243,7 @@ func indexBody() string {
 			Ask:             true,
 			HideSuggestions: true,
 			Placeholder:     "What do you need?",
-			// Landing conversations are ephemeral; refresh starts clean.
+			StorageNS:       "landing", // Carry a guest conversation through account entry.
 			// Who answers, for the byline over the reply. The default agent,
 			// which is what an unpicked box reaches — see agent.DefaultName.
 			AgentName: agent.DefaultName(),

--- a/home/layout_test.go
+++ b/home/layout_test.go
@@ -53,7 +53,10 @@ func TestHomeAndFeedKeepTheirOwnContent(t *testing.T) {
 		t.Fatal("missing view panels")
 	}
 	personal, feed := body[personalAt:feedAt], body[feedAt:]
-	for _, want := range []string{`id="home-agent"`, `<a class="card-head-link" href="/inbox">Inbox</a>`} {
+	if at := strings.Index(body, `id="home-agent"`); at < 0 || at >= personalAt || strings.Count(body, `id="home-agent"`) != 1 {
+		t.Error("one shared prompt must precede both view panels")
+	}
+	for _, want := range []string{`<a class="card-head-link" href="/inbox">Inbox</a>`} {
 		if !strings.Contains(personal, want) || strings.Contains(feed, want) {
 			t.Errorf("%s is not exclusive to Home", want)
 		}

--- a/home/login_continuity_test.go
+++ b/home/login_continuity_test.go
@@ -6,16 +6,16 @@ import (
 	"testing"
 )
 
-func TestLandingRefreshAndLoginStartClean(t *testing.T) {
-	if strings.Contains(indexBody(), `var NS="landing"`) {
-		t.Fatal("landing retains the guest conversation")
+func TestLandingConversationSurvivesAccountEntry(t *testing.T) {
+	if !strings.Contains(indexBody(), `var NS="landing"`) {
+		t.Fatal("landing must retain the guest conversation")
 	}
 	home, err := os.ReadFile("home.go")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if strings.Contains(string(home), "agent.HandoffHTML(r)") {
-		t.Fatal("login imports the old landing conversation")
+	if !strings.Contains(string(home), "agent.HandoffHTML(r)") {
+		t.Fatal("login must carry the landing conversation")
 	}
 }
 

--- a/home/views.js
+++ b/home/views.js
@@ -2,13 +2,20 @@
   const home = document.getElementById('home-cards');
   if (!home) return;
   const actions=home.querySelector('#home-conversation-actions');
+  const initial=home.querySelector('#mu-chat-conv');
+  const input=home.querySelector('#mu-chat-input');
   function conversation(active){
-    if(actions)actions.hidden=false;
+    if(actions)actions.hidden=!active;
+    if(initial)initial.hidden=!active;
   }
   window.addEventListener('mu-chat-active',event=>conversation(event.detail===true));
   const close=home.querySelector('#home-conversation-close');
-  if(close)close.addEventListener('click',event=>{event.preventDefault();event.stopPropagation();if(window.muChatClose)window.muChatClose();});
-  const initial=home.querySelector('#mu-chat-conv');
+  if(close)close.addEventListener('click',event=>{
+    event.preventDefault();event.stopPropagation();conversation(false);
+  });
+  if(input)input.addEventListener('focus',()=>{
+    if(initial&&initial.textContent.trim())conversation(true);
+  });
   conversation(!!initial && !!initial.textContent.trim());
 
   const upcoming = home.querySelector('[data-home-upcoming]');

--- a/inbox/page.go
+++ b/inbox/page.go
@@ -254,7 +254,7 @@ func list(w http.ResponseWriter, r *http.Request, accountID, box string) {
 				`address from anywhere — your own mail, your phone — and it turns up here. ` +
 				`The agent reads what arrives and answers in the thread.</p>` +
 				`<p class="ib-empty">This is what came in. Chats you started here are with ` +
-				`the agent, on ` + app.TextLink("Agents", "/agents") + `. Or ` +
+				`the agent, on ` + app.TextLink("Assistant", "/assistant") + `. Or ` +
 				app.TextLink("write one yourself", "/inbox/new") + `.</p>`)
 		}
 		b.WriteString(`</div>`)

--- a/internal/app/agentready_test.go
+++ b/internal/app/agentready_test.go
@@ -148,19 +148,18 @@ func TestAskingStillNeedsAModel(t *testing.T) {
 func TestARefusedQuestionStillGoesSomewhere(t *testing.T) {
 	AgentReady = func() bool { return true }
 	t.Cleanup(func() { AgentReady = nil })
-
 	got := ChatComponent(ChatConfig{Ask: true})
-
-	if !strings.Contains(got, "/archive?q=") {
-		t.Error("a refused question is not offered to the archive, which needs no " +
-			"account and would have answered it")
+	start := strings.Index(got, "if(resp.status===401)")
+	end := strings.Index(got[start:], "if(!resp.ok") + start
+	refusal := got[start:end]
+	for _, want := range []string{"/login?redirect=", "mu_chat_continue_draft:", "input.value=q;saveDraft();"} {
+		if !strings.Contains(refusal, want) {
+			t.Errorf("missing sign-in recovery: %s", want)
+		}
 	}
-	if !strings.Contains(got, "/agent?q=") {
-		t.Error("signing in does not carry the question, so somebody arrives at an " +
-			"empty box having already typed their question once")
-	}
-	// And the question itself has to travel, or both links are decoration.
-	if !strings.Contains(got, "encodeURIComponent(q)") {
-		t.Error("what was typed is not carried into either link")
+	for _, bad := range []string{"/archive?q=", "/agent?q=", "encodeURIComponent(q)"} {
+		if strings.Contains(refusal, bad) {
+			t.Errorf("private question put in a URL: %s", bad)
+		}
 	}
 }

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -357,14 +357,14 @@ func torFooterLink() string {
 var Template = `
 <html lang="%s">
   <head>
-    <title>%s | Mu</title>
+    <title>%s | Micro</title>
     <meta name="viewport" content="width=device-width, initial-scale=1, interactive-widget=resizes-content, viewport-fit=cover" />
     <meta name="description" content="%s">
     <meta name="referrer" content="no-referrer"/>
     <meta name="theme-color" content="#ffffff">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="default">
-    <meta name="apple-mobile-web-app-title" content="Mu">
+    <meta name="apple-mobile-web-app-title" content="Micro">
     <meta name="application-name" content="Mu">
     <link rel="apple-touch-icon" href="/icon-192.png">
     <link rel="preload" href="/home.png?` + Version + `" as="image">
@@ -397,7 +397,7 @@ var Template = `
     <div id="head">
       <button id="menu-toggle" onclick="toggleMenu()" aria-label="Menu"><span></span><span></span><span></span></button>
       <div id="brand">
-        <a href="/">Mu</a>
+        <a href="/">Micro</a>
       </div>
       <!-- One flex cluster, so the items sit next to each other by measuring
            themselves. They used to be three absolutely positioned elements

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -212,7 +212,7 @@ func TestRenderString(t *testing.T) {
 
 func TestRenderHTML(t *testing.T) {
 	result := RenderHTML("Test", "A test page", "<p>content</p>", nil)
-	if !strings.Contains(result, "<title>Test | Mu</title>") {
+	if !strings.Contains(result, "<title>Test | Micro</title>") {
 		t.Error("expected title")
 	}
 	if !strings.Contains(result, `lang="en"`) {
@@ -469,7 +469,7 @@ func TestRenderTemplate(t *testing.T) {
 	if !strings.Contains(result, "<strong>bold</strong>") {
 		t.Error("expected rendered markdown")
 	}
-	if !strings.Contains(result, "<title>Test | Mu</title>") {
+	if !strings.Contains(result, "<title>Test | Micro</title>") {
 		t.Error("expected page title")
 	}
 }

--- a/internal/app/chat.go
+++ b/internal/app/chat.go
@@ -724,7 +724,9 @@ if(overlay && input && form){
  form.addEventListener('submit',openConsole,true);
 }
 
+var questionAnchor=null;
 function revealQuestion(node){
+  if(stationary&&(conv.hidden||questionAnchor!==node))return;
   if(overlay){toBottom(false);return;}
   if(transcript){toBottom(false);return;}
   requestAnimationFrame(function(){
@@ -734,6 +736,13 @@ function revealQuestion(node){
     node.style.scrollMarginTop=Math.max(64,stickyTop+(form?form.getBoundingClientRect().height:0)+8)+"px";
     node.scrollIntoView({behavior:window.matchMedia("(prefers-reduced-motion: reduce)").matches?"instant":"smooth",block:"start"});
   });
+}
+// Keep Home aligned to the question as the answer grows, until the reader scrolls.
+if(stationary&&conv&&window.ResizeObserver){
+  new ResizeObserver(function(){if(questionAnchor&&questionAnchor.isConnected)revealQuestion(questionAnchor);}).observe(conv);
+  window.addEventListener('wheel',function(){questionAnchor=null;},{passive:true});
+  window.addEventListener('touchmove',function(){questionAnchor=null;},{passive:true});
+  window.addEventListener('keydown',function(e){if(e.target!==input&&['ArrowUp','ArrowDown','PageUp','PageDown','Home','End',' '].indexOf(e.key)>=0)questionAnchor=null;});
 }
 function toBottom(force,smooth){
   if(!overlay&&!transcript&&!contained) return;
@@ -872,7 +881,7 @@ if(!SESSION && PERSIST){
   }catch(e){}
 }
 
-if(SESSION&&PERSIST){try{var savedDraft=sessionStorage.getItem(draftKey());if(savedDraft)input.value=savedDraft;}catch(e){}}
+if(SESSION&&PERSIST){try{var savedDraft=sessionStorage.getItem('mu_chat_continue_draft:'+contextId)||sessionStorage.getItem(draftKey());if(savedDraft)input.value=savedDraft;sessionStorage.removeItem('mu_chat_continue_draft:'+contextId);}catch(e){}}
 
 // A conversation already on the page means the asking has happened, whether it
 // came back from sessionStorage or was rendered by the server. Without this a
@@ -901,7 +910,7 @@ function showSuggestions(){
 
 function save(){
   var transfer=document.getElementById('mu-chat-continue');
-  if(transfer)transfer.setAttribute('aria-disabled',String(!history.length || !!conv.querySelector('.mu-think,.mu-cursor')));
+  if(transfer)transfer.setAttribute('aria-disabled',String(!contextId && !history.length));
   if(SESSION||!PERSIST)return; // server owns reopened sessions; ephemeral surfaces don't save
   try{
     sessionStorage.setItem(CKEY,conv.innerHTML);
@@ -939,7 +948,7 @@ function ask(q){
   var epoch=viewEpoch;
   hideBrief();
   sugDiv.innerHTML='';
-  var u=document.createElement('div');u.className='mu-user';u.textContent=q;conv.appendChild(u);
+  var u=document.createElement('div');u.className='mu-user';u.textContent=q;conv.appendChild(u);if(stationary)questionAnchor=u;
   // Who is about to answer, above the answer, the same as the transcript draws
   // it on reload — see agent.renderTurn. Written before the reply arrives
   // because the name is known before the reply is, and a label that appears
@@ -1046,27 +1055,22 @@ function ask(q){
   fetch('/agent',{signal:streamController.signal,method:'POST',headers:{'Content-Type':'application/json','Accept':'text/event-stream'},body:body,credentials:'same-origin'})
   .then(function(resp){
     if(epoch!==viewEpoch)throw 'handled';
+    if(resp.status===402||resp.status===429){
+      return resp.json().catch(function(){return {};}).then(function(j){
+        stopWork();var message=resp.status===402?'You need more credits to continue.':'Please wait a moment before trying again.';
+        a.innerHTML='<div class="mu-err" role="status">'+esc(message)+(resp.status===402?' <a href="/wallet">View credits →</a>':'')+'</div>';input.value=q;saveDraft();save();throw 'handled';
+      });
+    }
     if(resp.status===401){
       return resp.json().catch(function(){return {};}).then(function(j){
         stopWork();
-        // A refusal has to leave somebody able to do something.
-        //
-        // It said "Sign in to ask the agent" with two links, on the front page,
-        // which is the page a stranger sees and the only page this branch ever
-        // renders on. So the main control of the signed-out product answered
-        // every question with a sign-up form — worse than the search box it
-        // replaced, which at least worked.
-        //
-        // Two ways on, and the first one works this second. The archive is
-        // public by construction, so searching what was just typed needs no
-        // account and no permission; signing in carries the question through
-        // and asks it on arrival, which is the same trip /agent?q= already
-        // makes. Neither is a form standing between somebody and an answer.
-        var msg=esc(j.error||'Nobody can ask the agent here without an account.');
-        var qq=encodeURIComponent(q);
-        a.innerHTML='<div class="mu-cta">'+msg+
-          ' <a href="/archive?q='+qq+'">Search the archive for this →</a>'+
-          ' <a href="/login?redirect='+encodeURIComponent('/agent?q='+q)+'" class="ml-3">Sign in and ask it</a></div>';
+        // Preserve the draft and conversation identity through sign-in.
+        // The question itself must never travel in a URL.
+        var msg=esc(j.error||'Sign in to continue this conversation.');
+        input.value=q;saveDraft();
+        var returnTo=contextId?'/assistant?session='+encodeURIComponent(contextId):'/home';
+        try{sessionStorage.setItem(contextId?'mu_chat_continue_draft:'+contextId:'mu_chat_draft:landing',q);}catch(e){}
+        a.innerHTML='<div class="mu-cta">'+msg+' <a href="/login?redirect='+encodeURIComponent(returnTo)+'">Sign in to continue →</a></div>';
         save();
         throw 'handled';
       });
@@ -1210,15 +1214,16 @@ window.addEventListener('popstate',function(e){
   else window.muChatNew();
 });
 
-// Move a completed exchange as one bundle; never put its words in a URL.
+// Open the saved conversation itself; no transcript copy and no words in a URL.
 var transfer=document.getElementById('mu-chat-continue');
 if(transfer && CONTINUE_NS)transfer.addEventListener('click',function(event){
   event.preventDefault();event.stopPropagation();
-  if(transfer.getAttribute('aria-disabled')==='true')return;
+  var error=document.getElementById('mu-chat-transfer-error');
+  if(!contextId){if(error)error.textContent='Send a question first, then continue here once it is saved.';return;}
   try{
-    sessionStorage.setItem('mu_chat_handoff:'+CONTINUE_NS,JSON.stringify({html:conv.innerHTML,history:history,context:contextId||'',draft:input.value||''}));
-    window.location.assign('/assistant?view=home');
-  }catch(e){document.getElementById('mu-chat-transfer-error').textContent='Could not move this conversation. Please try again.';}
+    sessionStorage.setItem('mu_chat_continue_draft:'+contextId,input.value||'');
+  }catch(e){} // A blocked browser store must not prevent opening a saved chat.
+  window.location.assign('/assistant?session='+encodeURIComponent(contextId));
 });
 
 // Start a fresh session (clears the log + thread id).

--- a/internal/app/chat.go
+++ b/internal/app/chat.go
@@ -1052,13 +1052,25 @@ function ask(q){
   }
   var streamController=new AbortController();
   detachActive=function(){terminal=true;clearTimeout(completionTimer);stopWork();streamController.abort();};
-  fetch('/agent',{signal:streamController.signal,method:'POST',headers:{'Content-Type':'application/json','Accept':'text/event-stream'},body:body,credentials:'same-origin'})
+  var requestHeaders={'Content-Type':'application/json','Accept':'text/event-stream'};
+  var csrfCookie=(document.cookie||'').match(/(?:^|; )csrf_token=([^;]+)/);
+  if(csrfCookie){try{requestHeaders['X-CSRF-Token']=decodeURIComponent(csrfCookie[1]);}catch(e){}}
+  fetch('/agent',{signal:streamController.signal,method:'POST',headers:requestHeaders,body:body,credentials:'same-origin'})
   .then(function(resp){
     if(epoch!==viewEpoch)throw 'handled';
     if(resp.status===402||resp.status===429){
       return resp.json().catch(function(){return {};}).then(function(j){
         stopWork();var message=resp.status===402?'You need more credits to continue.':'Please wait a moment before trying again.';
         a.innerHTML='<div class="mu-err" role="status">'+esc(message)+(resp.status===402?' <a href="/wallet">View credits →</a>':'')+'</div>';input.value=q;saveDraft();save();throw 'handled';
+      });
+    }
+    if(resp.status===403){
+      return resp.text().then(function(raw){
+        stopWork();input.value=q;saveDraft();
+        var message='This request was refused. Refresh the page to update your sign-in state, then try again.';
+        try{var refusal=JSON.parse(raw);if(typeof refusal.error==='string'&&refusal.error)message=refusal.error;}catch(e){}
+        if(/csrf/i.test(message))message='Your sign-in security token has changed. Refresh the page, then try again.';
+        a.innerHTML='<div class="mu-err" role="status">'+esc(message)+'</div>';save();throw 'handled';
       });
     }
     if(resp.status===401){

--- a/internal/app/chat_scroll_test.go
+++ b/internal/app/chat_scroll_test.go
@@ -18,17 +18,23 @@ func TestInlineQuestionScrollClearsStickyInput(t *testing.T) {
 	}
 	script := `
 const assert=require('assert');
-const stationary=true,transcript=false,contained=false,overlay=false;
+const stationary=true,transcript=false,contained=false,overlay=false,conv={hidden:false};
+let questionAnchor;
 const form={getBoundingClientRect(){return {height:42}}};
-const window={getComputedStyle(){return {top:'58px'}},matchMedia(){return {matches:false}}};
+const handlers={};let resize;
+class ResizeObserver{constructor(fn){resize=fn}observe(){}}
+const window={ResizeObserver,addEventListener(k,fn){handlers[k]=fn},getComputedStyle(){return {top:'58px'}},matchMedia(){return {matches:false}}};
 const requestAnimationFrame=fn=>fn();
 let calls=0;
 const question={isConnected:true,style:{},scrollIntoView(options){calls++;assert.equal(options.block,'start')}};
 ` + html[start:end] + `
-revealQuestion(question);
+questionAnchor=question;revealQuestion(question);
 assert.equal(calls,1);
 assert.equal(question.style.scrollMarginTop,'108px');
-question.isConnected=false;revealQuestion(question);assert.equal(calls,1);
+resize();assert.equal(calls,2);
+handlers.wheel();resize();revealQuestion(question);assert.equal(calls,2);
+questionAnchor=question;conv.hidden=true;resize();assert.equal(calls,2);
+conv.hidden=false;question.isConnected=false;revealQuestion(question);assert.equal(calls,2);
 `
 	if out, err := exec.Command(node, "-e", script).CombinedOutput(); err != nil {
 		t.Fatalf("%v\n%s", err, out)

--- a/internal/app/chat_transfer_test.go
+++ b/internal/app/chat_transfer_test.go
@@ -12,7 +12,7 @@ func TestContinueTransfersExchangeWithoutWordsInURL(t *testing.T) {
 		t.Skip("Node required")
 	}
 	body := ChatComponent(ChatConfig{Ask: true, ContinueNS: "assistant:account:alice:home"})
-	start, end := strings.Index(body, "// Move a completed exchange"), strings.Index(body, "// Start a fresh session")
+	start, end := strings.Index(body, "// Open the saved conversation itself"), strings.Index(body, "// Start a fresh session")
 	if start < 0 || end <= start {
 		t.Fatal("missing transfer controller")
 	}
@@ -25,10 +25,8 @@ const CONTINUE_NS='assistant:account:alice:home',conv={innerHTML:'<div>Private a
 const sessionStorage={setItem(key,value){stored={key,value}}};
 const window={location:{assign(value){url=value}}};
 ` + body[start:end] + `
-click({preventDefault(){},stopPropagation(){}});assert.equal(url,'/assistant?view=home');assert.equal(stored.key,'mu_chat_handoff:assistant:account:alice:home');
-const exchange=JSON.parse(stored.value);assert.equal(exchange.context,'original-thread');assert.deepEqual(exchange.history,history);assert.equal(exchange.html,conv.innerHTML);assert.equal(exchange.draft,'Follow up');
-url=undefined;button.disabled=true;click({preventDefault(){},stopPropagation(){}});assert.equal(url,undefined);
-button.disabled=false;sessionStorage.setItem=()=>{throw Error('storage unavailable')};click({preventDefault(){},stopPropagation(){}});assert.equal(url,undefined);assert(status.textContent.includes('Could not move'));
+click({preventDefault(){},stopPropagation(){}});assert.equal(url,'/assistant?session=original-thread');assert.equal(stored.key,'mu_chat_continue_draft:original-thread');assert.equal(stored.value,'Follow up');
+url=undefined;sessionStorage.setItem=()=>{throw Error('storage unavailable')};click({preventDefault(){},stopPropagation(){}});assert.equal(url,'/assistant?session=original-thread');
 `
 	if out, err := exec.Command(node, "-e", script).CombinedOutput(); err != nil {
 		t.Fatalf("%v\n%s", err, out)

--- a/internal/app/html/composition.css
+++ b/internal/app/html/composition.css
@@ -193,13 +193,13 @@ a.link-text {
 .assistant-page { max-width:800px; margin:0; }
 @media(max-width:900px) { #tabs { grid-template-columns:repeat(5,minmax(0,1fr)); } }
 
-/* Keep the Assistant composer below the fixed app header while reading. */
-.assistant-page #mu-chat-form { --mu-composer-top:58px; }
-@media(max-width:900px) { .assistant-page #mu-chat-form { --mu-composer-top:52px; } }
+/* Keep the in-page command composer below the fixed app header. */
+#home-agent #mu-chat-form, .assistant-page #mu-chat-form { --mu-composer-top:58px; }
+@media(max-width:900px) { #home-agent #mu-chat-form, .assistant-page #mu-chat-form { --mu-composer-top:52px; } }
 
 /* Quiet orientation, shared across desktop and mobile page shells. */
 #page-title { font-size:16px; font-weight:500; line-height:1.4; text-align:left; color:var(--text-secondary,#555); margin:0 0 8px; }
-/* Subtle rules distinguish unboxed sections without adding card chrome. */
+/* One card boundary encloses the heading, actions and content. */
 .section-card { min-width:0; margin:0 0 24px; border:1px solid var(--divider,#e8e8e8); border-radius:6px; padding:16px; background:var(--bg-primary,#fff); }
 .section-card-head { display:flex; align-items:baseline; justify-content:space-between; gap:16px; margin-bottom:16px; }
 .section-card-head h4 { margin:0; min-width:0; font-size:14px; font-weight:500; line-height:1.5; color:var(--text-secondary,#555); }
@@ -249,7 +249,7 @@ a.link-text {
 @media (max-width: 1099px) {
   .home-workspace > .home-column { display: contents; }
   .home-workspace #home-agent { order: 0; }
-  .home-workspace #home-recent { order: 2; }
+  .home-workspace #home-recent, .home-workspace #home-start { order: 2; }
   .home-workspace #home-todo { order: 3; }
   .home-workspace #home-upcoming { order: 4; }
   .home-workspace #home-inbox { order: 5; }
@@ -286,3 +286,29 @@ a.link-text {
 /* Set quoted scripture apart from the reflection without another heavy border. */
 .section-card .verse { background:#f5f5f5; padding:16px; border-radius:4px; max-height:none; overflow:visible; }
 .section-card .verse + p { margin-top:16px; }
+
+/* One stable command area above both Home views. */
+#home-agent { max-width:800px; margin-bottom:16px; }
+#home-agent #mu-chat-conv[hidden], #home-conversation-actions[hidden] { display:none !important; }
+#home-agent #mu-chat-conv { overflow-anchor:none; }
+.preview-rows .peek-main { display:flex; flex-direction:column; min-width:0; gap:4px; }
+.peek-snippet { display:block; color:var(--text-muted,#707070); font-size:13px; font-weight:400; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
+
+.activity-status { display:block; font-size:12px; font-weight:500; color:var(--text-secondary,#555); }
+.agent-peek-row { display:grid; grid-template-columns:minmax(0,1fr) auto; gap:4px 12px; }
+.agent-peek-row .agent-peek-name { grid-column:1; grid-row:1; }
+.agent-peek-row .activity-status { grid-column:2; grid-row:1; text-align:right; }
+.agent-peek-row .agent-peek-last { grid-column:1; grid-row:2; }
+.agent-peek-row .agent-peek-when { grid-column:2; grid-row:2; text-align:right; }
+
+/* Account entry uses the same typography, fields and spacing as application forms. */
+.auth-page #login, .auth-page #signup, .auth-page .auth-help, .auth-page #auth-status { width:100%; max-width:400px; margin:0 auto 16px; }
+.auth-page #login h1, .auth-page #signup h1 { font-size:16px; font-weight:500; margin:0; }
+.auth-page #login input, .auth-page #signup input { margin:0; }
+.auth-page .field-label { text-align:left; }
+.auth-page .auth-help { font-size:13px; }
+.auth-page #auth-status:empty { display:none; }
+.form-check { display:flex; flex-direction:row; align-items:center; gap:8px; }
+
+/* Static content cards use the same quiet boundary on every service page. */
+.card, .card:hover { box-shadow:none; }

--- a/service/docs/handler.go
+++ b/service/docs/handler.go
@@ -139,8 +139,8 @@ func list(r *http.Request, docs []*Doc, query string) string {
 // view is one document, read.
 func view(r *http.Request, d *Doc) string {
 	var b strings.Builder
-	b.WriteString(`<div class="collection-head"><a class="doc-back" href="/docs">← Documents</a>`)
-	b.WriteString(`<a class="doc-new" href="/docs?id=` + html.EscapeString(d.ID) + `&amp;edit=1">Edit</a></div>`)
+	b.WriteString(`<div class="collection-head"><a class="section-link" href="/docs">← Documents</a>`)
+	b.WriteString(`<a class="btn btn-quiet" href="/docs?id=` + html.EscapeString(d.ID) + `&amp;edit=1">Edit</a></div>`)
 	b.WriteString(`<article class="card record-card doc-view">`)
 	b.WriteString(`<h2>` + html.EscapeString(d.Title) + `</h2>`)
 	// Untrusted: this is one account's content and may be published to others.
@@ -164,9 +164,9 @@ func editor(r *http.Request, d *Doc) string {
 	if d.Public {
 		checked = " checked"
 	}
-	back := `<a class="doc-back" href="/docs">← Documents</a>`
+	back := `<a class="section-link" href="/docs">← Documents</a>`
 	if d.ID != "" {
-		back = `<a class="doc-back" href="/docs?id=` + html.EscapeString(d.ID) + `">← Back</a>`
+		back = `<a class="section-link" href="/docs?id=` + html.EscapeString(d.ID) + `">← Back</a>`
 	}
 	return `<form method="POST" action="/docs" class="record-editor">
 <input type="hidden" name="id" value="` + html.EscapeString(d.ID) + `">
@@ -187,8 +187,6 @@ func notice(msg string) string {
 }
 
 const pageCSS = `<style>
-.doc-back{font-size:14px;color:#888;text-decoration:none}
-.doc-new{font-size:14px;padding:6px 14px;border:1px solid #ccc;border-radius:6px;color:#111;text-decoration:none}
 .doc-toolbar{display:flex;flex-wrap:wrap;gap:6px}
 .doc-toolbar button{flex:0 0 auto;margin:0}
 .doc-view{overflow-wrap:anywhere}

--- a/service/files/handler.go
+++ b/service/files/handler.go
@@ -255,8 +255,6 @@ func listPage(w http.ResponseWriter, r *http.Request) {
 // block — name, then size · visibility · date on one muted line, then the
 // actions — and the buttons grow to something a thumb can hit.
 const filesPageCSS = `<style>
-.file-upload{display:flex;gap:8px;align-items:center;flex-wrap:wrap;margin:10px 0 4px}
-.file-upload input[type=file]{font-size:14px;max-width:100%;flex:1 1 auto;min-width:0}
 /* The card already provides the spacing data-table adds for a bare page. */
 .files-table{margin-bottom:0}
 .files-table .file-name{word-break:break-word}
@@ -264,8 +262,6 @@ const filesPageCSS = `<style>
 .file-actions form{display:inline}
 
 @media only screen and (max-width:600px){
-  .file-upload{flex-direction:column;align-items:stretch}
-  .file-upload button{width:100%}
 
   .files-table,.files-table tbody,.files-table tr,.files-table td{display:block;width:auto}
   .files-table thead{display:none}

--- a/service/tasks/handler.go
+++ b/service/tasks/handler.go
@@ -127,7 +127,7 @@ func listPage(w http.ResponseWriter, r *http.Request, names ...func(string, stri
 			blocked++
 		}
 	}
-	b.WriteString(`<div class="page-stack"><div class="task-tabs">`)
+	b.WriteString(`<div class="page-stack"><div class="app-filters">`)
 	tab(&b, "", filter, fmt.Sprintf("All (%d)", len(all)))
 	tab(&b, StatusTodo, filter, fmt.Sprintf("Todo (%d)", open))
 	tab(&b, StatusDoing, filter, fmt.Sprintf("Doing (%d)", doing))
@@ -137,8 +137,7 @@ func listPage(w http.ResponseWriter, r *http.Request, names ...func(string, stri
 	b.WriteString(`</div>`)
 
 	if len(list) == 0 {
-		b.WriteString(`<p class="text-sm text-muted">Nothing here. Add something above, ` +
-			`or an agent connected over <a href="/mcp">MCP</a> can with <code>tasks_create</code>.</p>`)
+		b.WriteString(`<p class="text-sm text-muted">Nothing here yet. Add something you want to do, or ask your assistant to help.</p>`)
 	}
 
 	running := 0
@@ -172,11 +171,7 @@ func tab(b *strings.Builder, status, active, label string) {
 	if status != "" {
 		href += "?status=" + status
 	}
-	class := "task-tab"
-	if status == active {
-		class += " active"
-	}
-	fmt.Fprintf(b, `<a href="%s" class="%s">%s</a>`, href, class, html.EscapeString(label))
+	b.WriteString(app.PillLink(label, href, status == active))
 }
 
 func taskRow(t *Task, csrf string, labels ...string) string {
@@ -324,12 +319,6 @@ const taskPollJS = `<script>
 </script>`
 
 const tasksPageCSS = `<style>
-.task-add{display:flex;flex-direction:column;gap:8px;margin:10px 0 4px}
-.task-add input[type=text],.task-add input:not([type]){min-width:0}
-.task-assign{font-size:13px;color:var(--text-muted);display:flex;align-items:center;gap:8px;cursor:pointer}
-.task-tabs{display:flex;gap:14px;flex-wrap:wrap}
-.task-tab{font-size:13px;color:var(--text-muted);text-decoration:none}
-.task-tab.active{color:var(--text-primary);font-weight:600}
 .task{display:flex;flex-direction:column;gap:var(--space-control)}
 .task-title{font-weight:var(--font-weight-normal,400)}
 .task-done .task-title{text-decoration:line-through;color:var(--text-muted)}
@@ -351,8 +340,6 @@ const tasksPageCSS = `<style>
 .task-running::after{content:"";animation:taskdots 1.2s steps(4,end) infinite}
 @keyframes taskdots{0%{content:""}25%{content:"."}50%{content:".."}75%{content:"..."}}
 @media only screen and (max-width:600px){
-  .task-add{grid-template-columns:1fr}
-  .task-add button{width:100%}
 }
 </style>`
 
@@ -386,16 +373,16 @@ func plural(n int) string {
 // long way from the words it belonged to. Giving each its own line costs
 // nothing and removes both problems.
 func addForm(csrf string) string {
-	return fmt.Sprintf(`<form method="POST" action="/tasks" class="task-add" onsubmit="var d=this.duelocal.value;this.due.value=d?new Date(d).toISOString():''">
+	return fmt.Sprintf(`<form method="POST" action="/tasks" class="form page-stack" onsubmit="var d=this.duelocal.value;this.due.value=d?new Date(d).toISOString():''">
   <input type="hidden" name="_csrf" value="%s">
   <input type="hidden" name="due" value="">
-  <input name="title" placeholder="What needs doing?" required>
-  <input name="detail" placeholder="Detail (optional)">
+  <label class="field-label">What needs doing?<input name="title" required></label>
+  <label class="field-label">Detail (optional)<input name="detail"></label>
   <div class="form-row">
     <label class="field-label">Due <input type="datetime-local" name="duelocal"></label>
     <button type="submit">Add</button>
   </div>
-  <label class="task-assign"><input type="checkbox" name="assign" value="agent"> <span>Give it to the agent — it starts working on this now</span></label>
+  <label class="field-label form-check"><input type="checkbox" name="assign" value="agent"> <span>Give it to the agent — it starts working on this now</span></label>
 </form>`, html.EscapeString(csrf))
 }
 


### PR DESCRIPTION
Home and Feed now share a stationary prompt: focusing does not open a modal or move the input, replies stay below it, and scrolling anchors to the question until the reader scrolls manually. Close preserves the exchange. Continue in Assistant opens the same saved thread, including when browser storage is unavailable.

Assistant uses the existing account-owned conversation renderer and history. Recent conversation titles and previews are stacked. Agent activity reflects account-scoped running flows and queued, blocked, or failed tasks.

Login/signup use shared forms with labels, safe return destinations, inline errors and recovery guidance. Guest conversations can continue after login. Todo, docs and files reuse shared controls. Credit and forbidden-request errors preserve questions; chat reads the current CSRF cookie at submission without relaxing server checks.

Validation: focused Go tests passed for account, home, agent, tasks, docs, files, inbox, internal/app and internal/server. JavaScript regression checks cover scrolling, close/resume and saved-thread transfer. Authenticated live deployment and physical mobile keyboard behaviour have not been verified. No voice mode or automatic password reset is introduced.