### PR TITLE
Replace landing brief with a short introduction

### DIFF
--- a/home/index.go
+++ b/home/index.go
@@ -277,7 +277,7 @@ func indexBody() string {
 			// furniture in front of somebody who has not asked anything yet.
 			Speak: false,
 		}) +
-		today("") + `
+		`<div class="ltoday" data-brief><p class="lrow lbrief">Ask a question, make a plan, or get something done.</p><p class="text-muted">Try “What’s happening in the news?”, “Help me plan a weekend in London”, or “What can I cook with chickpeas and spinach?”</p></div>` + `
 </div>
 
 <style>


### PR DESCRIPTION
Use the space beneath the landing prompt to explain what Micro can help with and offer three concrete example questions. Reuse the existing unboxed typography and hide-on-conversation behaviour. The public brief remains in Feed and personal Home content is unchanged. Static copy only; no model call is added.